### PR TITLE
fix: read_memory undefined parameter handling

### DIFF
--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -3166,7 +3166,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "read_memory": {
-        const { memory_id } = args as { memory_id: string };
+        const memory_id = (args as any).memory_id || (args as any).id;
+
+        if (!memory_id || typeof memory_id !== 'string' || memory_id.trim().length === 0) {
+          return {
+            content: [{ type: "text", text: "Error: 'memory_id' is required. Pass the full UUID or 8+ character prefix from recall results." }],
+            isError: true,
+          };
+        }
 
         // Response includes hierarchy: parent_id in memory, children_ids/children_count
         interface MemoryWithHierarchy {


### PR DESCRIPTION
## Summary
- `read_memory` MCP tool returned `Memory not found: undefined` when the LLM sent `id` instead of `memory_id` as the parameter name
- The destructuring `const { memory_id } = args` yielded `undefined`, which got interpolated into the API URL as `/api/memory/undefined`

## Fix
- Accept both `memory_id` and `id` as parameter names (defensive against LLM param name variation)
- Validate before hitting the backend API — return a clear error instead of passing `undefined`

Fixes #93