### PR TITLE
fix: wire retrieval_mode to skip graph traversal in semantic recall

### DIFF
--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -25,7 +25,9 @@ use crate::memory::segmentation::{InputSource, SegmentationEngine};
 use crate::memory::sessions::SessionEvent;
 use crate::memory::storage::SearchCriteria;
 use crate::memory::types::MemoryId;
-use crate::memory::{Experience, ExperienceType, Query as MemoryQuery, RetrievalMode, SharedMemory};
+use crate::memory::{
+    Experience, ExperienceType, Query as MemoryQuery, RetrievalMode, SharedMemory,
+};
 use crate::memory::{ProspectiveTrigger, TodoStatus};
 use crate::metrics;
 use crate::relevance;

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -25,7 +25,7 @@ use crate::memory::segmentation::{InputSource, SegmentationEngine};
 use crate::memory::sessions::SessionEvent;
 use crate::memory::storage::SearchCriteria;
 use crate::memory::types::MemoryId;
-use crate::memory::{Experience, ExperienceType, Query as MemoryQuery, SharedMemory};
+use crate::memory::{Experience, ExperienceType, Query as MemoryQuery, RetrievalMode, SharedMemory};
 use crate::memory::{ProspectiveTrigger, TodoStatus};
 use crate::metrics;
 use crate::relevance;
@@ -33,6 +33,18 @@ use crate::validation;
 
 /// Application state type alias
 pub type AppState = std::sync::Arc<MultiUserMemoryManager>;
+
+/// Map API mode string to RetrievalMode enum.
+/// Defaults to Hybrid for unknown values (backward compat).
+fn parse_retrieval_mode(mode: &str) -> RetrievalMode {
+    match mode {
+        "semantic" | "similarity" => RetrievalMode::Similarity,
+        "associative" => RetrievalMode::Associative,
+        "temporal" => RetrievalMode::Temporal,
+        "causal" => RetrievalMode::Causal,
+        _ => RetrievalMode::Hybrid,
+    }
+}
 
 // =============================================================================
 // CONTEXT SUMMARY TYPES
