### PR TITLE
fix: add missing Experience fields in python.rs

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -465,6 +465,9 @@ impl PyMemorySystem {
             media_refs: vec![],
             // Temporal extraction
             temporal_refs: vec![],
+            // NER + co-occurrence (populated by handler pipeline, empty for direct Python API)
+            ner_entities: vec![],
+            cooccurrence_pairs: vec![],
         };
 
         let memory_id = self


### PR DESCRIPTION
## Summary
- Add missing `ner_entities` and `cooccurrence_pairs` fields to the `Experience` constructor in `src/python.rs`
- These fields were added to the `Experience` struct but the Python bindings constructor was not updated
- Caused maturin build failure on CI (Linux and macOS x64 failed with `error[E0063]: missing fields`)

## Context
Blocks PyPI 0.1.81 publish — the pypi.yml workflow fails because `cargo build --features python` can't compile.