### PR TITLE
feat(specs): Add unified Memory API specification (OpenAPI 3.1)

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -11,27 +11,127 @@ Define a common interface that allows:
 
 ## Format
 
-- **OpenAPI 3.1** - Machine-readable API definition
-- **Markdown** - Design rationale, usage examples
+- **[openapi.yaml](./openapi.yaml)** - Machine-readable API definition (OpenAPI 3.1)
+- **[schemas/memory.md](./schemas/memory.md)** - Human-readable schema documentation
+
+## Quick Start
+
+### Store a Memory
+
+```bash
+curl -X POST https://your-api/api/remember \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "Use JWT tokens with 24h expiry",
+    "type": "Decision",
+    "tags": ["auth", "security"]
+  }'
+```
+
+### Search Memories
+
+```bash
+curl -X POST https://your-api/api/recall \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "authentication decisions",
+    "limit": 5
+  }'
+```
 
 ## Core Operations
 
-| Operation | Description |
-|-----------|-------------|
-| `remember` | Store a new memory |
-| `recall` | Semantic search across memories |
-| `recall_by_tags` | Tag-based filtering |
-| `forget` | Delete memory by ID |
-| `consolidate` | Trigger decay/consolidation (optional) |
+| Operation | Method | Endpoint | Description |
+|-----------|--------|----------|-------------|
+| `remember` | POST | /api/remember | Store a new memory |
+| `recall` | POST | /api/recall | Semantic search across memories |
+| `recall_by_tags` | POST | /api/recall/by-tags | Tag-based filtering |
+| `context` | POST | /api/context | Proactive context surfacing |
+| `forget` | DELETE | /api/forget/{id} | Delete memory by ID |
+| `consolidate` | POST | /api/consolidate | Trigger decay/consolidation |
+| `list` | GET | /api/memories | List with pagination |
+| `stats` | GET | /api/stats | Memory statistics |
+
+## Memory Schema Highlights
+
+### Core Fields
+
+```yaml
+Memory:
+  content: string        # The memory content (required)
+  type: MemoryType       # Classification (Decision, Learning, etc.)
+  tags: string[]         # User-defined tags
+  source_type: SourceType # Where it came from (user, api, file, etc.)
+  credibility: float     # Trust score (0.0-1.0)
+```
+
+### Emotional Metadata
+
+```yaml
+emotion: string           # Label (joy, frustration, curiosity, etc.)
+emotional_valence: float  # -1.0 (negative) to +1.0 (positive)
+emotional_arousal: float  # 0.0 (calm) to 1.0 (aroused)
+```
+
+### Episodic Structure
+
+```yaml
+episode_id: string        # Groups related memories
+sequence_number: integer  # Order within episode
+```
+
+See [schemas/memory.md](./schemas/memory.md) for complete field documentation.
 
 ## Implementations
 
