### PR TITLE
fix: 3 concurrency bugs — TOCTOU user init, watermark race, atomic ordering

### DIFF
--- a/src/vector_db/vamana.rs
+++ b/src/vector_db/vamana.rs
@@ -935,7 +935,7 @@ impl VamanaIndex {
         self.num_vectors
             .fetch_add(1, std::sync::atomic::Ordering::Release);
         self.incremental_inserts
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
         Ok(id)
     }
 
@@ -951,7 +951,7 @@ impl VamanaIndex {
     pub fn needs_rebuild(&self) -> bool {
         let needs_insert_rebuild = self
             .incremental_inserts
-            .load(std::sync::atomic::Ordering::Relaxed)
+            .load(std::sync::atomic::Ordering::Acquire)
             >= REBUILD_THRESHOLD;
         let needs_compaction = self.needs_compaction();
 
@@ -961,13 +961,13 @@ impl VamanaIndex {
     /// Get the number of incremental inserts since last rebuild
     pub fn incremental_insert_count(&self) -> usize {
         self.incremental_inserts
-            .load(std::sync::atomic::Ordering::Relaxed)
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 
     /// Reset incremental insert counter (call after rebuild)
     pub fn reset_incremental_counter(&self) {
         self.incremental_inserts
-            .store(0, std::sync::atomic::Ordering::Relaxed);
+            .store(0, std::sync::atomic::Ordering::Release);
     }
 
     /// Check if incremental repair is recommended


### PR DESCRIPTION
## Summary

Round 2 deep audit found concurrency bugs across the user initialization, fact extraction, and vector index subsystems:

- **CRITICAL: TOCTOU race in `get_user_memory()` and `get_user_graph()`.** Concurrent first-access requests for the same `user_id` both missed the moka cache, both tried to open RocksDB, and the second open failed with an exclusive file lock error — causing intermittent 500s. Fix: per-user creation mutex (`DashMap<String, Arc<Mutex<()>>>`) with double-checked locking. The same lock is shared between memory and graph init to prevent nested races.

- **MEDIUM: Fact extraction watermark set to `now()` instead of last memory timestamp.** If fact extraction takes 5 seconds and a memory is created at second 2, the watermark advances past it — that memory is **never** processed for semantic facts. Silent data loss. Fix: advance watermark to `max(memory.created_at)`.

- **MEDIUM: `incremental_inserts` used `Relaxed` atomic ordering.** On ARM64 (weakly-ordered), the rebuild threshold check could see stale counter values, delaying index quality recovery. Fix: `Release` on store, `Acquire` on load — consistent with `num_vectors`.

## Verified false positives (not bugs)
- Backup missing facts/learning history — both use same RocksDB as memories, already backed up
- Division by zero in relevance.rs:1481 — `overlap > 0` guarantees non-empty denominator
- index_memory persist order — `rebuild_from_rocksdb` handles restart correctly
- Centroid overflow in medoid — MiniLM embeddings are normalized [-1, 1]

## Test plan
- [x] `cargo check` — clean build
- [x] `cargo fmt --check` — clean
- [ ] Manual: concurrent first-access requests for same user_id no longer 500
- [ ] Manual: verify memories created during fact extraction cycle are processed next cycle