### PR TITLE
feat: MIF v2 vendor-neutral schema with format adapters

### DIFF
--- a/src/handlers/mif.rs
+++ b/src/handlers/mif.rs
@@ -1,10 +1,6 @@
-//! Memory Interchange Format (MIF) and Multimodal Search Handlers
+//! MIF v2 Handlers — Export, Import, Adapters, Graph Entity/Relationship, Storage
 //!
-//! This module handles:
-//! - MIF export with optional PII redaction and encryption
-//! - MIF import with merge strategies
-//! - Multimodal search (similarity, temporal, causal, associative, hybrid)
-//! - Robotics-specific search (spatial, mission, action_outcome)
+//! Thin HTTP layer over `crate::mif` for vendor-neutral memory interchange.
 
 use axum::{extract::State, response::Json};
 use serde::{Deserialize, Serialize};
@@ -14,17 +10,16 @@ use super::state::MultiUserMemoryManager;
 use super::types::RetrieveResponse;
 use crate::errors::{AppError, ValidationErrorExt};
 use crate::graph_memory;
-use crate::memory::{self, Memory, Query as MemoryQuery};
+use crate::mif::adapters::AdapterRegistry;
+use crate::mif::{export, import};
 use crate::validation;
 
-/// Application state type alias
 pub type AppState = std::sync::Arc<MultiUserMemoryManager>;
 
 // =============================================================================
-// MIF EXPORT TYPES
+// MIF EXPORT
 // =============================================================================
 
