### PR TITLE
fix: resolve API key mismatch between MCP client and server

### DIFF
--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -54,9 +54,16 @@ function isLocalServer(): boolean {
 // Sandbox mode — used by Smithery to scan tools without a running backend
 const SANDBOX_MODE = process.env.SMITHERY_SANDBOX === "true";
 
-// API Key - required for remote servers, auto-generated for local
-// Set via SHODH_API_KEY env var, or configure in MCP settings
-let API_KEY = process.env.SHODH_API_KEY || (SANDBOX_MODE ? "sandbox" : "");
+// API Key resolution order:
+//   1. SHODH_API_KEY (explicit, preferred)
+//   2. SHODH_DEV_API_KEY (matches what the server accepts in dev mode)
+//   3. First key from SHODH_API_KEYS (matches server production config)
+//   4. Auto-generate for local servers (passed to server as SHODH_DEV_API_KEY)
+//   5. Error for remote servers
+let API_KEY = process.env.SHODH_API_KEY
+  || process.env.SHODH_DEV_API_KEY
+  || (process.env.SHODH_API_KEYS?.split(",")[0]?.trim())
+  || (SANDBOX_MODE ? "sandbox" : "");
 if (!API_KEY) {
   if (isLocalServer()) {
     // Auto-generate a random key for local development — zero config

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -36,6 +36,7 @@ fn should_hide_dev_key() -> bool {
 /// Log security warnings at startup based on environment configuration
 pub fn log_security_status() {
     let has_api_keys = env::var("SHODH_API_KEYS")
+        .or_else(|_| env::var("SHODH_API_KEY"))
         .map(|k| !k.trim().is_empty())
         .unwrap_or(false);
     let has_dev_key = env::var("SHODH_DEV_API_KEY")
@@ -177,35 +178,42 @@ fn constant_time_compare(a: &str, b: &str) -> bool {
 
 /// Validate API key against configured keys using constant-time comparison
 pub fn validate_api_key(provided_key: &str) -> Result<(), AuthError> {
-    // Get API keys from environment (comma-separated for multiple keys)
+    // Get API keys from environment.
+    // Resolution order: SHODH_API_KEYS (plural, comma-separated) → SHODH_API_KEY (singular)
+    //                 → SHODH_DEV_API_KEY (dev mode) → built-in default (dev mode only)
     let valid_keys = match env::var("SHODH_API_KEYS") {
         Ok(keys) if !keys.trim().is_empty() => keys,
-        _ => {
-            // In production, refuse to start without API keys
-            let is_production = env::var("SHODH_ENV")
-                .map(|v| v.to_lowercase() == "production" || v.to_lowercase() == "prod")
-                .unwrap_or(false);
+        _ => match env::var("SHODH_API_KEY") {
+            Ok(key) if !key.trim().is_empty() => key,
+            _ => {
+                // In production, refuse to start without API keys
+                let is_production = env::var("SHODH_ENV")
+                    .map(|v| v.to_lowercase() == "production" || v.to_lowercase() == "prod")
+                    .unwrap_or(false);
 
-            if is_production {
-                tracing::error!("SHODH_API_KEYS not set in production mode");
-                return Err(AuthError::NotConfigured);
-            }
+                if is_production {
+                    tracing::error!("SHODH_API_KEYS not set in production mode");
+                    return Err(AuthError::NotConfigured);
+                }
 
-            // Development mode: use SHODH_DEV_API_KEY, or fall back to built-in default
-            match env::var("SHODH_DEV_API_KEY") {
-                Ok(key) if !key.trim().is_empty() => {
-                    tracing::warn!("Using SHODH_DEV_API_KEY for development (not for production!)");
-                    key
-                }
-                _ => {
-                    tracing::warn!(
-                        "No API key configured. Falling back to default dev key. \
-                         Set SHODH_DEV_API_KEY to override."
-                    );
-                    DEFAULT_DEV_API_KEY.to_string()
+                // Development mode: use SHODH_DEV_API_KEY, or fall back to built-in default
+                match env::var("SHODH_DEV_API_KEY") {
+                    Ok(key) if !key.trim().is_empty() => {
+                        tracing::warn!(
+                            "Using SHODH_DEV_API_KEY for development (not for production!)"
+                        );
+                        key
+                    }
+                    _ => {
+                        tracing::warn!(
+                            "No API key configured. Falling back to default dev key. \
+                             Set SHODH_DEV_API_KEY to override."
+                        );
+                        DEFAULT_DEV_API_KEY.to_string()
+                    }
                 }
             }
-        }
+        },
     };
 
     let keys: Vec<&str> = valid_keys.split(',').map(|k| k.trim()).collect();


### PR DESCRIPTION
## Summary

- MCP client now checks `SHODH_API_KEY` → `SHODH_DEV_API_KEY` → first key from `SHODH_API_KEYS` → auto-generate
- Server now also accepts `SHODH_API_KEY` (singular) in addition to `SHODH_API_KEYS` (plural)
- Users no longer need to care about singular vs plural naming — either works

## Root Cause

The MCP client (`index.ts:59`) only checked `SHODH_API_KEY`. The server (`auth.rs:181`) only checked `SHODH_API_KEYS`. When a user set one but not the other, the MCP would auto-generate a random key that didn't match the server, causing silent auth failures.

## Test Plan

- [ ] Set only `SHODH_API_KEY=mykey` → both MCP and server should use it
- [ ] Set only `SHODH_API_KEYS=key1,key2` → MCP should use `key1`, server accepts both
- [ ] Set only `SHODH_DEV_API_KEY=devkey` → both should use it
- [ ] Set nothing → auto-generate for local, error for remote

Closes #115