### PR TITLE
fix: remove stuck 429 resource limit, enable mmap vectors (#97)

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -49,8 +49,8 @@ use crate::metrics::{
 use crate::constants::{
     DEFAULT_COMPRESSION_AGE_DAYS, DEFAULT_IMPORTANCE_THRESHOLD, DEFAULT_MAX_HEAP_PER_USER_MB,
     DEFAULT_SESSION_MEMORY_SIZE_MB, DEFAULT_WORKING_MEMORY_SIZE, EDGE_SEMANTIC_WEIGHT_FLOOR,
-    ESTIMATED_BYTES_PER_MEMORY, HEBBIAN_BOOST_HELPFUL, HEBBIAN_DECAY_MISLEADING,
-    POTENTIATION_ACCESS_THRESHOLD, POTENTIATION_MAINTENANCE_BOOST, TIER_PROMOTION_SESSION_AGE_SECS,
+    HEBBIAN_BOOST_HELPFUL, HEBBIAN_DECAY_MISLEADING, POTENTIATION_ACCESS_THRESHOLD,
+    POTENTIATION_MAINTENANCE_BOOST, TIER_PROMOTION_SESSION_AGE_SECS,
     TIER_PROMOTION_SESSION_IMPORTANCE, TIER_PROMOTION_WORKING_AGE_SECS,
     TIER_PROMOTION_WORKING_IMPORTANCE,
 };
@@ -587,7 +587,6 @@ impl MemorySystem {
         mut experience: Experience,
         created_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<MemoryId> {
-        self.check_resource_limits()?;
         let importance = self.calculate_importance(&experience);
 
         // Generate embedding if not provided
@@ -633,9 +632,6 @@ impl MemorySystem {
         mut experience: Experience,
         created_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<MemoryId> {
-        // CRITICAL: Check resource limits before recording to prevent OOM
-        self.check_resource_limits()?;
-
         let memory_id = MemoryId(Uuid::new_v4());
 
         // Calculate importance
@@ -967,9 +963,6 @@ impl MemorySystem {
         agent_id: Option<String>,
         run_id: Option<String>,
     ) -> Result<MemoryId> {
-        // CRITICAL: Check resource limits before recording to prevent OOM
-        self.check_resource_limits()?;
-
         let memory_id = MemoryId(Uuid::new_v4());
 
         // Calculate importance
@@ -4796,30 +4789,6 @@ impl MemorySystem {
         }
     }
 
-    /// Check resource limits to prevent OOM from single user
-    ///
-    /// Uses ESTIMATED_BYTES_PER_MEMORY constant for size estimation.
-    /// See constants.rs for justification of the estimate.
-    pub fn check_resource_limits(&self) -> Result<(), crate::errors::AppError> {
-        // Get current memory counts from stats
-        let stats = self.stats.read();
-        let total_memories = stats.working_memory_count + stats.session_memory_count;
-
-        // Estimate size using documented constant (see constants.rs for breakdown)
-        let estimated_size_bytes = total_memories * ESTIMATED_BYTES_PER_MEMORY;
-        let estimated_size_mb = estimated_size_bytes / (1024 * 1024);
-
-        if estimated_size_mb > self.config.max_heap_per_user_mb {
-            return Err(crate::errors::AppError::ResourceLimit {
-                resource: "user_memory".to_string(),
-                current: estimated_size_mb,
-                limit: self.config.max_heap_per_user_mb,
-            });
-        }
-
-        Ok(())
-    }
-
     // =========================================================================
     // OUTCOME FEEDBACK SYSTEM - Hebbian "Fire Together, Wire Together"
     // =========================================================================
@@ -5212,9 +5181,6 @@ impl MemorySystem {
         changed_by: Option<String>,
         change_reason: Option<String>,
     ) -> Result<(MemoryId, bool)> {
-        // Check resource limits
-        self.check_resource_limits()?;
-
         // Try to find existing memory with this external_id
         if let Some(mut existing) = self.long_term_memory.find_by_external_id(&external_id)? {
             // === UPDATE PATH ===

--- a/src/memory/retrieval.rs
+++ b/src/memory/retrieval.rs
@@ -162,12 +162,14 @@ impl RetrievalEngine {
             max_degree: 32,        // Increased for better recall at scale
             search_list_size: 100, // 2x for better accuracy with 10M vectors
             alpha: 1.2,
-            use_mmap: false, // Keep in memory for low-latency robotics
+            use_mmap: true, // Memory-mapped: OS manages paging, RSS stays low at scale
             ..Default::default()
         };
 
-        let vector_index =
-            VamanaIndex::new(vamana_config).context("Failed to initialize Vamana vector index")?;
+        let vamana_storage = storage_path.join("vector_index");
+        std::fs::create_dir_all(&vamana_storage)?;
+        let vector_index = VamanaIndex::with_storage_path(vamana_config, Some(vamana_storage))
+            .context("Failed to initialize Vamana vector index")?;
         let id_mapping = IdMapping::new();
 
         // NOTE: Memory graph (Hebbian associations) has been consolidated into GraphMemory


### PR DESCRIPTION
## Summary

- **Removed `check_resource_limits()`** — the broken guard that caused permanent 429s
- **Enabled mmap for Vamana vectors** — OS manages paging, RSS stays proportional to working set

## Why the old check was wrong

| Problem | Detail |
|---------|--------|
| Bad estimate | 20KB per memory (actual: ~1.6KB in Vamana, content is on disk in RocksDB) |
| Wrong metric | Counted memory tier stats, not actual RAM consumers (vectors) |
| No recovery | Once tripped at ~25K memories, permanently blocked all writes |
| Root cause of #97 | Users hit 429 that never cleared — kill/restart was the only fix |

## What now enforces memory ceilings

| Mechanism | Scope |
|-----------|-------|
| Shared RocksDB block cache (256MB) | All DB reads across all users (PR #100) |
| SPANN auto-switch at 100K vectors | Disk-based IVF+PQ replaces in-memory Vamana |
| Vamana mmap (this PR) | OS pages cold vectors out, RSS = working set |
| Moka idle eviction (30-min TTI) | Releases entire DB handles for inactive users (PR #100) |

## Mmap detail

Vamana vectors were `use_mmap: false` (all vectors in heap). Now `use_mmap: true` with explicit storage path. The OS kernel manages which pages stay resident — hot vectors in page cache, cold ones on disk. At 50K vectors (384-dim f32), the file is ~75MB but RSS will be much lower since only recently-accessed pages stay resident.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo fmt` — clean
- [x] 539 tests passed across 5 key suites (regression, persistence, storage edge cases, integration, lib unit)
- [x] Zero regressions

Fixes #97
Mitigates #90