### PR TITLE
feat: bidirectional memory-edge tier coupling + tier labels

### DIFF
--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -1431,7 +1431,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
             response += `• ${matchBar} ${score}% │ ${timeStr}\n`;
             response += `  ${content.slice(0, 200)}${content.length > 200 ? '...' : ''}\n`;
-            response += `  ┗━ ${getType(m)} │ ${m.id.slice(0, 8)}...\n`;
+            response += `  ┗━ ${getType(m)}${m.tier ? ` │ ${m.tier}` : ''} │ ${m.id.slice(0, 8)}...\n`;
             if (i < memories.length - 1) response += `\n`;
           }
         }
@@ -1638,7 +1638,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           }[getType(m)] || '📦';
 
           response += `${String(i + 1).padStart(2)}. ${typeIcon} ${content.slice(0, 150)}${content.length > 150 ? '...' : ''}\n`;
-          response += `    ┗━ ${getType(m)} │ ${m.id.slice(0, 8)}...\n`;
+          response += `    ┗━ ${getType(m)}${m.tier ? ` │ ${m.tier}` : ''} │ ${m.id.slice(0, 8)}...\n`;
         }
 
         return {
@@ -2186,7 +2186,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               const sentenceEnd = preview.slice(0, 200).lastIndexOf('. ');
               preview = sentenceEnd > 80 ? preview.slice(0, sentenceEnd + 1) : preview.slice(0, 200) + '...';
             }
-            return `${i + 1}. ${importanceBar} [${score}%]${timeStr} ${preview}\n   ${m.memory_type} | ${m.relevance_reason}${entityMatchStr}${tagsStr}`;
+            return `${i + 1}. ${importanceBar} [${score}%]${timeStr} ${preview}\n   ${m.memory_type}${m.tier ? ` | ${m.tier}` : ''} | ${m.relevance_reason}${entityMatchStr}${tagsStr}`;
           })
           .join("\n\n");
 
@@ -2991,6 +2991,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           };
           importance: number;
           created_at: string;
+          tier?: string;
           parent_id?: string;
           children_ids: string[];
           children_count: number;
@@ -3021,7 +3022,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         let response = `Memory: ${memory.id}\n`;
         response += `━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`;
         response += `Type: ${memory.experience.experience_type} | Tags: ${tags}\n`;
-        response += `Created: ${created} | Importance: ${(memory.importance * 100).toFixed(0)}%\n`;
+        response += `Tier: ${memory.tier || 'Unknown'} | Created: ${created} | Importance: ${(memory.importance * 100).toFixed(0)}%\n`;
 
         // Hierarchy info
         if (memory.parent_id) {
@@ -3457,7 +3458,7 @@ server.setRequestHandler(GetPromptRequestSchema, async (request) => {
         });
         const memories = result.memories || [];
         const memoryText = memories.length > 0
-          ? memories.map((m) => `- ${getContent(m)} (${getType(m)})`).join("\n")
+          ? memories.map((m) => `- ${getContent(m)} (${getType(m)}${m.tier ? ` | ${m.tier}` : ''})`).join("\n")
           : "No memories found.";
         return {
           messages: [

--- a/src/handlers/crud.rs
+++ b/src/handlers/crud.rs
@@ -75,6 +75,7 @@ pub struct ListMemoryItem {
     pub importance: f32,
     pub tags: Vec<String>,
     pub created_at: String,
+    pub tier: String,
 }
 
 // =============================================================================
@@ -303,6 +304,7 @@ pub async fn list_memories(
             importance: m.importance(),
             tags: m.experience.entities.clone(),
             created_at: m.created_at.to_rfc3339(),
+            tier: format!("{:?}", m.tier),
         })
         .collect();
 
@@ -409,6 +411,7 @@ async fn list_memories_inner(
             importance: m.importance(),
             tags: m.experience.entities.clone(),
             created_at: m.created_at.to_rfc3339(),
+            tier: format!("{:?}", m.tier),
         })
         .collect();
 

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -148,6 +148,7 @@ pub struct ProactiveSurfacedMemory {
     pub importance: f32,
     pub created_at: String,
     pub tags: Vec<String>,
+    pub tier: String,
     /// Why this memory was surfaced ("semantic", "entity", "combined")
     pub relevance_reason: String,
     /// Entities from this memory that matched the query context
@@ -424,6 +425,7 @@ pub async fn recall(
                 importance: m.importance(),
                 created_at: m.created_at.to_rfc3339(),
                 score,
+                tier: format!("{:?}", m.tier),
             }
         })
         .collect();