-| Project | Backend | Embeddings |
-|---------|---------|------------|
-| [shodh-memory](https://github.com/varun29ankuS/shodh-memory) | RocksDB (local) | MiniLM-L6-v2 (ONNX) |
-| [shodh-cloudflare](https://github.com/doobidoo/shodh-cloudflare) | D1 + Vectorize (edge) | Workers AI (bge-small) |
-| [mcp-memory-service](https://github.com/doobidoo/mcp-memory-service) | Local | ONNX |
+| Project | Backend | Embeddings | Status |
+|---------|---------|------------|--------|
+| [shodh-memory](https://github.com/varun29ankuS/shodh-memory) | RocksDB (local) | MiniLM-L6-v2 (ONNX) | Reference |
+| [shodh-cloudflare](https://github.com/doobidoo/shodh-cloudflare) | D1 + Vectorize (edge) | Workers AI (bge-small) | Production |
+| [mcp-memory-service](https://github.com/doobidoo/mcp-memory-service) | SQLite-vec / Hybrid | MiniLM-L6-v2 (ONNX) | Production |
+
+## Migration Notes
+
+Different embedding models produce incompatible vector spaces. When migrating:
+
+1. Export memories from source
+2. Re-embed all content with target model
+3. Import to target system
+
+The API contract remains the same; only the embeddings change.
+
+## Authentication
+
+All endpoints (except `/api/health`) require Bearer token authentication:
+
+```
+Authorization: Bearer your-api-key
+```
+
+## Versioning
+
+This specification follows semantic versioning:
+- **Major**: Breaking changes to required fields or core operations
+- **Minor**: New optional fields or operations
+- **Patch**: Documentation fixes, clarifications
+
+Current version: **1.0.0**
 
 ## Contributing
 
-PRs welcome! Start with the OpenAPI spec in `openapi.yaml`.
+PRs welcome! To propose changes:
+
+1. Fork this repository
+2. Edit `openapi.yaml` or `schemas/memory.md`
+3. Ensure changes are backwards-compatible (or bump major version)
+4. Submit PR with rationale
+
+## Related Documents
+
+- [CODEBASE_INTEGRATION.md](./CODEBASE_INTEGRATION.md) - Codebase awareness specification (draft)
+
+## License
+
+MIT - See repository root for details.

--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -1,0 +1,908 @@
+openapi: 3.1.0
+info:
+  title: SHODH Memory API
+  description: |
+    Unified API specification for semantic memory implementations.
+
+    This specification defines a common interface for memory systems that support:
+    - Semantic search with vector embeddings
+    - Emotional metadata (valence, arousal, emotion labels)
+    - Episodic memory structure (episode threading)
+    - Source tracking and credibility scoring
+    - Quality-based retrieval and consolidation
+
+    ## Implementations
+
+    | Project | Backend | Embeddings |
+    |---------|---------|------------|
+    | [shodh-memory](https://github.com/varun29ankuS/shodh-memory) | RocksDB | MiniLM-L6-v2 (ONNX) |
+    | [shodh-cloudflare](https://github.com/doobidoo/shodh-cloudflare) | D1 + Vectorize | Workers AI (bge-small) |
+    | [mcp-memory-service](https://github.com/doobidoo/mcp-memory-service) | SQLite-vec / Hybrid | MiniLM-L6-v2 (ONNX) |
+
+    ## Migration Notes
+
+    Different embedding models produce incompatible vector spaces. Migration between
+    implementations requires re-embedding all memories.
+  version: 1.0.0
+  contact:
+    name: SHODH Memory Community
+    url: https://github.com/varun29ankuS/shodh-memory/discussions
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+
+servers:
+  - url: http://localhost:8000
+    description: Local development server
+  - url: https://{worker}.workers.dev
+    description: Cloudflare Workers (edge)
+    variables:
+      worker:
+        default: shodh-memory
+        description: Worker subdomain
+
+tags:
+  - name: Memory Operations
+    description: Core CRUD operations for memories
+  - name: Search
+    description: Semantic and tag-based search
+  - name: Maintenance
+    description: Consolidation, stats, and health checks
+
+paths:
+  /api/remember:
+    post:
+      summary: Store a new memory
+      description: |
+        Creates a new memory with optional emotional metadata, episodic structure,
+        and source tracking. Content is automatically embedded for semantic search.
+
+        Duplicate memories (same content hash) are rejected with 409 Conflict.
+      operationId: remember
+      tags:
+        - Memory Operations
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RememberRequest'
+            examples:
+              basic:
+                summary: Basic memory
+                value:
+                  content: "Use JWT tokens with 24h expiry for authentication"
+                  type: Decision
+                  tags: ["auth", "security"]
+              emotional:
+                summary: Memory with emotional metadata
+                value:
+                  content: "Finally fixed the production bug after 6 hours"
+                  type: Discovery
+                  tags: ["bugfix", "production"]
+                  emotion: relief
+                  emotional_valence: 0.8
+                  emotional_arousal: 0.3
+              episodic:
+                summary: Memory in an episode
+                value:
+                  content: "Step 2: Implement user registration"
+                  type: Task
+                  episode_id: "auth-implementation-2024"
+                  sequence_number: 2
+      responses:
+        '201':
+          description: Memory created successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RememberResponse'
+        '400':
+          description: Invalid request (missing content)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Duplicate memory exists
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  error:
+                    type: string
+                    example: "Memory already exists"
+                  existing_id:
+                    type: string
+                    format: uuid
+
+  /api/recall:
+    post:
+      summary: Semantic search for memories
+      description: |
+        Searches memories using semantic similarity. The query is embedded
+        and compared against stored memory embeddings.
+
+        Supports multiple retrieval modes:
+        - `semantic`: Pure vector similarity
+        - `associative`: Follow Hebbian memory edges
+        - `hybrid`: Combine semantic + associative (default)
+      operationId: recall
+      tags:
+        - Search
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecallRequest'
+            examples:
+              basic:
+                summary: Simple search
+                value:
+                  query: "authentication decisions"
+                  limit: 5
+              filtered:
+                summary: Search with type filter
+                value:
+                  query: "database optimization"
+                  limit: 10
+                  memory_types: ["Decision", "Learning"]
+              quality_boosted:
+                summary: Quality-boosted search
+                value:
+                  query: "error handling patterns"
+                  limit: 10
+                  quality_boost: true
+                  quality_weight: 0.3
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecallResponse'
+
+  /api/recall/by-tags:
+    post:
+      summary: Search memories by tags
+      description: |
+        Returns memories matching ANY of the provided tags.
+        Results are ordered by recency (newest first).
+      operationId: recallByTags
+      tags:
+        - Search
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - tags
+              properties:
+                tags:
+                  type: array
+                  items:
+                    type: string
+                  minItems: 1
+                  example: ["auth", "security"]
+                limit:
+                  type: integer
+                  minimum: 1
+                  maximum: 100
+                  default: 20
+      responses:
+        '200':
+          description: Matching memories
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecallResponse'
+
+  /api/context:
+    post:
+      summary: Proactive context surfacing
+      description: |
+        Given a conversation context, surfaces relevant memories without
+        explicit search. Optionally auto-ingests the context as a Conversation
+        memory for continuity tracking.
+
+        This is the recommended way to maintain conversation awareness.
+      operationId: proactiveContext
+      tags:
+        - Search
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - context
+              properties:
+                context:
+                  type: string
+                  description: Current conversation context or user message
+                  example: "I'm working on the authentication system"
+                max_results:
+                  type: integer
+                  minimum: 1
+                  maximum: 20
+                  default: 5
+                auto_ingest:
+                  type: boolean
+                  default: true
+                  description: Whether to store the context as a Conversation memory
+      responses:
+        '200':
+          description: Surfaced memories
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  surfaced_memories:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Memory'
+                  count:
+                    type: integer
+                  ingested:
+                    type: boolean
+                  ingested_id:
+                    type: string
+                    format: uuid
+                    nullable: true
+
+  /api/forget/{id}:
+    delete:
+      summary: Delete a memory
+      description: Permanently deletes a memory by its ID.
+      operationId: forget
+      tags:
+        - Memory Operations
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Memory deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  deleted:
+                    type: boolean
+                    example: true
+        '404':
+          description: Memory not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/forget/by-tags:
+    post:
+      summary: Delete memories by tags
+      description: |
+        Deletes all memories matching ANY of the provided tags.
+        Use with caution - this is a bulk delete operation.
+      operationId: forgetByTags
+      tags:
+        - Memory Operations
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - tags
+              properties:
+                tags:
+                  type: array
+                  items:
+                    type: string
+                  minItems: 1
+      responses:
+        '200':
+          description: Deletion result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  deleted_count:
+                    type: integer
+
+  /api/memories:
+    get:
+      summary: List memories
+      description: Returns memories with pagination, optionally filtered by type.
+      operationId: listMemories
+      tags:
+        - Memory Operations
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: type
+          in: query
+          description: Filter by memory type
+          schema:
+            $ref: '#/components/schemas/MemoryType'
+      responses:
+        '200':
+          description: List of memories
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  memories:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Memory'
+                  count:
+                    type: integer
+                    description: Number of memories in this response
+                  total:
+                    type: integer
+                    description: Total number of memories matching filters
+
+  /api/memories/{id}:
+    get:
+      summary: Get a specific memory
+      operationId: getMemory
+      tags:
+        - Memory Operations
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Memory details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Memory'
+        '404':
+          description: Memory not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    patch:
+      summary: Update memory metadata
+      description: |
+        Updates memory metadata without changing content or re-embedding.
+        Useful for updating tags, quality scores, or custom metadata.
+      operationId: updateMemory
+      tags:
+        - Memory Operations
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tags:
+                  type: array
+                  items:
+                    type: string
+                memory_type:
+                  $ref: '#/components/schemas/MemoryType'
+                metadata:
+                  type: object
+                  additionalProperties: true
+      responses:
+        '200':
+          description: Memory updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Memory'
+
+  /api/consolidate:
+    post:
+      summary: Trigger memory consolidation
+      description: |
+        Triggers the consolidation process for a given time horizon.
+
+        Consolidation performs:
+        - Exponential decay scoring
+        - Association discovery between memories
+        - Semantic clustering and compression
+        - Quality-based archival of low-value memories
+
+        This is an optional operation - some implementations run consolidation
+        automatically on a schedule.
+      operationId: consolidate
+      tags:
+        - Maintenance
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - time_horizon
+              properties:
+                time_horizon:
+                  type: string
+                  enum: [daily, weekly, monthly, quarterly, yearly]
+                  description: Time horizon for consolidation scope
+      responses:
+        '200':
+          description: Consolidation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  processed:
+                    type: integer
+                    description: Number of memories processed
+                  archived:
+                    type: integer
+                    description: Number of memories archived
+                  associations_created:
+                    type: integer
+                    description: New memory associations discovered
+
+  /api/stats:
+    get:
+      summary: Get memory statistics
+      description: Returns aggregate statistics about stored memories.
+      operationId: getStats
+      tags:
+        - Maintenance
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total_memories:
+                    type: integer
+                  memories_last_7_days:
+                    type: integer
+                  by_type:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        memory_type:
+                          type: string
+                        count:
+                          type: integer
+                  database:
+                    type: string
+                    description: Storage backend identifier
+                  vector_store:
+                    type: string
+                    description: Vector index identifier
+
+  /api/health:
+    get:
+      summary: Health check
+      description: Returns service health status. Does not require authentication.
+      operationId: healthCheck
+      tags:
+        - Maintenance
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [healthy, degraded, unhealthy]
+                  version:
+                    type: string
+                  uptime_seconds:
+                    type: integer
+
+  /api/tags:
+    get:
+      summary: List all tags
+      description: Returns all unique tags used across memories.
+      operationId: listTags
+      tags:
+        - Maintenance
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: List of tags
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tags:
+                    type: array
+                    items:
+                      type: string
+                  count:
+                    type: integer
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: API key passed as Bearer token
+
+  schemas:
+    Memory:
+      type: object
+      required:
+        - id
+        - content
+        - content_hash
+        - created_at
+      properties:
+        # Identification
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier
+        content:
+          type: string
+          description: The memory content
+        content_hash:
+          type: string
+          description: SHA-256 hash for deduplication
+
+        # Classification
+        type:
+          $ref: '#/components/schemas/MemoryType'
+        tags:
+          type: array
+          items:
+            type: string
+          default: []
+
+        # Source & Trust
+        source_type:
+          $ref: '#/components/schemas/SourceType'
+        credibility:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          default: 1.0
+          description: Trust score (0.0-1.0)
+
+        # Emotional Metadata
+        emotion:
+          type: string
+          nullable: true
+          description: Emotion label (joy, frustration, surprise, relief, etc.)
+          examples: ["joy", "frustration", "surprise", "relief", "curiosity"]
+        emotional_valence:
+          type: number
+          format: float
+          minimum: -1
+          maximum: 1
+          nullable: true
+          description: Negative to positive sentiment (-1.0 to 1.0)
+        emotional_arousal:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          nullable: true
+          description: Calm to aroused intensity (0.0 to 1.0)
+
+        # Episodic Memory
+        episode_id:
+          type: string
+          nullable: true
+          description: Groups related memories into coherent episodes
+        sequence_number:
+          type: integer
+          nullable: true
+          description: Order within an episode
+
+        # Timestamps
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_accessed_at:
+          type: string
+          format: date-time
+          nullable: true
+
+        # Quality & Access
+        quality_score:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          nullable: true
+          description: AI-evaluated quality score
+        access_count:
+          type: integer
+          default: 0
+          description: Number of times retrieved
+
+        # Implementation-specific
+        embedding:
+          type: array
+          items:
+            type: number
+            format: float
+          nullable: true
+          description: Vector embedding (dimensions vary by implementation)
+        metadata:
+          type: object
+          additionalProperties: true
+          description: Implementation-specific metadata
+
+    MemoryType:
+      type: string
+      enum:
+        - Observation
+        - Decision
+        - Learning
+        - Error
+        - Discovery
+        - Pattern
+        - Context
+        - Task
+        - CodeEdit
+        - FileAccess
+        - Search
+        - Command
+        - Conversation
+      default: Observation
+      description: |
+        Memory classification:
+        - **Observation**: General observations and notes
+        - **Decision**: Decisions made with rationale
+        - **Learning**: Things learned from experience
+        - **Error**: Error resolutions and debugging insights
+        - **Discovery**: New discoveries and insights
+        - **Pattern**: Recognized patterns in code or behavior
+        - **Context**: Contextual background information
+        - **Task**: Task-related notes and progress
+        - **CodeEdit**: Code modifications made
+        - **FileAccess**: Files read or accessed
+        - **Search**: Search queries and results
+        - **Command**: Commands executed
+        - **Conversation**: Auto-ingested conversation context
+
+    SourceType:
+      type: string
+      enum:
+        - user
+        - system
+        - api
+        - file
+        - web
+        - ai_generated
+        - inferred
+      default: user
+      description: |
+        Where the memory originated:
+        - **user**: Direct user input
+        - **system**: System-generated events
+        - **api**: External API responses
+        - **file**: Content from files
+        - **web**: Web content
+        - **ai_generated**: AI-generated content
+        - **inferred**: Inferred from context
+
+    RememberRequest:
+      type: object
+      required:
+        - content
+      properties:
+        content:
+          type: string
+          minLength: 1
+          description: The memory content to store
+        type:
+          $ref: '#/components/schemas/MemoryType'
+        tags:
+          type: array
+          items:
+            type: string
+          default: []
+        source_type:
+          $ref: '#/components/schemas/SourceType'
+        credibility:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          default: 1.0
+        emotion:
+          type: string
+          nullable: true
+        emotional_valence:
+          type: number
+          format: float
+          minimum: -1
+          maximum: 1
+          nullable: true
+        emotional_arousal:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          nullable: true
+        episode_id:
+          type: string
+          nullable: true
+        sequence_number:
+          type: integer
+          nullable: true
+        metadata:
+          type: object
+          additionalProperties: true
+          description: Custom metadata fields
+
+    RememberResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        id:
+          type: string
+          format: uuid
+        content_hash:
+          type: string
+
+    RecallRequest:
+      type: object
+      required:
+        - query
+      properties:
+        query:
+          type: string
+          minLength: 1
+          description: Natural language search query
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 5
+        mode:
+          type: string
+          enum: [semantic, associative, hybrid]
+          default: hybrid
+          description: Retrieval mode
+        memory_types:
+          type: array
+          items:
+            $ref: '#/components/schemas/MemoryType'
+          nullable: true
+          description: Filter by memory types
+        quality_boost:
+          type: boolean
+          default: false
+          description: Enable quality-weighted ranking
+        quality_weight:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          default: 0.3
+          description: Weight for quality score in ranking (0.3 = 30% quality, 70% semantic)
+
+    RecallResponse:
+      type: object
+      properties:
+        memories:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/Memory'
+              - type: object
+                properties:
+                  similarity_score:
+                    type: number
+                    format: float
+                    minimum: 0
+                    maximum: 1
+                    description: Semantic similarity to query
+                  relevance_score:
+                    type: number
+                    format: float
+                    minimum: 0
+                    maximum: 1
+                    description: Combined relevance score (if quality_boost enabled)
+        count:
+          type: integer
+        query:
+          type: string
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error message
+        code:
+          type: string
+          description: Error code for programmatic handling
+        details:
+          type: object
+          additionalProperties: true
+          description: Additional error details

--- a/specs/schemas/memory.md
+++ b/specs/schemas/memory.md
@@ -1,0 +1,285 @@
+# Memory Schema Documentation
+
+Human-readable documentation for the unified SHODH Memory schema.
+
+## Core Memory Object
+
+Every memory implementation must support these fields:
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | UUID | Unique identifier for the memory |
+| `content` | string | The actual memory content |
+| `content_hash` | string | SHA-256 hash for deduplication |
+| `created_at` | datetime | When the memory was created |
+
+### Classification Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | enum | `Observation` | Memory type classification |
+| `tags` | string[] | `[]` | User-defined tags for categorization |
+
+#### Memory Types
+
+```
+Observation  - General observations and notes
+Decision     - Decisions made with rationale
+Learning     - Things learned from experience
+Error        - Error resolutions and debugging insights
+Discovery    - New discoveries and insights
+Pattern      - Recognized patterns in code or behavior
+Context      - Contextual background information
+Task         - Task-related notes and progress
+CodeEdit     - Code modifications made
+FileAccess   - Files read or accessed
+Search       - Search queries and results
+Command      - Commands executed
+Conversation - Auto-ingested conversation context
+```
+
+### Source & Trust Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `source_type` | enum | `user` | Where the memory originated |
+| `credibility` | float | `1.0` | Trust score (0.0-1.0) |
+
+#### Source Types
+
+```
+user         - Direct user input
+system       - System-generated events
+api          - External API responses
+file         - Content from files
+web          - Web content
+ai_generated - AI-generated content
+inferred     - Inferred from context
+```
+
+### Emotional Metadata (Optional)
+
+These fields capture the emotional context of memories, useful for:
+- Understanding decision-making context
+- Prioritizing memories during recall
+- Building more human-like memory systems
+
+| Field | Type | Range | Description |
+|-------|------|-------|-------------|
+| `emotion` | string | - | Emotion label (joy, frustration, surprise, etc.) |
+| `emotional_valence` | float | -1.0 to 1.0 | Negative to positive sentiment |
+| `emotional_arousal` | float | 0.0 to 1.0 | Calm to aroused intensity |
+
+#### Common Emotion Labels
+
+```
+joy          - Positive achievement or success
+frustration  - Obstacles or difficulties
+surprise     - Unexpected findings
+relief       - Problem resolution
+curiosity    - Exploration and learning
+confusion    - Uncertainty or complexity
+satisfaction - Task completion
+anxiety      - Concerns or worries
+```
+
+#### Valence-Arousal Examples
+
+| Emotion | Valence | Arousal |
+|---------|---------|---------|
+| Excited | +0.8 | 0.9 |
+| Calm | +0.3 | 0.1 |
+| Frustrated | -0.7 | 0.8 |
+| Sad | -0.5 | 0.2 |
+| Curious | +0.4 | 0.5 |
+
+### Episodic Memory Fields (Optional)
+
+For threading related memories into coherent episodes:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `episode_id` | string | Groups related memories together |
+| `sequence_number` | integer | Order within the episode |
+
+#### Episode Example
+
+```json
+[
+  {
+    "content": "Starting authentication implementation",
+    "episode_id": "auth-impl-2024",
+    "sequence_number": 1
+  },
+  {
+    "content": "Decided to use JWT tokens",
+    "episode_id": "auth-impl-2024",
+    "sequence_number": 2,
+    "type": "Decision"
+  },
+  {
+    "content": "Completed OAuth2 integration",
+    "episode_id": "auth-impl-2024",
+    "sequence_number": 3
+  }
+]
+```
+
+### Timestamp Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `created_at` | datetime | When memory was created |
+| `updated_at` | datetime | When memory was last modified |
+| `last_accessed_at` | datetime | When memory was last retrieved |
+
+### Quality & Access Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `quality_score` | float | - | AI-evaluated quality (0.0-1.0) |
+| `access_count` | integer | `0` | Number of times retrieved |
+
+#### Quality Scoring
+
+Quality scores help prioritize memories during:
+- Search result ranking
+- Consolidation decisions
+- Memory decay calculations
+
+```
+0.8-1.0  High quality   - Preserved longest
+0.5-0.7  Medium quality - Standard retention
+0.0-0.4  Low quality    - Candidates for archival
+```
+
+### Implementation-Specific Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `embedding` | float[] | Vector embedding (dimensions vary) |
+| `metadata` | object | Custom implementation-specific data |
+
+#### Embedding Dimensions by Implementation
+
+| Implementation | Model | Dimensions |
+|----------------|-------|------------|
+| shodh-memory | MiniLM-L6-v2 | 384 |
+| shodh-cloudflare | bge-small-en-v1.5 | 384 |
+| mcp-memory-service | MiniLM-L6-v2 | 384 |
+
+---
+
+## Complete Example
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "content": "Use JWT tokens with 24h expiry and refresh tokens for mobile apps",
+  "content_hash": "a1b2c3d4e5f6...",
+  "type": "Decision",
+  "tags": ["auth", "security", "mobile"],
+
+  "source_type": "user",
+  "credibility": 0.95,
+
+  "emotion": "satisfaction",
+  "emotional_valence": 0.7,
+  "emotional_arousal": 0.4,
+
+  "episode_id": "auth-implementation-2024",
+  "sequence_number": 3,
+
+  "created_at": "2024-12-30T10:00:00Z",
+  "updated_at": "2024-12-30T14:30:00Z",
+  "last_accessed_at": "2024-12-30T16:00:00Z",
+
+  "quality_score": 0.85,
+  "access_count": 5,
+
+  "metadata": {
+    "project": "mobile-app",
+    "reviewer": "security-team"
+  }
+}
+```
+
+---
+
+## Field Compatibility Matrix
+
+| Field | shodh-memory | shodh-cloudflare | mcp-memory-service |
+|-------|--------------|------------------|-------------------|
+| `id` | UUID | UUID | content_hash |
+| `content` | string | string | string |
+| `content_hash` | SHA-256 | SHA-256 | SHA-256 |
+| `type` | enum | enum | string (flexible) |
+| `tags` | string[] | JSON string | string[] |
+| `source_type` | enum | enum | metadata field |
+| `credibility` | float | float | quality_score |
+| `emotion` | string | string | metadata field |
+| `emotional_valence` | float | float | metadata field |
+| `emotional_arousal` | float | float | metadata field |
+| `episode_id` | string | string | metadata field |
+| `sequence_number` | int | int | metadata field |
+| `quality_score` | float | float | float |
+| `access_count` | int | int | int |
+| `embedding` | float[384] | float[384] | float[384] |
+
+---
+
+## Migration Notes
+
+### Between Implementations
+
+1. **Export memories** from source system
+2. **Transform fields** to match target schema
+3. **Re-embed content** (different models = different vectors)
+4. **Import to target** with new embeddings
+
+### Embedding Incompatibility
+
+Different embedding models produce incompatible vector spaces:
+
+```
+MiniLM-L6-v2 embedding    =/=    bge-small-en-v1.5 embedding
+```
+
+Always re-embed when migrating between implementations with different models.
+
+### Graceful Degradation
+
+If a field is not supported by an implementation:
+- Store it in `metadata` if possible
+- Omit it without error
+- Document the limitation
+
+---
+
+## Best Practices
+
+### Tags
+
+- Use lowercase, hyphenated tags: `user-auth`, `bug-fix`
+- Limit to 5-10 tags per memory
+- Use consistent vocabulary across memories
+
+### Emotional Metadata
+
+- Only add when emotionally significant
+- Use valence+arousal together or not at all
+- Common emotions: joy, frustration, curiosity, relief
+
+### Episodes
+
+- Group logically related memories
+- Use descriptive episode IDs: `feature-auth-2024`, `bugfix-123`
+- Keep episodes to 3-10 memories for coherence
+
+### Quality Scores
+
+- Let the system score automatically when possible
+- Manual overrides: use user ratings (thumbs up/down)
+- Review low-quality memories periodically


### PR DESCRIPTION
## Summary

Adds unified Memory API specification to `/specs` directory as discussed in #2.

### Files Added/Modified

- **`specs/openapi.yaml`** - OpenAPI 3.1.0 specification with:
  - 8 core endpoints (remember, recall, recall_by_tags, context, forget, consolidate, list, stats)
  - Complete Memory schema with all unified fields
  - Request/response examples for each operation
  - Authentication documentation (Bearer token)

- **`specs/schemas/memory.md`** - Human-readable documentation:
  - Field descriptions, types, and ranges
  - Emotional metadata guide (valence, arousal, emotion labels)
  - Episodic memory structure (episode_id, sequence_number)
  - Implementation compatibility matrix
  - Migration notes between implementations

- **`specs/README.md`** - Updated with:
  - Quick start curl examples
  - Core operations reference table
  - Schema highlights

### Schema Highlights

**Core Fields:**
- `content`, `content_hash`, `type`, `tags`

**Source & Trust (from your suggestions):**
- `source_type`: enum [user, system, api, file, web, ai_generated, inferred]
- `credibility`: float [0, 1]

**Episodic Memory (from your suggestions):**
- `episode_id`, `sequence_number`

**Emotional Metadata:**
- `emotion`, `emotional_valence`, `emotional_arousal`

**Quality & Access:**
- `quality_score`, `access_count`

### Implementations Unified

| Project | Backend | Embeddings |
|---------|---------|------------|
| shodh-memory | RocksDB | MiniLM-L6-v2 |
| shodh-cloudflare | D1 + Vectorize | Workers AI (bge-small) |
| mcp-memory-service | SQLite-vec / Hybrid | MiniLM-L6-v2 |

### Next Steps

After this PR is merged:
1. I'll update shodh-cloudflare to document spec compliance
2. I'll add the missing fields (episode_id, emotional_*) to mcp-memory-service metadata
3. We can continue the SecondBrain voice collaboration discussion

Related: Discussion #2