### PR TITLE
fix: complete forget/delete lifecycle — BM25, soft-forget, GDPR

### DIFF
--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -420,8 +420,8 @@ impl RelationshipEdge {
                 if let Some(next_tier) = self.tier.next_tier() {
                     let old_tier = self.tier;
                     self.tier = next_tier;
-                    // Reset strength to next tier's initial weight (consolidation)
-                    self.strength = next_tier.initial_weight();
+                    // Preserve strength if already above next tier's initial weight
+                    self.strength = self.strength.max(next_tier.initial_weight());
 
                     // PIPE-4: Initialize activation_timestamps on L1→L2 promotion
                     if old_tier == EdgeTier::L1Working {


### PR DESCRIPTION
## Summary

- **BM25 ghost documents**: Every forget/delete path skipped BM25 keyword index cleanup — deleted memories remained keyword-searchable indefinitely. Added `hybrid_search.remove_memory()` to all 6 forget paths (ById, pattern, tags, date_range, type, all).
- **Soft-forget broken**: `OlderThan` and `LowImportance` only set a metadata flag while leaving vector, BM25, and graph indices fully intact. Changed `mark_forgotten_by_age/importance` to return `Vec<MemoryId>` so callers clean secondary indices.
- **GDPR incomplete**: `forget_all()` left behind semantic facts, temporal facts, and BM25 data. Added prefix-based batch delete for all fact keys and BM25 commit.
- **Compression resurrection**: `get_uncompressed_older_than()` didn't filter forgotten memories, so consolidation picked up and rewrote soft-deleted memories. Added `is_forgotten()` check.
- **Index consistency**: `set_memory_parent()` used `store()` instead of `update()`, leaking stale index entries. Graph tier promotion reset edge strength on L1→L2 promotion.

## Test plan

- [x] `cargo check` — clean compilation
- [x] `cargo test --lib` — all 458 tests pass
- [ ] E2E: store memory → delete → verify BM25 search returns nothing
- [ ] E2E: soft-forget via OlderThan → verify vector+BM25 return nothing
- [ ] E2E: forget_all after consolidation → verify facts and BM25 cleared