@@ -1151,6 +1153,7 @@ pub async fn proactive_context(
                         importance: m.importance(),
                         created_at: m.created_at.to_rfc3339(),
                         tags: m.experience.tags.clone(),
+                        tier: format!("{:?}", m.tier),
                         relevance_reason,
                         matched_entities: matched,
                         embedding: m.experience.embeddings.clone().unwrap_or_default(),
@@ -1761,6 +1764,7 @@ pub async fn recall_tracked(
                 importance: m.importance(),
                 created_at: m.created_at.to_rfc3339(),
                 score,
+                tier: format!("{:?}", m.tier),
             }
         })
         .collect();

--- a/src/handlers/types.rs
+++ b/src/handlers/types.rs
@@ -219,6 +219,7 @@ pub struct RecallMemory {
     pub importance: f32,
     pub created_at: String,
     pub score: f32,
+    pub tier: String,
 }
 
 #[derive(Serialize)]

--- a/src/memory/introspection.rs
+++ b/src/memory/introspection.rs
@@ -248,6 +248,46 @@ pub enum ConsolidationEvent {
         memory_ids: Vec<String>,
         timestamp: DateTime<Utc>,
     },
+
+    // Memory-Edge Tier Coupling Events
+    // Direction 1: Edge tier promotion → Memory importance boost
+    /// Edge tier promotion boosted a memory's importance
+    EdgePromotionBoostApplied {
+        memory_id: String,
+        entity_name: String,
+        old_tier: String,
+        new_tier: String,
+        importance_boost: f64,
+        new_importance: f64,
+        timestamp: DateTime<Utc>,
+    },
+
+    // Direction 2: Edge pruning → Orphan detection
+    /// Memory became a graph orphan (lost all edges)
+    GraphOrphanDetected {
+        memory_id: String,
+        entity_count: usize,
+        compensatory_boost: f64,
+        timestamp: DateTime<Utc>,
+    },
+
+    // Direction 3: Graph health → Promotion threshold adjustment
+    /// Memory tier promotion threshold adjusted by graph health
+    GraphAdjustedPromotion {
+        memory_id: String,
+        base_threshold: f64,
+        adjusted_threshold: f64,
+        l2_plus_edge_count: usize,
+        promoted: bool,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// Graph decay consolidated into single call site (double-decay fix diagnostic)
+    GraphDecayConsolidated {
+        pruned_count: usize,
+        orphaned_entities: usize,
+        timestamp: DateTime<Utc>,
+    },
 }
 
 /// Types of memory interference (SHO-106)
@@ -852,6 +892,12 @@ impl ConsolidationEventBuffer {
                 ConsolidationEvent::PatternDetected { .. } => {
                     // Generic pattern - logged for introspection
                 }
+
+                // Memory-Edge Tier Coupling events — logged for introspection
+                ConsolidationEvent::EdgePromotionBoostApplied { .. } => {}
+                ConsolidationEvent::GraphOrphanDetected { .. } => {}
+                ConsolidationEvent::GraphAdjustedPromotion { .. } => {}
+                ConsolidationEvent::GraphDecayConsolidated { .. } => {}
             }
         }
 
@@ -1180,6 +1226,12 @@ impl ConsolidationEventBuffer {
                 ConsolidationEvent::SalienceSpikeDetected { .. } => {}
                 ConsolidationEvent::BehavioralChangeDetected { .. } => {}
                 ConsolidationEvent::PatternDetected { .. } => {}
+
+                // Memory-Edge Tier Coupling events — logged for introspection
+                ConsolidationEvent::EdgePromotionBoostApplied { .. } => {}
+                ConsolidationEvent::GraphOrphanDetected { .. } => {}
+                ConsolidationEvent::GraphAdjustedPromotion { .. } => {}
+                ConsolidationEvent::GraphDecayConsolidated { .. } => {}
             }
         }
 
@@ -1218,6 +1270,11 @@ impl ConsolidationEvent {
             ConsolidationEvent::SalienceSpikeDetected { timestamp, .. } => *timestamp,
             ConsolidationEvent::BehavioralChangeDetected { timestamp, .. } => *timestamp,
             ConsolidationEvent::PatternDetected { timestamp, .. } => *timestamp,
+            // Memory-Edge Tier Coupling events
+            ConsolidationEvent::EdgePromotionBoostApplied { timestamp, .. } => *timestamp,
+            ConsolidationEvent::GraphOrphanDetected { timestamp, .. } => *timestamp,
+            ConsolidationEvent::GraphAdjustedPromotion { timestamp, .. } => *timestamp,
+            ConsolidationEvent::GraphDecayConsolidated { timestamp, .. } => *timestamp,
         }
     }
 
@@ -1261,6 +1318,11 @@ impl ConsolidationEvent {
                 | ConsolidationEvent::SemanticClusterFormed { .. }
                 | ConsolidationEvent::SalienceSpikeDetected { .. }
                 | ConsolidationEvent::PatternDetected { .. }
+                // Memory-Edge Tier Coupling events are significant
+                | ConsolidationEvent::EdgePromotionBoostApplied { .. }
+                | ConsolidationEvent::GraphOrphanDetected { .. }
+                | ConsolidationEvent::GraphAdjustedPromotion { .. }
+                | ConsolidationEvent::GraphDecayConsolidated { .. }
         )
     }
 }

