### PR TITLE
fix: 4 bugs from deep audit — compaction corruption, PQ bounds, scoring NaN

### DIFF
--- a/src/relevance.rs
+++ b/src/relevance.rs
@@ -1500,6 +1500,10 @@ impl RelevanceEngine {
         boost_hours: u64,
         multiplier: f32,
     ) -> f32 {
+        if boost_hours == 0 {
+            return base_score;
+        }
+
         let now = Utc::now();
         let age = now.signed_duration_since(created_at);
         let age_hours = age.num_hours() as u64;

--- a/src/vector_db/pq.rs
+++ b/src/vector_db/pq.rs
@@ -273,8 +273,15 @@ impl ProductQuantizer {
         let mut vector = Vec::with_capacity(self.config.dimension);
 
         for (subvec_idx, &code) in codes.iter().enumerate() {
-            let centroid = &self.centroids[subvec_idx][code as usize];
-            vector.extend_from_slice(centroid);
+            let subspace = &self.centroids[subvec_idx];
+            let code_idx = code as usize;
+            if code_idx >= subspace.len() {
+                return Err(anyhow!(
+                    "PQ code {} out of bounds for subspace {} with {} centroids (data corruption?)",
+                    code_idx, subvec_idx, subspace.len()
+                ));
+            }
+            vector.extend_from_slice(&subspace[code_idx]);
         }
 
         Ok(vector)
@@ -296,9 +303,16 @@ impl ProductQuantizer {
             let start = subvec_idx * subvec_dim;
             let end = start + subvec_dim;
             let query_subvec = &query[start..end];
-            let centroid = &self.centroids[subvec_idx][code as usize];
+            let subspace = &self.centroids[subvec_idx];
+            let code_idx = code as usize;
+            if code_idx >= subspace.len() {
+                return Err(anyhow!(
+                    "PQ code {} out of bounds for subspace {} with {} centroids (data corruption?)",
+                    code_idx, subvec_idx, subspace.len()
+                ));
+            }
 
-            total_dist += squared_l2_distance_slice(query_subvec, centroid);
+            total_dist += squared_l2_distance_slice(query_subvec, &subspace[code_idx]);
         }
 
         Ok(total_dist)
@@ -333,11 +347,18 @@ impl ProductQuantizer {
     }
 
     /// Fast distance computation using pre-built lookup table
+    ///
+    /// Returns `f32::MAX` if a PQ code is out of bounds (corrupted data)
+    /// rather than panicking, since this is called in the hot search path.
     #[inline]
     pub fn distance_with_table(&self, table: &[Vec<f32>], codes: &[u8]) -> f32 {
         let mut total = 0.0f32;
         for (subvec_idx, &code) in codes.iter().enumerate() {
-            total += table[subvec_idx][code as usize];
+            let code_idx = code as usize;
+            if subvec_idx >= table.len() || code_idx >= table[subvec_idx].len() {
+                return f32::MAX; // Corrupted code — push to bottom of results
+            }
+            total += table[subvec_idx][code_idx];
         }
         total
     }

--- a/src/vector_db/pq.rs
+++ b/src/vector_db/pq.rs
@@ -278,7 +278,9 @@ impl ProductQuantizer {
             if code_idx >= subspace.len() {
                 return Err(anyhow!(
                     "PQ code {} out of bounds for subspace {} with {} centroids (data corruption?)",
-                    code_idx, subvec_idx, subspace.len()
+                    code_idx,
+                    subvec_idx,
+                    subspace.len()
                 ));
             }
             vector.extend_from_slice(&subspace[code_idx]);
@@ -308,7 +310,9 @@ impl ProductQuantizer {
             if code_idx >= subspace.len() {
                 return Err(anyhow!(
                     "PQ code {} out of bounds for subspace {} with {} centroids (data corruption?)",
-                    code_idx, subvec_idx, subspace.len()
+                    code_idx,
+                    subvec_idx,
+                    subspace.len()
                 ));
             }
 


### PR DESCRIPTION
## Summary

Deep audit found 4 bugs across the retrieval, vector search, scoring, and hook subsystems:

- **CRITICAL: Vamana compaction silently corrupted all search results.** `auto_rebuild_if_needed()` rebuilt the index with new sequential vector IDs but never updated the `id_mapping` (vector_id → memory_id). After any compaction or rebuild triggered by deletion ratio or insert threshold, every search returned wrong memories. Fix: bypass Vamana's internal rebuild and use `rebuild_from_rocksdb()` which rebuilds both index and mapping atomically from the single source of truth.

- **HIGH: PQ centroid out-of-bounds panic on corrupted data.** `decode()`, `asymmetric_distance()`, and `distance_with_table()` accessed centroid arrays with unchecked `code as usize`. Corrupted PQ codes or PQ trained with <256 vectors caused immediate index-out-of-bounds panic. Fix: bounds checks with descriptive errors; hot-path `distance_with_table()` returns `f32::MAX` to push corrupted entries to bottom of results.

- **MEDIUM: Recency boost produced NaN scores when `boost_hours=0`.** `0.0f32 / 0.0f32 = NaN` (IEEE 754) propagated through all scoring, silently corrupting sort order. Fix: early return `base_score` when `boost_hours == 0`.

- **LOW: Hook `unblockDependents()` failure caused orchestration deadlock.** If the API call failed, dependent todos stayed blocked forever. Fix: try-catch with single retry + error logging.

## Verified false positives (not bugs)
- GDPR `interference_meta:total` — prefix iterator already catches it
- MCP URL encoding — all IDs are UUIDs (hex + hyphens, URL-safe)
- Retrieval off-by-one with limit=0 — no caller passes limit=0

## Test plan
- [x] `cargo check` — clean build
- [x] `cargo clippy` — no new warnings
- [ ] Manual: trigger compaction via delete >30% vectors, verify search still returns correct memories
- [ ] Manual: verify PQ search with <256 training vectors doesn't panic