### PR TITLE
fix: add POST /api/forget route for single memory deletion

### DIFF
--- a/src/handlers/router.rs
+++ b/src/handlers/router.rs
@@ -104,6 +104,7 @@ pub fn build_protected_routes(state: AppState) -> Router {
         // =================================================================
         // FORGET OPERATIONS
         // =================================================================
+        .route("/api/forget", post(crud::forget_by_id))
         .route("/api/forget/age", post(crud::forget_by_age))
         .route("/api/forget/importance", post(crud::forget_by_importance))
         .route("/api/forget/pattern", post(crud::forget_by_pattern))


### PR DESCRIPTION
## Summary

- Adds `POST /api/forget` accepting `{"user_id", "memory_id"}` in the JSON body
- Matches the POST convention used by all other forget endpoints (`/api/forget/age`, `/api/forget/tags`, etc.)
- Existing `DELETE /api/forget/{memory_id}?user_id=...` route is preserved

Fixes #33

## Test plan

- [x] `cargo check` — compiles clean
- [x] `cargo fmt` — formatted
- [ ] `POST /api/forget {"user_id":"...", "memory_id":"..."}` returns 200 with success response
- [ ] `DELETE /api/forget/{id}?user_id=...` still works (regression check)
- [ ] Short ID prefixes resolve correctly via `resolve_memory()`