### PR TITLE
feat: Cloudflare Worker API compatibility aliases

### DIFF
--- a/src/handlers/mif.rs
+++ b/src/handlers/mif.rs
@@ -1120,6 +1120,7 @@ pub async fn import_mif(
             id: memory::TodoId(uuid::Uuid::new_v4()),
             seq_num: 0,
             project_prefix: None,
+            project: None,
             user_id: req.user_id.clone(),
             content: mif_todo.content.clone(),
             status,

--- a/src/handlers/router.rs
+++ b/src/handlers/router.rs
@@ -30,6 +30,7 @@ pub fn build_public_routes(state: AppState) -> Router {
         // =================================================================
         // HEALTH & KUBERNETES PROBES
         // =================================================================
+        .route("/", get(health::health)) // Cloudflare compat alias
         .route("/health", get(health::health))
         .route("/health/live", get(health::health_live))
         .route("/health/ready", get(health::health_ready))
@@ -94,11 +95,13 @@ pub fn build_protected_routes(state: AppState) -> Router {
         // MEMORY CRUD OPERATIONS
         // =================================================================
         .route("/api/memory/{memory_id}", get(crud::get_memory))
+        .route("/api/memories/{memory_id}", get(crud::get_memory)) // Cloudflare compat alias
         .route("/api/memory/{memory_id}", put(crud::update_memory))
         .route("/api/memory/{memory_id}", delete(crud::delete_memory))
         .route("/api/forget/{memory_id}", delete(crud::delete_memory)) // OpenAPI alias
         .route("/api/list/{user_id}", get(crud::list_memories)) // TUI uses this
         .route("/api/memories", post(crud::list_memories_post)) // POST version
+        .route("/api/memories", get(crud::list_memories_get)) // Cloudflare compat alias
         .route("/api/memories/bulk", post(crud::bulk_delete_memories))
         .route("/api/memories/clear", post(crud::clear_all_memories))
         // =================================================================
@@ -284,6 +287,7 @@ pub fn build_protected_routes(state: AppState) -> Router {
         .route("/api/projects/list", post(todos::list_projects)) // MCP alias
         .route("/api/projects/add", post(todos::create_project)) // Legacy alias
         .route("/api/projects/{project_id}", get(todos::get_project))
+        .route("/api/projects/{project_id}", delete(todos::delete_project)) // Cloudflare compat alias
         .route(
             "/api/projects/{project_id}/update",
             post(todos::update_project),

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -4282,12 +4282,14 @@ impl MemorySystem {
 
         let orphaned_count = total_storage.saturating_sub(total_indexed);
 
+        let is_healthy = orphaned_count == 0;
         Ok(IndexIntegrityReport {
             total_storage,
             total_indexed,
             orphaned_count,
             orphaned_ids,
-            is_healthy: orphaned_count == 0,
+            is_healthy,
+            healthy: is_healthy,
         })
     }
 

--- a/src/memory/todos.rs
+++ b/src/memory/todos.rs
@@ -289,6 +289,7 @@ impl TodoStore {
                 }
             }
             todo.seq_num = self.next_seq_num(&todo.user_id, todo.project_id.as_ref())?;
+            todo.sync_compat_fields();
         }
         Ok(())
     }
@@ -313,6 +314,7 @@ impl TodoStore {
             todo_to_store.seq_num =
                 self.next_seq_num(&todo_to_store.user_id, todo_to_store.project_id.as_ref())?;
         }
+        todo_to_store.sync_compat_fields();
 
         let key = format!("{}:{}", todo_to_store.user_id, todo_to_store.id.0);
         let value = serde_json::to_vec(&todo_to_store).context("Failed to serialize todo")?;
@@ -436,8 +438,9 @@ impl TodoStore {
 
         match self.todo_db.get(key.as_bytes())? {
             Some(value) => {
-                let todo: Todo =
+                let mut todo: Todo =
                     serde_json::from_slice(&value).context("Failed to deserialize todo")?;
+                todo.sync_compat_fields();
                 Ok(Some(todo))
             }
             None => Ok(None),

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -2791,6 +2791,9 @@ pub struct IndexIntegrityReport {
     pub orphaned_ids: Vec<MemoryId>,
     /// Whether the index is healthy (no orphans)
     pub is_healthy: bool,
+    /// Compat alias for `is_healthy` (Cloudflare Worker clients use `healthy`)
+    #[serde(default, skip_deserializing)]
+    pub healthy: bool,
 }
 
 /// Retrieval statistics for SHO-26 associative retrieval (debugging/observability)
@@ -3363,6 +3366,10 @@ pub struct Todo {
     #[serde(default)]
     pub project_prefix: Option<String>,
 
+    /// Compat alias for `project_prefix` (Cloudflare Worker clients use `project`)
+    #[serde(default, skip_deserializing)]
+    pub project: Option<String>,
+
     /// User who owns this todo
     pub user_id: String,
 
@@ -3444,6 +3451,7 @@ impl Todo {
             id: TodoId::new(),
             seq_num: 0,           // Will be assigned by TodoStore on creation
             project_prefix: None, // Will be set by TodoStore based on project
+            project: None,        // Synced from project_prefix
             user_id,
             content,
             status: TodoStatus::Todo,
@@ -3465,6 +3473,12 @@ impl Todo {
             embedding: None,
             related_memory_ids: Vec::new(),
         }
+    }
+
+    /// Sync compat alias fields from their canonical counterparts.
+    /// Call after construction or deserialization to keep aliases in sync.
+    pub fn sync_compat_fields(&mut self) {
+        self.project = self.project_prefix.clone();
     }
 
     /// Get the user-facing short ID (BOLT-1, MEM-2, SHO-3, etc.)


### PR DESCRIPTION
## Summary
- Accept `Authorization: Bearer` as fallback to `X-API-Key` in auth middleware
- Add route aliases: `GET /`, `GET /api/memories`, `GET /api/memories/{id}`, `DELETE /api/projects/{id}`
- Add response field compat: `healthy` on IndexIntegrityReport, `project` on Todo (synced from canonical fields)
- Refactor `list_memories` into shared inner function for both GET (query params) and POST (JSON body)

Enables Cloudflare Worker deployments to talk to the native Rust backend without forking the MCP server. Closes the need for PR #32.

## Test plan
- [x] `cargo check` — compiles
- [x] `cargo fmt` — formatted
- [x] `cargo clippy` — no new warnings
- [x] `cargo test --lib` — 458/458 passed
- [ ] Manual: `curl -H "Authorization: Bearer <key>" localhost:3030/health`
- [ ] Manual: `curl localhost:3030/` returns health JSON
- [ ] Manual: `GET /api/memories?user_id=test` returns memory list
- [ ] Manual: verify todo JSON includes both `project_prefix` and `project`