--- a/src/memory/learning_history.rs
+++ b/src/memory/learning_history.rs
@@ -321,6 +321,31 @@ impl LearningHistoryStore {
                 None,
                 None,
             ),
+            // Memory-Edge Tier Coupling events
+            ConsolidationEvent::EdgePromotionBoostApplied { memory_id, .. } => (
+                LearningEventType::MaintenanceCycleCompleted,
+                Some(memory_id.clone()),
+                None,
+                None,
+            ),
+            ConsolidationEvent::GraphOrphanDetected { memory_id, .. } => (
+                LearningEventType::MaintenanceCycleCompleted,
+                Some(memory_id.clone()),
+                None,
+                None,
+            ),
+            ConsolidationEvent::GraphAdjustedPromotion { memory_id, .. } => (
+                LearningEventType::MaintenanceCycleCompleted,
+                Some(memory_id.clone()),
+                None,
+                None,
+            ),
+            ConsolidationEvent::GraphDecayConsolidated { .. } => (
+                LearningEventType::MaintenanceCycleCompleted,
+                None,
+                None,
+                None,
+            ),
         }
     }
 

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -4181,6 +4181,33 @@ pub struct MaintenanceResult {
     pub facts_reinforced: usize,
 }
 
+/// Signal emitted when an edge tier promotion occurs during strengthen().
+/// Used to propagate edge-tier promotions back to memory importance (Direction 1 coupling).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EdgePromotionBoost {
+    /// The memory ID whose importance should be boosted
+    pub memory_id: String,
+    /// The entity name involved in the promoted edge
+    pub entity_name: String,
+    /// The old tier before promotion (e.g., "L1Working")
+    pub old_tier: String,
+    /// The new tier after promotion (e.g., "L2Episodic")
+    pub new_tier: String,
+    /// The importance boost to apply
+    pub boost: f64,
+}
+
+/// Result of graph decay with details needed for orphan detection (Direction 2 coupling).
+#[derive(Debug, Clone, Default)]
+pub struct GraphDecayResult {
+    /// Number of edges pruned during decay
+    pub pruned_count: usize,
+    /// Entity IDs that lost all their edges (became orphaned)
+    pub orphaned_entity_ids: Vec<String>,
+    /// Memory IDs associated with orphaned entities
+    pub orphaned_memory_ids: Vec<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- **Bidirectional coupling** between memory tiers (Working→Session→LongTerm) and edge tiers (L1→L2→L3) — three directions:
  - Edge promotion → memory importance boost (+0.015 for L2, +0.03 for L3)
  - Edge pruning → orphan detection + compensatory boost (+0.05)
  - Graph health → promotion threshold adjustment (±15% discount/10% penalty)
- **Double-decay bug fix**: `apply_decay()` was called twice per maintenance cycle (mod.rs + state.rs), edges decayed at 2x rate
- **Tier labels in API responses**: all memory endpoints now return `tier` field (Working/Session/LongTerm/Archive), surfaced in MCP server formatted output

## Files Changed (11)

| File | Changes |
|------|---------|
| `src/constants.rs` | 7 new coupling constants with academic rationale |
| `src/memory/types.rs` | `EdgePromotionBoost` + `GraphDecayResult` structs |
| `src/memory/introspection.rs` | 4 new `ConsolidationEvent` variants |
| `src/graph_memory.rs` | Return type changes for `strengthen()`, `strengthen_memory_edges()`, `apply_decay()` |
| `src/memory/mod.rs` | 3 new methods + double-decay fix + graph-adjusted thresholds |
| `src/handlers/state.rs` | Wire coupling in maintenance orchestration |
| `src/memory/learning_history.rs` | Match arms for new events |
| `src/handlers/types.rs` | `tier` field on `RecallMemory` |
| `src/handlers/recall.rs` | `tier` field on `ProactiveSurfacedMemory` + construction sites |
| `src/handlers/crud.rs` | `tier` field on `ListMemoryItem` + construction sites |
| `mcp-server/index.ts` | Tier display in recall, list, proactive_context, read_memory, quick_recall |

## Test plan

- [x] `cargo check` — compiles (only pre-existing warning)
- [x] `cargo clippy --lib` — no new warnings
- [x] `cargo test --lib` — 458 passed, 0 failed
- [ ] Manual: verify tier appears in `/api/recall` JSON response
- [ ] Manual: verify MCP recall tool shows tier in formatted output
- [ ] Manual: verify proactive_context surfaces tier label