### PR TITLE
fix: round 3 byte-offset + dedup bugs

### DIFF
--- a/src/memory/compression.rs
+++ b/src/memory/compression.rs
@@ -946,7 +946,10 @@ impl SemanticConsolidator {
 
     /// Extract a procedure from content (looks for action words)
     fn extract_procedure(&self, content: &str) -> Option<String> {
-        let lower = content.to_lowercase();
+        // Use to_ascii_lowercase() to preserve byte alignment with `content`.
+        // to_lowercase() can change byte lengths for non-ASCII chars (e.g. İ→i̇),
+        // making byte offsets from `lower.find()` invalid for indexing into `content`.
+        let lower = content.to_ascii_lowercase();
         let action_markers = [
             "to ",
             "run ",
@@ -984,7 +987,8 @@ impl SemanticConsolidator {
 
     /// Extract a definition from content
     fn extract_definition(&self, content: &str) -> Option<String> {
-        let lower = content.to_lowercase();
+        // Use to_ascii_lowercase() to preserve byte alignment with `content`.
+        let lower = content.to_ascii_lowercase();
         let def_markers = [
             " is ",
             " are ",
@@ -1027,7 +1031,8 @@ impl SemanticConsolidator {
 
     /// Extract a pattern from error content (returns the actual sentence)
     fn extract_pattern(&self, content: &str) -> Option<String> {
-        let lower = content.to_lowercase();
+        // Use to_ascii_lowercase() to preserve byte alignment with `content`.
+        let lower = content.to_ascii_lowercase();
         let pattern_markers = [
             "error",
             "failed",
@@ -1057,7 +1062,8 @@ impl SemanticConsolidator {
 
     /// Extract a preference from conversation content (returns the actual sentence)
     fn extract_preference(&self, content: &str) -> Option<String> {
-        let lower = content.to_lowercase();
+        // Use to_ascii_lowercase() to preserve byte alignment with `content`.
+        let lower = content.to_ascii_lowercase();
         let pref_markers = [
             "prefer",
             "like",


### PR DESCRIPTION
## Summary
- **compression.rs**: `to_lowercase()` → `to_ascii_lowercase()` in 4 extraction functions. `to_lowercase()` can change byte lengths for non-ASCII chars (e.g. Turkish İ→i̇), making byte offsets from `lower.find()` invalid for indexing into the original string — panics on `content[..pos]`.
- **streaming.rs**: Dedup cache at capacity now retains half instead of full `.clear()`. Full clear allowed recent duplicates to pass through immediately after eviction.
- **ner.rs**: Entity position search compares against original name (not lowercased) to avoid byte length mismatch, and clamps fallback end offset to `text.len()`.

## Verified false positives (11 findings eliminated)
- Jaccard empty sets (conservative 0.0 is correct)
- Injection cooldown snapshot (deliberate async design)
- Hybrid search blend formula (intentional scale preservation, reranking disabled)
- Decay C1 discontinuity (by design per Wixted 2004)
- Negative feedback missing update (correct — nothing to penalize)
- Beta NaN (LCG never returns 0.0 — min is 1/u64::MAX)
- Weights sum to zero (already guarded by `if sum > 0.0`)

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo clippy` clean (no new warnings)
- [ ] Verify non-ASCII content doesn't panic in compression extractors