### PR TITLE
fix: ad-hoc sign ONNX Runtime dylib on macOS

### DIFF
--- a/src/embeddings/downloader.rs
+++ b/src/embeddings/downloader.rs
@@ -549,6 +549,45 @@ fn extract_onnx_runtime(archive_path: &Path, dest_dir: &Path) -> Result<()> {
                 let dest_path = dest_dir.join(lib_name);
                 entry.unpack(&dest_path)?;
                 tracing::info!("Extracted {}", lib_name);
+
+                // macOS Gatekeeper blocks unsigned dylibs downloaded from the internet.
+                // Remove the quarantine xattr and ad-hoc sign so dlopen succeeds.
+                #[cfg(target_os = "macos")]
+                {
+                    // Remove com.apple.quarantine attribute (silent fail if not present)
+                    let _ = std::process::Command::new("xattr")
+                        .args(["-d", "com.apple.quarantine"])
+                        .arg(&dest_path)
+                        .output();
+
+                    // Ad-hoc code sign (no identity needed, just removes the unsigned flag)
+                    match std::process::Command::new("codesign")
+                        .args(["--force", "--deep", "-s", "-"])
+                        .arg(&dest_path)
+                        .output()
+                    {
+                        Ok(output) if output.status.success() => {
+                            tracing::info!(
+                                "Ad-hoc signed {} for macOS Gatekeeper",
+                                lib_name
+                            );
+                        }
+                        Ok(output) => {
+                            tracing::warn!(
+                                "codesign returned non-zero for {}: {}",
+                                lib_name,
+                                String::from_utf8_lossy(&output.stderr)
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "codesign not available ({}), dlopen may fail on macOS",
+                                e
+                            );
+                        }
+                    }
+                }
+
                 return Ok(());
             }
         }

--- a/src/embeddings/downloader.rs
+++ b/src/embeddings/downloader.rs
@@ -567,10 +567,7 @@ fn extract_onnx_runtime(archive_path: &Path, dest_dir: &Path) -> Result<()> {
                         .output()
                     {
                         Ok(output) if output.status.success() => {
-                            tracing::info!(
-                                "Ad-hoc signed {} for macOS Gatekeeper",
-                                lib_name
-                            );
+                            tracing::info!("Ad-hoc signed {} for macOS Gatekeeper", lib_name);
                         }
                         Ok(output) => {
                             tracing::warn!(


### PR DESCRIPTION
## Summary

Fixes the `dlopen failed` crash on macOS reported in #114.

macOS Gatekeeper quarantines dylibs downloaded from the internet. When `shodh init` or auto-download fetches `libonnxruntime.dylib`, the quarantine xattr causes `dlopen` to fail with `GenericFailure`, crashing the server on first NER model load.

After extracting the ONNX Runtime archive on macOS:
1. `xattr -d com.apple.quarantine` — removes the quarantine flag
2. `codesign --force --deep -s -` — ad-hoc signs the dylib (no Apple Developer identity needed)

Gated behind `#[cfg(target_os = "macos")]`. Non-fatal warnings if `codesign` is unavailable.

## Test plan

- [ ] `cargo check` — compiles clean
- [ ] Fresh `shodh init` on macOS — dylib downloads, signs, server starts without dlopen error
- [ ] Existing installs (dylib already present) — `is_onnx_runtime_downloaded()` returns true, skips download+sign
- [ ] Linux/Windows — `#[cfg]` gate ensures no codesign calls