### PR TITLE
perf: lazy decay + mimalloc to eliminate Windows memory explosion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,6 +1909,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,6 +2120,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -3463,6 +3482,7 @@ dependencies = [
  "lru",
  "lz4",
  "memmap2",
+ "mimalloc",
  "moka",
  "ndarray 0.16.1",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,9 @@ path = "src/mcp.rs"
 # MCP Protocol
 rmcp = { version = "0.12", features = ["server", "macros", "transport-io"] }
 clap = { version = "4.5", features = ["derive", "env"] }
+# Global allocator — replaces Windows default heap (eliminates segment doubling / commit bloat)
+mimalloc = "0.1"
+
 # Core
 anyhow = "1.0"
 thiserror = "2.0"

--- a/src/handlers/consolidation.rs
+++ b/src/handlers/consolidation.rs
@@ -70,7 +70,7 @@ pub async fn consolidate_memories(
         tokio::task::spawn_blocking(move || {
             let memory_guard = memory.read();
             // run_maintenance returns the number of decayed memories
-            memory_guard.run_maintenance(0.95, &user_id_for_maintenance) // 5% decay factor
+            memory_guard.run_maintenance(0.95, &user_id_for_maintenance, true) // 5% decay factor, always heavy for on-demand
         })
         .await
         .map_err(|e| AppError::Internal(anyhow::anyhow!("Maintenance task panicked: {e}")))?

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -7,6 +7,9 @@
 //!
 //! Both modes use the same core memory functionality, ready for future MCP push.
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use rmcp::{

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -205,13 +205,13 @@ fn spread_single_direction(
                     }
                 };
 
-                // Importance-weighted decay
-                let importance = edge.strength;
-                let decay_rate = calculate_importance_weighted_decay(importance);
+                // Importance-weighted decay (using effective_strength for time-aware decay)
+                let effective = edge.effective_strength();
+                let decay_rate = calculate_importance_weighted_decay(effective);
                 let decay = (-decay_rate * hop as f32).exp();
 
                 let spread_amount =
-                    source_activation * decay * edge.strength * tier_trust * degree_norm;
+                    source_activation * decay * effective * tier_trust * degree_norm;
 
                 let new_activation = activation_map.entry(target_uuid).or_insert(0.0);
                 *new_activation += spread_amount;
@@ -594,12 +594,12 @@ pub fn spreading_activation_retrieve_with_stats(
                         }
                     };
 
-                    // SHO-26: Importance-weighted decay
-                    let importance = edge.strength;
-                    let decay_rate = calculate_importance_weighted_decay(importance);
+                    // SHO-26: Importance-weighted decay (using effective_strength for time-aware decay)
+                    let effective = edge.effective_strength();
+                    let decay_rate = calculate_importance_weighted_decay(effective);
                     let decay = (-decay_rate * hop as f32).exp();
 
-                    let spread_amount = source_activation * decay * edge.strength * tier_trust;
+                    let spread_amount = source_activation * decay * effective * tier_trust;
 
                     let new_activation = activation_map.entry(target_uuid).or_insert(0.0);
                     *new_activation += spread_amount;

--- a/src/memory/storage.rs
+++ b/src/memory/storage.rs
@@ -2199,8 +2199,11 @@ impl MemoryStorage {
     pub fn get_all(&self) -> Result<Vec<Memory>> {
         let mut memories = Vec::new();
 
-        // Iterate through all memories
-        let iter = self.db.iterator(IteratorMode::Start);
+        // fill_cache(false) prevents this maintenance scan from polluting
+        // the block cache with cold data, reducing C++ peak memory
+        let mut read_opts = rocksdb::ReadOptions::default();
+        read_opts.fill_cache(false);
+        let iter = self.db.iterator_opt(IteratorMode::Start, read_opts);
         for item in iter {
             if let Ok((key, value)) = item {
                 // Only process valid 16-byte UUID keys (consistent with get_stats)


### PR DESCRIPTION
## Summary

- **Bug fix**: Spreading activation used raw `edge.strength` instead of `edge.effective_strength()`, completely ignoring time-based decay during graph traversal
- **Lazy decay**: Replace eager full-scan `apply_decay()` (34k edges every 5 min) with opportunistic on-read pruning — edges below threshold are queued during normal reads and batch-deleted on maintenance
- **Light/heavy cycles**: Heavy ops (fact extraction, auto-repair, DB flush) run every 30 min instead of every 5 min. Dirty flag skips fact extraction when no new memories stored
- **mimalloc global allocator**: Recovers C++ heap pages that Windows CRT `malloc`/`free` never decommits
- **Block cache**: Added 32MB bounded cache to GraphMemory RocksDB (was missing entirely). `fill_cache(false)` on all full-scan iterators
- **Write optimization**: `batch_decay_edges_in_place()` only writes edges whose strength actually changed

## Results (Windows 11)

| Metric | Before | After |
|--------|--------|-------|
| Baseline memory | ~900 MB | ~460 MB |
| After 5-min cycle | 5+ GB (permanent) | ~500 MB (flat) |
| Recovery after spike | Never (CRT never decommits) | Immediate (mimalloc decommits) |

## Test plan

- [x] `cargo check` + `cargo clippy` clean (no new warnings)
- [x] Release build succeeds
- [x] Server baseline: ~460 MB (was 900 MB+)
- [x] Light maintenance cycles (every 5 min): memory stays flat at ~500 MB
- [ ] Heavy cycle (30 min): verify fact extraction runs, memory recovers
- [ ] MCP tools work: remember → recall → proactive_context