### PR TITLE
fix: enable jemalloc for RocksDB C++ allocations on Linux/macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1941,6 +1941,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -3900,6 +3901,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Storage
-rocksdb = { version = "0.24", default-features = false, features = ["lz4"] }
 bincode = { version = "2.0.0-rc.3", features = ["serde"] }
 bincode1 = { package = "bincode", version = "1.3" }  # Legacy format support for pre-2.0 memories
 rmp-serde = "1.3"  # MessagePack - binary format that supports serde tagged enums
@@ -285,6 +284,18 @@ telemetry = [
     "opentelemetry_sdk"
 ]
 
+
+# jemalloc replaces the system C allocator inside RocksDB's C++ code (not just Rust).
+# Without it, glibc/CRT malloc fragments heavily and never returns memory to the OS.
+# Confirmed fix by rust-rocksdb maintainer (zaidoon1) in facebook/rocksdb#12364.
+# PRs #989 (ran-openai) and #1026 (timothyg-stripe) fixed jemalloc linking in v0.24.0.
+[target.'cfg(not(windows))'.dependencies]
+rocksdb = { version = "0.24", default-features = false, features = ["lz4", "jemalloc"] }
+
+# jemalloc doesn't compile with MSVC — Windows uses default CRT allocator.
+# Fundamental fix requires facebook/rocksdb#14403 (custom allocator C API for mimalloc).
+[target.'cfg(windows)'.dependencies]
+rocksdb = { version = "0.24", default-features = false, features = ["lz4"] }
 
 [workspace]
 # Standalone workspace - not part of parent kalki-v2


### PR DESCRIPTION
## Summary

- Platform-gate `rocksdb` dependency: Linux/macOS gets `jemalloc` feature, Windows stays on CRT allocator
- jemalloc replaces system malloc **inside RocksDB's C++ code** (not just Rust), preventing memory fragmentation and RSS bloat that glibc's allocator causes
- Windows excluded because jemalloc doesn't compile with MSVC — fundamental fix awaits [facebook/rocksdb#14403](https://github.com/facebook/rocksdb/issues/14403) (custom allocator C API for mimalloc)

## Context

Confirmed fix per rust-rocksdb maintainer (zaidoon1) in [facebook/rocksdb#12364](https://github.com/facebook/rocksdb/issues/12364). User @leeqx confirmed: "after actually enabling jemalloc, I can confirm the memory issue is definitely fixed."

rust-rocksdb v0.24.0 includes both jemalloc linking fixes:
- PR #989 (ran-openai) — fixed jemalloc static linking
- PR #1026 (timothyg-stripe) — fixed jemalloc feature flag propagation

Mitigates #90

## Why mimalloc alone isn't enough

We already use `mimalloc` as Rust's `#[global_allocator]`, but this only covers Rust-side allocations. RocksDB's C++ code calls `malloc`/`free` directly through the system C runtime, bypassing Rust's allocator entirely. The `jemalloc` feature compiles RocksDB with `-DWITH_JEMALLOC=ON`, replacing the C allocator for all internal RocksDB operations.

## Test plan

- [x] `cargo check` passes on Windows (uses non-jemalloc path)
- [ ] CI build on Linux confirms jemalloc links correctly
- [ ] Memory test: RSS stays bounded under sustained writes