### PR TITLE
fix: backup/restore hardening + zero-vector recall fix

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -185,13 +185,14 @@ impl ShodhBackupEngine {
         // Step 2a: Checkpoint graph DB if provided
         if let Some(graph) = graph_db {
             let graph_checkpoint_dir = secondary_dir.join("graph");
-            let checkpoint = Checkpoint::new(graph).map_err(|e| {
-                anyhow!("Failed to create checkpoint handle for graph DB: {}", e)
-            })?;
-            checkpoint.create_checkpoint(&graph_checkpoint_dir).map_err(|e| {
-                let _ = fs::remove_dir_all(&graph_checkpoint_dir);
-                anyhow!("Failed to checkpoint graph DB: {}", e)
-            })?;
+            let checkpoint = Checkpoint::new(graph)
+                .map_err(|e| anyhow!("Failed to create checkpoint handle for graph DB: {}", e))?;
+            checkpoint
+                .create_checkpoint(&graph_checkpoint_dir)
+                .map_err(|e| {
+                    let _ = fs::remove_dir_all(&graph_checkpoint_dir);
+                    anyhow!("Failed to checkpoint graph DB: {}", e)
+                })?;
             let graph_size = dir_size(&graph_checkpoint_dir).unwrap_or(0);
             tracing::debug!(size_kb = graph_size / 1024, "Graph DB checkpointed");
         }
@@ -576,9 +577,7 @@ impl ShodhBackupEngine {
             return Ok(());
         }
 
-        let mut entries: Vec<_> = fs::read_dir(dir)?
-            .filter_map(|e| e.ok())
-            .collect();
+        let mut entries: Vec<_> = fs::read_dir(dir)?.filter_map(|e| e.ok()).collect();
         entries.sort_by_key(|e| e.file_name());
 
         for entry in entries {

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -74,6 +74,11 @@ impl ShodhBackupEngine {
         Ok(Self { backup_path })
     }
 
+    /// Get the backup storage path.
+    pub fn backup_path(&self) -> &Path {
+        &self.backup_path
+    }
+
     /// Create a full backup of a RocksDB database
     ///
     /// # Arguments
@@ -145,15 +150,27 @@ impl ShodhBackupEngine {
         Ok(metadata)
     }
 
-    /// Create a comprehensive backup of the main database and all secondary stores.
+    /// Create a comprehensive backup of the main database, secondary stores, and graph.
     ///
     /// Uses RocksDB BackupEngine for the main memories DB and Checkpoint API
-    /// for secondary stores (todos, reminders, facts, files, feedback, audit).
+    /// for secondary stores (todos, reminders, facts, files, feedback, audit)
+    /// and the knowledge graph database.
     pub fn create_comprehensive_backup(
         &self,
         db: &DB,
         user_id: &str,
         secondary_stores: &[SecondaryStoreRef<'_>],
+    ) -> Result<BackupMetadata> {
+        self.create_comprehensive_backup_with_graph(db, user_id, secondary_stores, None)
+    }
+
+    /// Create a comprehensive backup including the knowledge graph DB.
+    pub fn create_comprehensive_backup_with_graph(
+        &self,
+        db: &DB,
+        user_id: &str,
+        secondary_stores: &[SecondaryStoreRef<'_>],
+        graph_db: Option<&DB>,
     ) -> Result<BackupMetadata> {
         // Step 1: Create main memories backup (existing logic)
         let mut metadata = self.create_backup(db, user_id)?;
@@ -164,6 +181,20 @@ impl ShodhBackupEngine {
             .join(user_id)
             .join(format!("secondary_{}", metadata.backup_id));
         fs::create_dir_all(&secondary_dir)?;
+
+        // Step 2a: Checkpoint graph DB if provided
+        if let Some(graph) = graph_db {
+            let graph_checkpoint_dir = secondary_dir.join("graph");
+            let checkpoint = Checkpoint::new(graph).map_err(|e| {
+                anyhow!("Failed to create checkpoint handle for graph DB: {}", e)
+            })?;
+            checkpoint.create_checkpoint(&graph_checkpoint_dir).map_err(|e| {
+                let _ = fs::remove_dir_all(&graph_checkpoint_dir);
+                anyhow!("Failed to checkpoint graph DB: {}", e)
+            })?;
+            let graph_size = dir_size(&graph_checkpoint_dir).unwrap_or(0);
+            tracing::debug!(size_kb = graph_size / 1024, "Graph DB checkpointed");
+        }
 
         let mut backed_up_stores = Vec::new();
         let mut total_secondary_bytes: u64 = 0;
@@ -180,43 +211,38 @@ impl ShodhBackupEngine {
                 continue;
             }
 
-            match Checkpoint::new(store_ref.db) {
-                Ok(checkpoint) => {
-                    if let Err(e) = checkpoint.create_checkpoint(&store_checkpoint_dir) {
-                        tracing::warn!(
-                            store = store_ref.name,
-                            error = %e,
-                            "Failed to checkpoint secondary store, skipping"
-                        );
-                        // Clean up partial checkpoint
-                        if let Err(cleanup_err) = fs::remove_dir_all(&store_checkpoint_dir) {
-                            tracing::warn!(
-                                store = store_ref.name,
-                                error = %cleanup_err,
-                                "Failed to clean up partial checkpoint directory"
-                            );
-                        }
-                        continue;
-                    }
+            let checkpoint = Checkpoint::new(store_ref.db).map_err(|e| {
+                anyhow!(
+                    "Failed to create checkpoint handle for secondary store '{}': {}",
+                    store_ref.name,
+                    e
+                )
+            })?;
 
-                    let store_size = dir_size(&store_checkpoint_dir).unwrap_or(0);
-                    total_secondary_bytes += store_size;
-                    backed_up_stores.push(store_ref.name.to_string());
-
-                    tracing::debug!(
-                        store = store_ref.name,
-                        size_kb = store_size / 1024,
-                        "Secondary store checkpointed"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        store = store_ref.name,
-                        error = %e,
-                        "Failed to create checkpoint handle for secondary store"
-                    );
-                }
+            if let Err(e) = checkpoint.create_checkpoint(&store_checkpoint_dir) {
+                // Clean up partial checkpoint before returning error
+                let _ = fs::remove_dir_all(&store_checkpoint_dir);
+                return Err(anyhow!(
+                    "Failed to checkpoint secondary store '{}': {}",
+                    store_ref.name,
+                    e
+                ));
             }
+
+            let store_size = dir_size(&store_checkpoint_dir).unwrap_or(0);
+            total_secondary_bytes += store_size;
+            backed_up_stores.push(store_ref.name.to_string());
+
+            tracing::debug!(
+                store = store_ref.name,
+                size_kb = store_size / 1024,
+                "Secondary store checkpointed"
+            );
+        }
+
+        // Track graph in metadata if it was checkpointed
+        if graph_db.is_some() {
+            backed_up_stores.push("graph".to_string());
         }
 
         // Step 3: Update metadata with secondary store info
@@ -533,19 +559,41 @@ impl ShodhBackupEngine {
     fn calculate_backup_checksum(&self, backup_dir: &Path, backup_id: u32) -> Result<String> {
         let mut hasher = Sha256::new();
 
-        // Hash the backup ID directory contents
+        // Hash main backup directory (sorted by filename for deterministic ordering)
         let backup_path = backup_dir.join(format!("{backup_id}"));
+        self.hash_directory_sorted(&backup_path, &mut hasher)?;
 
-        if backup_path.exists() {
-            for entry in fs::read_dir(&backup_path)? {
-                let entry = entry?;
-                let file_contents = fs::read(entry.path())?;
-                hasher.update(&file_contents);
-            }
-        }
+        // Hash secondary store directory (B5: was previously excluded)
+        let secondary_path = backup_dir.join(format!("secondary_{backup_id}"));
+        self.hash_directory_sorted(&secondary_path, &mut hasher)?;
 
         let result = hasher.finalize();
         Ok(format!("{result:x}"))
+    }
+
+    fn hash_directory_sorted(&self, dir: &Path, hasher: &mut Sha256) -> Result<()> {
+        if !dir.exists() {
+            return Ok(());
+        }
+
+        let mut entries: Vec<_> = fs::read_dir(dir)?
+            .filter_map(|e| e.ok())
+            .collect();
+        entries.sort_by_key(|e| e.file_name());
+
+        for entry in entries {
+            let path = entry.path();
+            // Hash filename for rename detection
+            hasher.update(entry.file_name().to_string_lossy().as_bytes());
+            if path.is_dir() {
+                // Recurse into subdirectories (secondary stores have nested structure)
+                self.hash_directory_sorted(&path, hasher)?;
+            } else {
+                let file_contents = fs::read(&path)?;
+                hasher.update(&file_contents);
+            }
+        }
+        Ok(())
     }
 
     fn estimate_memory_count(&self, db: &DB) -> Result<usize> {
@@ -559,6 +607,11 @@ impl ShodhBackupEngine {
 
         Ok(count)
     }
+}
+
+/// Public wrapper for copy_dir_recursive (used by restore handler).
+pub fn copy_dir_recursive_pub(src: &Path, dst: &Path) -> Result<()> {
+    copy_dir_recursive(src, dst)
 }
 
 /// Calculate total size of a directory recursively

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -1005,6 +1005,11 @@ pub struct GraphMemory {
 }
 
 impl GraphMemory {
+    /// Get a reference to the underlying RocksDB instance (for backup/checkpoint).
+    pub fn get_db(&self) -> &DB {
+        &self.db
+    }
+
     // Column family accessors — cheap HashMap lookups on DB internals
     fn entities_cf(&self) -> &ColumnFamily {
         self.db

--- a/src/handlers/consolidation.rs
+++ b/src/handlers/consolidation.rs
@@ -378,12 +378,7 @@ pub async fn create_backup(
     } else {
         state
             .backup_engine()
-            .create_comprehensive_backup_with_graph(
-                &db,
-                &req.user_id,
-                &store_refs,
-                graph_db_ref,
-            )
+            .create_comprehensive_backup_with_graph(&db, &req.user_id, &store_refs, graph_db_ref)
     };
 
     match result {
@@ -562,11 +557,7 @@ pub async fn restore_backup(
         &user_id,
         "BACKUP_RESTORED",
         &format!("backup_{}", req.backup_id.unwrap_or(0)),
-        &format!(
-            "Restored {} stores: {:?}",
-            all_restored.len(),
-            all_restored
-        ),
+        &format!("Restored {} stores: {:?}", all_restored.len(), all_restored),
     );
 
     Ok(Json(RestoreBackupResponse {

--- a/src/handlers/router.rs
+++ b/src/handlers/router.rs
@@ -171,6 +171,7 @@ pub fn build_protected_routes(state: AppState) -> Router {
         .route("/api/backup/verify", post(consolidation::verify_backup))
         .route("/api/backup/purge", post(consolidation::purge_backups))
         .route("/api/backups/purge", post(consolidation::purge_backups)) // MCP alias
+        .route("/api/backup/restore", post(consolidation::restore_backup))
         // =================================================================
         // FACTS
         // =================================================================

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -1603,10 +1603,12 @@ impl MultiUserMemoryManager {
                     let graph_lock = self.get_user_graph(name).ok();
                     let graph_guard = graph_lock.as_ref().map(|g| g.read());
                     let graph_db_ref = graph_guard.as_ref().map(|g| g.get_db());
-                    match self
-                        .backup_engine
-                        .create_comprehensive_backup_with_graph(&db, name, &store_refs, graph_db_ref)
-                    {
+                    match self.backup_engine.create_comprehensive_backup_with_graph(
+                        &db,
+                        name,
+                        &store_refs,
+                        graph_db_ref,
+                    ) {
                         Ok(metadata) => {
                             tracing::info!(
                                 user_id = name,

--- a/src/handlers/types.rs
+++ b/src/handlers/types.rs
@@ -570,6 +570,20 @@ pub struct PurgeBackupsResponse {
     pub purged_count: usize,
 }
 
+#[derive(Deserialize)]
+pub struct RestoreBackupRequest {
+    pub user_id: String,
+    #[serde(default)]
+    pub backup_id: Option<u32>,
+}
+
+#[derive(Serialize)]
+pub struct RestoreBackupResponse {
+    pub success: bool,
+    pub message: String,
+    pub restored_stores: Vec<String>,
+}
+
 // =============================================================================
 // CONTEXT STATUS
 // =============================================================================


### PR DESCRIPTION
## Summary

- **3 critical backup bugs fixed**: missing restore endpoint (B1), graph DB excluded from backups (B2), graph not rebuilt on restore (B9)
- **3 medium backup bugs fixed**: non-deterministic checksums (B4), secondary stores excluded from checksum (B5), silent checkpoint failures (B7)
- **1 medium recall bug fixed**: zero-vector fallback polluting semantic search results (R1)
- **MCP tool added**: `backup_restore` for restoring backups from Claude/Cursor
- **Graph DB now included** in both manual and scheduled backup paths

## Changes (8 files, +309/-62)

| Bug | Severity | Fix |
|-----|----------|-----|
| B1 | Critical | `POST /api/backup/restore` endpoint with full restore handler |
| B2 | Critical | `create_comprehensive_backup_with_graph()` checkpoints graph DB |
| B9 | Critical | Restore handler copies graph checkpoint back to graph path |
| B4 | Medium | Sorted recursive hashing with filenames for deterministic checksums |
| B5 | Medium | Secondary stores + graph included in checksum calculation |
| B7 | Medium | Checkpoint failures return `Err` instead of silent `continue` |
| R1 | Medium | Empty vec + `Option` skip pattern replaces zero-vector fallback |

## Test plan
- [ ] `cargo check` passes clean
- [ ] `cargo clippy --lib` passes clean
- [ ] Create backup → verify graph directory exists in `secondary_{id}/graph/`
- [ ] Verify backup checksum is deterministic across runs
- [ ] Restore backup via MCP `backup_restore` tool
- [ ] Trigger recall with broken embeddings — verify no zero-vector search