-/// Request for MIF export
 #[derive(Debug, Deserialize)]
 pub struct MifExportRequest {
     pub user_id: String,
@@ -36,1221 +31,245 @@ pub struct MifExportRequest {
     pub since: Option<String>,
     #[serde(default)]
     pub redact_pii: bool,
-    #[serde(default)]
-    pub encrypt: bool,
-    #[serde(default)]
-    pub encryption_key: Option<String>,
-    #[serde(default = "default_mif_format")]
+    #[serde(default = "default_format")]
     pub format: String,
 }
 
-fn default_mif_format() -> String {
-    "json".to_string()
+fn default_format() -> String {
+    "shodh".to_string()
 }
 
-/// Request for MIF import
-#[derive(Debug, Deserialize)]
-pub struct MifImportRequest {
-    pub user_id: String,
-    #[serde(default = "default_merge_strategy")]
-    pub merge_strategy: String,
-    #[serde(default)]
-    pub decrypt: bool,
-    #[serde(default)]
-    pub decryption_key: Option<String>,
-    pub data: MifImportData,
-}
-
-fn default_merge_strategy() -> String {
-    "skip_duplicates".to_string()
-}
-
-/// The actual MIF data being imported
-#[derive(Debug, Deserialize)]
-pub struct MifImportData {
-    pub mif_version: String,
-    #[serde(default)]
-    pub memories: Vec<MifMemory>,
-    #[serde(default)]
-    pub todos: Vec<MifTodo>,
-    #[serde(default)]
-    pub graph: Option<MifGraph>,
-}
-
-/// MIF Memory object
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MifMemory {
-    pub id: String,
-    pub content: String,
-    #[serde(rename = "type")]
-    pub memory_type: String,
-    #[serde(default = "default_importance")]
-    pub importance: f32,
-    pub created_at: String,
-    #[serde(default)]
-    pub updated_at: String,
-    #[serde(default)]
-    pub accessed_at: String,
-    #[serde(default)]
-    pub access_count: u32,
-    #[serde(default = "default_decay_rate")]
-    pub decay_rate: f32,
-    #[serde(default)]
-    pub tags: Vec<String>,
-    #[serde(default)]
-    pub source: MifSource,
-    #[serde(default)]
-    pub entities: Vec<MifEntity>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub embedding: Option<MifEmbedding>,
-    #[serde(default)]
-    pub relations: MifRelations,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub redactions: Option<Vec<MifRedaction>>,
-}
-
-fn default_importance() -> f32 {
-    0.5
-}
-
-fn default_decay_rate() -> f32 {
-    0.1
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct MifSource {
-    #[serde(rename = "type", default)]
-    pub source_type: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub session_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub agent: Option<String>,
-}
-
-/// PII redaction record
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MifRedaction {
-    #[serde(rename = "type")]
-    pub redaction_type: String,
-    pub original_length: usize,
-    pub position: (usize, usize),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct MifEntity {
-    #[serde(default)]
-    pub text: String,
-    #[serde(rename = "type", default)]
-    pub entity_type: String,
-    #[serde(default = "default_confidence")]
-    pub confidence: f32,
-}
-
-fn default_confidence() -> f32 {
-    1.0
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MifEmbedding {
-    pub model: String,
-    pub dimensions: usize,
-    pub vector: Vec<f32>,
-    #[serde(default = "default_normalized")]
-    pub normalized: bool,
-}
-
-fn default_normalized() -> bool {
-    true
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct MifRelations {
-    #[serde(default)]
-    pub related_memories: Vec<String>,
-    #[serde(default)]
-    pub related_todos: Vec<String>,
-}
-
-/// MIF Todo object
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MifTodo {
-    pub id: String,
-    #[serde(default)]
-    pub short_id: String,
-    pub content: String,
-    #[serde(default = "default_todo_status")]
-    pub status: String,
-    #[serde(default = "default_priority")]
-    pub priority: String,
-    pub created_at: String,
-    #[serde(default)]
-    pub updated_at: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub due_date: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub completed_at: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub project: Option<MifProject>,
-    #[serde(default)]
-    pub contexts: Vec<String>,
-    #[serde(default)]
-    pub tags: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub notes: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub parent_id: Option<String>,
-    #[serde(default)]
-    pub subtask_ids: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub blocked_on: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub recurrence: Option<String>,
-    #[serde(default)]
-    pub related_memory_ids: Vec<String>,
-    #[serde(default)]
-    pub comments: Vec<MifComment>,
-}
-
-fn default_todo_status() -> String {
-    "todo".to_string()
-}
-
-fn default_priority() -> String {
-    "medium".to_string()
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MifProject {
-    pub id: String,
-    pub name: String,
-    #[serde(default = "default_prefix")]
-    pub prefix: String,
-}
-
-fn default_prefix() -> String {
-    "TODO".to_string()
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MifComment {
-    pub id: String,
-    pub content: String,
-    #[serde(rename = "type", default = "default_comment_type")]
-    pub comment_type: String,
-    pub created_at: String,
-}
-
-fn default_comment_type() -> String {
-    "comment".to_string()
-}
-
-/// MIF Graph structure
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MifGraph {
-    #[serde(default = "default_graph_format")]
-    pub format: String,
-    #[serde(default)]
-    pub node_count: usize,
-    #[serde(default)]
-    pub edge_count: usize,
-    #[serde(default)]
-    pub nodes: Vec<MifNode>,
-    #[serde(default)]
-    pub edges: Vec<MifEdge>,
-    #[serde(default)]
-    pub hebbian_config: MifHebbianConfig,
-}
-
-fn default_graph_format() -> String {
-    "adjacency_list".to_string()
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MifNode {
-    pub id: String,
-    #[serde(rename = "type")]
-    pub node_type: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub entity_type: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MifEdge {
-    pub source: String,
-    pub target: String,
-    #[serde(default = "default_edge_weight")]
-    pub weight: f32,
-    #[serde(rename = "type", default = "default_edge_type")]
-    pub edge_type: String,
-    #[serde(default)]
-    pub created_at: String,
-    #[serde(default)]
-    pub strengthened_count: u32,
-}
-
-fn default_edge_weight() -> f32 {
-    0.5
-}
-
-fn default_edge_type() -> String {
-    "semantic_association".to_string()
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct MifHebbianConfig {
-    #[serde(default = "default_learning_rate")]
-    pub learning_rate: f32,
-    #[serde(default = "default_hebbian_decay")]
-    pub decay_rate: f32,
-    #[serde(default = "default_ltp_threshold")]
-    pub ltp_threshold: f32,
-    #[serde(default = "default_max_weight")]
-    pub max_weight: f32,
-}
-
-fn default_learning_rate() -> f32 {
-    0.1
-}
-
-fn default_hebbian_decay() -> f32 {
-    0.05
-}
-
-fn default_ltp_threshold() -> f32 {
-    0.8
-}
-
-fn default_max_weight() -> f32 {
-    1.0
-}
-
-/// MIF Metadata
-#[derive(Debug, Serialize)]
-pub struct MifMetadata {
-    pub total_memories: usize,
-    pub total_todos: usize,
-    pub date_range: MifDateRange,
-    pub memory_types: HashMap<String, usize>,
-    pub top_entities: Vec<MifTopEntity>,
-    pub projects: Vec<MifProjectStats>,
-    pub privacy: MifPrivacy,
-}
-
-#[derive(Debug, Serialize)]
-pub struct MifDateRange {
-    pub earliest: String,
-    pub latest: String,
-}
-
-#[derive(Debug, Serialize)]
-pub struct MifTopEntity {
-    pub text: String,
-    pub count: usize,
-}
-
-#[derive(Debug, Serialize)]
-pub struct MifProjectStats {
-    pub id: String,
-    pub name: String,
-    pub todo_count: usize,
-}
-
-#[derive(Debug, Serialize)]
-pub struct MifPrivacy {
-    pub pii_detected: bool,
-    pub secrets_detected: bool,
-    pub redacted_fields: Vec<String>,
-}
-
-/// Full MIF export document
-#[derive(Debug, Serialize)]
-pub struct MifExport {
-    #[serde(rename = "$schema")]
-    pub schema: String,
-    pub mif_version: String,
-    pub generator: MifGenerator,
-    pub export: MifExportMeta,
-    pub memories: Vec<MifMemory>,
-    pub todos: Vec<MifTodo>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub graph: Option<MifGraph>,
-    pub metadata: MifMetadata,
-}
-
-#[derive(Debug, Serialize)]
-pub struct MifGenerator {
-    pub name: String,
-    pub version: String,
-}
-
-#[derive(Debug, Serialize)]
-pub struct MifExportMeta {
-    pub id: String,
-    pub created_at: String,
-    pub user_id: String,
-    pub checksum: String,
-}
-
-// =============================================================================
-// MIF IMPORT TYPES
-// =============================================================================
-
-/// Response for MIF import
-#[derive(Debug, Serialize)]
-pub struct MifImportResponse {
-    pub success: bool,
-    pub imported: MifImportCounts,
-    pub skipped: MifSkipCounts,
-    pub warnings: Vec<String>,
-}
-
-#[derive(Debug, Serialize, Default)]
-pub struct MifImportCounts {
-    pub memories: usize,
-    pub todos: usize,
-    pub edges: usize,
-}
-
-#[derive(Debug, Serialize, Default)]
-pub struct MifSkipCounts {
-    pub duplicates: usize,
-    pub invalid: usize,
-}
-
-// =============================================================================
-// PII DETECTION AND REDACTION
-// =============================================================================
-
-/// PII patterns for detection
-pub struct PiiPatterns {
-    email: regex::Regex,
-    phone: regex::Regex,
-    ssn: regex::Regex,
-    api_key: regex::Regex,
-    credit_card: regex::Regex,
-    #[allow(dead_code)] // Reserved for future PII detection expansion
-    ip_address: regex::Regex,
-}
-
-impl PiiPatterns {
-    pub fn new() -> Self {
-        Self {
-            email: regex::Regex::new(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}").unwrap(),
-            phone: regex::Regex::new(r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b").unwrap(),
-            ssn: regex::Regex::new(r"\b\d{3}-\d{2}-\d{4}\b").unwrap(),
-            api_key: regex::Regex::new(
-                r#"(?i)(api[_-]?key|secret|token|password)\s*[:=]\s*['"]?[\w-]{16,}['"]?"#,
-            )
-            .unwrap(),
-            credit_card: regex::Regex::new(r"\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b").unwrap(),
-            ip_address: regex::Regex::new(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b").unwrap(),
-        }
-    }
-
-    /// Detect and redact PII from content
-    pub fn redact(&self, content: &str) -> (String, Vec<MifRedaction>, bool) {
-        let mut redacted = content.to_string();
-        let mut redactions = Vec::new();
-        let mut pii_found = false;
-
-        // Email
-        for m in self.email.find_iter(content) {
-            pii_found = true;
-            redactions.push(MifRedaction {
-                redaction_type: "email".to_string(),
-                original_length: m.as_str().len(),
-                position: (m.start(), m.end()),
-            });
-        }
-        redacted = self
-            .email
-            .replace_all(&redacted, "[REDACTED:email]")
-            .to_string();
-
-        // Phone
-        for m in self.phone.find_iter(content) {
-            pii_found = true;
-            redactions.push(MifRedaction {
-                redaction_type: "phone".to_string(),
-                original_length: m.as_str().len(),
-                position: (m.start(), m.end()),
-            });
-        }
-        redacted = self
-            .phone
-            .replace_all(&redacted, "[REDACTED:phone]")
-            .to_string();
-
-        // SSN
-        for m in self.ssn.find_iter(content) {
-            pii_found = true;
-            redactions.push(MifRedaction {
-                redaction_type: "ssn".to_string(),
-                original_length: m.as_str().len(),
-                position: (m.start(), m.end()),
-            });
-        }
-        redacted = self
-            .ssn
-            .replace_all(&redacted, "[REDACTED:ssn]")
-            .to_string();
-
-        // API keys
-        for m in self.api_key.find_iter(content) {
-            pii_found = true;
-            redactions.push(MifRedaction {
-                redaction_type: "api_key".to_string(),
-                original_length: m.as_str().len(),
-                position: (m.start(), m.end()),
-            });
-        }
-        redacted = self
-            .api_key
-            .replace_all(&redacted, "[REDACTED:api_key]")
-            .to_string();
-
-        // Credit card
-        for m in self.credit_card.find_iter(content) {
-            pii_found = true;
-            redactions.push(MifRedaction {
-                redaction_type: "credit_card".to_string(),
-                original_length: m.as_str().len(),
-                position: (m.start(), m.end()),
-            });
-        }
-        redacted = self
-            .credit_card
-            .replace_all(&redacted, "[REDACTED:credit_card]")
-            .to_string();
-
-        (redacted, redactions, pii_found)
-    }
-}
-
-impl Default for PiiPatterns {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-// =============================================================================
-// ENCRYPTION (AES-256-GCM)
-// =============================================================================
-
-/// Encrypted MIF export wrapper
-#[derive(Debug, Serialize)]
-pub struct MifEncryptedExport {
-    #[serde(rename = "$schema")]
-    pub schema: String,
-    pub mif_version: String,
-    pub encryption: MifEncryptionMeta,
-}
-
-#[derive(Debug, Serialize)]
-pub struct MifEncryptionMeta {
-    pub algorithm: String,
-    pub key_derivation: String,
-    pub encrypted_payload: String,
-    pub iv: String,
-    pub auth_tag: String,
-}
-
-/// Encrypt MIF export data using AES-256-GCM
-/// Prepared for encrypted MIF export feature (requires key management integration)
-#[allow(dead_code)]
-pub fn encrypt_mif_data(
-    data: &[u8],
-    key: &[u8; 32],
-) -> Result<(Vec<u8>, [u8; 12], [u8; 16]), anyhow::Error> {
-    use aes_gcm::{
-        aead::{generic_array::GenericArray, Aead, KeyInit},
-        Aes256Gcm, Nonce,
-    };
-    use rand::RngCore;
-
-    let mut nonce_bytes = [0u8; 12];
-    rand::thread_rng().fill_bytes(&mut nonce_bytes);
-    let nonce = Nonce::from_slice(&nonce_bytes);
-
-    let cipher = Aes256Gcm::new(GenericArray::from_slice(key));
-
-    let ciphertext = cipher
-        .encrypt(nonce, data)
-        .map_err(|e| anyhow::anyhow!("Encryption failed: {}", e))?;
-
-    let (ct, tag) = ciphertext.split_at(ciphertext.len() - 16);
-    let mut auth_tag = [0u8; 16];
-    auth_tag.copy_from_slice(tag);
-
-    Ok((ct.to_vec(), nonce_bytes, auth_tag))
-}
-
-/// Decrypt MIF export data using AES-256-GCM
-/// Prepared for encrypted MIF import feature (requires key management integration)
-#[allow(dead_code)]
-pub fn decrypt_mif_data(
-    ciphertext: &[u8],
-    key: &[u8; 32],
-    nonce: &[u8; 12],
-    auth_tag: &[u8; 16],
-) -> Result<Vec<u8>, anyhow::Error> {
-    use aes_gcm::{
-        aead::{generic_array::GenericArray, Aead, KeyInit},
-        Aes256Gcm, Nonce,
-    };
-
-    let mut ct_with_tag = ciphertext.to_vec();
-    ct_with_tag.extend_from_slice(auth_tag);
-
-    let cipher = Aes256Gcm::new(GenericArray::from_slice(key));
-    let nonce = Nonce::from_slice(nonce);
-
-    cipher
-        .decrypt(nonce, ct_with_tag.as_slice())
-        .map_err(|e| anyhow::anyhow!("Decryption failed: {}", e))
-}
-
-// =============================================================================
-// MIF EXPORT HANDLER
-// =============================================================================
-
-/// Export memories in MIF (Memory Interchange Format)
 #[tracing::instrument(skip(state), fields(user_id = %req.user_id))]
 pub async fn export_mif(
     State(state): State<AppState>,
     Json(req): Json<MifExportRequest>,
-) -> Result<Json<MifExport>, AppError> {
+) -> Result<Json<serde_json::Value>, AppError> {
     validation::validate_user_id(&req.user_id).map_validation_err("user_id")?;
 
-    let memory_sys = state
-        .get_user_memory(&req.user_id)
-        .map_err(AppError::Internal)?;
-
     let user_id = req.user_id.clone();
-    let include_embeddings = req.include_embeddings;
-    let redact_pii = req.redact_pii;
 
-    let pii_patterns = if redact_pii {
-        Some(PiiPatterns::new())
-    } else {
-        None
-    };
-
-    use std::cell::Cell;
-    let pii_detected = Cell::new(false);
-    let secrets_detected = Cell::new(false);
-    let mut redacted_fields: Vec<String> = Vec::new();
-
-    // Get all memories
-    let memories: Vec<MifMemory> = {
+    // Gather data
+    let memory_sys = state
+        .get_user_memory(&user_id)
+        .map_err(AppError::Internal)?;
+    let memories = {
         let guard = memory_sys.read();
-        guard
-            .get_all_memories()
-            .unwrap_or_default()
-            .into_iter()
-            .map(|m| {
-                let embedding = if include_embeddings {
-                    m.experience.embeddings.as_ref().map(|e| MifEmbedding {
-                        model: "minilm-l6-v2".to_string(),
-                        dimensions: e.len(),
-                        vector: e.clone(),
-                        normalized: true,
-                    })
-                } else {
-                    None
-                };
-
-                let (content, redactions) = if let Some(ref patterns) = pii_patterns {
-                    let (redacted_content, redaction_records, found_pii) =
-                        patterns.redact(&m.experience.content);
-                    if found_pii {
-                        pii_detected.set(true);
-                        if redaction_records
-                            .iter()
-                            .any(|r| r.redaction_type == "api_key")
-                        {
-                            secrets_detected.set(true);
-                        }
-                    }
-                    (
-                        redacted_content,
-                        if redaction_records.is_empty() {
-                            None
-                        } else {
-                            Some(redaction_records)
-                        },
-                    )
-                } else {
-                    (m.experience.content.clone(), None)
-                };
-
-                let entities: Vec<MifEntity> = m
-                    .experience
-                    .entities
-                    .iter()
-                    .map(|e| MifEntity {
-                        text: e.clone(),
-                        entity_type: "UNKNOWN".to_string(),
-                        confidence: 1.0,
-                    })
-                    .collect();
-
-                let (source_type, session_id) = m
-                    .experience
-                    .context
-                    .as_ref()
-                    .map(|ctx| {
-                        let src = format!("{:?}", ctx.source.source_type).to_lowercase();
-                        let sess = ctx.episode.episode_id.clone();
-                        (src, sess)
-                    })
-                    .unwrap_or_else(|| ("conversation".to_string(), None));
-
-                let tags: Vec<String> = m
-                    .experience
-                    .metadata
-                    .get("tags")
-                    .map(|t| t.split(',').map(|s| s.trim().to_string()).collect())
-                    .unwrap_or_default();
-
-                MifMemory {
-                    id: format!("mem_{}", m.id.0),
-                    content,
-                    memory_type: format!("{:?}", m.experience.experience_type),
-                    importance: m.importance(),
-                    created_at: m.created_at.to_rfc3339(),
-                    updated_at: m.created_at.to_rfc3339(),
-                    accessed_at: m.last_accessed().to_rfc3339(),
-                    access_count: m.access_count(),
-                    decay_rate: 0.1,
-                    tags,
-                    source: MifSource {
-                        source_type,
-                        session_id,
-                        agent: Some("shodh-memory".to_string()),
-                    },
-                    entities,
-                    embedding,
-                    relations: MifRelations {
-                        related_memories: m
-                            .experience
-                            .related_memories
-                            .iter()
-                            .map(|id| format!("mem_{}", id.0))
-                            .collect(),
-                        related_todos: m
-                            .related_todo_ids
-                            .iter()
-                            .map(|id| format!("todo_{}", id.0))
-                            .collect(),
-                    },
-                    redactions,
-                }
-            })
-            .collect()
+        guard.get_all_memories().unwrap_or_default()
     };
 
-    if redact_pii {
-        for mem in &memories {
-            if let Some(ref redacts) = mem.redactions {
-                for r in redacts {
-                    if !redacted_fields.contains(&r.redaction_type) {
-                        redacted_fields.push(r.redaction_type.clone());
-                    }
-                }
-            }
-        }
-    }
-
-    // Get all todos
-    let todos: Vec<MifTodo> = state
-        .todo_store
-        .list_todos_for_user(&user_id, None)
-        .unwrap_or_default()
-        .into_iter()
-        .map(|t| {
-            let project = t.project_id.as_ref().and_then(|pid| {
-                state
-                    .todo_store
-                    .get_project(&user_id, pid)
-                    .ok()
-                    .flatten()
-                    .map(|p| MifProject {
-                        id: p.id.0.to_string(),
-                        name: p.name,
-                        prefix: p.prefix.unwrap_or_else(|| "TODO".to_string()),
-                    })
-            });
-
-            MifTodo {
-                id: format!("todo_{}", t.id.0),
-                short_id: t.short_id(),
-                content: t.content,
-                status: format!("{:?}", t.status).to_lowercase(),
-                priority: t.priority.indicator().to_string(),
-                created_at: t.created_at.to_rfc3339(),
-                updated_at: t.updated_at.to_rfc3339(),
-                due_date: t.due_date.map(|d| d.to_rfc3339()),
-                completed_at: t.completed_at.map(|d| d.to_rfc3339()),
-                project,
-                contexts: t.contexts,
-                tags: t.tags,
-                notes: t.notes,
-                parent_id: t.parent_id.map(|id| format!("todo_{}", id.0)),
-                subtask_ids: vec![],
-                blocked_on: t.blocked_on,
-                recurrence: t.recurrence.map(|r| format!("{:?}", r).to_lowercase()),
-                related_memory_ids: t
-                    .related_memory_ids
-                    .iter()
-                    .map(|id| format!("mem_{}", id.0))
-                    .collect(),
-                comments: vec![],
-            }
-        })
-        .collect();
-
-    // Build graph if requested
     let graph = if req.include_graph {
-        let graph_memory = state.get_user_graph(&user_id).map_err(AppError::Internal)?;
-        let graph_guard = graph_memory.read();
-
-        let mut nodes = Vec::new();
-
-        for m in &memories {
-            nodes.push(MifNode {
-                id: m.id.clone(),
-                node_type: "memory".to_string(),
-                entity_type: None,
-            });
-        }
-
-        if let Ok(entities) = graph_guard.get_all_entities() {
-            for entity in entities {
-                let entity_type = entity
-                    .labels
-                    .first()
-                    .map(|l| format!("{:?}", l))
-                    .unwrap_or_else(|| "UNKNOWN".to_string());
-                nodes.push(MifNode {
-                    id: format!("entity:{}", entity.name),
-                    node_type: "entity".to_string(),
-                    entity_type: Some(entity_type),
-                });
-            }
-        }
-
-        for t in &todos {
-            nodes.push(MifNode {
-                id: t.id.clone(),
-                node_type: "todo".to_string(),
-                entity_type: None,
-            });
-        }
-
-        let mut edges = Vec::new();
-        if let Ok(relationships) = graph_guard.get_all_relationships() {
-            for rel in relationships {
-                edges.push(MifEdge {
-                    source: format!("entity:{}", rel.from_entity),
-                    target: format!("entity:{}", rel.to_entity),
-                    weight: rel.strength,
-                    edge_type: format!("{:?}", rel.relation_type).to_lowercase(),
-                    created_at: rel.created_at.to_rfc3339(),
-                    strengthened_count: rel.activation_count,
-                });
-            }
-        }
-
-        Some(MifGraph {
-            format: "adjacency_list".to_string(),
-            node_count: nodes.len(),
-            edge_count: edges.len(),
-            nodes,
-            edges,
-            hebbian_config: MifHebbianConfig {
-                learning_rate: 0.1,
-                decay_rate: 0.05,
-                ltp_threshold: 0.8,
-                max_weight: 1.0,
-            },
-        })
+        Some(state.get_user_graph(&user_id).map_err(AppError::Internal)?)
     } else {
         None
     };
 
-    // Build metadata
-    let mut memory_types: HashMap<String, usize> = HashMap::new();
-    for m in &memories {
-        *memory_types.entry(m.memory_type.clone()).or_insert(0) += 1;
-    }
-
-    let all_todos_for_count = state
+    let todos = state
         .todo_store
         .list_todos_for_user(&user_id, None)
         .unwrap_or_default();
-    let projects: Vec<MifProjectStats> = state
-        .todo_store
-        .list_projects(&user_id)
-        .unwrap_or_default()
-        .into_iter()
-        .map(|p| {
-            let todo_count = all_todos_for_count
-                .iter()
-                .filter(|t| t.project_id.as_ref() == Some(&p.id))
-                .count();
-            MifProjectStats {
-                id: p.id.0.to_string(),
-                name: p.name,
-                todo_count,
-            }
-        })
-        .collect();
 
-    let earliest = memories
-        .iter()
-        .map(|m| &m.created_at)
-        .min()
-        .cloned()
-        .unwrap_or_default();
-    let latest = memories
-        .iter()
-        .map(|m| &m.created_at)
-        .max()
-        .cloned()
+    let projects = state.todo_store.list_projects(&user_id).unwrap_or_default();
+
+    let reminders = state
+        .prospective_store
+        .list_for_user(&user_id, None)
         .unwrap_or_default();
 
-    let metadata = MifMetadata {
-        total_memories: memories.len(),
-        total_todos: todos.len(),
-        date_range: MifDateRange { earliest, latest },
-        memory_types,
-        top_entities: vec![],
-        projects,
-        privacy: MifPrivacy {
-            pii_detected: pii_detected.get(),
-            secrets_detected: secrets_detected.get(),
-            redacted_fields,
-        },
+    let since = req
+        .since
+        .as_ref()
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&chrono::Utc));
+
+    let options = export::ExportOptions {
+        user_id: user_id.clone(),
+        include_embeddings: req.include_embeddings,
+        include_graph: req.include_graph,
+        redact_pii: req.redact_pii,
+        since,
     };
 
-    let export_id = format!(
-        "exp_{}",
-        uuid::Uuid::new_v4().to_string().replace('-', "")[..12].to_string()
-    );
-    let now = chrono::Utc::now();
+    let graph_ref = graph.as_ref().map(|g| g.read());
+    let graph_guard = graph_ref.as_deref();
 
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(format!(
-        "{}{}{}",
-        memories.len(),
-        todos.len(),
-        now.to_rfc3339()
-    ));
-    let checksum = format!("sha256:{}", hex::encode(hasher.finalize()));
+    let doc = export::build_document(
+        &memories,
+        graph_guard,
+        &todos,
+        &projects,
+        &reminders,
+        &options,
+    )
+    .map_err(AppError::Internal)?;
 
-    let export = MifExport {
-        schema: "https://shodh-memory.dev/schemas/mif-v1.json".to_string(),
-        mif_version: "1.0".to_string(),
-        generator: MifGenerator {
-            name: "shodh-memory".to_string(),
-            version: env!("CARGO_PKG_VERSION").to_string(),
-        },
-        export: MifExportMeta {
-            id: export_id,
-            created_at: now.to_rfc3339(),
-            user_id: user_id.clone(),
-            checksum,
-        },
-        memories,
-        todos,
-        graph,
-        metadata,
+    // Convert to requested output format
+    let output = if req.format == "shodh" || req.format == "json" {
+        serde_json::to_value(&doc).map_err(|e| AppError::Internal(e.into()))?
+    } else {
+        let registry = AdapterRegistry::new();
+        let bytes = registry
+            .export_with(&req.format, &doc)
+            .map_err(AppError::Internal)?;
+        let output_str = String::from_utf8(bytes).map_err(|e| AppError::Internal(e.into()))?;
+        // For non-JSON formats, wrap in an object
+        serde_json::json!({
+            "format": req.format,
+            "data": output_str,
+            "memory_count": doc.memories.len(),
+            "todo_count": doc.todos.len(),
+        })
     };
 
     state.log_event(
         &user_id,
         "MIF_EXPORT",
-        &export.export.id,
+        &doc.export_meta.id,
         &format!(
-            "Exported {} memories, {} todos",
-            export.metadata.total_memories, export.metadata.total_todos
+            "Exported {} memories, {} todos (format: {})",
+            doc.memories.len(),
+            doc.todos.len(),
+            req.format,
         ),
     );
 
-    Ok(Json(export))
+    Ok(Json(output))
 }
 
 // =============================================================================
-// MIF IMPORT HANDLER
+// MIF IMPORT
 // =============================================================================
 
-/// Import memories from MIF format
+#[derive(Debug, Deserialize)]
+pub struct MifImportRequest {
+    pub user_id: String,
+    #[serde(default = "default_skip_duplicates")]
+    pub skip_duplicates: bool,
+    #[serde(default)]
+    pub format: Option<String>,
+    pub data: serde_json::Value,
+}
+
+fn default_skip_duplicates() -> bool {
+    true
+}
+
+#[derive(Debug, Serialize)]
+pub struct MifImportResponse {
+    pub success: bool,
+    pub result: import::ImportResult,
+}
+
+#[tracing::instrument(skip(state, req), fields(user_id = %req.user_id))]
 pub async fn import_mif(
     State(state): State<AppState>,
     Json(req): Json<MifImportRequest>,
 ) -> Result<Json<MifImportResponse>, AppError> {
     validation::validate_user_id(&req.user_id).map_validation_err("user_id")?;
 
-    if !req.data.mif_version.starts_with("1.") {
-        return Err(AppError::InvalidInput {
-            field: "mif_version".to_string(),
-            reason: format!(
-                "Unsupported MIF version: {}. Only 1.x is supported.",
-                req.data.mif_version
-            ),
-        });
-    }
+    // Convert data to bytes for adapter detection
+    let data_bytes = serde_json::to_vec(&req.data).map_err(|e| AppError::Internal(e.into()))?;
 
-    let memory_sys = state
-        .get_user_memory(&req.user_id)
-        .map_err(AppError::Internal)?;
+    // Parse through adapter registry (auto-detect or explicit format)
+    let registry = AdapterRegistry::new();
+    let doc = if let Some(ref fmt) = req.format {
+        registry
+            .import_with(fmt, &data_bytes)
+            .map_err(AppError::Internal)?
+    } else {
+        registry
+            .auto_import(&data_bytes)
+            .map_err(AppError::Internal)?
+    };
 
-    let mut imported = MifImportCounts::default();
-    let mut skipped = MifSkipCounts::default();
-    let mut warnings = Vec::new();
+    // Validate version
+    import::validate_version(&doc).map_err(AppError::Internal)?;
+
+    let options = import::ImportOptions {
+        user_id: req.user_id.clone(),
+        skip_duplicates: req.skip_duplicates,
+    };
+
+    let mut result = import::ImportResult::default();
+
+    // Build dedup set from existing memories
+    let dedup_set = if req.skip_duplicates {
+        let memory_sys = state
+            .get_user_memory(&req.user_id)
+            .map_err(AppError::Internal)?;
+        let guard = memory_sys.read();
+        let existing: Vec<String> = guard
+            .get_all_memories()
+            .unwrap_or_default()
+            .iter()
+            .map(|m| m.experience.content.clone())
+            .collect();
+        import::build_dedup_set(&existing)
+    } else {
+        std::collections::HashSet::new()
+    };
 
     // Import memories
-    for mif_mem in &req.data.memories {
-        let exp_type = match mif_mem.memory_type.as_str() {
-            "Observation" => memory::ExperienceType::Observation,
-            "Decision" => memory::ExperienceType::Decision,
-            "Learning" => memory::ExperienceType::Learning,
-            "Error" => memory::ExperienceType::Error,
-            "Discovery" => memory::ExperienceType::Discovery,
-            "Pattern" => memory::ExperienceType::Pattern,
-            "Context" => memory::ExperienceType::Context,
-            "Task" => memory::ExperienceType::Task,
-            "CodeEdit" => memory::ExperienceType::CodeEdit,
-            "FileAccess" => memory::ExperienceType::FileAccess,
-            "Search" => memory::ExperienceType::Search,
-            "Command" => memory::ExperienceType::Command,
-            "Conversation" => memory::ExperienceType::Conversation,
-            "Intention" => memory::ExperienceType::Intention,
-            _ => memory::ExperienceType::Observation,
-        };
+    let (prepared_memories, skipped) = import::prepare_memories(&doc, &dedup_set, &options);
+    result.duplicates_skipped = skipped;
 
-        let created_at = chrono::DateTime::parse_from_rfc3339(&mif_mem.created_at)
-            .map(|dt| dt.with_timezone(&chrono::Utc))
-            .ok();
+    {
+        let memory_sys = state
+            .get_user_memory(&req.user_id)
+            .map_err(AppError::Internal)?;
+        let guard = memory_sys.read();
 
-        let mut metadata: HashMap<String, String> = HashMap::new();
-        if !mif_mem.tags.is_empty() {
-            metadata.insert("tags".to_string(), mif_mem.tags.join(","));
+        for (memory_id, experience, created_at) in prepared_memories {
+            match guard.remember_with_id(memory_id, experience, created_at) {
+                Ok(_) => result.memories_imported += 1,
+                Err(e) => result.errors.push(format!("Memory: {e}")),
+            }
         }
+    }
 
-        let experience = memory::Experience {
-            experience_type: exp_type,
-            content: mif_mem.content.clone(),
-            entities: mif_mem.entities.iter().map(|e| e.text.clone()).collect(),
-            metadata,
-            embeddings: mif_mem.embedding.as_ref().map(|e| e.vector.clone()),
-            ..Default::default()
-        };
-
-        let should_import = match req.merge_strategy.as_str() {
-            "skip_duplicates" => {
-                let guard = memory_sys.read();
-                let query = memory::Query {
-                    query_text: Some(mif_mem.content.clone()),
-                    max_results: 5,
-                    ..Default::default()
-                };
-                let existing = guard.recall(&query).unwrap_or_default();
-
-                if existing
-                    .iter()
-                    .any(|m| m.experience.content == mif_mem.content)
-                {
-                    skipped.duplicates += 1;
-                    false
-                } else {
-                    true
-                }
-            }
-            "overwrite" => true,
-            "rename" => true,
-            _ => true,
-        };
-
-        if should_import {
-            let guard = memory_sys.read();
-            match guard.remember(experience, created_at) {
-                Ok(_) => imported.memories += 1,
-                Err(e) => {
-                    warnings.push(format!("Failed to import memory {}: {}", mif_mem.id, e));
-                    skipped.invalid += 1;
-                }
-            }
+    // Import projects first (todos may reference them)
+    let prepared_projects = import::prepare_projects(&doc, &req.user_id);
+    for project in prepared_projects {
+        match state.todo_store.store_project(&project) {
+            Ok(_) => result.projects_imported += 1,
+            Err(e) => result
+                .errors
+                .push(format!("Project '{}': {e}", project.name)),
         }
     }
 
     // Import todos
-    for mif_todo in &req.data.todos {
-        let status = match mif_todo.status.as_str() {
-            "backlog" => memory::TodoStatus::Backlog,
-            "todo" => memory::TodoStatus::Todo,
-            "in_progress" => memory::TodoStatus::InProgress,
-            "blocked" => memory::TodoStatus::Blocked,
-            "done" => memory::TodoStatus::Done,
-            "cancelled" => memory::TodoStatus::Cancelled,
-            _ => memory::TodoStatus::Todo,
-        };
-
-        let priority = match mif_todo.priority.as_str() {
-            "urgent" | "!!!" => memory::TodoPriority::Urgent,
-            "high" | "!!" => memory::TodoPriority::High,
-            "medium" | "!" => memory::TodoPriority::Medium,
-            "low" | "-" => memory::TodoPriority::Low,
-            _ => memory::TodoPriority::None,
-        };
-
-        let created_at = chrono::DateTime::parse_from_rfc3339(&mif_todo.created_at)
-            .map(|dt| dt.with_timezone(&chrono::Utc))
-            .unwrap_or_else(|_| chrono::Utc::now());
-
-        let due_date = mif_todo
-            .due_date
-            .as_ref()
-            .and_then(|d| chrono::DateTime::parse_from_rfc3339(d).ok())
-            .map(|dt| dt.with_timezone(&chrono::Utc));
-
-        let todo = memory::Todo {
-            id: memory::TodoId(uuid::Uuid::new_v4()),
-            seq_num: 0,
-            project_prefix: None,
-            project: None,
-            user_id: req.user_id.clone(),
-            content: mif_todo.content.clone(),
-            status,
-            priority,
-            project_id: None,
-            parent_id: None,
-            created_at,
-            updated_at: created_at,
-            due_date,
-            completed_at: None,
-            contexts: mif_todo.contexts.clone(),
-            tags: mif_todo.tags.clone(),
-            notes: mif_todo.notes.clone(),
-            blocked_on: mif_todo.blocked_on.clone(),
-            recurrence: None,
-            sort_order: 0,
-            comments: Vec::new(),
-            embedding: None,
-            related_memory_ids: Vec::new(),
-            external_id: None,
-        };
-
+    let prepared_todos = import::prepare_todos(&doc, &req.user_id);
+    for todo in prepared_todos {
         match state.todo_store.store_todo(&todo) {
-            Ok(_) => imported.todos += 1,
-            Err(e) => {
-                warnings.push(format!("Failed to import todo {}: {}", mif_todo.id, e));
-                skipped.invalid += 1;
-            }
+            Ok(_) => result.todos_imported += 1,
+            Err(e) => result.errors.push(format!("Todo: {e}")),
         }
     }
 
-    // Import graph edges if present
-    if let Some(ref graph) = req.data.graph {
-        // Only attempt edge import if there are entity-type edges
-        let entity_edges: Vec<_> = graph
-            .edges
-            .iter()
-            .filter(|e| e.source.starts_with("entity:") && e.target.starts_with("entity:"))
-            .collect();
-
-        if !entity_edges.is_empty() {
-            let graph_memory = state
-                .get_user_graph(&req.user_id)
-                .map_err(AppError::Internal)?;
-            let graph_guard = graph_memory.read();
-
-            for edge in entity_edges {
-                // Parse entity identifiers: "entity:{uuid}" or "entity:{name}"
-                let source_id = &edge.source["entity:".len()..];
-                let target_id = &edge.target["entity:".len()..];
-
-                // Try resolving as UUID first, then by name
-                let from_entity = uuid::Uuid::parse_str(source_id)
-                    .ok()
-                    .and_then(|uuid| graph_guard.get_entity(&uuid).ok().flatten())
-                    .or_else(|| graph_guard.find_entity_by_name(source_id).ok().flatten());
-
-                let to_entity = uuid::Uuid::parse_str(target_id)
-                    .ok()
-                    .and_then(|uuid| graph_guard.get_entity(&uuid).ok().flatten())
-                    .or_else(|| graph_guard.find_entity_by_name(target_id).ok().flatten());
-
-                let (Some(from_node), Some(to_node)) = (from_entity, to_entity) else {
-                    warnings.push(format!(
-                        "Edge skipped: could not resolve entities '{}' → '{}'",
-                        source_id, target_id
-                    ));
-                    continue;
-                };
-
-                let relation_type = match edge.edge_type.as_str() {
-                    "relatedto" => graph_memory::RelationType::RelatedTo,
-                    "associatedwith" => graph_memory::RelationType::AssociatedWith,
-                    "partof" => graph_memory::RelationType::PartOf,
-                    "contains" => graph_memory::RelationType::Contains,
-                    "ownedby" => graph_memory::RelationType::OwnedBy,
-                    "createdby" => graph_memory::RelationType::CreatedBy,
-                    "developedby" => graph_memory::RelationType::DevelopedBy,
-                    "uses" => graph_memory::RelationType::Uses,
-                    "workswith" => graph_memory::RelationType::WorksWith,
-                    "worksat" => graph_memory::RelationType::WorksAt,
-                    "employedby" => graph_memory::RelationType::EmployedBy,
-                    "locatedin" => graph_memory::RelationType::LocatedIn,
-                    "locatedat" => graph_memory::RelationType::LocatedAt,
-                    "causes" => graph_memory::RelationType::Causes,
-                    "resultsin" => graph_memory::RelationType::ResultsIn,
-                    "learned" => graph_memory::RelationType::Learned,
-                    "knows" => graph_memory::RelationType::Knows,
-                    "teaches" => graph_memory::RelationType::Teaches,
-                    "coretrieved" => graph_memory::RelationType::CoRetrieved,
-                    "cooccurs" => graph_memory::RelationType::CoOccurs,
-                    other => graph_memory::RelationType::Custom(other.to_string()),
-                };
-
-                let created_at = chrono::DateTime::parse_from_rfc3339(&edge.created_at)
-                    .map(|dt| dt.with_timezone(&chrono::Utc))
-                    .unwrap_or_else(|_| chrono::Utc::now());
-
-                let entity_confidence = Some((from_node.salience + to_node.salience) / 2.0);
-
-                let new_edge = graph_memory::RelationshipEdge {
-                    uuid: uuid::Uuid::new_v4(),
-                    from_entity: from_node.uuid,
-                    to_entity: to_node.uuid,
-                    relation_type,
-                    strength: edge.weight,
-                    created_at,
-                    valid_at: created_at,
-                    invalidated_at: None,
-                    source_episode_id: None,
-                    context: String::new(),
-                    last_activated: created_at,
-                    activation_count: edge.strengthened_count.max(1),
-                    ltp_status: graph_memory::LtpStatus::None,
-                    tier: graph_memory::EdgeTier::L1Working,
-                    activation_timestamps: None,
-                    entity_confidence,
-                };
-
-                match graph_guard.add_relationship(new_edge) {
-                    Ok(_) => imported.edges += 1,
-                    Err(e) => {
-                        warnings.push(format!(
-                            "Failed to import edge {} → {}: {}",
-                            source_id, target_id, e
-                        ));
-                    }
-                }
-            }
+    // Import reminders
+    let prepared_reminders = import::prepare_reminders(&doc, &req.user_id);
+    for reminder in prepared_reminders {
+        match state.prospective_store.store(&reminder) {
+            Ok(_) => result.reminders_imported += 1,
+            Err(e) => result.errors.push(format!("Reminder: {e}")),
         }
+    }
+
+    // Import knowledge graph
+    if let Some(ref kg) = doc.knowledge_graph {
+        let graph_arc = state
+            .get_user_graph(&req.user_id)
+            .map_err(AppError::Internal)?;
+        let graph_guard = graph_arc.read();
+
+        let (entities_imported, entity_errors) = import::import_graph_entities(kg, &graph_guard);
+        result.entities_imported = entities_imported;
+        result.errors.extend(entity_errors);
+
+        let (edges_imported, edge_errors) =
+            import::import_graph_relationships(kg, &graph_guard, &doc.vendor_extensions);
+        result.edges_imported = edges_imported;
+        result.errors.extend(edge_errors);
     }
 
     state.log_event(
@@ -1258,207 +277,52 @@ pub async fn import_mif(
         "MIF_IMPORT",
         "import",
         &format!(
-            "Imported {} memories, {} todos, {} edges. Skipped: {} duplicates, {} invalid",
-            imported.memories, imported.todos, imported.edges, skipped.duplicates, skipped.invalid
+            "Imported {} memories, {} todos, {} projects, {} reminders, {} entities, {} edges. Skipped {} dupes, {} errors",
+            result.memories_imported,
+            result.todos_imported,
+            result.projects_imported,
+            result.reminders_imported,
+            result.entities_imported,
+            result.edges_imported,
+            result.duplicates_skipped,
+            result.errors.len(),
         ),
     );
 
     Ok(Json(MifImportResponse {
-        success: true,
-        imported,
-        skipped,
-        warnings,
+        success: result.errors.is_empty(),
+        result,
     }))
 }
 
 // =============================================================================
-// MULTIMODAL SEARCH HANDLERS
+// ADAPTER LISTING
 // =============================================================================
 
-/// Request for multimodal search
-#[derive(Debug, Deserialize)]
-pub struct MultiModalSearchRequest {
-    pub user_id: String,
-    pub query_text: String,
-    pub mode: String,
-    pub limit: Option<usize>,
-}
-
-/// Advanced multi-modal retrieval
-pub async fn multimodal_search(
-    State(state): State<AppState>,
-    Json(req): Json<MultiModalSearchRequest>,
-) -> Result<Json<RetrieveResponse>, AppError> {
-    validation::validate_user_id(&req.user_id).map_validation_err("user_id")?;
-
-    let memory_sys = state
-        .get_user_memory(&req.user_id)
-        .map_err(AppError::Internal)?;
-
-    let memory_guard = memory_sys.read();
-
-    let retrieval_mode = match req.mode.as_str() {
-        "similarity" => memory::RetrievalMode::Similarity,
-        "temporal" => memory::RetrievalMode::Temporal,
-        "causal" => memory::RetrievalMode::Causal,
-        "associative" => memory::RetrievalMode::Associative,
-        "hybrid" => memory::RetrievalMode::Hybrid,
-        "spatial" => memory::RetrievalMode::Spatial,
-        "mission" => memory::RetrievalMode::Mission,
-        "action_outcome" => memory::RetrievalMode::ActionOutcome,
-        _ => {
-            return Err(AppError::InvalidInput {
-                field: "mode".to_string(),
-                reason: format!(
-                    "Invalid mode: {}. Must be one of: similarity, temporal, causal, associative, hybrid, spatial, mission, action_outcome",
-                    req.mode
-                ),
-            })
-        }
-    };
-
-    let query = MemoryQuery {
-        query_text: Some(req.query_text.clone()),
-        max_results: req.limit.unwrap_or(10),
-        retrieval_mode,
-        ..Default::default()
-    };
-
-    let shared_memories = memory_guard.recall(&query).map_err(AppError::Internal)?;
-    let raw_memories: Vec<Memory> = shared_memories.iter().map(|m| (**m).clone()).collect();
-    let count = raw_memories.len();
-
-    // Serialize memories to JSON for response
-    let memories: Vec<serde_json::Value> = raw_memories
+pub async fn list_adapters() -> Json<serde_json::Value> {
+    let registry = AdapterRegistry::new();
+    let adapters: Vec<serde_json::Value> = registry
+        .list_adapters()
         .into_iter()
-        .filter_map(|m| serde_json::to_value(&m).ok())
+        .map(|(name, format_id)| {
+            serde_json::json!({
+                "name": name,
+                "format": format_id,
+            })
+        })
         .collect();
 
-    state.log_event(
-        &req.user_id,
-        "MULTIMODAL_SEARCH",
-        &req.mode,
-        &format!("Retrieved {} memories using {} mode", count, req.mode),
-    );
-
-    Ok(Json(RetrieveResponse { memories, count }))
+    Json(serde_json::json!({
+        "adapters": adapters,
+        "default_export": "shodh",
+        "default_import": "auto-detect",
+    }))
 }
 
 // =============================================================================
-// ROBOTICS SEARCH HANDLER
+// GRAPH ENTITY HANDLERS (kept here for backward compat)
 // =============================================================================
 
-/// Request for robotics-specific memory search
-#[derive(Debug, Deserialize)]
-pub struct RoboticsSearchRequest {
-    pub user_id: String,
-    pub mode: String,
-    pub query_text: Option<String>,
-    pub robot_id: Option<String>,
-    pub mission_id: Option<String>,
-    pub lat: Option<f64>,
-    pub lon: Option<f64>,
-    pub radius_meters: Option<f64>,
-    pub action_type: Option<String>,
-    pub min_reward: Option<f32>,
-    pub max_reward: Option<f32>,
-    pub limit: Option<usize>,
-}
-
-/// Robotics-specific memory search
-pub async fn robotics_search(
-    State(state): State<AppState>,
-    Json(req): Json<RoboticsSearchRequest>,
-) -> Result<Json<RetrieveResponse>, AppError> {
-    validation::validate_user_id(&req.user_id).map_validation_err("user_id")?;
-
-    let memory_sys = state
-        .get_user_memory(&req.user_id)
-        .map_err(AppError::Internal)?;
-
-    let memory_guard = memory_sys.read();
-
-    let retrieval_mode = match req.mode.as_str() {
-        "spatial" => memory::RetrievalMode::Spatial,
-        "mission" => memory::RetrievalMode::Mission,
-        "action_outcome" => memory::RetrievalMode::ActionOutcome,
-        "hybrid" => memory::RetrievalMode::Hybrid,
-        "similarity" => memory::RetrievalMode::Similarity,
-        _ => {
-            return Err(AppError::InvalidInput {
-                field: "mode".to_string(),
-                reason: "Invalid mode. Use: spatial, mission, action_outcome, hybrid, similarity"
-                    .to_string(),
-            })
-        }
-    };
-
-    let geo_filter = match (req.lat, req.lon, req.radius_meters) {
-        (Some(lat), Some(lon), Some(radius)) => Some(memory::GeoFilter::new(lat, lon, radius)),
-        _ => None,
-    };
-
-    let reward_range = match (req.min_reward, req.max_reward) {
-        (Some(min), Some(max)) => Some((min, max)),
-        (Some(min), None) => Some((min, 1.0)),
-        (None, Some(max)) => Some((-1.0, max)),
-        _ => None,
-    };
-
-    if matches!(retrieval_mode, memory::RetrievalMode::Spatial) && geo_filter.is_none() {
-        return Err(AppError::InvalidInput {
-            field: "lat/lon/radius_meters".to_string(),
-            reason: "Spatial mode requires lat, lon, and radius_meters".to_string(),
-        });
-    }
-
-    if matches!(retrieval_mode, memory::RetrievalMode::Mission) && req.mission_id.is_none() {
-        return Err(AppError::InvalidInput {
-            field: "mission_id".to_string(),
-            reason: "Mission mode requires mission_id".to_string(),
-        });
-    }
-
-    let query = MemoryQuery {
-        query_text: req.query_text,
-        robot_id: req.robot_id.clone(),
-        mission_id: req.mission_id.clone(),
-        geo_filter,
-        action_type: req.action_type.clone(),
-        reward_range,
-        max_results: req.limit.unwrap_or(10),
-        retrieval_mode,
-        ..Default::default()
-    };
-
-    let shared_memories = memory_guard.recall(&query).map_err(AppError::Internal)?;
-    let raw_memories: Vec<Memory> = shared_memories.iter().map(|m| (**m).clone()).collect();
-    let count = raw_memories.len();
-
-    // Serialize memories to JSON for response
-    let memories: Vec<serde_json::Value> = raw_memories
-        .into_iter()
-        .filter_map(|m| serde_json::to_value(&m).ok())
-        .collect();
-
-    state.log_event(
-        &req.user_id,
-        "ROBOTICS_SEARCH",
-        &req.mode,
-        &format!(
-            "Retrieved {} robotics memories (robot={:?}, mission={:?})",
-            count, req.robot_id, req.mission_id
-        ),
-    );
-
-    Ok(Json(RetrieveResponse { memories, count }))
-}
-
-// =============================================================================
-// GRAPH ENTITY HANDLERS
-// =============================================================================
-
-/// Request to add entity to graph
 #[derive(Debug, Deserialize)]
 pub struct AddEntityRequest {
     pub user_id: String,
@@ -1467,7 +331,6 @@ pub struct AddEntityRequest {
     pub attributes: Option<HashMap<String, String>>,
 }
 
-/// Add entity to knowledge graph
 pub async fn add_entity(
     State(state): State<AppState>,
     Json(req): Json<AddEntityRequest>,
@@ -1491,13 +354,10 @@ pub async fn add_entity(
         "Product" => graph_memory::EntityLabel::Product,
         "Skill" => graph_memory::EntityLabel::Skill,
         "Date" => graph_memory::EntityLabel::Date,
-        // Document, Code, Time mapped to Other for extensibility
-        "Document" | "Code" | "Time" => graph_memory::EntityLabel::Other(req.label.clone()),
         _ => graph_memory::EntityLabel::Other(req.label.clone()),
     };
 
-    // Create EntityNode with attributes
-    let mut attributes = std::collections::HashMap::new();
+    let mut attributes = HashMap::new();
     if let Some(attrs) = &req.attributes {
         for (key, value) in attrs {
             attributes.insert(
@@ -1537,7 +397,6 @@ pub async fn add_entity(
     })))
 }
 
-/// Request to add relationship between entities
 #[derive(Debug, Deserialize)]
 pub struct AddRelationshipRequest {
     pub user_id: String,
@@ -1547,7 +406,6 @@ pub struct AddRelationshipRequest {
     pub strength: Option<f32>,
 }
 
-/// Add relationship to knowledge graph
 pub async fn add_relationship(
     State(state): State<AppState>,
     Json(req): Json<AddRelationshipRequest>,
@@ -1581,13 +439,11 @@ pub async fn add_relationship(
         "Knows" => graph_memory::RelationType::Knows,
         "Teaches" => graph_memory::RelationType::Teaches,
         "CoRetrieved" => graph_memory::RelationType::CoRetrieved,
-        // Map non-existent variants to Custom for extensibility
         _ => graph_memory::RelationType::Custom(req.relation_type.clone()),
     };
 
     let strength = req.strength.unwrap_or(0.5);
 
-    // Need to find entity UUIDs by name first
     let from_entity = graph_guard
         .find_entity_by_name(&req.from_entity)
         .map_err(AppError::Internal)?
@@ -1595,7 +451,6 @@ pub async fn add_relationship(
             field: "from_entity".to_string(),
             reason: format!("Entity '{}' not found", req.from_entity),
         })?;
-    let from_uuid = from_entity.uuid;
 
     let to_entity = graph_guard
         .find_entity_by_name(&req.to_entity)
@@ -1604,15 +459,13 @@ pub async fn add_relationship(
             field: "to_entity".to_string(),
             reason: format!("Entity '{}' not found", req.to_entity),
         })?;
-    let to_uuid = to_entity.uuid;
 
-    // PIPE-5: Calculate entity confidence from connected entities' salience
     let entity_confidence = Some((from_entity.salience + to_entity.salience) / 2.0);
 
     let edge = graph_memory::RelationshipEdge {
         uuid: uuid::Uuid::new_v4(),
-        from_entity: from_uuid,
-        to_entity: to_uuid,
+        from_entity: from_entity.uuid,
+        to_entity: to_entity.uuid,
         relation_type: relation_type.clone(),
         strength,
         created_at: chrono::Utc::now(),
@@ -1651,7 +504,10 @@ pub async fn add_relationship(
     })))
 }
 
-/// Get uncompressed old memories (for manual compression review)
+// =============================================================================
+// STORAGE HANDLER
+// =============================================================================
+
 #[derive(Debug, Deserialize)]
 pub struct GetUncompressedRequest {
     pub user_id: String,
@@ -1676,8 +532,6 @@ pub async fn get_uncompressed_old(
         .map_err(AppError::Internal)?;
 
     let count = raw_memories.len();
-
-    // Serialize memories to JSON for response
     let memories: Vec<serde_json::Value> = raw_memories
         .into_iter()
         .filter_map(|m| serde_json::to_value(&m).ok())

--- a/src/handlers/router.rs
+++ b/src/handlers/router.rs
@@ -398,12 +398,16 @@ pub fn build_protected_routes(state: AppState) -> Router {
         .route("/api/events", get(webhooks::memory_events_sse)) // TUI alias
         .route("/api/stream", get(webhooks::streaming_memory_ws))
         // =================================================================
-        // SEARCH & MIF (Memory Interchange Format)
+        // MULTIMODAL & ROBOTICS SEARCH
         // =================================================================
-        .route("/api/search/multimodal", post(mif::multimodal_search))
-        .route("/api/search/robotics", post(mif::robotics_search))
+        .route("/api/search/multimodal", post(search::multimodal_search))
+        .route("/api/search/robotics", post(search::robotics_search))
+        // =================================================================
+        // MIF (Memory Interchange Format) v2
+        // =================================================================
         .route("/api/export/mif", post(mif::export_mif))
         .route("/api/import/mif", post(mif::import_mif))
+        .route("/api/mif/adapters", get(mif::list_adapters))
         // =================================================================
         // STATE
         // =================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod integrations;
 pub mod memory;
 pub mod metrics;
 pub mod middleware;
+pub mod mif;
 pub mod query_parsing;
 pub mod relevance;
 pub mod similarity;

--- a/src/mif/adapters/generic.rs
+++ b/src/mif/adapters/generic.rs
@@ -1,0 +1,173 @@
+//! Generic JSON adapter.
+//!
+//! Handles any JSON array of objects with at least a `content` field:
+//! ```json
+//! [
+//!   {
+//!     "content": "Some memory text",
+//!     "timestamp": "2024-01-15T10:30:00Z",
+//!     "tags": ["tag1", "tag2"],
+//!     "type": "observation",
+//!     "metadata": {"key": "value"}
+//!   }
+//! ]
+//! ```
+//! This is the most permissive adapter — it accepts anything that looks like
+//! a JSON array of objects. It's tried last in auto-detection.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use chrono::Utc;
+
+use super::MifAdapter;
+use crate::mif::schema::*;
+
+pub struct GenericJsonAdapter;
+
+impl MifAdapter for GenericJsonAdapter {
+    fn name(&self) -> &str {
+        "Generic JSON"
+    }
+
+    fn format_id(&self) -> &str {
+        "generic"
+    }
+
+    fn detect(&self, data: &[u8]) -> bool {
+        let s = match std::str::from_utf8(data) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        let trimmed = s.trim_start();
+        // Must be a JSON array with at least one object containing "content"
+        trimmed.starts_with('[') && trimmed.contains("\"content\"")
+    }
+
+    fn to_mif(&self, data: &[u8]) -> Result<MifDocument> {
+        let s = std::str::from_utf8(data)?;
+        let items: Vec<serde_json::Value> = serde_json::from_str(s)?;
+
+        let mut memories = Vec::new();
+
+        for item in &items {
+            let content = match item.get("content").and_then(|v| v.as_str()) {
+                Some(c) if !c.is_empty() => c,
+                _ => continue,
+            };
+
+            let id = item
+                .get("id")
+                .and_then(|v| v.as_str())
+                .and_then(|s| uuid::Uuid::parse_str(s).ok())
+                .unwrap_or_else(uuid::Uuid::new_v4);
+
+            let created_at = item
+                .get("timestamp")
+                .or_else(|| item.get("created_at"))
+                .or_else(|| item.get("date"))
+                .and_then(|v| v.as_str())
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(Utc::now);
+
+            let memory_type = item
+                .get("type")
+                .or_else(|| item.get("memory_type"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("observation")
+                .to_lowercase();
+
+            let tags: Vec<String> = item
+                .get("tags")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let mut metadata: HashMap<String, String> = HashMap::new();
+            if let Some(meta) = item.get("metadata").and_then(|v| v.as_object()) {
+                for (k, v) in meta {
+                    metadata.insert(
+                        k.clone(),
+                        v.as_str()
+                            .map(String::from)
+                            .unwrap_or_else(|| v.to_string()),
+                    );
+                }
+            }
+
+            memories.push(MifMemory {
+                id,
+                content: content.to_string(),
+                memory_type,
+                created_at,
+                tags,
+                entities: Vec::new(),
+                metadata,
+                embeddings: None,
+                source: Some(MifSource {
+                    source_type: "generic_json".to_string(),
+                    session_id: None,
+                    agent: None,
+                }),
+                parent_id: None,
+                related_memory_ids: Vec::new(),
+                related_todo_ids: Vec::new(),
+                agent_id: None,
+                external_id: item.get("id").and_then(|v| v.as_str()).map(String::from),
+                version: 1,
+            });
+        }
+
+        let now = Utc::now();
+        Ok(MifDocument {
+            mif_version: "2.0".to_string(),
+            generator: MifGenerator {
+                name: "generic-json-import".to_string(),
+                version: "1.0".to_string(),
+            },
+            export_meta: MifExportMeta {
+                id: uuid::Uuid::new_v4().to_string(),
+                created_at: now,
+                user_id: String::new(),
+                checksum: String::new(),
+                privacy: None,
+            },
+            memories,
+            knowledge_graph: None,
+            todos: Vec::new(),
+            projects: Vec::new(),
+            reminders: Vec::new(),
+            vendor_extensions: HashMap::new(),
+        })
+    }
+
+    fn from_mif(&self, doc: &MifDocument) -> Result<Vec<u8>> {
+        let items: Vec<serde_json::Value> = doc
+            .memories
+            .iter()
+            .map(|m| {
+                let mut obj = serde_json::json!({
+                    "id": m.id.to_string(),
+                    "content": m.content,
+                    "type": m.memory_type,
+                    "timestamp": m.created_at.to_rfc3339(),
+                });
+                if !m.tags.is_empty() {
+                    obj["tags"] = serde_json::to_value(&m.tags).unwrap_or_default();
+                }
+                if !m.metadata.is_empty() {
+                    obj["metadata"] = serde_json::to_value(&m.metadata).unwrap_or_default();
+                }
+                obj
+            })
+            .collect();
+
+        let json = serde_json::to_vec_pretty(&items)?;
+        Ok(json)
+    }
+}

--- a/src/mif/adapters/markdown.rs
+++ b/src/mif/adapters/markdown.rs
@@ -1,0 +1,238 @@
+//! Markdown adapter with YAML frontmatter.
+//!
+//! Supports Letta/Obsidian-style memory files:
+//! ```markdown
+//! ---
+//! type: observation
+//! tags: [rust, programming]
+//! created_at: 2024-01-15T10:30:00Z
+//! ---
+//! The user prefers Rust for systems programming.
+//! ---
+//! ---
+//! type: decision
+//! tags: [architecture]
+//! ---
+//! We decided to use RocksDB for storage.
+//! ```
+//!
+//! Multiple memories are separated by double `---` (frontmatter end + next frontmatter start).
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use chrono::Utc;
+
+use super::MifAdapter;
+use crate::mif::schema::*;
+
+pub struct MarkdownAdapter;
+
+impl MifAdapter for MarkdownAdapter {
+    fn name(&self) -> &str {
+        "Markdown (YAML frontmatter)"
+    }
+
+    fn format_id(&self) -> &str {
+        "markdown"
+    }
+
+    fn detect(&self, data: &[u8]) -> bool {
+        let s = match std::str::from_utf8(data) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        let trimmed = s.trim_start();
+        // Must start with YAML frontmatter delimiter
+        trimmed.starts_with("---")
+    }
+
+    fn to_mif(&self, data: &[u8]) -> Result<MifDocument> {
+        let s = std::str::from_utf8(data)?;
+        let blocks = split_frontmatter_blocks(s);
+
+        let mut memories = Vec::new();
+
+        for (frontmatter, body) in blocks {
+            let content = body.trim();
+            if content.is_empty() {
+                continue;
+            }
+
+            let fm = parse_frontmatter(&frontmatter);
+
+            let id = fm
+                .get("id")
+                .and_then(|s| uuid::Uuid::parse_str(s).ok())
+                .unwrap_or_else(uuid::Uuid::new_v4);
+
+            let memory_type = fm
+                .get("type")
+                .cloned()
+                .unwrap_or_else(|| "observation".to_string());
+
+            let created_at = fm
+                .get("created_at")
+                .or_else(|| fm.get("date"))
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(Utc::now);
+
+            let tags: Vec<String> = fm
+                .get("tags")
+                .map(|t| {
+                    // Handle both "[tag1, tag2]" and "tag1, tag2" formats
+                    let cleaned = t.trim_start_matches('[').trim_end_matches(']');
+                    cleaned
+                        .split(',')
+                        .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            // Collect remaining frontmatter fields as metadata
+            let metadata: HashMap<String, String> = fm
+                .iter()
+                .filter(|(k, _)| {
+                    !matches!(k.as_str(), "type" | "tags" | "created_at" | "date" | "id")
+                })
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+
+            memories.push(MifMemory {
+                id,
+                content: content.to_string(),
+                memory_type,
+                created_at,
+                tags,
+                entities: Vec::new(),
+                metadata,
+                embeddings: None,
+                source: Some(MifSource {
+                    source_type: "markdown".to_string(),
+                    session_id: None,
+                    agent: None,
+                }),
+                parent_id: None,
+                related_memory_ids: Vec::new(),
+                related_todo_ids: Vec::new(),
+                agent_id: None,
+                external_id: None,
+                version: 1,
+            });
+        }
+
+        let now = Utc::now();
+        Ok(MifDocument {
+            mif_version: "2.0".to_string(),
+            generator: MifGenerator {
+                name: "markdown-import".to_string(),
+                version: "1.0".to_string(),
+            },
+            export_meta: MifExportMeta {
+                id: uuid::Uuid::new_v4().to_string(),
+                created_at: now,
+                user_id: String::new(),
+                checksum: String::new(),
+                privacy: None,
+            },
+            memories,
+            knowledge_graph: None,
+            todos: Vec::new(),
+            projects: Vec::new(),
+            reminders: Vec::new(),
+            vendor_extensions: HashMap::new(),
+        })
+    }
+
+    fn from_mif(&self, doc: &MifDocument) -> Result<Vec<u8>> {
+        let mut output = String::new();
+
+        for (i, m) in doc.memories.iter().enumerate() {
+            if i > 0 {
+                output.push_str("\n---\n");
+            }
+            output.push_str("---\n");
+            output.push_str(&format!("type: {}\n", m.memory_type));
+            output.push_str(&format!("created_at: {}\n", m.created_at.to_rfc3339()));
+            if !m.tags.is_empty() {
+                output.push_str(&format!("tags: [{}]\n", m.tags.join(", ")));
+            }
+            output.push_str("---\n");
+            output.push_str(&m.content);
+            output.push('\n');
+        }
+
+        Ok(output.into_bytes())
+    }
+}
+
+/// Split markdown into (frontmatter, body) blocks.
+///
+/// Each block starts with `---` (frontmatter), ends with `---` (delimiter),
+/// followed by the body content. Multiple blocks are separated by `---\n---`.
+fn split_frontmatter_blocks(input: &str) -> Vec<(String, String)> {
+    let mut blocks = Vec::new();
+    let lines: Vec<&str> = input.lines().collect();
+
+    if lines.is_empty() || lines[0].trim() != "---" {
+        return blocks;
+    }
+
+    let mut i = 0;
+    while i < lines.len() {
+        // Expect opening ---
+        if lines[i].trim() != "---" {
+            i += 1;
+            continue;
+        }
+        i += 1; // skip opening ---
+
+        // Collect frontmatter until closing ---
+        let mut frontmatter = String::new();
+        while i < lines.len() && lines[i].trim() != "---" {
+            frontmatter.push_str(lines[i]);
+            frontmatter.push('\n');
+            i += 1;
+        }
+        if i < lines.len() {
+            i += 1; // skip closing ---
+        }
+
+        // Collect body until next opening --- or end
+        let mut body = String::new();
+        while i < lines.len() && lines[i].trim() != "---" {
+            body.push_str(lines[i]);
+            body.push('\n');
+            i += 1;
+        }
+
+        if !frontmatter.is_empty() || !body.is_empty() {
+            blocks.push((frontmatter, body));
+        }
+    }
+
+    blocks
+}
+
+/// Parse simple YAML frontmatter into key-value pairs.
+///
+/// Handles `key: value` format. Does not support nested YAML.
+fn parse_frontmatter(fm: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for line in fm.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some(pos) = line.find(':') {
+            let key = line[..pos].trim().to_string();
+            let value = line[pos + 1..].trim().to_string();
+            if !key.is_empty() {
+                map.insert(key, value);
+            }
+        }
+    }
+    map
+}

--- a/src/mif/adapters/mem0.rs
+++ b/src/mif/adapters/mem0.rs
@@ -1,0 +1,189 @@
+//! mem0 format adapter.
+//!
+//! mem0 exports memories as a JSON array of objects:
+//! ```json
+//! [
+//!   {
+//!     "id": "...",
+//!     "memory": "The user prefers dark mode",
+//!     "hash": "...",
+//!     "metadata": {"category": "preference"},
+//!     "created_at": "2024-01-15T10:30:00Z",
+//!     "updated_at": "2024-01-15T10:30:00Z",
+//!     "user_id": "user-123"
+//!   }
+//! ]
+//! ```
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use chrono::Utc;
+
+use super::MifAdapter;
+use crate::mif::schema::*;
+
+pub struct Mem0Adapter;
+
+impl MifAdapter for Mem0Adapter {
+    fn name(&self) -> &str {
+        "mem0"
+    }
+
+    fn format_id(&self) -> &str {
+        "mem0"
+    }
+
+    fn detect(&self, data: &[u8]) -> bool {
+        let s = match std::str::from_utf8(data) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        let trimmed = s.trim_start();
+        if !trimmed.starts_with('[') {
+            return false;
+        }
+        // mem0 arrays have objects with a "memory" field (not "content")
+        trimmed.contains("\"memory\"") && !trimmed.contains("\"mif_version\"")
+    }
+
+    fn to_mif(&self, data: &[u8]) -> Result<MifDocument> {
+        let s = std::str::from_utf8(data)?;
+        let items: Vec<serde_json::Value> = serde_json::from_str(s)?;
+
+        let mut memories = Vec::new();
+        let mut user_id = String::new();
+
+        for item in &items {
+            let memory_text = item
+                .get("memory")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            if memory_text.is_empty() {
+                continue;
+            }
+
+            let id = item
+                .get("id")
+                .and_then(|v| v.as_str())
+                .and_then(|s| uuid::Uuid::parse_str(s).ok())
+                .unwrap_or_else(uuid::Uuid::new_v4);
+
+            if user_id.is_empty() {
+                if let Some(uid) = item.get("user_id").and_then(|v| v.as_str()) {
+                    user_id = uid.to_string();
+                }
+            }
+
+            let created_at = item
+                .get("created_at")
+                .and_then(|v| v.as_str())
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(Utc::now);
+
+            // Extract metadata
+            let mut metadata: HashMap<String, String> = HashMap::new();
+            if let Some(meta) = item.get("metadata").and_then(|v| v.as_object()) {
+                for (k, v) in meta {
+                    metadata.insert(
+                        k.clone(),
+                        v.as_str()
+                            .map(String::from)
+                            .unwrap_or_else(|| v.to_string()),
+                    );
+                }
+            }
+
+            // Determine memory type from metadata category
+            let memory_type = metadata
+                .get("category")
+                .map(|c| match c.as_str() {
+                    "preference" | "preferences" => "observation",
+                    "decision" => "decision",
+                    "learning" | "fact" => "learning",
+                    "error" | "mistake" => "error",
+                    "task" | "todo" => "task",
+                    _ => "observation",
+                })
+                .unwrap_or("observation")
+                .to_string();
+
+            let tags: Vec<String> = metadata
+                .get("tags")
+                .map(|t| t.split(',').map(|s| s.trim().to_string()).collect())
+                .unwrap_or_default();
+
+            memories.push(MifMemory {
+                id,
+                content: memory_text.to_string(),
+                memory_type,
+                created_at,
+                tags,
+                entities: Vec::new(),
+                metadata,
+                embeddings: None,
+                source: Some(MifSource {
+                    source_type: "mem0".to_string(),
+                    session_id: None,
+                    agent: None,
+                }),
+                parent_id: None,
+                related_memory_ids: Vec::new(),
+                related_todo_ids: Vec::new(),
+                agent_id: item
+                    .get("agent_id")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                external_id: item.get("id").and_then(|v| v.as_str()).map(String::from),
+                version: 1,
+            });
+        }
+
+        let now = Utc::now();
+        Ok(MifDocument {
+            mif_version: "2.0".to_string(),
+            generator: MifGenerator {
+                name: "mem0-import".to_string(),
+                version: "1.0".to_string(),
+            },
+            export_meta: MifExportMeta {
+                id: uuid::Uuid::new_v4().to_string(),
+                created_at: now,
+                user_id,
+                checksum: String::new(),
+                privacy: None,
+            },
+            memories,
+            knowledge_graph: None,
+            todos: Vec::new(),
+            projects: Vec::new(),
+            reminders: Vec::new(),
+            vendor_extensions: HashMap::new(),
+        })
+    }
+
+    fn from_mif(&self, doc: &MifDocument) -> Result<Vec<u8>> {
+        // Convert MIF memories to mem0 format
+        let items: Vec<serde_json::Value> = doc
+            .memories
+            .iter()
+            .map(|m| {
+                let mut obj = serde_json::json!({
+                    "id": m.id.to_string(),
+                    "memory": m.content,
+                    "created_at": m.created_at.to_rfc3339(),
+                    "updated_at": m.created_at.to_rfc3339(),
+                    "user_id": &doc.export_meta.user_id,
+                });
+                if !m.metadata.is_empty() {
+                    obj["metadata"] = serde_json::to_value(&m.metadata).unwrap_or_default();
+                }
+                obj
+            })
+            .collect();
+
+        let json = serde_json::to_vec_pretty(&items)?;
+        Ok(json)
+    }
+}

--- a/src/mif/adapters/mod.rs
+++ b/src/mif/adapters/mod.rs
@@ -1,0 +1,115 @@
+//! MIF Adapter trait and registry for format detection and conversion.
+//!
+//! Each adapter handles a specific interchange format:
+//! - `shodh` — MIF v2 JSON (native, lossless round-trip) + v1 backward compat
+//! - `mem0` — mem0 memory format: `[{memory, metadata, ...}]`
+//! - `generic` — Generic JSON array: `[{content, timestamp, tags, ...}]`
+//! - `markdown` — Markdown with YAML frontmatter (Letta/Obsidian style)
+
+pub mod generic;
+pub mod markdown;
+pub mod mem0;
+pub mod shodh;
+
+use anyhow::Result;
+
+use super::schema::MifDocument;
+
+/// Trait for converting between external formats and MIF v2.
+pub trait MifAdapter: Send + Sync {
+    /// Human-readable adapter name.
+    fn name(&self) -> &str;
+
+    /// MIME type or format identifier for this adapter.
+    fn format_id(&self) -> &str;
+
+    /// Sniff the first bytes of data to detect if this adapter can handle it.
+    /// Returns true if the data looks like this format.
+    fn detect(&self, data: &[u8]) -> bool;
+
+    /// Convert external format bytes into a MifDocument.
+    fn to_mif(&self, data: &[u8]) -> Result<MifDocument>;
+
+    /// Convert a MifDocument into the external format bytes.
+    #[allow(clippy::wrong_self_convention)]
+    fn from_mif(&self, doc: &MifDocument) -> Result<Vec<u8>>;
+}
+
+/// Registry of available adapters with auto-detection.
+pub struct AdapterRegistry {
+    adapters: Vec<Box<dyn MifAdapter>>,
+}
+
+impl AdapterRegistry {
+    /// Create a registry with all built-in adapters.
+    pub fn new() -> Self {
+        Self {
+            adapters: vec![
+                Box::new(shodh::ShodhAdapter),
+                Box::new(mem0::Mem0Adapter),
+                Box::new(generic::GenericJsonAdapter),
+                Box::new(markdown::MarkdownAdapter),
+            ],
+        }
+    }
+
+    /// Auto-detect the format and convert to MifDocument.
+    ///
+    /// Tries each adapter's `detect()` in order. The shodh adapter is checked
+    /// first (most specific), then mem0, generic JSON, and finally markdown.
+    pub fn auto_import(&self, data: &[u8]) -> Result<MifDocument> {
+        for adapter in &self.adapters {
+            if adapter.detect(data) {
+                return adapter.to_mif(data);
+            }
+        }
+        anyhow::bail!("No adapter could detect the input format. Supported: shodh (MIF JSON), mem0, generic JSON array, markdown.")
+    }
+
+    /// Import using a specific adapter by format ID.
+    pub fn import_with(&self, format_id: &str, data: &[u8]) -> Result<MifDocument> {
+        for adapter in &self.adapters {
+            if adapter.format_id() == format_id {
+                return adapter.to_mif(data);
+            }
+        }
+        anyhow::bail!(
+            "Unknown format: '{}'. Available: {}",
+            format_id,
+            self.list_formats().join(", ")
+        )
+    }
+
+    /// Export using a specific adapter by format ID.
+    pub fn export_with(&self, format_id: &str, doc: &MifDocument) -> Result<Vec<u8>> {
+        for adapter in &self.adapters {
+            if adapter.format_id() == format_id {
+                return adapter.from_mif(doc);
+            }
+        }
+        anyhow::bail!(
+            "Unknown format: '{}'. Available: {}",
+            format_id,
+            self.list_formats().join(", ")
+        )
+    }
+
+    /// List all available format IDs.
+    pub fn list_formats(&self) -> Vec<&str> {
+        self.adapters.iter().map(|a| a.format_id()).collect()
+    }
+
+    /// List all adapters with their names and format IDs.
+    pub fn list_adapters(&self) -> Vec<(&str, &str)> {
+        self.adapters
+            .iter()
+            .map(|a| (a.name(), a.format_id()))
+            .collect()
+    }
+}
+
+impl Default for AdapterRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/mif/adapters/shodh.rs
+++ b/src/mif/adapters/shodh.rs
@@ -1,0 +1,269 @@
+//! Shodh-native MIF adapter.
+//!
+//! Handles MIF v2 JSON (lossless round-trip) and MIF v1 backward compatibility.
+//! v1 documents have `mif_version: "1.0"` and use `mem_`/`todo_` prefixed IDs.
+//! v2 documents have `mif_version: "2.0"` and use raw UUIDs.
+
+use anyhow::Result;
+use chrono::Utc;
+use std::collections::HashMap;
+
+use super::MifAdapter;
+use crate::mif::schema::*;
+
+pub struct ShodhAdapter;
+
+impl MifAdapter for ShodhAdapter {
+    fn name(&self) -> &str {
+        "Shodh Memory (MIF v2/v1)"
+    }
+
+    fn format_id(&self) -> &str {
+        "shodh"
+    }
+
+    fn detect(&self, data: &[u8]) -> bool {
+        let s = match std::str::from_utf8(data) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        let trimmed = s.trim_start();
+        if !trimmed.starts_with('{') {
+            return false;
+        }
+        // Look for MIF markers: mif_version field or shodh-memory generator
+        trimmed.contains("\"mif_version\"") || trimmed.contains("\"shodh-memory\"")
+    }
+
+    fn to_mif(&self, data: &[u8]) -> Result<MifDocument> {
+        let s = std::str::from_utf8(data)?;
+
+        // Try v2 first (direct deserialization)
+        if let Ok(doc) = serde_json::from_str::<MifDocument>(s) {
+            return Ok(doc);
+        }
+
+        // Try v1 format and convert
+        let v1: serde_json::Value = serde_json::from_str(s)?;
+        convert_v1_to_v2(&v1)
+    }
+
+    fn from_mif(&self, doc: &MifDocument) -> Result<Vec<u8>> {
+        let json = serde_json::to_vec_pretty(doc)?;
+        Ok(json)
+    }
+}
+
+/// Convert MIF v1 JSON to MIF v2 document.
+///
+/// v1 format differences:
+/// - IDs are strings with `mem_`/`todo_` prefixes
+/// - Memory types use PascalCase ("Observation" vs "observation")
+/// - No vendor_extensions section
+/// - Graph uses adjacency list with `entity:name` node IDs
+fn convert_v1_to_v2(v1: &serde_json::Value) -> Result<MifDocument> {
+    let version = v1
+        .get("mif_version")
+        .and_then(|v| v.as_str())
+        .unwrap_or("1.0");
+
+    if !version.starts_with("1.") {
+        anyhow::bail!("Expected MIF v1.x, got: {version}");
+    }
+
+    let mut memories = Vec::new();
+    if let Some(mems) = v1.get("memories").and_then(|v| v.as_array()) {
+        for m in mems {
+            if let Some(mem) = convert_v1_memory(m) {
+                memories.push(mem);
+            }
+        }
+    }
+
+    let mut todos = Vec::new();
+    if let Some(ts) = v1.get("todos").and_then(|v| v.as_array()) {
+        for t in ts {
+            if let Some(todo) = convert_v1_todo(t) {
+                todos.push(todo);
+            }
+        }
+    }
+
+    let now = Utc::now();
+    let export_id = v1
+        .get("export")
+        .and_then(|e| e.get("id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("v1-import")
+        .to_string();
+    let user_id = v1
+        .get("export")
+        .and_then(|e| e.get("user_id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    Ok(MifDocument {
+        mif_version: "2.0".to_string(),
+        generator: MifGenerator {
+            name: "shodh-memory-v1-import".to_string(),
+            version: version.to_string(),
+        },
+        export_meta: MifExportMeta {
+            id: export_id,
+            created_at: now,
+            user_id,
+            checksum: String::new(),
+            privacy: None,
+        },
+        memories,
+        knowledge_graph: None,
+        todos,
+        projects: Vec::new(),
+        reminders: Vec::new(),
+        vendor_extensions: HashMap::new(),
+    })
+}
+
+fn convert_v1_memory(m: &serde_json::Value) -> Option<MifMemory> {
+    let content = m.get("content")?.as_str()?;
+    let id_str = m.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let uuid = strip_prefix_to_uuid(id_str, "mem_");
+
+    let memory_type = m
+        .get("type")
+        .or_else(|| m.get("memory_type"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("observation")
+        .to_lowercase();
+
+    let created_at = m
+        .get("created_at")
+        .and_then(|v| v.as_str())
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&Utc))
+        .unwrap_or_else(Utc::now);
+
+    let entities: Vec<MifEntityRef> = m
+        .get("entities")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|e| {
+                    let text = e.get("text").and_then(|v| v.as_str())?;
+                    let entity_type = e
+                        .get("type")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown")
+                        .to_lowercase();
+                    Some(MifEntityRef {
+                        name: text.to_string(),
+                        entity_type,
+                        confidence: e.get("confidence").and_then(|v| v.as_f64()).unwrap_or(1.0)
+                            as f32,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let tags: Vec<String> = m
+        .get("tags")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Some(MifMemory {
+        id: uuid,
+        content: content.to_string(),
+        memory_type,
+        created_at,
+        tags,
+        entities,
+        metadata: HashMap::new(),
+        embeddings: None,
+        source: None,
+        parent_id: None,
+        related_memory_ids: extract_uuid_list(m, "relations", "related_memories", "mem_"),
+        related_todo_ids: extract_uuid_list(m, "relations", "related_todos", "todo_"),
+        agent_id: None,
+        external_id: None,
+        version: 1,
+    })
+}
+
+fn convert_v1_todo(t: &serde_json::Value) -> Option<MifTodo> {
+    let content = t.get("content")?.as_str()?;
+    let id_str = t.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let uuid = strip_prefix_to_uuid(id_str, "todo_");
+
+    let created_at = t
+        .get("created_at")
+        .and_then(|v| v.as_str())
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&Utc))
+        .unwrap_or_else(Utc::now);
+
+    let updated_at = t
+        .get("updated_at")
+        .and_then(|v| v.as_str())
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&Utc))
+        .unwrap_or(created_at);
+
+    Some(MifTodo {
+        id: uuid,
+        content: content.to_string(),
+        status: t
+            .get("status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("todo")
+            .to_string(),
+        priority: t
+            .get("priority")
+            .and_then(|v| v.as_str())
+            .unwrap_or("medium")
+            .to_string(),
+        created_at,
+        updated_at,
+        due_date: None,
+        completed_at: None,
+        project_id: None,
+        parent_id: None,
+        tags: Vec::new(),
+        contexts: Vec::new(),
+        notes: t.get("notes").and_then(|v| v.as_str()).map(String::from),
+        blocked_on: None,
+        recurrence: None,
+        comments: Vec::new(),
+        related_memory_ids: Vec::new(),
+        external_id: None,
+    })
+}
+
+fn strip_prefix_to_uuid(s: &str, prefix: &str) -> uuid::Uuid {
+    let stripped = s.strip_prefix(prefix).unwrap_or(s);
+    uuid::Uuid::parse_str(stripped).unwrap_or_else(|_| uuid::Uuid::new_v4())
+}
+
+fn extract_uuid_list(
+    val: &serde_json::Value,
+    container_key: &str,
+    array_key: &str,
+    prefix: &str,
+) -> Vec<uuid::Uuid> {
+    val.get(container_key)
+        .and_then(|c| c.get(array_key))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .map(|s| strip_prefix_to_uuid(s, prefix))
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/src/mif/export.rs
+++ b/src/mif/export.rs
@@ -1,0 +1,531 @@
+//! Streaming export from shodh internals to MifDocument.
+//!
+//! Converts internal Memory, Todo, Project, Reminder, and Graph data
+//! into the vendor-neutral MIF v2 schema. Entity types are preserved
+//! by looking up EntityNode labels from the knowledge graph.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::graph_memory::{EntityLabel, GraphMemory, RelationshipEdge};
+use crate::memory::types::{
+    ExperienceType, Memory, ProspectiveTask, ProspectiveTrigger, SourceType, Todo, TodoPriority,
+    TodoStatus,
+};
+use crate::memory::Project;
+
+use super::pii::PiiPatterns;
+use super::schema::*;
+
+/// Options controlling what gets exported.
+#[derive(Debug, Clone)]
+pub struct ExportOptions {
+    pub user_id: String,
+    pub include_embeddings: bool,
+    pub include_graph: bool,
+    pub redact_pii: bool,
+    pub since: Option<DateTime<Utc>>,
+}
+
+/// Build a complete MIF v2 document from shodh internals.
+///
+/// This function takes pre-fetched data (memories, graph, todos, etc.) so the
+/// caller can control locking and streaming. Entity types are resolved from the
+/// graph when available; otherwise fall back to "unknown".
+pub fn build_document(
+    memories: &[std::sync::Arc<Memory>],
+    graph: Option<&GraphMemory>,
+    todos: &[Todo],
+    projects: &[Project],
+    reminders: &[ProspectiveTask],
+    options: &ExportOptions,
+) -> Result<MifDocument> {
+    let pii = if options.redact_pii {
+        Some(PiiPatterns::new())
+    } else {
+        None
+    };
+
+    let mut privacy = MifPrivacy {
+        pii_detected: false,
+        secrets_detected: false,
+        redacted_fields: Vec::new(),
+    };
+
+    // Build entity UUID -> EntityNode lookup from graph for type resolution
+    let entity_map: HashMap<Uuid, Vec<String>> = if let Some(g) = graph {
+        g.get_all_entities()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|e| {
+                let types: Vec<String> = e.labels.iter().map(label_to_string).collect();
+                (e.uuid, types)
+            })
+            .collect()
+    } else {
+        HashMap::new()
+    };
+
+    // Convert memories
+    let mut mif_memories = Vec::with_capacity(memories.len());
+    let mut vendor_memory_meta: HashMap<String, serde_json::Value> = HashMap::new();
+
+    for m in memories {
+        if let Some(ref since) = options.since {
+            if m.created_at < *since {
+                continue;
+            }
+        }
+
+        let (content, _redactions) = if let Some(ref patterns) = pii {
+            let (redacted, records, found) = patterns.redact(&m.experience.content);
+            if found {
+                privacy.pii_detected = true;
+                if patterns.has_secrets(&m.experience.content) {
+                    privacy.secrets_detected = true;
+                }
+                for r in &records {
+                    if !privacy.redacted_fields.contains(&r.redaction_type) {
+                        privacy.redacted_fields.push(r.redaction_type.clone());
+                    }
+                }
+            }
+            (
+                redacted,
+                if records.is_empty() {
+                    None
+                } else {
+                    Some(records)
+                },
+            )
+        } else {
+            (m.experience.content.clone(), None)
+        };
+
+        // Resolve entity types from graph
+        let entities: Vec<MifEntityRef> = m
+            .entity_refs
+            .iter()
+            .map(|eref| {
+                let entity_type = entity_map
+                    .get(&eref.entity_id)
+                    .and_then(|types| types.first().cloned())
+                    .unwrap_or_else(|| "unknown".to_string());
+                MifEntityRef {
+                    name: eref.name.clone(),
+                    entity_type,
+                    confidence: 1.0,
+                }
+            })
+            .collect();
+
+        // Also include experience.entities that didn't make it to entity_refs
+        let ref_names: std::collections::HashSet<&str> =
+            m.entity_refs.iter().map(|r| r.name.as_str()).collect();
+        let mut extra_entities: Vec<MifEntityRef> = m
+            .experience
+            .entities
+            .iter()
+            .filter(|e| !ref_names.contains(e.as_str()))
+            .map(|e| MifEntityRef {
+                name: e.clone(),
+                entity_type: "unknown".to_string(),
+                confidence: 0.8,
+            })
+            .collect();
+
+        let mut all_entities = entities;
+        all_entities.append(&mut extra_entities);
+
+        let embeddings = if options.include_embeddings {
+            m.experience.embeddings.as_ref().map(|v| MifEmbedding {
+                model: "minilm-l6-v2".to_string(),
+                dimensions: v.len(),
+                vector: v.clone(),
+                normalized: true,
+            })
+        } else {
+            None
+        };
+
+        let (source_type, session_id) = m
+            .experience
+            .context
+            .as_ref()
+            .map(|ctx| {
+                let src = source_type_to_string(&ctx.source.source_type);
+                let sess = ctx.episode.episode_id.clone();
+                (src, sess)
+            })
+            .unwrap_or_else(|| ("unknown".to_string(), None));
+
+        let agent_name = m
+            .experience
+            .context
+            .as_ref()
+            .and_then(|ctx| ctx.source.source_id.clone());
+
+        let tags: Vec<String> = m.experience.tags.clone();
+
+        let memory_type = experience_type_to_string(&m.experience.experience_type);
+
+        let related_memory_ids: Vec<Uuid> = m
+            .experience
+            .related_memories
+            .iter()
+            .map(|id| id.0)
+            .collect();
+        let related_todo_ids: Vec<Uuid> = m.related_todo_ids.iter().map(|id| id.0).collect();
+
+        mif_memories.push(MifMemory {
+            id: m.id.0,
+            content,
+            memory_type,
+            created_at: m.created_at,
+            tags,
+            entities: all_entities,
+            metadata: m.experience.metadata.clone(),
+            embeddings,
+            source: Some(MifSource {
+                source_type,
+                session_id,
+                agent: agent_name,
+            }),
+            parent_id: m.parent_id.as_ref().map(|p| p.0),
+            related_memory_ids,
+            related_todo_ids,
+            agent_id: m.agent_id.clone(),
+            external_id: m.external_id.clone(),
+            version: m.version,
+        });
+
+        // Vendor extension: shodh-specific metadata per memory
+        vendor_memory_meta.insert(
+            m.id.0.to_string(),
+            serde_json::json!({
+                "importance": m.importance(),
+                "access_count": m.access_count(),
+                "tier": format!("{:?}", m.tier).to_lowercase(),
+                "activation": m.importance(), // activation approximated by importance
+                "last_accessed": m.last_accessed().to_rfc3339(),
+            }),
+        );
+    }
+
+    // Convert knowledge graph
+    let knowledge_graph = if options.include_graph {
+        if let Some(g) = graph {
+            Some(build_knowledge_graph(g)?)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // Convert todos
+    let mif_todos: Vec<MifTodo> = todos.iter().map(convert_todo).collect();
+
+    // Convert projects
+    let mif_projects: Vec<MifProject> = projects.iter().map(convert_project).collect();
+
+    // Convert reminders
+    let mif_reminders: Vec<MifReminder> = reminders.iter().map(convert_reminder).collect();
+
+    // Build vendor extensions
+    let mut vendor_extensions: HashMap<String, serde_json::Value> = HashMap::new();
+    let mut edge_metadata: HashMap<String, serde_json::Value> = HashMap::new();
+
+    if let Some(g) = graph {
+        for edge in g.get_all_relationships().unwrap_or_default() {
+            edge_metadata.insert(
+                edge.uuid.to_string(),
+                serde_json::json!({
+                    "strength": edge.strength,
+                    "ltp_status": format!("{:?}", edge.ltp_status),
+                    "tier": format!("{:?}", edge.tier),
+                    "activation_count": edge.activation_count,
+                    "last_activated": edge.last_activated.to_rfc3339(),
+                }),
+            );
+        }
+    }
+
+    vendor_extensions.insert(
+        "shodh-memory".to_string(),
+        serde_json::json!({
+            "version": env!("CARGO_PKG_VERSION"),
+            "memory_metadata": vendor_memory_meta,
+            "edge_metadata": edge_metadata,
+        }),
+    );
+
+    // Build checksum
+    let mut hasher = Sha256::new();
+    hasher.update(format!(
+        "{}:{}:{}:{}",
+        mif_memories.len(),
+        mif_todos.len(),
+        mif_projects.len(),
+        mif_reminders.len()
+    ));
+    let checksum = format!("sha256:{}", hex::encode(hasher.finalize()));
+
+    let now = Utc::now();
+    let export_id = Uuid::new_v4().to_string();
+
+    Ok(MifDocument {
+        mif_version: "2.0".to_string(),
+        generator: MifGenerator {
+            name: "shodh-memory".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+        export_meta: MifExportMeta {
+            id: export_id,
+            created_at: now,
+            user_id: options.user_id.clone(),
+            checksum,
+            privacy: Some(privacy),
+        },
+        memories: mif_memories,
+        knowledge_graph,
+        todos: mif_todos,
+        projects: mif_projects,
+        reminders: mif_reminders,
+        vendor_extensions,
+    })
+}
+
+fn build_knowledge_graph(graph: &GraphMemory) -> Result<MifKnowledgeGraph> {
+    let entities = graph
+        .get_all_entities()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|e| MifGraphEntity {
+            id: e.uuid,
+            name: e.name,
+            types: e.labels.iter().map(label_to_string).collect(),
+            attributes: e.attributes,
+            summary: e.summary,
+            created_at: e.created_at,
+            last_seen_at: e.last_seen_at,
+        })
+        .collect();
+
+    let relationships = graph
+        .get_all_relationships()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|e| convert_relationship(&e))
+        .collect();
+
+    Ok(MifKnowledgeGraph {
+        entities,
+        relationships,
+        episodes: Vec::new(), // Episodes exported via entity_ids references
+    })
+}
+
+fn convert_relationship(edge: &RelationshipEdge) -> MifGraphRelationship {
+    let confidence = Some(edge.strength.clamp(0.0, 1.0));
+    MifGraphRelationship {
+        id: edge.uuid,
+        source_entity_id: edge.from_entity,
+        target_entity_id: edge.to_entity,
+        relation_type: relation_type_to_string(&edge.relation_type),
+        context: edge.context.clone(),
+        confidence,
+        created_at: edge.created_at,
+        valid_at: edge.valid_at,
+        invalidated_at: edge.invalidated_at,
+    }
+}
+
+fn convert_todo(t: &Todo) -> MifTodo {
+    let comments: Vec<MifTodoComment> = t
+        .comments
+        .iter()
+        .map(|c| MifTodoComment {
+            id: c.id.0,
+            content: c.content.clone(),
+            comment_type: format!("{:?}", c.comment_type).to_lowercase(),
+            created_at: c.created_at,
+            author: Some(c.author.clone()),
+        })
+        .collect();
+
+    MifTodo {
+        id: t.id.0,
+        content: t.content.clone(),
+        status: todo_status_to_string(&t.status),
+        priority: todo_priority_to_string(&t.priority),
+        created_at: t.created_at,
+        updated_at: t.updated_at,
+        due_date: t.due_date,
+        completed_at: t.completed_at,
+        project_id: t.project_id.as_ref().map(|p| p.0),
+        parent_id: t.parent_id.as_ref().map(|p| p.0),
+        tags: t.tags.clone(),
+        contexts: t.contexts.clone(),
+        notes: t.notes.clone(),
+        blocked_on: t.blocked_on.clone(),
+        recurrence: t
+            .recurrence
+            .as_ref()
+            .map(|r| format!("{r:?}").to_lowercase()),
+        comments,
+        related_memory_ids: t.related_memory_ids.iter().map(|id| id.0).collect(),
+        external_id: t.external_id.clone(),
+    }
+}
+
+fn convert_project(p: &Project) -> MifProject {
+    MifProject {
+        id: p.id.0,
+        name: p.name.clone(),
+        prefix: p.prefix.clone().unwrap_or_default(),
+        description: p.description.clone(),
+        status: format!("{:?}", p.status).to_lowercase(),
+        created_at: p.created_at,
+        color: p.color.clone(),
+        icon: None,
+    }
+}
+
+fn convert_reminder(r: &ProspectiveTask) -> MifReminder {
+    let trigger = match &r.trigger {
+        ProspectiveTrigger::AtTime { at } => MifTrigger::Time { at: *at },
+        ProspectiveTrigger::AfterDuration { seconds, from } => MifTrigger::Duration {
+            seconds: *seconds,
+            from: *from,
+        },
+        ProspectiveTrigger::OnContext {
+            keywords,
+            threshold,
+        } => MifTrigger::Context {
+            keywords: keywords.clone(),
+            threshold: *threshold,
+        },
+    };
+
+    MifReminder {
+        id: r.id.0,
+        content: r.content.clone(),
+        trigger,
+        status: format!("{:?}", r.status).to_lowercase(),
+        priority: r.priority,
+        tags: r.tags.clone(),
+        created_at: r.created_at,
+        triggered_at: r.triggered_at,
+        dismissed_at: r.dismissed_at,
+    }
+}
+
+// =============================================================================
+// STRING CONVERSION HELPERS
+// =============================================================================
+
+fn label_to_string(label: &EntityLabel) -> String {
+    match label {
+        EntityLabel::Person => "person".to_string(),
+        EntityLabel::Organization => "organization".to_string(),
+        EntityLabel::Location => "location".to_string(),
+        EntityLabel::Technology => "technology".to_string(),
+        EntityLabel::Concept => "concept".to_string(),
+        EntityLabel::Event => "event".to_string(),
+        EntityLabel::Date => "date".to_string(),
+        EntityLabel::Product => "product".to_string(),
+        EntityLabel::Skill => "skill".to_string(),
+        EntityLabel::Keyword => "keyword".to_string(),
+        EntityLabel::Other(s) => s.to_lowercase(),
+    }
+}
+
+pub(crate) fn experience_type_to_string(t: &ExperienceType) -> String {
+    match t {
+        ExperienceType::Observation => "observation",
+        ExperienceType::Decision => "decision",
+        ExperienceType::Learning => "learning",
+        ExperienceType::Error => "error",
+        ExperienceType::Discovery => "discovery",
+        ExperienceType::Pattern => "pattern",
+        ExperienceType::Context => "context",
+        ExperienceType::Task => "task",
+        ExperienceType::CodeEdit => "code_edit",
+        ExperienceType::FileAccess => "file_access",
+        ExperienceType::Search => "search",
+        ExperienceType::Command => "command",
+        ExperienceType::Conversation => "conversation",
+        ExperienceType::Intention => "intention",
+    }
+    .to_string()
+}
+
+fn source_type_to_string(s: &SourceType) -> String {
+    match s {
+        SourceType::User => "user",
+        SourceType::System => "system",
+        SourceType::ExternalApi => "api",
+        SourceType::File => "file",
+        SourceType::Web => "web",
+        SourceType::AiGenerated => "ai_generated",
+        SourceType::Inferred => "inferred",
+        SourceType::Unknown => "unknown",
+    }
+    .to_string()
+}
+
+fn relation_type_to_string(r: &crate::graph_memory::RelationType) -> String {
+    use crate::graph_memory::RelationType;
+    match r {
+        RelationType::WorksWith => "works_with",
+        RelationType::WorksAt => "works_at",
+        RelationType::EmployedBy => "employed_by",
+        RelationType::PartOf => "part_of",
+        RelationType::Contains => "contains",
+        RelationType::OwnedBy => "owned_by",
+        RelationType::LocatedIn => "located_in",
+        RelationType::LocatedAt => "located_at",
+        RelationType::Uses => "uses",
+        RelationType::CreatedBy => "created_by",
+        RelationType::DevelopedBy => "developed_by",
+        RelationType::Causes => "causes",
+        RelationType::ResultsIn => "results_in",
+        RelationType::Learned => "learned",
+        RelationType::Knows => "knows",
+        RelationType::Teaches => "teaches",
+        RelationType::RelatedTo => "related_to",
+        RelationType::AssociatedWith => "associated_with",
+        RelationType::CoRetrieved => "co_retrieved",
+        RelationType::CoOccurs => "co_occurs",
+        RelationType::Custom(s) => return s.to_lowercase(),
+    }
+    .to_string()
+}
+
+fn todo_status_to_string(s: &TodoStatus) -> String {
+    match s {
+        TodoStatus::Backlog => "backlog",
+        TodoStatus::Todo => "todo",
+        TodoStatus::InProgress => "in_progress",
+        TodoStatus::Blocked => "blocked",
+        TodoStatus::Done => "done",
+        TodoStatus::Cancelled => "cancelled",
+    }
+    .to_string()
+}
+
+fn todo_priority_to_string(p: &TodoPriority) -> String {
+    match p {
+        TodoPriority::Urgent => "urgent",
+        TodoPriority::High => "high",
+        TodoPriority::Medium => "medium",
+        TodoPriority::Low => "low",
+        TodoPriority::None => "none",
+    }
+    .to_string()
+}

--- a/src/mif/import.rs
+++ b/src/mif/import.rs
@@ -1,0 +1,499 @@
+//! Reference-preserving import from MifDocument to shodh internals.
+//!
+//! Key improvements over v1:
+//! - UUID preservation: memories keep their original IDs via `remember_with_id()`
+//! - Content-hash dedup: O(1) duplicate check via SHA256 HashSet (replaces O(n*k) recall)
+//! - Reference mapping: remaps parent_id, related_ids when collisions occur
+//! - Graph reconstruction: entities and edges restored with proper types
+
+use std::collections::{HashMap, HashSet};
+
+use crate::graph_memory::{
+    EdgeTier, EntityLabel, EntityNode, GraphMemory, LtpStatus, RelationType, RelationshipEdge,
+};
+use crate::memory::types::{
+    Experience, ExperienceType, MemoryId, ProspectiveTask, ProspectiveTaskId,
+    ProspectiveTaskStatus, ProspectiveTrigger, Todo, TodoId, TodoPriority, TodoStatus,
+};
+use crate::memory::{Project, ProjectId, ProjectStatus};
+use anyhow::{bail, Result};
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+
+use super::schema::*;
+
+/// Options controlling import behavior.
+#[derive(Debug, Clone)]
+pub struct ImportOptions {
+    pub user_id: String,
+    pub skip_duplicates: bool,
+}
+
+/// Result of an import operation.
+#[derive(Debug, Default, serde::Serialize)]
+pub struct ImportResult {
+    pub memories_imported: usize,
+    pub todos_imported: usize,
+    pub projects_imported: usize,
+    pub reminders_imported: usize,
+    pub edges_imported: usize,
+    pub entities_imported: usize,
+    pub duplicates_skipped: usize,
+    pub errors: Vec<String>,
+}
+
+/// Build a content-hash set from existing memories for O(1) dedup.
+pub fn build_dedup_set(existing_contents: &[String]) -> HashSet<[u8; 32]> {
+    existing_contents.iter().map(|c| content_hash(c)).collect()
+}
+
+fn content_hash(content: &str) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    hasher.finalize().into()
+}
+
+/// Convert MIF memories into Experience structs ready for `remember_with_id()`.
+///
+/// A prepared memory ready for import: (id, experience, optional creation timestamp).
+pub type PreparedMemory = (MemoryId, Experience, Option<DateTime<Utc>>);
+
+/// Returns a vec of prepared memories plus the count of skipped duplicates.
+/// The caller is responsible for actually storing them.
+pub fn prepare_memories(
+    doc: &MifDocument,
+    dedup_set: &HashSet<[u8; 32]>,
+    options: &ImportOptions,
+) -> (Vec<PreparedMemory>, usize) {
+    let mut prepared = Vec::new();
+    let mut skipped = 0;
+
+    for mem in &doc.memories {
+        // Dedup check
+        if options.skip_duplicates && dedup_set.contains(&content_hash(&mem.content)) {
+            skipped += 1;
+            continue;
+        }
+
+        let exp_type = parse_experience_type(&mem.memory_type);
+
+        let mut metadata = mem.metadata.clone();
+        if !mem.tags.is_empty() && !metadata.contains_key("tags") {
+            metadata.insert("tags".to_string(), mem.tags.join(","));
+        }
+
+        let entities: Vec<String> = mem.entities.iter().map(|e| e.name.clone()).collect();
+
+        let embeddings = mem.embeddings.as_ref().map(|e| e.vector.clone());
+
+        let experience = Experience {
+            experience_type: exp_type,
+            content: mem.content.clone(),
+            entities,
+            metadata,
+            embeddings,
+            tags: mem.tags.clone(),
+            ..Default::default()
+        };
+
+        let memory_id = MemoryId(mem.id);
+        let created_at = Some(mem.created_at);
+
+        prepared.push((memory_id, experience, created_at));
+    }
+
+    (prepared, skipped)
+}
+
+/// Convert MIF todos into internal Todo structs.
+///
+/// Returns todos ready for `store_todo()`. Project IDs are preserved if present.
+pub fn prepare_todos(doc: &MifDocument, user_id: &str) -> Vec<Todo> {
+    doc.todos
+        .iter()
+        .map(|t| {
+            let status = parse_todo_status(&t.status);
+            let priority = parse_todo_priority(&t.priority);
+
+            let comments = t
+                .comments
+                .iter()
+                .map(|c| crate::memory::types::TodoComment {
+                    id: crate::memory::types::TodoCommentId(c.id),
+                    todo_id: TodoId(t.id),
+                    author: c.author.clone().unwrap_or_else(|| "import".to_string()),
+                    content: c.content.clone(),
+                    comment_type: parse_comment_type(&c.comment_type),
+                    created_at: c.created_at,
+                    updated_at: None,
+                })
+                .collect();
+
+            let related_memory_ids: Vec<MemoryId> = t
+                .related_memory_ids
+                .iter()
+                .map(|id| MemoryId(*id))
+                .collect();
+
+            Todo {
+                id: TodoId(t.id),
+                seq_num: 0,
+                project_prefix: None,
+                project: None,
+                user_id: user_id.to_string(),
+                content: t.content.clone(),
+                status,
+                priority,
+                project_id: t.project_id.map(ProjectId),
+                parent_id: t.parent_id.map(TodoId),
+                contexts: t.contexts.clone(),
+                tags: t.tags.clone(),
+                notes: t.notes.clone(),
+                blocked_on: t.blocked_on.clone(),
+                recurrence: None,
+                created_at: t.created_at,
+                updated_at: t.updated_at,
+                due_date: t.due_date,
+                completed_at: t.completed_at,
+                sort_order: 0,
+                comments,
+                embedding: None,
+                related_memory_ids,
+                external_id: t.external_id.clone(),
+            }
+        })
+        .collect()
+}
+
+/// Convert MIF projects into internal Project structs.
+pub fn prepare_projects(doc: &MifDocument, user_id: &str) -> Vec<Project> {
+    doc.projects
+        .iter()
+        .map(|p| Project {
+            id: ProjectId(p.id),
+            user_id: user_id.to_string(),
+            name: p.name.clone(),
+            prefix: if p.prefix.is_empty() {
+                None
+            } else {
+                Some(p.prefix.clone())
+            },
+            description: p.description.clone(),
+            status: parse_project_status(&p.status),
+            color: p.color.clone(),
+            parent_id: None,
+            created_at: p.created_at,
+            completed_at: None,
+            codebase_path: None,
+            codebase_indexed: false,
+            codebase_indexed_at: None,
+            codebase_file_count: 0,
+            embedding: None,
+            related_memory_ids: Vec::new(),
+            todo_counts: Default::default(),
+        })
+        .collect()
+}
+
+/// Convert MIF reminders into internal ProspectiveTask structs.
+pub fn prepare_reminders(doc: &MifDocument, user_id: &str) -> Vec<ProspectiveTask> {
+    doc.reminders
+        .iter()
+        .map(|r| {
+            let trigger = match &r.trigger {
+                MifTrigger::Time { at } => ProspectiveTrigger::AtTime { at: *at },
+                MifTrigger::Duration { seconds, from } => ProspectiveTrigger::AfterDuration {
+                    seconds: *seconds,
+                    from: *from,
+                },
+                MifTrigger::Context {
+                    keywords,
+                    threshold,
+                } => ProspectiveTrigger::OnContext {
+                    keywords: keywords.clone(),
+                    threshold: *threshold,
+                },
+            };
+
+            let status = parse_reminder_status(&r.status);
+
+            ProspectiveTask {
+                id: ProspectiveTaskId(r.id),
+                user_id: user_id.to_string(),
+                content: r.content.clone(),
+                trigger,
+                status,
+                created_at: r.created_at,
+                triggered_at: r.triggered_at,
+                dismissed_at: r.dismissed_at,
+                tags: r.tags.clone(),
+                priority: r.priority,
+                embedding: None,
+                related_memory_ids: Vec::new(),
+            }
+        })
+        .collect()
+}
+
+/// Import graph entities from MIF document.
+///
+/// Returns the count of entities imported and any errors.
+pub fn import_graph_entities(kg: &MifKnowledgeGraph, graph: &GraphMemory) -> (usize, Vec<String>) {
+    let mut imported = 0;
+    let mut errors = Vec::new();
+
+    for entity in &kg.entities {
+        let labels: Vec<EntityLabel> = entity.types.iter().map(|t| parse_entity_label(t)).collect();
+
+        let node = EntityNode {
+            uuid: entity.id,
+            name: entity.name.clone(),
+            labels: if labels.is_empty() {
+                vec![EntityLabel::Concept]
+            } else {
+                labels
+            },
+            created_at: entity.created_at,
+            last_seen_at: entity.last_seen_at,
+            mention_count: 1,
+            summary: entity.summary.clone(),
+            attributes: entity.attributes.clone(),
+            name_embedding: None,
+            salience: 0.5,
+            is_proper_noun: true,
+        };
+
+        match graph.add_entity(node) {
+            Ok(_) => imported += 1,
+            Err(e) => errors.push(format!("Entity '{}': {}", entity.name, e)),
+        }
+    }
+
+    (imported, errors)
+}
+
+/// Import graph relationships from MIF document.
+///
+/// Returns the count of edges imported and any errors.
+pub fn import_graph_relationships(
+    kg: &MifKnowledgeGraph,
+    graph: &GraphMemory,
+    vendor_extensions: &HashMap<String, serde_json::Value>,
+) -> (usize, Vec<String>) {
+    let mut imported = 0;
+    let mut errors = Vec::new();
+
+    // Extract shodh edge metadata if available for restoring strength/LTP
+    let edge_meta = vendor_extensions
+        .get("shodh-memory")
+        .and_then(|v| v.get("edge_metadata"))
+        .and_then(|v| v.as_object());
+
+    for rel in &kg.relationships {
+        let relation_type = parse_relation_type(&rel.relation_type);
+        let strength = rel.confidence.unwrap_or(0.5);
+
+        // Restore shodh-specific metadata from vendor extensions
+        let (ltp_status, tier, activation_count) = if let Some(meta) = edge_meta {
+            if let Some(em) = meta.get(&rel.id.to_string()) {
+                let ltp = em
+                    .get("ltp_status")
+                    .and_then(|v| v.as_str())
+                    .map(parse_ltp_status)
+                    .unwrap_or_default();
+                let tier = em
+                    .get("tier")
+                    .and_then(|v| v.as_str())
+                    .map(parse_edge_tier)
+                    .unwrap_or_default();
+                let count = em
+                    .get("activation_count")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(1) as u32;
+                (ltp, tier, count)
+            } else {
+                (LtpStatus::None, EdgeTier::L1Working, 1)
+            }
+        } else {
+            (LtpStatus::None, EdgeTier::L1Working, 1)
+        };
+
+        let edge = RelationshipEdge {
+            uuid: rel.id,
+            from_entity: rel.source_entity_id,
+            to_entity: rel.target_entity_id,
+            relation_type,
+            strength,
+            created_at: rel.created_at,
+            valid_at: rel.valid_at,
+            invalidated_at: rel.invalidated_at,
+            source_episode_id: None,
+            context: rel.context.clone(),
+            last_activated: rel.created_at,
+            activation_count,
+            ltp_status,
+            tier,
+            activation_timestamps: None,
+            entity_confidence: rel.confidence,
+        };
+
+        match graph.add_relationship(edge) {
+            Ok(_) => imported += 1,
+            Err(e) => errors.push(format!("Edge {}: {}", rel.id, e)),
+        }
+    }
+
+    (imported, errors)
+}
+
+/// Validate MIF document version.
+pub fn validate_version(doc: &MifDocument) -> Result<()> {
+    if !doc.mif_version.starts_with("2.") && !doc.mif_version.starts_with("1.") {
+        bail!(
+            "Unsupported MIF version: {}. Supported: 1.x, 2.x",
+            doc.mif_version
+        );
+    }
+    Ok(())
+}
+
+// =============================================================================
+// STRING → ENUM PARSERS
+// =============================================================================
+
+pub(crate) fn parse_experience_type(s: &str) -> ExperienceType {
+    match s.to_lowercase().as_str() {
+        "observation" => ExperienceType::Observation,
+        "decision" => ExperienceType::Decision,
+        "learning" => ExperienceType::Learning,
+        "error" => ExperienceType::Error,
+        "discovery" => ExperienceType::Discovery,
+        "pattern" => ExperienceType::Pattern,
+        "context" => ExperienceType::Context,
+        "task" => ExperienceType::Task,
+        "code_edit" | "codeedit" => ExperienceType::CodeEdit,
+        "file_access" | "fileaccess" => ExperienceType::FileAccess,
+        "search" => ExperienceType::Search,
+        "command" => ExperienceType::Command,
+        "conversation" => ExperienceType::Conversation,
+        "intention" => ExperienceType::Intention,
+        _ => ExperienceType::Observation,
+    }
+}
+
+fn parse_todo_status(s: &str) -> TodoStatus {
+    match s {
+        "backlog" => TodoStatus::Backlog,
+        "todo" => TodoStatus::Todo,
+        "in_progress" => TodoStatus::InProgress,
+        "blocked" => TodoStatus::Blocked,
+        "done" => TodoStatus::Done,
+        "cancelled" => TodoStatus::Cancelled,
+        _ => TodoStatus::Todo,
+    }
+}
+
+fn parse_todo_priority(s: &str) -> TodoPriority {
+    match s {
+        "urgent" | "!!!" => TodoPriority::Urgent,
+        "high" | "!!" => TodoPriority::High,
+        "medium" | "!" => TodoPriority::Medium,
+        "low" => TodoPriority::Low,
+        "none" | "" => TodoPriority::None,
+        _ => TodoPriority::Medium,
+    }
+}
+
+fn parse_comment_type(s: &str) -> crate::memory::types::TodoCommentType {
+    use crate::memory::types::TodoCommentType;
+    match s {
+        "comment" => TodoCommentType::Comment,
+        "progress" => TodoCommentType::Progress,
+        "resolution" => TodoCommentType::Resolution,
+        "activity" => TodoCommentType::Activity,
+        _ => TodoCommentType::Comment,
+    }
+}
+
+fn parse_project_status(s: &str) -> ProjectStatus {
+    match s {
+        "active" => ProjectStatus::Active,
+        "onhold" | "on_hold" => ProjectStatus::OnHold,
+        "completed" => ProjectStatus::Completed,
+        "archived" => ProjectStatus::Archived,
+        _ => ProjectStatus::Active,
+    }
+}
+
+fn parse_reminder_status(s: &str) -> ProspectiveTaskStatus {
+    match s {
+        "pending" => ProspectiveTaskStatus::Pending,
+        "triggered" => ProspectiveTaskStatus::Triggered,
+        "dismissed" => ProspectiveTaskStatus::Dismissed,
+        "expired" => ProspectiveTaskStatus::Expired,
+        _ => ProspectiveTaskStatus::Pending,
+    }
+}
+
+fn parse_entity_label(s: &str) -> EntityLabel {
+    match s.to_lowercase().as_str() {
+        "person" => EntityLabel::Person,
+        "organization" => EntityLabel::Organization,
+        "location" => EntityLabel::Location,
+        "technology" => EntityLabel::Technology,
+        "concept" => EntityLabel::Concept,
+        "event" => EntityLabel::Event,
+        "date" => EntityLabel::Date,
+        "product" => EntityLabel::Product,
+        "skill" => EntityLabel::Skill,
+        "keyword" => EntityLabel::Keyword,
+        other => EntityLabel::Other(other.to_string()),
+    }
+}
+
+pub(crate) fn parse_relation_type(s: &str) -> RelationType {
+    match s {
+        "works_with" | "workswith" => RelationType::WorksWith,
+        "works_at" | "worksat" => RelationType::WorksAt,
+        "employed_by" | "employedby" => RelationType::EmployedBy,
+        "part_of" | "partof" => RelationType::PartOf,
+        "contains" => RelationType::Contains,
+        "owned_by" | "ownedby" => RelationType::OwnedBy,
+        "located_in" | "locatedin" => RelationType::LocatedIn,
+        "located_at" | "locatedat" => RelationType::LocatedAt,
+        "uses" => RelationType::Uses,
+        "created_by" | "createdby" => RelationType::CreatedBy,
+        "developed_by" | "developedby" => RelationType::DevelopedBy,
+        "causes" => RelationType::Causes,
+        "results_in" | "resultsin" => RelationType::ResultsIn,
+        "learned" => RelationType::Learned,
+        "knows" => RelationType::Knows,
+        "teaches" => RelationType::Teaches,
+        "related_to" | "relatedto" => RelationType::RelatedTo,
+        "associated_with" | "associatedwith" => RelationType::AssociatedWith,
+        "co_retrieved" | "coretrieved" => RelationType::CoRetrieved,
+        "co_occurs" | "cooccurs" => RelationType::CoOccurs,
+        other => RelationType::Custom(other.to_string()),
+    }
+}
+
+fn parse_ltp_status(s: &str) -> LtpStatus {
+    match s {
+        "None" => LtpStatus::None,
+        "Weekly" => LtpStatus::Weekly,
+        "Full" => LtpStatus::Full,
+        s if s.starts_with("Burst") => LtpStatus::Burst {
+            detected_at: Utc::now(),
+        },
+        _ => LtpStatus::None,
+    }
+}
+
+fn parse_edge_tier(s: &str) -> EdgeTier {
+    match s {
+        "L1Working" => EdgeTier::L1Working,
+        "L2Episodic" => EdgeTier::L2Episodic,
+        "L3Semantic" => EdgeTier::L3Semantic,
+        _ => EdgeTier::L1Working,
+    }
+}

--- a/src/mif/mod.rs
+++ b/src/mif/mod.rs
@@ -1,0 +1,19 @@
+//! Memory Interchange Format (MIF) v2
+//!
+//! Vendor-neutral schema for exporting, importing, and converting memory data
+//! across different AI memory systems (shodh-memory, mem0, generic JSON, markdown).
+//!
+//! Architecture:
+//! - `schema` — MIF v2 types (vendor-neutral core + vendor extensions)
+//! - `export` — streaming export from shodh internals → MifDocument
+//! - `import` — reference-preserving import from MifDocument → shodh internals
+//! - `pii` — PII detection and redaction
+//! - `adapters` — format converters (shodh JSON, mem0, generic, markdown)
+
+pub mod adapters;
+pub mod export;
+pub mod import;
+pub mod pii;
+pub mod schema;
+
+pub use schema::MifDocument;

--- a/src/mif/pii.rs
+++ b/src/mif/pii.rs
@@ -1,0 +1,69 @@
+//! PII detection and redaction for MIF exports.
+
+use crate::mif::schema::MifRedaction;
+
+/// Compiled PII patterns for detection.
+pub struct PiiPatterns {
+    email: regex::Regex,
+    phone: regex::Regex,
+    ssn: regex::Regex,
+    api_key: regex::Regex,
+    credit_card: regex::Regex,
+}
+
+impl Default for PiiPatterns {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PiiPatterns {
+    pub fn new() -> Self {
+        Self {
+            email: regex::Regex::new(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}").unwrap(),
+            phone: regex::Regex::new(r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b").unwrap(),
+            ssn: regex::Regex::new(r"\b\d{3}-\d{2}-\d{4}\b").unwrap(),
+            api_key: regex::Regex::new(
+                r#"(?i)(api[_-]?key|secret|token|password)\s*[:=]\s*['"]?[\w-]{16,}['"]?"#,
+            )
+            .unwrap(),
+            credit_card: regex::Regex::new(r"\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b").unwrap(),
+        }
+    }
+
+    /// Detect and redact PII from content.
+    ///
+    /// Returns `(redacted_content, redaction_records, pii_found)`.
+    pub fn redact(&self, content: &str) -> (String, Vec<MifRedaction>, bool) {
+        let mut redacted = content.to_string();
+        let mut redactions = Vec::new();
+        let mut pii_found = false;
+
+        let patterns: &[(&regex::Regex, &str, &str)] = &[
+            (&self.email, "email", "[REDACTED:email]"),
+            (&self.phone, "phone", "[REDACTED:phone]"),
+            (&self.ssn, "ssn", "[REDACTED:ssn]"),
+            (&self.api_key, "api_key", "[REDACTED:api_key]"),
+            (&self.credit_card, "credit_card", "[REDACTED:credit_card]"),
+        ];
+
+        for (regex, kind, replacement) in patterns {
+            for m in regex.find_iter(content) {
+                pii_found = true;
+                redactions.push(MifRedaction {
+                    redaction_type: kind.to_string(),
+                    original_length: m.as_str().len(),
+                    position: (m.start(), m.end()),
+                });
+            }
+            redacted = regex.replace_all(&redacted, *replacement).to_string();
+        }
+
+        (redacted, redactions, pii_found)
+    }
+
+    /// Check if content contains any secrets (API keys, tokens, passwords).
+    pub fn has_secrets(&self, content: &str) -> bool {
+        self.api_key.is_match(content)
+    }
+}

--- a/src/mif/schema.rs
+++ b/src/mif/schema.rs
@@ -1,0 +1,358 @@
+//! MIF v2 Schema — vendor-neutral types for memory interchange.
+//!
+//! Design principles:
+//! 1. Core layer is universal: content, timestamps, types, tags, metadata.
+//! 2. Knowledge graph uses property graph model (nodes + edges with properties).
+//! 3. UUIDs preserved across round-trips for lossless import/export.
+//! 4. Vendor extensions section for system-specific metadata (Hebbian state, decay, LTP).
+//! 5. All string enums use lowercase snake_case for cross-system compatibility.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+// =============================================================================
+// TOP-LEVEL DOCUMENT
+// =============================================================================
+
+/// MIF v2 document — the top-level interchange container.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifDocument {
+    pub mif_version: String,
+    pub generator: MifGenerator,
+    pub export_meta: MifExportMeta,
+    #[serde(default)]
+    pub memories: Vec<MifMemory>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub knowledge_graph: Option<MifKnowledgeGraph>,
+    #[serde(default)]
+    pub todos: Vec<MifTodo>,
+    #[serde(default)]
+    pub projects: Vec<MifProject>,
+    #[serde(default)]
+    pub reminders: Vec<MifReminder>,
+    /// Vendor-specific metadata. Key = vendor name (e.g., "shodh-memory").
+    /// Allows lossless round-trip of system-specific data without polluting the core schema.
+    #[serde(default)]
+    pub vendor_extensions: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifGenerator {
+    pub name: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifExportMeta {
+    pub id: String,
+    pub created_at: DateTime<Utc>,
+    pub user_id: String,
+    pub checksum: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub privacy: Option<MifPrivacy>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifPrivacy {
+    pub pii_detected: bool,
+    pub secrets_detected: bool,
+    #[serde(default)]
+    pub redacted_fields: Vec<String>,
+}
+
+// =============================================================================
+// MEMORIES
+// =============================================================================
+
+/// A single memory in vendor-neutral form.
+///
+/// All IDs are raw UUIDs — no `mem_` or `todo_` prefixes.
+/// Entity types are preserved (not "UNKNOWN").
+/// Embeddings are model-tagged for cross-system portability.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifMemory {
+    pub id: Uuid,
+    pub content: String,
+    /// Lowercase type string: "observation", "decision", "learning", "error",
+    /// "discovery", "pattern", "context", "task", "code_edit", "file_access",
+    /// "search", "command", "conversation", "intention".
+    pub memory_type: String,
+    pub created_at: DateTime<Utc>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub entities: Vec<MifEntityRef>,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embeddings: Option<MifEmbedding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<MifSource>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    #[serde(default)]
+    pub related_memory_ids: Vec<Uuid>,
+    #[serde(default)]
+    pub related_todo_ids: Vec<Uuid>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_id: Option<String>,
+    #[serde(default = "default_version")]
+    pub version: u32,
+}
+
+fn default_version() -> u32 {
+    1
+}
+
+/// An entity mentioned in a memory, with its type preserved.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifEntityRef {
+    pub name: String,
+    /// Lowercase entity type: "person", "organization", "location", "technology",
+    /// "concept", "event", "date", "product", "skill", "keyword", "unknown".
+    #[serde(default = "default_entity_type")]
+    pub entity_type: String,
+    #[serde(default = "default_confidence")]
+    pub confidence: f32,
+}
+
+fn default_entity_type() -> String {
+    "unknown".to_string()
+}
+
+fn default_confidence() -> f32 {
+    1.0
+}
+
+/// Model-tagged embedding vector for cross-system portability.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifEmbedding {
+    pub model: String,
+    pub dimensions: usize,
+    pub vector: Vec<f32>,
+    #[serde(default = "default_true")]
+    pub normalized: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MifSource {
+    #[serde(default)]
+    pub source_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+}
+
+// =============================================================================
+// KNOWLEDGE GRAPH
+// =============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifKnowledgeGraph {
+    #[serde(default)]
+    pub entities: Vec<MifGraphEntity>,
+    #[serde(default)]
+    pub relationships: Vec<MifGraphRelationship>,
+    #[serde(default)]
+    pub episodes: Vec<MifGraphEpisode>,
+}
+
+/// A node in the knowledge graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifGraphEntity {
+    pub id: Uuid,
+    pub name: String,
+    /// Lowercase type strings: ["person"], ["technology", "concept"], etc.
+    #[serde(default)]
+    pub types: Vec<String>,
+    #[serde(default)]
+    pub attributes: HashMap<String, String>,
+    #[serde(default)]
+    pub summary: String,
+    pub created_at: DateTime<Utc>,
+    pub last_seen_at: DateTime<Utc>,
+}
+
+/// An edge in the knowledge graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifGraphRelationship {
+    pub id: Uuid,
+    pub source_entity_id: Uuid,
+    pub target_entity_id: Uuid,
+    /// Lowercase snake_case: "works_with", "part_of", "located_in", "causes", etc.
+    pub relation_type: String,
+    #[serde(default)]
+    pub context: String,
+    /// Normalized confidence/strength (0.0–1.0). Vendor-neutral.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f32>,
+    pub created_at: DateTime<Utc>,
+    pub valid_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invalidated_at: Option<DateTime<Utc>>,
+}
+
+/// An episodic node — a temporal grouping of entities.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifGraphEpisode {
+    pub id: Uuid,
+    pub name: String,
+    #[serde(default)]
+    pub content: String,
+    #[serde(default)]
+    pub entity_ids: Vec<Uuid>,
+    #[serde(default)]
+    pub source: String,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+    pub created_at: DateTime<Utc>,
+}
+
+// =============================================================================
+// TODOS
+// =============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifTodo {
+    pub id: Uuid,
+    pub content: String,
+    /// "backlog", "todo", "in_progress", "blocked", "done", "cancelled"
+    pub status: String,
+    /// "urgent", "high", "medium", "low", "none"
+    pub priority: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub due_date: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<Uuid>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub contexts: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blocked_on: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recurrence: Option<String>,
+    #[serde(default)]
+    pub comments: Vec<MifTodoComment>,
+    #[serde(default)]
+    pub related_memory_ids: Vec<Uuid>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifTodoComment {
+    pub id: Uuid,
+    pub content: String,
+    /// "comment", "progress", "resolution", "activity"
+    #[serde(default = "default_comment_type")]
+    pub comment_type: String,
+    pub created_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+}
+
+fn default_comment_type() -> String {
+    "comment".to_string()
+}
+
+// =============================================================================
+// PROJECTS
+// =============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifProject {
+    pub id: Uuid,
+    pub name: String,
+    #[serde(default)]
+    pub prefix: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// "active", "archived", "completed"
+    #[serde(default = "default_project_status")]
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+}
+
+fn default_project_status() -> String {
+    "active".to_string()
+}
+
+// =============================================================================
+// REMINDERS
+// =============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifReminder {
+    pub id: Uuid,
+    pub content: String,
+    pub trigger: MifTrigger,
+    /// "pending", "triggered", "dismissed", "expired"
+    pub status: String,
+    #[serde(default = "default_priority")]
+    pub priority: u8,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub triggered_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dismissed_at: Option<DateTime<Utc>>,
+}
+
+fn default_priority() -> u8 {
+    3
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MifTrigger {
+    Time {
+        at: DateTime<Utc>,
+    },
+    Duration {
+        seconds: u64,
+        from: DateTime<Utc>,
+    },
+    Context {
+        keywords: Vec<String>,
+        #[serde(default = "default_threshold")]
+        threshold: f32,
+    },
+}
+
+fn default_threshold() -> f32 {
+    0.65
+}
+
+// =============================================================================
+// PII REDACTION RECORD
+// =============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MifRedaction {
+    pub redaction_type: String,
+    pub original_length: usize,
+    pub position: (usize, usize),
+}


### PR DESCRIPTION
## Summary

Redesigns the Memory Interchange Format (MIF) as a vendor-neutral standard with pluggable adapters, fixing all known issues with the v1 implementation.

### What was broken (v1)
- Entity types exported as **"UNKNOWN"** — graph lookup was missing
- Import **destroyed UUIDs** — generated new IDs, breaking all references
- **O(n*k) dedup** — recalled all memories per import candidate
- Merge strategies were **no-ops** — silently ignored
- Encryption was **dead code** — unused stubs bloating the module
- Export **bulk-loaded all memories** — OOM risk on large stores
- `handlers/mif.rs` was **1688 lines** with search handlers mixed in

### What's fixed (v2)

**New module: `src/mif/`**
- `schema.rs` — Vendor-neutral types: MifDocument, MifMemory, MifKnowledgeGraph, MifTodo, MifProject, MifReminder with vendor extensions
- `export.rs` — Streaming export with entity type resolution from GraphMemory, per-memory vendor extensions, PII redaction
- `import.rs` — UUID-preserving import via `remember_with_id()`, O(1) SHA256 content-hash dedup, graph reconstruction
- `pii.rs` — PII detection/redaction (email, phone, SSN, API key, credit card)

**Adapter pattern: `src/mif/adapters/`**
- `MifAdapter` trait with `detect()`, `to_mif()`, `from_mif()` 
- `shodh.rs` — MIF v2 JSON (lossless round-trip) + v1 backward compat
- `mem0.rs` — mem0 format: `[{memory, metadata, ...}]`
- `generic.rs` — Generic JSON array: `[{content, timestamp, tags, ...}]`
- `markdown.rs` — Markdown with YAML frontmatter (Letta/Obsidian style)
- `AdapterRegistry` with auto-detection (most specific → generic fallback)

**Handler cleanup**
- `handlers/mif.rs` rewritten: 1688 → ~300 lines (thin HTTP layer)
- Multimodal/robotics search moved to `handlers/search.rs`
- Dead encryption code removed entirely

**New API endpoint**: `GET /api/mif/adapters` — lists available formats

### Files changed
- 10 new files in `src/mif/`
- 5 modified files (handlers, lib.rs, memory/mod.rs)
- **+2958 / -1413 lines** net

## Test plan
- [ ] `cargo check` — clean ✅
- [ ] `cargo clippy` — no warnings in new files ✅
- [ ] Round-trip: export MIF v2 → import → verify UUIDs, entity types preserved
- [ ] Import mem0 JSON → memories created with correct content/timestamps
- [ ] Import markdown → memory created with frontmatter metadata
- [ ] Existing multimodal/robotics search routes work after file split
- [ ] PII redaction works on export with `redact_pii=true`