### PR TITLE
fix: 12 verified audit bugs — GDPR, OOM, vector leak, race conditions

### DIFF
--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -2438,6 +2438,10 @@ impl GraphMemory {
         self.relationship_count.store(0, Ordering::Relaxed);
         self.episode_count.store(0, Ordering::Relaxed);
 
+        // Drain pending maintenance queues — they reference now-deleted entities/edges
+        let _ = std::mem::take(&mut *self.pending_prune.lock());
+        let _ = std::mem::take(&mut *self.pending_orphan_checks.lock());
+
         tracing::info!(
             "Graph data cleared (GDPR erasure): {} entities, {} relationships, {} episodes",
             entity_count,


### PR DESCRIPTION
## Summary

Fixes 12 verified bugs from the deep codebase audit (4 critical, 5 high, 2 medium). All bugs were independently verified by specialized agents before fixing.

### Critical (4)
- **C1**: MIF edge import was a no-op — now resolves `entity:{uuid}` identifiers and calls `add_relationship()`
- **C3**: `clear_all()` didn't drain pending prune/orphan queues, leaving stale references after GDPR erasure
- **C4**: `rebuild_index()` loaded ALL memories into RAM at once — now streams by ID (O(1) peak memory)
- **C7**: Todo delete leaked Vamana vector embeddings — added reverse mapping + `mark_deleted()` cleanup

### High (5)
- **H1**: Entity dedup in relevance scoring — prevented double-counting same entity
- **H3**: Multi-word NER entities (e.g., "Claude Code") were filtered out by word-level split — fixed with substring match
- **H4**: A/B test weight swap race condition — eliminated global mutation with per-request `weights_override` parameter
- **H8**: GDPR `delete_user()` left orphaned data in shared RocksDB — added prefix-scan purge across all CFs (todos, reminders, files, feedback, audit)
- **H10**: SSE `memory_events_sse` broadcast ALL events to ALL clients — added `user_id` query param filtering (secure by default: no user_id = no events)

### Medium (2)
- **M3**: `log2(1)=0` made first-access indistinguishable from never-accessed in relevance scoring — fixed with `log2(n+1)`
- **M11**: Global `INGEST_DEDUP` map not scoped by user_id — cross-user collision in multi-tenant deployment

### Files changed (9)
| File | Changes |
|------|---------|
| `src/graph_memory.rs` | C3: drain pending queues in clear_all |
| `src/handlers/mif.rs` | C1: full edge import with entity resolution |
| `src/handlers/recall.rs` | H3: multi-word entity filter, M11: user-scoped dedup |
| `src/handlers/state.rs` | H8: GDPR shared DB purge |
| `src/handlers/webhooks.rs` | H10: SSE user filtering |
| `src/memory/retrieval.rs` | C4: streaming rebuild index |
| `src/memory/storage.rs` | C4: get_all_ids() method |
| `src/memory/todos.rs` | C7: vector cleanup on delete |
| `src/relevance.rs` | H1, H4, M3: entity dedup, weight isolation, access scoring |

## Test plan
- [ ] `cargo check` + `cargo clippy` — clean (verified)
- [ ] `cargo fmt -- --check` — clean (verified)
- [ ] Build release and restart server
- [ ] MIF round-trip: export → import → verify edges appear in graph
- [ ] Delete todo → verify vector index doesn't leak (check index size)
- [ ] GDPR delete_user → verify shared DB CFs are clean
- [ ] SSE endpoint without `?user_id=` returns no events
- [ ] A/B test under concurrent load — no weight corruption