### PR TITLE
fix: production hardening — eviction I/O, broadcast capacity, search allocs

### DIFF
--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -3923,7 +3923,7 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("Shodh-Memory MCP server v0.1.51 running");
+  console.error("Shodh-Memory MCP server v0.1.75 running");
   console.error(`Connecting to: ${API_URL}`);
   console.error(`User ID: ${USER_ID}`);
   console.error(`Streaming: ${STREAM_ENABLED ? "enabled" : "disabled"}`);

--- a/src/vector_db/spann.rs
+++ b/src/vector_db/spann.rs
@@ -594,7 +594,8 @@ impl SpannIndex {
 
         // Collect candidates from all probed partitions
         // Use max-heap to keep k smallest distances: pop() removes largest (worst) match
-        let mut heap: BinaryHeap<(ordered_float::OrderedFloat<f32>, u32)> = BinaryHeap::new();
+        let mut heap: BinaryHeap<(ordered_float::OrderedFloat<f32>, u32)> =
+            BinaryHeap::with_capacity(k);
 
         if !partitions.is_empty() {
             // In-memory search (before save or after full load)

--- a/src/vector_db/vamana.rs
+++ b/src/vector_db/vamana.rs
@@ -21,8 +21,7 @@
 //! ```
 
 use super::distance_inline::{
-    cosine_similarity_inline, dot_product_inline, euclidean_squared_inline,
-    normalized_distance_inline,
+    cosine_similarity_inline, euclidean_squared_inline, normalized_distance_inline,
 };
 use anyhow::{anyhow, Result};
 use memmap2::MmapMut;
@@ -573,9 +572,10 @@ impl VamanaIndex {
         let graph = self.graph.read();
         let storage = self.vectors.read(); // Hold lock for entire search (zero-copy access)
 
-        let mut visited = HashSet::new();
-        let mut candidates = BinaryHeap::new();
-        let mut w = BinaryHeap::new();
+        let search_cap = self.config.search_list_size;
+        let mut visited = HashSet::with_capacity(search_cap);
+        let mut candidates = BinaryHeap::with_capacity(search_cap);
+        let mut w = BinaryHeap::with_capacity(search_cap);
 
         // Start from entry point (zero-copy slice access)
         let entry_slice = Self::get_slice_from_storage(&storage, entry)?;


### PR DESCRIPTION
## Summary

- **Eviction listener I/O decoupled**: `save_vector_index()` (5-100ms disk I/O) now runs in a background `std::thread` instead of blocking inside moka's synchronous eviction callback. Prevents stalling all requests for a user during cache eviction.
- **Broadcast channel scaled**: Capacity changed from hardcoded `16` to `(max_users_in_memory * 4).max(64)` — prevents event loss at 100+ concurrent users.
- **Vamana search pre-allocation**: `HashSet` and `BinaryHeap` collections in `greedy_search()` now use `with_capacity(search_list_size)`, eliminating 2-3 reallocations per vector search call.
- **SPANN search pre-allocation**: `BinaryHeap::with_capacity(k)` in SPANN search path.
- **Unused import removed**: `dot_product_inline` — eliminates the only compiler warning.
- **MCP version sync**: `v0.1.51` → `v0.1.75` to match `package.json`.

## Test plan

- [ ] `cargo check` — clean compile, zero warnings
- [ ] `cargo clippy` — no new warnings
- [ ] `cargo fmt -- --check` — passes
- [ ] CI passes (build + format + clippy)
- [ ] Manual: verify eviction logging still works under load
- [ ] Manual: verify broadcast events received by dashboard at scale