@@ -310,6 +322,7 @@ pub async fn recall(
 
     let limit = req.limit;
     let mode = req.mode.clone();
+    let retrieval_mode_for_recall = parse_retrieval_mode(&mode);
 
     // PROSPECTIVE MEMORY + RECALL: Run inside a single spawn_blocking to share
     // the computed query embedding between prospective semantic matching and recall.
@@ -391,6 +404,7 @@ pub async fn recall(
                 user_id: Some(user_id_for_recall),
                 query_text: Some(query_for_recall),
                 max_results: limit,
+                retrieval_mode: retrieval_mode_for_recall,
                 prospective_signals: prospective_signals.clone(),
                 ..Default::default()
             };
@@ -1280,7 +1294,7 @@ pub async fn proactive_context(
     let entity_names_for_recall = context_entity_names.clone();
     let entity_match_weight = req.entity_match_weight;
     let recency_weight = req.recency_weight;
-    let semantic_threshold = req.semantic_threshold;
+    let _semantic_threshold = req.semantic_threshold;
     let embedding_for_query = context_embedding.clone();
     let memories: Vec<ProactiveSurfacedMemory> = {
         let memory = memory_system.clone();
@@ -1414,7 +1428,7 @@ pub async fn proactive_context(
             // Drop results below minimum absolute score — don't pad with irrelevant filler
             // Also drop results that are < 30% of the top score (too weak relative to best)
             let top_score = enriched.first().map(|(_, s, _)| *s).unwrap_or(0.0);
-            let abs_min = semantic_threshold;
+            let abs_min = 0.05_f32;
             let relative_min = top_score * 0.30;
             let effective_min = abs_min.max(relative_min);
             enriched.retain(|(_, s, _)| *s >= effective_min);
@@ -2145,6 +2159,7 @@ pub async fn recall_tracked(
     let query_text = req.query.clone();
     let limit = req.limit;
     let user_id = req.user_id.clone();
+    let retrieval_mode = parse_retrieval_mode(&req.mode);
 
     let memories = {
         let memory = memory.clone();
@@ -2154,6 +2169,7 @@ pub async fn recall_tracked(
                 user_id: Some(user_id),
                 query_text: Some(query_text),
                 max_results: limit,
+                retrieval_mode,
                 ..Default::default()
             };
             memory_guard.recall(&query).unwrap_or_default()

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -1294,7 +1294,7 @@ pub async fn proactive_context(
     let entity_names_for_recall = context_entity_names.clone();
     let entity_match_weight = req.entity_match_weight;
     let recency_weight = req.recency_weight;
-    let _semantic_threshold = req.semantic_threshold;
+    let semantic_threshold = req.semantic_threshold;
     let embedding_for_query = context_embedding.clone();
     let memories: Vec<ProactiveSurfacedMemory> = {
         let memory = memory_system.clone();
@@ -1428,7 +1428,7 @@ pub async fn proactive_context(
             // Drop results below minimum absolute score — don't pad with irrelevant filler
             // Also drop results that are < 30% of the top score (too weak relative to best)
             let top_score = enriched.first().map(|(_, s, _)| *s).unwrap_or(0.0);
-            let abs_min = 0.05_f32;
+            let abs_min = semantic_threshold;
             let relative_min = top_score * 0.30;
             let effective_min = abs_min.max(relative_min);
             enriched.retain(|(_, s, _)| *s >= effective_min);

--- a/src/handlers/types.rs
+++ b/src/handlers/types.rs
@@ -412,6 +412,8 @@ pub struct TrackedRetrieveRequest {
     pub query: String,
     #[serde(default = "default_recall_limit")]
     pub limit: usize,
+    #[serde(default = "default_recall_mode")]
+    pub mode: String,
 }
 
 /// Response with tracking ID for feedback

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1896,7 +1896,10 @@ impl MemorySystem {
                 (r, d, entity_count, weights, phrases, disc)
             } else {
                 if !use_graph && self.graph_memory.is_some() {
-                    tracing::debug!("Layer 2: SKIPPED (retrieval_mode={:?})", query.retrieval_mode);
+                    tracing::debug!(
+                        "Layer 2: SKIPPED (retrieval_mode={:?})",
+                        query.retrieval_mode
+                    );
                 }
                 // No graph traversal - still analyze query for IC weights and phrase boosts
                 let (disc, _) = query_analysis.keyword_discriminativeness();

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1693,6 +1693,10 @@ impl MemorySystem {
         // ===========================================================================
         // LAYER 2: GRAPH EXPANSION (Knowledge Graph Traversal)
         // ===========================================================================
+        let use_graph = matches!(
+            query.retrieval_mode,
+            RetrievalMode::Hybrid | RetrievalMode::Associative | RetrievalMode::Causal
+        );
         let (
             graph_results,
             graph_density,
@@ -1708,7 +1712,7 @@ impl MemorySystem {
             Vec<(String, f32)>,
             f32, // Keyword discriminativeness for dynamic BM25/vector weight adjustment
         ) = {
-            if let Some(graph) = &self.graph_memory {
+            if let Some(graph) = self.graph_memory.as_ref().filter(|_| use_graph) {
                 let g = graph.read();
                 // Extract IC weights for BM25 term boosting
                 let weights = query_analysis.to_ic_weights();
@@ -1891,7 +1895,10 @@ impl MemorySystem {
                 }
                 (r, d, entity_count, weights, phrases, disc)
             } else {
-                // No graph memory - still analyze query for IC weights and phrase boosts
+                if !use_graph && self.graph_memory.is_some() {
+                    tracing::debug!("Layer 2: SKIPPED (retrieval_mode={:?})", query.retrieval_mode);
+                }
+                // No graph traversal - still analyze query for IC weights and phrase boosts
                 let (disc, _) = query_analysis.keyword_discriminativeness();
                 (
                     Vec::new(),


### PR DESCRIPTION
Closes #95

## Summary
- Map API `mode` string (`"semantic"`, `"associative"`, etc.) to `RetrievalMode` enum in `recall` and `recall/tracked` handlers
- Gate Layer 2 graph traversal on `retrieval_mode` — only Hybrid, Associative, and Causal modes enter graph expansion
- Add `mode` field to `TrackedRetrieveRequest` for parity with `RecallRequest`
- Semantic/Similarity mode now skips graph entirely, eliminating write lock contention

## Measured impact (from issue reporter)
| Scenario | Before | After |
|----------|--------|-------|
| `mode: "semantic"` | 0.73–1.18s | 0.05–0.15s |
| `mode: "semantic"` under concurrent writes | 18–20s | 0.05–0.15s |

## Test plan
- [x] `cargo check` — compiles clean
- [x] `cargo clippy` — no new warnings
- [ ] `curl -X POST .../api/recall -d '{"user_id":"test","query":"test","mode":"semantic"}'` — server logs show `Layer 2: SKIPPED`
- [ ] `mode: "hybrid"` (default) — unchanged behavior, graph traversal runs as before