### PR TITLE
perf: right-size memory — 1.5GB → 330MB per user

### DIFF
--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -1053,6 +1053,8 @@ impl GraphMemory {
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
         opts.set_compression_type(rocksdb::DBCompressionType::Lz4);
+        opts.set_write_buffer_size(16 * 1024 * 1024); // 16MB — graph entries are small KV pairs
+        opts.set_max_write_buffer_number(2);
 
         // Build column family descriptors — all CFs share the same options
         let cf_descriptors: Vec<ColumnFamilyDescriptor> = GRAPH_CF_NAMES

--- a/src/memory/hybrid_search.rs
+++ b/src/memory/hybrid_search.rs
@@ -191,9 +191,9 @@ impl BM25Index {
             Index::create_in_dir(path, schema.clone()).context("Failed to create BM25 index")?
         };
 
-        // 50MB writer heap
+        // 15MB writer heap — sufficient for edge workloads
         let writer = index
-            .writer(50_000_000)
+            .writer(15_000_000)
             .context("Failed to create index writer")?;
 
         let reader = index

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -489,10 +489,9 @@ impl MemorySystem {
             compressor: CompressionPipeline::new(),
             retriever,
             embedder,
-            // LRU embedding caches: max 10,000 entries each (~15MB for 384-dim embeddings)
-            // Prevents unbounded memory growth while maintaining high hit rates
-            query_cache: moka::sync::Cache::builder().max_capacity(10_000).build(),
-            content_cache: moka::sync::Cache::builder().max_capacity(10_000).build(),
+            // LRU embedding caches: max 2,000 entries each (~3MB for 384-dim embeddings)
+            query_cache: moka::sync::Cache::builder().max_capacity(2_000).build(),
+            content_cache: moka::sync::Cache::builder().max_capacity(2_000).build(),
             stats: Arc::new(RwLock::new(initial_stats)),
             logger,
             consolidation_events, // Use the shared buffer created earlier

--- a/src/memory/storage.rs
+++ b/src/memory/storage.rs
@@ -997,20 +997,20 @@ impl MemoryStorage {
         // WAL stays in default location (same as data dir) - avoids corruption issues
         opts.set_manual_wal_flush(false); // Auto-flush WAL entries
 
-        // Write performance optimizations for 10M+ memories per user
-        opts.set_max_write_buffer_number(4);
-        opts.set_write_buffer_size(128 * 1024 * 1024); // 128MB write buffer (2x for scale)
+        // Write performance — sized for edge deployment (tune up via env for heavy workloads)
+        opts.set_max_write_buffer_number(2);
+        opts.set_write_buffer_size(32 * 1024 * 1024); // 32MB write buffer
         opts.set_level_zero_file_num_compaction_trigger(4);
-        opts.set_target_file_size_base(128 * 1024 * 1024); // 128MB SST files
-        opts.set_max_bytes_for_level_base(512 * 1024 * 1024); // 512MB L1
+        opts.set_target_file_size_base(64 * 1024 * 1024); // 64MB SST files
+        opts.set_max_bytes_for_level_base(256 * 1024 * 1024); // 256MB L1
         opts.set_max_background_jobs(4);
         opts.set_level_compaction_dynamic_level_bytes(true);
 
-        // Read performance optimizations for 10M+ memories
+        // Read performance — 64MB block cache covers ~16K blocks, ample for edge use
         use rocksdb::{BlockBasedOptions, Cache};
         let mut block_opts = BlockBasedOptions::default();
         block_opts.set_bloom_filter(10.0, false); // 10 bits/key = ~1% FPR
-        block_opts.set_block_cache(&Cache::new_lru_cache(512 * 1024 * 1024)); // 512MB cache
+        block_opts.set_block_cache(&Cache::new_lru_cache(64 * 1024 * 1024)); // 64MB cache
         block_opts.set_cache_index_and_filter_blocks(true);
         block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true); // Pin L0 for fast reads
         opts.set_block_based_table_factory(&block_opts);


### PR DESCRIPTION
## Summary

- RocksDB block cache: 512MB → 64MB
- Write buffers: 128MB x 4 → 32MB x 2  
- Graph DB: explicit 16MB x 2 (was 64MB x 2 default)
- Tantivy BM25 writer: 50MB → 15MB
- Moka embedding caches: 10K → 2K entries

Single-user RSS: ~1.5GB → ~330MB expected

## Test plan

- [ ] `cargo check` + `cargo fmt --check` clean
- [ ] Rebuild, restart, verify RSS < 500MB
- [ ] MCP tools (remember, recall, proactive_context) still work