### PR TITLE
fix: improve knowledge graph quality — 10 bugs

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -934,6 +934,18 @@ pub const LTP_DECAY_FACTOR: f32 = 0.1;
 /// - Matches SPREADING_ACTIVATION_THRESHOLD
 pub const LTP_MIN_STRENGTH: f32 = 0.01;
 
+/// LTP prune floor — strip LTP protection when strength reaches this level
+///
+/// If a potentiated edge's strength drops to LTP_PRUNE_FLOOR, its LTP status
+/// is downgraded to None and normal prune logic applies. This prevents
+/// immortal zombie edges that retain LTP protection despite near-zero strength.
+///
+/// Justification:
+/// - 0.05 is above LTP_MIN_STRENGTH (0.01) so the edge has meaningfully decayed
+/// - 5x above the absolute floor gives enough margin for recovery attempts
+/// - Without this, Weekly/Full edges persist forever even if never reactivated
+pub const LTP_PRUNE_FLOOR: f32 = 0.05;
+
 // =============================================================================
 // MULTI-SCALE LTP CONSTANTS (PIPE-4)
 // Based on multi-timescale memory consolidation research

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -749,8 +749,10 @@ impl MemorySystem {
                             let sim = crate::similarity::cosine_similarity(emb1, emb2).max(0.0);
                             EDGE_SEMANTIC_WEIGHT_FLOOR + (1.0 - EDGE_SEMANTIC_WEIGHT_FLOOR) * sim
                         }
-                        // No embeddings available → full weight (legacy behavior)
-                        _ => 1.0,
+                        // No embeddings available → conservative weight
+                        // Must stay above L1_PRUNE_THRESHOLD / L1_INITIAL_WEIGHT = 0.1/0.3 ≈ 0.334
+                        // so cold-start edges aren't born already prunable
+                        _ => 0.35,
                     };
 
                     let edge = crate::graph_memory::RelationshipEdge {


### PR DESCRIPTION
## Summary

Deep audit of the knowledge graph subsystem identified 10 confirmed bugs across 4 categories. Each was verified line-by-line with system-level interaction analysis to ensure fixes don't break retrieval, consolidation, or cold start behavior.

### Wave 1 — Correctness
- **GQ-1**: BFS traversal now accepts optional `min_strength` filter (backward-compatible, prevents ghost edge Hebbian revival)
- **GQ-2**: Semantic weight fallback changed from `1.0` to `0.35` — ensures cold-start edges survive initial pruning (`0.3 × 0.35 = 0.105 > L1_PRUNE_THRESHOLD 0.1`)
- **GQ-3**: Zombie LTP edges now prunable — expired burst edges get downgraded in `decay()`, and near-zero potentiated edges have LTP stripped at `LTP_PRUNE_FLOOR = 0.05`
- **GQ-4**: Fuzzy entity lookup is now deterministic — collects all candidates and picks highest salience (breaks ties by shortest name)

### Wave 2 — Entity Hygiene
- **GQ-5**: New `delete_entity()` removes from all 7 stores (entities_db, 3 name indices, embedding cache, pair index, counter). Called from `apply_decay()` for orphaned entities
- **GQ-6**: Proper nouns skip stemmed index (prevents "Paris" → "pari" collisions)
- **GQ-7**: Fallback NER label changed from `Person` to `Concept` (unknown entities shouldn't get 0.8 salience)

### Wave 3 — NER Quality
- **GQ-8**: Single-char org keywords filtered (`"x"` no longer classified as Organization)

### Wave 4 — Structural
- **GQ-11**: Replay edges now indexed in `entity_edges_db` (visible to traversal and degree cap enforcement)
- **GQ-12**: `apply_decay()` uses in-place mutation instead of double deserialization (N reads instead of 2N)

## Test plan
- [x] `cargo check` — compiles cleanly
- [x] `cargo clippy --lib` — no new warnings
- [x] `cargo test --lib` — 459 tests pass (0 failures)
- [x] `cargo test --test consolidation_tests` — 53 tests pass
- [x] `cargo test --lib graph` — 61 graph tests pass
- [x] `cargo test --lib pipe5` — 12 LTP tests pass
- [x] Updated `test_potentiated_never_pruned` → split into `test_potentiated_above_floor_never_pruned` + `test_potentiated_at_floor_stripped_and_prunable`