### PR TITLE
fix: split Docker push — GHCR first, Docker Hub optional

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,6 +46,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Step 1: Always build and push to GHCR (uses GITHUB_TOKEN, always works)
+      - name: Build and push to GHCR
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.version.outputs.GHCR_IMAGE }}:latest
+            ${{ steps.version.outputs.GHCR_IMAGE }}:${{ steps.version.outputs.VERSION }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.version.outputs.VERSION }}
+            org.opencontainers.image.description=Cognitive memory system for AI agents
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Step 2: Optionally push to Docker Hub (non-blocking — uses GHA cache)
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -54,15 +71,13 @@ jobs:
         continue-on-error: true
         id: dockerhub_login
 
-      - name: Build and push (GHCR + Docker Hub)
+      - name: Push to Docker Hub
         if: steps.dockerhub_login.outcome == 'success'
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: |
-            ${{ steps.version.outputs.GHCR_IMAGE }}:latest
-            ${{ steps.version.outputs.GHCR_IMAGE }}:${{ steps.version.outputs.VERSION }}
             ${{ env.DOCKERHUB_IMAGE }}:latest
             ${{ env.DOCKERHUB_IMAGE }}:${{ steps.version.outputs.VERSION }}
           labels: |
@@ -70,20 +85,4 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.VERSION }}
             org.opencontainers.image.description=Cognitive memory system for AI agents
           cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push (GHCR only)
-        if: steps.dockerhub_login.outcome != 'success'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: |
-            ${{ steps.version.outputs.GHCR_IMAGE }}:latest
-            ${{ steps.version.outputs.GHCR_IMAGE }}:${{ steps.version.outputs.VERSION }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.version=${{ steps.version.outputs.VERSION }}
-            org.opencontainers.image.description=Cognitive memory system for AI agents
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        continue-on-error: true


### PR DESCRIPTION
## Summary
- Restructure Docker workflow: push to GHCR first (always succeeds), then Docker Hub as a separate `continue-on-error` step
- Prevents Docker Hub token issues from failing the entire workflow
- Docker Hub push uses GHA build cache (no rebuild)

## Context
The build compiled successfully and GHCR push worked, but Docker Hub push failed with `401 Unauthorized: insufficient scopes`. Because both were in one `docker buildx build` command, the GHCR success was masked by the Docker Hub failure.