### PR TITLE
fix: Docker build — copy benches/tests, update bench structs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,10 @@ WORKDIR /app
 # Copy manifests first for Docker layer caching
 COPY Cargo.toml Cargo.lock ./
 
-# Copy source code
+# Copy source and all paths referenced by Cargo.toml (benches, tests)
 COPY src ./src
+COPY benches ./benches
+COPY tests ./tests
 
 # Download ONNX Runtime for embedding model inference
 ARG ORT_VERSION=1.23.2

--- a/benches/associative_retrieval_benchmarks.rs
+++ b/benches/associative_retrieval_benchmarks.rs
@@ -19,7 +19,7 @@
 use chrono::Utc;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use shodh_memory::graph_memory::{
-    EntityLabel, EntityNode, EpisodeSource, EpisodicNode, GraphMemory, RelationType,
+    EntityLabel, EntityNode, EpisodeSource, EpisodicNode, GraphMemory, LtpStatus, RelationType,
     RelationshipEdge,
 };
 use std::collections::{HashMap, HashSet};
@@ -63,7 +63,10 @@ fn create_relationship(
         context: String::new(),
         last_activated: Utc::now(),
         activation_count: 0,
-        potentiated: false,
+        ltp_status: LtpStatus::None,
+        tier: Default::default(),
+        activation_timestamps: None,
+        entity_confidence: None,
     }
 }
 

--- a/benches/graph_benchmarks.rs
+++ b/benches/graph_benchmarks.rs
@@ -13,7 +13,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criteri
 use shodh_memory::chrono::Utc;
 use shodh_memory::embeddings::ner::{NerConfig, NerEntityType, NeuralNer};
 use shodh_memory::graph_memory::{
-    EntityLabel, EntityNode, GraphMemory, RelationType, RelationshipEdge,
+    EntityLabel, EntityNode, GraphMemory, LtpStatus, RelationType, RelationshipEdge,
 };
 use shodh_memory::uuid::Uuid;
 use std::collections::HashMap;
@@ -78,7 +78,10 @@ fn create_relationship(
         // Hebbian plasticity fields
         last_activated: Utc::now(),
         activation_count: 0,
-        potentiated: false,
+        ltp_status: LtpStatus::None,
+        tier: Default::default(),
+        activation_timestamps: None,
+        entity_confidence: None,
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `COPY benches ./benches` and `COPY tests ./tests` to Dockerfile — Cargo.toml declares 12 bench targets that reference these dirs
- Update `RelationshipEdge` construction in benchmark files to match LTP struct changes from PR #49

## Context
Docker build was failing because `cargo build --release` couldn't find bench source files. The benchmark structs also needed updating after the `potentiated: bool` → `ltp_status: LtpStatus` migration.