### PR TITLE
fix: restore X-API-Key header in MCP WebSocket connection

### DIFF
--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -161,9 +161,13 @@ async function connectStream(): Promise<void> {
   streamHandshakeComplete = false;
 
   try {
-    // Note: /api/stream is public (no auth required), so no headers needed
+    // Note: /api/stream requires X-API-Key header for authentication
     // Bun supports headers via: new WebSocket(url, { headers: {...} })
-    streamSocket = new WebSocket(WS_URL);
+    streamSocket = new WebSocket(WS_URL, {
+      headers: {
+        "X-API-Key": API_KEY
+      }
+    });
 
     streamSocket.onopen = () => {
       streamConnecting = false;


### PR DESCRIPTION

### Summary
The MCP server fails to connect to the backend because the /api/stream endpoint is a protected route but was being accessed without authentication. This PR restores the X-API-Key header in the WebSocket handshake.

### Technical Details
The backend requires an X-API-Key for the streaming endpoint as defined in [src/handlers/router.rs#L400](https://github.com/varun29ankuS/shodh-memory/blob/main/src/handlers/router.rs#L400). All protected routes pass through [src/auth.rs#L223-L228](https://github.com/varun29ankuS/shodh-memory/blob/main/src/auth.rs#L223-L228) where the header is validated.

This regression was introduced in [a7475b3b](https://github.com/varun29ankuS/shodh-memory/commit/a7475b3b) (part of #84) which incorrectly assumed this endpoint was public. This fix restores the header in the WebSocket constructor in [mcp-server/index.ts#L166-L170](https://github.com/varun29ankuS/shodh-memory/blob/main/mcp-server/index.ts#L166-L170).

### Verification
Verified by starting the backend and MCP server with matching keys and confirming the successful connection.
