### PR TITLE
fix: replace partial_cmp with total_cmp to prevent sort panic on Rust 1.81+

### DIFF
--- a/src/ab_testing.rs
+++ b/src/ab_testing.rs
@@ -1084,7 +1084,7 @@ impl ABTestAnalyzer {
             lifts.push(lift);
         }
 
-        lifts.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        lifts.sort_by(|a, b| a.total_cmp(b));
 
         let prob_treatment_better = treatment_wins as f64 / n_samples as f64;
         let expected_lift = lift_sum / n_samples as f64;
@@ -2212,8 +2212,8 @@ mod tests {
             .collect();
 
         // Sort by score descending
-        control_ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-        treatment_ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        control_ranked.sort_by(|a, b| b.1.total_cmp(&a.1));
+        treatment_ranked.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         println!("🔍 RANKING COMPARISON (top 8):");
         println!("   Control ranking:");

--- a/src/embeddings/keywords.rs
+++ b/src/embeddings/keywords.rs
@@ -126,11 +126,7 @@ impl KeywordExtractor {
             .collect();
 
         // Sort by importance descending
-        keywords.sort_by(|a, b| {
-            b.importance
-                .partial_cmp(&a.importance)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        keywords.sort_by(|a, b| b.importance.total_cmp(&a.importance));
         keywords
     }
 

--- a/src/embeddings/ner.rs
+++ b/src/embeddings/ner.rs
@@ -924,7 +924,7 @@ pub fn argmax_softmax(logits: &[f32]) -> Option<(usize, f32)> {
     logits
         .iter()
         .enumerate()
-        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap_or(std::cmp::Ordering::Equal))
+        .max_by(|a, b| a.1.total_cmp(b.1))
         .map(|(idx, &val)| (idx, (val - max_logit).exp() / exp_sum))
 }
 

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -1506,7 +1506,7 @@ impl GraphMemory {
         }
 
         // Sort by score descending
-        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         // Take top results
         for (uuid, _score) in scored.into_iter().take(max_results) {
@@ -1697,7 +1697,7 @@ impl GraphMemory {
             match a.2.cmp(&b.2) {
                 CmpOrdering::Equal => {
                     // Within same protection class, weaker edges first (prune candidates)
-                    a.1.partial_cmp(&b.1).unwrap_or(CmpOrdering::Equal)
+                    a.1.total_cmp(&b.1)
                 }
                 other => other,
             }
@@ -1792,11 +1792,7 @@ impl GraphMemory {
         }
 
         // Phase 3: Sort by effective strength descending (strongest first)
-        edges.sort_by(|a, b| {
-            b.effective_strength()
-                .partial_cmp(&a.effective_strength())
-                .unwrap_or(CmpOrdering::Equal)
-        });
+        edges.sort_by(|a, b| b.effective_strength().total_cmp(&a.effective_strength()));
 
         // Phase 4: Truncate to limit if specified
         if let Some(max) = limit {
@@ -2344,9 +2340,7 @@ impl GraphMemory {
         impl Ord for PQEntry {
             fn cmp(&self, other: &Self) -> CmpOrdering {
                 // BinaryHeap is a max-heap: higher score = popped first = explored first
-                self.score
-                    .partial_cmp(&other.score)
-                    .unwrap_or(CmpOrdering::Equal)
+                self.score.total_cmp(&other.score)
             }
         }
 
@@ -2458,11 +2452,7 @@ impl GraphMemory {
         }
 
         // Sort entities by path score (decay_factor) descending
-        all_entities.sort_by(|a, b| {
-            b.decay_factor
-                .partial_cmp(&a.decay_factor)
-                .unwrap_or(CmpOrdering::Equal)
-        });
+        all_entities.sort_by(|a, b| b.decay_factor.total_cmp(&a.decay_factor));
 
         // Hebbian strengthening
         if !edges_to_strengthen.is_empty() {
@@ -3250,7 +3240,7 @@ impl GraphMemory {
         }
 
         // Sort by strength descending and limit
-        associations.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        associations.sort_by(|a, b| b.1.total_cmp(&a.1));
         associations.truncate(max_results);
 
         Ok(associations)
@@ -3507,11 +3497,7 @@ impl GraphMemory {
         }
 
         // Sort by strength (strongest first)
-        relationships.sort_by(|a, b| {
-            b.strength
-                .partial_cmp(&a.strength)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        relationships.sort_by(|a, b| b.strength.total_cmp(&a.strength));
 
         Ok(relationships)
     }

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -1491,11 +1491,7 @@ impl MultiUserMemoryManager {
             .chain(issue_entities)
             .chain(verb_entities)
             .collect();
-        all_entities.sort_by(|a, b| {
-            b.1.salience
-                .partial_cmp(&a.1.salience)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        all_entities.sort_by(|a, b| b.1.salience.total_cmp(&a.1.salience));
         let entity_cap = self.server_config.max_entities_per_memory;
         all_entities.truncate(entity_cap);
 

--- a/src/memory/compression.rs
+++ b/src/memory/compression.rs
@@ -818,7 +818,7 @@ impl SemanticConsolidator {
     fn select_representative(members: &[(String, MemoryId, f32)]) -> &str {
         members
             .iter()
-            .max_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal))
+            .max_by(|a, b| a.2.total_cmp(&b.2))
             .map(|(text, _, _)| text.as_str())
             .unwrap_or("")
     }
@@ -924,7 +924,7 @@ impl SemanticConsolidator {
         }
 
         // Sort by confidence descending so we keep higher-confidence versions
-        candidates.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        candidates.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         let mut kept: Vec<(String, f32, HashSet<String>)> = Vec::new();
         for (text, conf) in candidates {

--- a/src/memory/context.rs
+++ b/src/memory/context.rs
@@ -377,7 +377,7 @@ impl ContextManager {
             })
             .collect();
 
-        scored_contexts.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        scored_contexts.sort_by(|a, b| b.0.total_cmp(&a.0));
         scored_contexts
             .into_iter()
             .take(top_k)

--- a/src/memory/facts.rs
+++ b/src/memory/facts.rs
@@ -178,11 +178,7 @@ impl SemanticFactStore {
         }
 
         // Sort by confidence (highest first)
-        facts.sort_by(|a, b| {
-            b.confidence
-                .partial_cmp(&a.confidence)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        facts.sort_by(|a, b| b.confidence.total_cmp(&a.confidence));
 
         Ok(facts)
     }

--- a/src/memory/feedback.rs
+++ b/src/memory/feedback.rs
@@ -545,7 +545,7 @@ impl FeedbackMomentum {
         self.helpful_contexts
             .iter()
             .map(|fp| fp.similarity(current))
-            .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+            .max_by(|a, b| a.total_cmp(b))
     }
 
     /// Check if current context matches misleading pattern
@@ -553,7 +553,7 @@ impl FeedbackMomentum {
         self.misleading_contexts
             .iter()
             .map(|fp| fp.similarity(current))
-            .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+            .max_by(|a, b| a.total_cmp(b))
     }
 
     /// Apply time-based decay to momentum (AUD-6)

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -226,7 +226,7 @@ fn spread_single_direction(
         let max_activation = activation_map
             .values()
             .cloned()
-            .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+            .max_by(|a, b| a.total_cmp(b))
             .unwrap_or(1.0);
 
         if max_activation > SPREADING_NORMALIZATION_FACTOR {
@@ -620,7 +620,7 @@ pub fn spreading_activation_retrieve_with_stats(
             let max_activation = activation_map
                 .values()
                 .cloned()
-                .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+                .max_by(|a, b| a.total_cmp(b))
                 .unwrap_or(1.0);
 
             if max_activation > SPREADING_NORMALIZATION_FACTOR {
@@ -791,11 +791,7 @@ pub fn spreading_activation_retrieve_with_stats(
     }
 
     // Step 6: Sort by final score (descending)
-    scored_memories.sort_by(|a, b| {
-        b.final_score
-            .partial_cmp(&a.final_score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    scored_memories.sort_by(|a, b| b.final_score.total_cmp(&a.final_score));
 
     // Step 7: Apply limit
     scored_memories.truncate(query.max_results);
@@ -977,7 +973,7 @@ mod tests {
         use crate::constants::SPREADING_NORMALIZATION_FACTOR;
 
         // Simulate activation accumulation over hops
-        let mut activations = vec![1.0, 0.8, 0.5, 0.3];
+        let mut activations: Vec<f32> = vec![1.0, 0.8, 0.5, 0.3];
 
         // Simulate 5 hops of accumulation (each hop adds to existing)
         for _ in 0..5 {
@@ -989,7 +985,7 @@ mod tests {
             let max_activation = activations
                 .iter()
                 .cloned()
-                .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+                .max_by(|a, b| a.total_cmp(b))
                 .unwrap_or(1.0);
 
             if max_activation > SPREADING_NORMALIZATION_FACTOR {
@@ -1004,7 +1000,7 @@ mod tests {
         let final_max = activations
             .iter()
             .cloned()
-            .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+            .max_by(|a, b| a.total_cmp(b))
             .unwrap_or(0.0);
 
         assert!(final_max <= SPREADING_NORMALIZATION_FACTOR + 0.001);

--- a/src/memory/hybrid_search.rs
+++ b/src/memory/hybrid_search.rs
@@ -469,7 +469,7 @@ impl RRFusion {
 
         // Sort by RRF score descending
         let mut results: Vec<_> = scores.into_iter().collect();
-        results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         results
     }
@@ -525,7 +525,7 @@ impl CrossEncoderReranker {
         }
 
         // Sort by reranked score descending
-        results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         Ok(results)
     }
@@ -830,11 +830,7 @@ impl HybridSearchEngine {
                 }
 
                 // Re-sort by final score
-                results.sort_by(|a, b| {
-                    b.score
-                        .partial_cmp(&a.score)
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                });
+                results.sort_by(|a, b| b.score.total_cmp(&a.score));
 
                 results
             } else {

--- a/src/memory/injection.rs
+++ b/src/memory/injection.rs
@@ -209,11 +209,7 @@ impl InjectionEngine {
         mut candidates: Vec<InjectionCandidate>,
     ) -> Vec<MemoryId> {
         // Sort by relevance descending
-        candidates.sort_by(|a, b| {
-            b.relevance_score
-                .partial_cmp(&a.relevance_score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        candidates.sort_by(|a, b| b.relevance_score.total_cmp(&a.relevance_score));
 
         let selected: Vec<MemoryId> = candidates
             .into_iter()

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1304,9 +1304,7 @@ impl MemorySystem {
             let temporal_b = Self::calculate_temporal_relevance(age_days_b);
             let score_b = b.importance() * temporal_b;
 
-            score_b
-                .partial_cmp(&score_a)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            score_b.total_cmp(&score_a)
         });
 
         memories.truncate(query.max_results);
@@ -1838,7 +1836,7 @@ impl MemorySystem {
                 }
                 let mut r: Vec<_> = seen.into_iter().map(|(id, (a, h))| (id, a, h)).collect();
                 // CRITICAL: Sort by activation score so RRF rank is meaningful
-                r.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+                r.sort_by(|a, b| b.1.total_cmp(&a.1));
                 if !r.is_empty() {
                     tracing::debug!("Layer 2: {} graph results, {} query entities, bidirectional={}, top_activation={:.3}",
                         r.len(), entity_count, query_entities.len() >= 2, r.first().map(|x| x.1).unwrap_or(0.0));
@@ -2094,7 +2092,7 @@ impl MemorySystem {
             }
 
             let mut res: Vec<_> = fused.into_iter().collect();
-            res.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            res.sort_by(|a, b| b.1.total_cmp(&a.1));
             res.truncate(query.max_results);
             tracing::debug!("Layer 4: {} fused results", res.len());
             (res, heb)
@@ -2344,9 +2342,7 @@ impl MemorySystem {
             memories.sort_by(|a, b| {
                 let score_a = Self::linguistic_boost(&a.experience.content, &analysis);
                 let score_b = Self::linguistic_boost(&b.experience.content, &analysis);
-                score_b
-                    .partial_cmp(&score_a)
-                    .unwrap_or(std::cmp::Ordering::Equal)
+                score_b.total_cmp(&score_a)
             });
         }
 
@@ -2500,7 +2496,7 @@ impl MemorySystem {
         }
 
         // Sort by adjusted score (descending)
-        boosted.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        boosted.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         // Rebuild memories with updated scores
         boosted
@@ -6151,11 +6147,7 @@ impl MemorySystem {
             }
         }
 
-        results.sort_by(|a, b| {
-            b.confidence
-                .partial_cmp(&a.confidence)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        results.sort_by(|a, b| b.confidence.total_cmp(&a.confidence));
         Ok(results)
     }
 

--- a/src/memory/prospective.rs
+++ b/src/memory/prospective.rs
@@ -487,7 +487,7 @@ impl ProspectiveStore {
 
         // Sort by score (highest first), then by priority
         matches.sort_by(|a, b| {
-            let score_cmp = b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal);
+            let score_cmp = b.1.total_cmp(&a.1);
             if score_cmp != std::cmp::Ordering::Equal {
                 return score_cmp;
             }

--- a/src/memory/replay.rs
+++ b/src/memory/replay.rs
@@ -146,11 +146,7 @@ impl ReplayManager {
             .collect();
 
         // Sort by priority (highest first)
-        candidates.sort_by(|a, b| {
-            b.priority_score
-                .partial_cmp(&a.priority_score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        candidates.sort_by(|a, b| b.priority_score.total_cmp(&a.priority_score));
 
         // Take top REPLAY_BATCH_SIZE candidates
         candidates.truncate(REPLAY_BATCH_SIZE);
@@ -431,7 +427,7 @@ impl InterferenceDetector {
             .collect();
 
         // Sort by score descending
-        scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scores.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         let mut winners: Vec<(String, f32)> = Vec::new();
         let mut suppressed: Vec<String> = Vec::new();

--- a/src/memory/retrieval.rs
+++ b/src/memory/retrieval.rs
@@ -814,7 +814,7 @@ impl RetrievalEngine {
 
         // Convert to vec and sort by similarity descending (highest first)
         let mut memory_ids: Vec<(MemoryId, f32)> = best_scores.into_iter().collect();
-        memory_ids.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        memory_ids.sort_by(|a, b| b.1.total_cmp(&a.1));
         memory_ids.truncate(limit);
 
         Ok(memory_ids)
@@ -880,7 +880,7 @@ impl RetrievalEngine {
 
         // Convert to vec and sort by similarity descending (highest first)
         let mut memory_ids: Vec<(MemoryId, f32)> = best_scores.into_iter().collect();
-        memory_ids.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        memory_ids.sort_by(|a, b| b.1.total_cmp(&a.1));
         memory_ids.truncate(limit);
 
         Ok(memory_ids)
@@ -1109,7 +1109,7 @@ impl RetrievalEngine {
             })
             .collect();
 
-        sorted.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        sorted.sort_by(|a, b| b.0.total_cmp(&a.0));
 
         Ok(sorted.into_iter().take(limit).map(|(_, m)| m).collect())
     }
@@ -1152,9 +1152,7 @@ impl RetrievalEngine {
                 Some(geo) => geo_filter.haversine_distance(geo[0], geo[1]),
                 None => f64::MAX,
             };
-            dist_a
-                .partial_cmp(&dist_b)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            dist_a.total_cmp(&dist_b)
         });
 
         memories.truncate(limit);
@@ -1213,9 +1211,7 @@ impl RetrievalEngine {
         memories.sort_by(|a, b| {
             let reward_a = a.experience.reward.unwrap_or(0.0);
             let reward_b = b.experience.reward.unwrap_or(0.0);
-            reward_b
-                .partial_cmp(&reward_a)
-                .unwrap_or(std::cmp::Ordering::Equal)
+            reward_b.total_cmp(&reward_a)
         });
 
         memories.truncate(limit);

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -2422,8 +2422,7 @@ impl WorkingMemory {
         // Sort by importance and recency
         results.sort_by(|a, b| {
             b.importance()
-                .partial_cmp(&a.importance())
-                .unwrap_or(std::cmp::Ordering::Equal)
+                .total_cmp(&a.importance())
                 .then(b.last_accessed().cmp(&a.last_accessed()))
         });
 
@@ -2603,7 +2602,7 @@ impl SessionMemory {
             .map(|(id, entry)| (id.clone(), entry.memory.importance()))
             .collect();
 
-        sorted.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        sorted.sort_by(|a, b| a.1.total_cmp(&b.1));
 
         for (id, _) in sorted {
             if self.current_size_bytes + needed_bytes <= self.max_size_mb * 1024 * 1024 {
@@ -2630,11 +2629,7 @@ impl SessionMemory {
             .cloned() // Arc::clone is cheap
             .collect();
 
-        results.sort_by(|a, b| {
-            b.importance()
-                .partial_cmp(&a.importance())
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        results.sort_by(|a, b| b.importance().total_cmp(&a.importance()));
         results.truncate(limit);
         Ok(results)
     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -1010,7 +1010,7 @@ impl PyMemorySystem {
             mut items: Vec<(String, String, f32, String)>,
             max: usize,
         ) -> Vec<(String, String, f32, String)> {
-            items.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
+            items.sort_by(|a, b| b.2.total_cmp(&a.2));
             items.truncate(max);
             items
         }
@@ -1860,7 +1860,7 @@ impl PyMemorySystem {
             .collect();
 
         // Sort by score and take top results
-        scored_memories.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored_memories.sort_by(|a, b| b.1.total_cmp(&a.1));
         scored_memories.truncate(max_results);
 
         let latency_ms = start.elapsed().as_secs_f64() * 1000.0;

--- a/src/relevance.rs
+++ b/src/relevance.rs
@@ -863,11 +863,7 @@ impl RelevanceEngine {
             .collect();
 
         // Sort by relevance score (descending)
-        results.sort_by(|a, b| {
-            b.relevance_score
-                .partial_cmp(&a.relevance_score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        results.sort_by(|a, b| b.relevance_score.total_cmp(&a.relevance_score));
 
         // Quality-based filtering: only return memories above minimum relevance
         // This prevents returning low-quality matches just to fill max_results
@@ -1067,11 +1063,7 @@ impl RelevanceEngine {
             )
             .collect();
 
-        results.sort_by(|a, b| {
-            b.relevance_score
-                .partial_cmp(&a.relevance_score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        results.sort_by(|a, b| b.relevance_score.total_cmp(&a.relevance_score));
 
         // Quality-based filtering: only return memories above minimum relevance
         const MIN_RELEVANCE_SCORE: f32 = 0.25;
@@ -1271,11 +1263,7 @@ impl RelevanceEngine {
                 if !candidate_ids.is_empty() {
                     // Sort by score descending and take top candidates
                     let mut sorted_candidates: Vec<_> = candidate_ids.into_iter().collect();
-                    sorted_candidates.sort_by(|a, b| {
-                        b.1 .0
-                            .partial_cmp(&a.1 .0)
-                            .unwrap_or(std::cmp::Ordering::Equal)
-                    });
+                    sorted_candidates.sort_by(|a, b| b.1 .0.total_cmp(&a.1 .0));
 
                     for (memory_id, (score, matched)) in
                         sorted_candidates.into_iter().take(max_candidates)

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1304,8 +1304,7 @@ impl StreamingMemoryExtractor {
                     .collect();
 
                 // Sort by score descending
-                candidates
-                    .sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+                candidates.sort_by(|a, b| b.1.total_cmp(&a.1));
 
                 // Filter by threshold, cooldown, and limit
                 let sessions_guard = futures::executor::block_on(async { sessions.read().await });

--- a/src/vector_db/pq.rs
+++ b/src/vector_db/pq.rs
@@ -433,7 +433,7 @@ impl CompressedVectorStore {
             .collect();
 
         // Sort by distance and take top k
-        distances.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        distances.sort_by(|a, b| a.1.total_cmp(&b.1));
         distances.truncate(k);
 
         Ok(distances)

--- a/src/vector_db/spann.rs
+++ b/src/vector_db/spann.rs
@@ -570,8 +570,7 @@ impl SpannIndex {
             .map(|(i, c)| (i, self.compute_distance(query, c)))
             .collect();
 
-        partition_distances
-            .sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        partition_distances.sort_by(|a, b| a.1.total_cmp(&b.1));
         let probe_partitions: Vec<usize> = partition_distances
             .iter()
             .take(self.config.num_probes)
@@ -659,7 +658,7 @@ impl SpannIndex {
 
         // Convert heap to sorted results (smallest distance first)
         let mut results: Vec<(u32, f32)> = heap.into_iter().map(|(d, id)| (id, d.0)).collect();
-        results.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| a.1.total_cmp(&b.1));
 
         Ok(results)
     }

--- a/src/vector_db/vamana.rs
+++ b/src/vector_db/vamana.rs
@@ -667,11 +667,7 @@ impl VamanaIndex {
 
         // Sort candidates by distance (NaN values sort to end)
         let mut sorted_candidates = candidates.to_vec();
-        sorted_candidates.sort_by(|a, b| {
-            a.distance
-                .partial_cmp(&b.distance)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
+        sorted_candidates.sort_by(|a, b| a.distance.total_cmp(&b.distance));
 
         // Pre-load all candidate vectors to avoid repeated storage lookups
         // This trades memory for CPU - worth it for the O(n²) inner loop
@@ -918,8 +914,7 @@ impl VamanaIndex {
                         .collect();
 
                     // Sort by distance (lower = closer for all metrics)
-                    neighbor_distances
-                        .sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal));
+                    neighbor_distances.sort_by(|a, b| a.1.total_cmp(&b.1));
 
                     // Keep only max_degree closest neighbors
                     graph[neighbor_id as usize].neighbors = neighbor_distances
@@ -1152,7 +1147,7 @@ impl VamanaIndex {
             distances.push((id, dist));
         }
 
-        distances.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal));
+        distances.sort_by(|a, b| a.1.total_cmp(&b.1));
         distances.truncate(k);
 
         Ok(distances)
@@ -1603,9 +1598,7 @@ impl Eq for SearchCandidate {}
 
 impl Ord for SearchCandidate {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.distance
-            .partial_cmp(&other.distance)
-            .unwrap_or(Ordering::Equal)
+        self.distance.total_cmp(&other.distance)
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaces all 55 `partial_cmp(...).unwrap_or(Ordering::Equal)` sites with `f32/f64::total_cmp()` across 24 files
- Fixes runtime panic: `user-provided comparison function does not correctly implement a total order`
- Caused by Rust 1.81+ driftsort algorithm validating total ordering — `partial_cmp` with `unwrap_or(Equal)` violates transitivity when NaN is present

## Root Cause

Rust 1.81 switched from merge sort to driftsort, which actively validates the total ordering contract. The pattern `a.partial_cmp(b).unwrap_or(Ordering::Equal)` maps NaN comparisons to Equal, breaking transitivity (if `NaN == x` and `NaN == y`, then `x == y` must hold, but it doesn't).

## Fix

`f64::total_cmp()` (stable since Rust 1.62) provides a true total order where NaN values are deterministically ordered: `-NaN < -Inf < ... < 0 < ... < +Inf < +NaN`. This eliminates the panic without changing sort semantics for normal (non-NaN) float values.

## Files Changed (24)

Vector DB: `vamana.rs`, `spann.rs`, `pq.rs`
Graph: `graph_memory.rs`, `graph_retrieval.rs`
Memory: `mod.rs`, `retrieval.rs`, `hybrid_search.rs`, `types.rs`, `context.rs`, `compression.rs`, `facts.rs`, `feedback.rs`, `injection.rs`, `prospective.rs`, `replay.rs`
Handlers: `recall.rs`, `state.rs`
Other: `ab_testing.rs`, `streaming.rs`, `relevance.rs`, `python.rs`, `keywords.rs`, `ner.rs`

## Test Plan

- [x] `cargo check` — compiles clean
- [x] `cargo fmt` — formatted
- [x] `cargo clippy --lib` — no new warnings (only pre-existing)
- [x] `cargo test --lib` — all 458 tests pass
- [x] Zero remaining `partial_cmp` sites in `src/`