### PR TITLE
feat: tool-aware feedback attribution

### DIFF
--- a/hooks/memory-hook.ts
+++ b/hooks/memory-hook.ts
@@ -64,6 +64,9 @@ interface ProactiveContextResponse {
 
 const HOOK_TIMEOUT_MS = 5000;
 
+/** Tool actions collected since last proactive_context call for feedback attribution */
+const pendingToolActions: { tool_name: string; inputs: Record<string, string>; success: boolean; output_snippet?: string }[] = [];
+
 async function callBrain(endpoint: string, body: Record<string, unknown>): Promise<unknown> {
   try {
     const controller = new AbortController();
@@ -136,6 +139,9 @@ export function buildPreToolContext(toolName: string, toolInput: Record<string, 
 }
 
 async function surfaceProactiveContext(context: string, maxResults = 3, autoIngest = false): Promise<string | null> {
+  // Drain pending tool actions for feedback attribution
+  const toolActions = pendingToolActions.splice(0, pendingToolActions.length);
+
   const response = (await callBrain("/api/proactive_context", {
     user_id: SHODH_USER_ID,
     context,
@@ -144,6 +150,7 @@ async function surfaceProactiveContext(context: string, maxResults = 3, autoInge
     entity_match_weight: 0.3,
     recency_weight: 0.2,
     auto_ingest: autoIngest,
+    ...(toolActions.length > 0 ? { tool_actions: toolActions } : {}),
   })) as ProactiveContextResponse | null;
 
   if (!response) return null;
@@ -252,6 +259,30 @@ async function handlePostToolUse(input: HookInput): Promise<void> {
   const toolOutput = input.tool_output;
 
   if (!toolName) return;
+
+  // Record tool action for feedback attribution (before any early returns)
+  if (toolName !== "Task") {
+    const actionRecord: (typeof pendingToolActions)[number] = {
+      tool_name: toolName,
+      inputs: {},
+      success: true,
+    };
+    if (toolInput) {
+      for (const [k, v] of Object.entries(toolInput)) {
+        if (typeof v === "string") {
+          actionRecord.inputs[k] = v.slice(0, 500);
+        }
+      }
+    }
+    if (toolOutput) {
+      actionRecord.success = !isErrorOutput(toolOutput);
+      actionRecord.output_snippet = toolOutput.slice(0, 200);
+    }
+    pendingToolActions.push(actionRecord);
+    if (pendingToolActions.length > 50) {
+      pendingToolActions.splice(0, pendingToolActions.length - 50);
+    }
+  }
 
   // Orchestration: handle Task tool completions
   if (toolName === "Task") {

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -828,6 +828,21 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: "Automatically store the context as a Conversation memory (default: true). Set to false to only surface memories without storing.",
               default: true,
             },
+            tool_actions: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  tool_name: { type: "string", description: "Tool or actuator name (e.g., 'Edit', 'Bash', 'navigate', 'grasp')" },
+                  inputs: { type: "object", additionalProperties: { type: "string" }, description: "Key-value input parameters" },
+                  success: { type: "boolean", description: "Whether the action succeeded" },
+                  output_snippet: { type: "string", description: "First 200 chars of output" },
+                  reward: { type: "number", description: "Reward signal for robotics (-1.0 to 1.0)" },
+                },
+                required: ["tool_name", "success"],
+              },
+              description: "Tool/actuator actions performed since last proactive_context call. Used for causal feedback attribution.",
+            },
           },
           required: ["context"],
         },
@@ -2142,6 +2157,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           max_results = 5,
           memory_types = [],
           auto_ingest = true,
+          tool_actions = [],
         } = args as {
           context: string;
           semantic_threshold?: number;
@@ -2150,6 +2166,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           max_results?: number;
           memory_types?: string[];
           auto_ingest?: boolean;
+          tool_actions?: { tool_name: string; inputs?: Record<string, string>; success: boolean; output_snippet?: string; reward?: number }[];
         };
 
         // --- Response types matching ProactiveContextResponse (Rust backend) ---
@@ -2249,6 +2266,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           // Implicit feedback: send previous response so backend can evaluate which memories helped
           previous_response: lastProactiveResponse || undefined,
           user_followup: lastProactiveResponse ? cleanedContext : undefined,
+          // Tool-aware feedback attribution: causal signal from tool/actuator actions
+          ...(tool_actions.length > 0 ? { tool_actions } : {}),
         });
 
         const memories = result.memories || [];

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -126,6 +126,13 @@ pub struct ProactiveContextRequest {
     /// User's followup message after agent response (for delayed signals)
     #[serde(default)]
     pub user_followup: Option<String>,
+    /// Tool/actuator actions performed since last proactive_context call.
+    /// Used for tool-aware feedback attribution: matches actions against
+    /// previously surfaced memories to detect concrete usage.
+    /// Claude Code: collected by hooks (Read, Edit, Bash calls).
+    /// Robotics: constructed from action-outcome Experience fields.
+    #[serde(default)]
+    pub tool_actions: Vec<crate::memory::feedback::ToolAction>,
 }
 
 fn default_proactive_max_results() -> usize {
@@ -923,6 +930,7 @@ pub async fn proactive_context(
         let response_text = super::utils::strip_mcp_response_noise(prev_response);
         let followup = req.user_followup.clone();
         let memory_for_embed = memory_system.clone();
+        let tool_actions_for_feedback = std::mem::take(&mut req.tool_actions);
 
         // Process feedback and collect memory IDs for reinforcement.
         // Split into 3 phases to minimize write-lock hold time on the shared FeedbackStore:
@@ -933,7 +941,15 @@ pub async fn proactive_context(
             // Phase 1: Extract pending data under brief write lock
             let (pending, context_pattern) = {
                 let mut store = feedback_store.write();
-                let pending = store.take_pending(&user_id_for_feedback);
+                let pending = store.take_pending(&user_id_for_feedback).map(|mut p| {
+                    // Attach tool actions from current request to previous pending.
+                    // These actions happened AFTER memories were surfaced (previous call)
+                    // and BEFORE this call — exactly the attribution window.
+                    if !tool_actions_for_feedback.is_empty() {
+                        p.tool_actions = tool_actions_for_feedback;
+                    }
+                    p
+                });
                 let context_pattern = pending.as_ref().and_then(|p| {
                     if p.context_embedding.is_empty() {
                         return None;

--- a/src/memory/feedback.rs
+++ b/src/memory/feedback.rs
@@ -52,6 +52,23 @@ const SIGNAL_IGNORED_PENALTY: f32 = -0.2; // Memory shown but completely unused
 const ENTITY_WEIGHT: f32 = 0.4;
 const SEMANTIC_WEIGHT: f32 = 0.6;
 
+/// Tool-usage attribution constants
+/// Minimum Jaccard token overlap between memory content and tool action inputs.
+/// Lower than entity overlap (0.1) because tool inputs are short with high
+/// information density per token (file paths, commands, coordinates).
+const TOOL_USAGE_MIN_OVERLAP: f32 = 0.08;
+/// Above this Jaccard overlap, signal gets high confidence (0.9).
+const TOOL_USAGE_STRONG_THRESHOLD: f32 = 0.25;
+/// Positive signal when tool action matches memory and succeeds.
+/// Stronger than SIGNAL_STRONG_MULTIPLIER (0.8) because tool usage is
+/// a concrete behavioral signal, not just word overlap.
+const TOOL_USAGE_SUCCESS_SIGNAL: f32 = 0.7;
+/// Negative signal when tool action matches memory but fails.
+const TOOL_USAGE_FAILURE_SIGNAL: f32 = -0.4;
+/// Blend weight for tool signal vs entity+semantic.
+/// When a tool action matches, 35% of final signal comes from tool attribution.
+const TOOL_USAGE_WEIGHT: f32 = 0.35;
+
 /// Stability adjustment rates
 const STABILITY_INCREMENT: f32 = 0.05;
 const STABILITY_DECREMENT_MULTIPLIER: f32 = 0.1;
@@ -141,6 +158,53 @@ pub enum SignalTrigger {
         memory_entities_used: usize,
         response_entities_total: usize,
     },
+
+    /// Tool/actuator action matched surfaced memory content.
+    /// The agent performed a concrete action aligned with the memory's guidance.
+    /// Covers both Claude Code tools (Read, Edit, Bash) and robot actuators
+    /// (navigate, grasp, sense).
+    ToolUsage {
+        /// Jaccard token overlap between memory content and tool inputs (0.0-1.0)
+        content_overlap: f32,
+        /// Tool or actuator name
+        tool_name: String,
+        /// Whether the tool action succeeded
+        success: bool,
+    },
+}
+
+/// A tool or actuator action performed between feedback cycles.
+///
+/// Unified abstraction covering Claude Code tools (Read, Edit, Write, Bash)
+/// and robot actuator commands (navigate, grasp, sense). The feedback system
+/// matches action inputs/outputs against surfaced memory content to determine
+/// whether a memory influenced a concrete action.
+///
+/// For Claude Code: collected by hooks between proactive_context calls.
+/// For robotics: constructed from Experience fields when remember() follows recall().
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolAction {
+    /// Tool or actuator name: "Edit", "Bash", "navigate", "grasp"
+    pub tool_name: String,
+
+    /// Key-value inputs.
+    /// Claude Code: {"file_path": "/src/main.rs", "command": "cargo build"}.
+    /// Robotics: {"target": "waypoint_7", "speed": "0.5"}.
+    #[serde(default)]
+    pub inputs: HashMap<String, String>,
+
+    /// Whether the action succeeded.
+    /// Claude Code: true unless tool_output contains error markers.
+    /// Robotics: derived from outcome_type (success/partial = true).
+    pub success: bool,
+
+    /// First 200 chars of output. Used for content matching.
+    #[serde(default)]
+    pub output_snippet: Option<String>,
+
+    /// Reward signal (robotics only, -1.0 to 1.0). None for Claude Code tools.
+    #[serde(default)]
+    pub reward: Option<f32>,
 }
 
 /// A single feedback signal
@@ -609,6 +673,11 @@ pub struct PendingFeedback {
     pub surfaced_memories: Vec<SurfacedMemoryInfo>,
     pub context: String,
     pub context_embedding: Vec<f32>,
+    /// Tool/actuator actions performed after memories were surfaced.
+    /// Claude Code: collected by hooks between proactive_context calls.
+    /// Robotics: populated from action-outcome Experience fields.
+    #[serde(default)]
+    pub tool_actions: Vec<ToolAction>,
 }
 
 impl PendingFeedback {
@@ -624,6 +693,7 @@ impl PendingFeedback {
             surfaced_memories: memories,
             context,
             context_embedding,
+            tool_actions: Vec::new(),
         }
     }
 
@@ -855,6 +925,27 @@ pub fn process_implicit_feedback_with_semantics(
             )
         };
 
+        // Tool-usage attribution: blend if tool actions matched this memory
+        let (combined_value, combined_confidence, trigger) =
+            if let Some((tool_val, tool_conf, tool_name, tool_overlap)) =
+                compute_tool_usage_signal(memory, &pending.tool_actions)
+            {
+                let blended_value =
+                    (TOOL_USAGE_WEIGHT * tool_val) + ((1.0 - TOOL_USAGE_WEIGHT) * combined_value);
+                let blended_conf = tool_conf.max(combined_confidence);
+                (
+                    blended_value,
+                    blended_conf,
+                    SignalTrigger::ToolUsage {
+                        content_overlap: tool_overlap,
+                        tool_name,
+                        success: tool_val > 0.0,
+                    },
+                )
+            } else {
+                (combined_value, combined_confidence, trigger)
+            };
+
         let mut signal = SignalRecord::new(combined_value, combined_confidence, trigger);
 
         // Apply negative keyword penalty if detected in followup
@@ -871,6 +962,96 @@ pub fn process_implicit_feedback_with_semantics(
     }
 
     signals
+}
+
+/// Compute tool-usage attribution signal for a single memory.
+///
+/// Checks whether any tool action's inputs or output contain content
+/// from the surfaced memory. Uses normalized Jaccard token overlap
+/// because tool inputs are short and keyword-heavy (file paths, commands,
+/// coordinates, waypoints).
+///
+/// Returns `(signal_value, confidence, tool_name, overlap)` for the best
+/// matching tool action, or None if no match above threshold.
+pub fn compute_tool_usage_signal(
+    memory: &SurfacedMemoryInfo,
+    tool_actions: &[ToolAction],
+) -> Option<(f32, f32, String, f32)> {
+    if tool_actions.is_empty() {
+        return None;
+    }
+
+    let memory_tokens: HashSet<&str> = memory
+        .content_preview
+        .split(|c: char| !c.is_alphanumeric() && c != '_' && c != '-' && c != '.' && c != '/')
+        .filter(|w| w.len() >= 3)
+        .collect();
+
+    if memory_tokens.is_empty() {
+        return None;
+    }
+
+    let mut best_overlap = 0.0f32;
+    let mut best_tool = String::new();
+    let mut best_success = false;
+    let mut best_reward: Option<f32> = None;
+
+    for action in tool_actions {
+        let mut action_text = String::new();
+        for value in action.inputs.values() {
+            action_text.push(' ');
+            action_text.push_str(value);
+        }
+        if let Some(ref snippet) = action.output_snippet {
+            action_text.push(' ');
+            action_text.push_str(snippet);
+        }
+
+        let action_tokens: HashSet<&str> = action_text
+            .split(|c: char| !c.is_alphanumeric() && c != '_' && c != '-' && c != '.' && c != '/')
+            .filter(|w| w.len() >= 3)
+            .collect();
+
+        if action_tokens.is_empty() {
+            continue;
+        }
+
+        let intersection = memory_tokens.intersection(&action_tokens).count() as f32;
+        let union = memory_tokens.union(&action_tokens).count() as f32;
+        let overlap = if union > 0.0 {
+            intersection / union
+        } else {
+            0.0
+        };
+
+        if overlap > best_overlap {
+            best_overlap = overlap;
+            best_tool = action.tool_name.clone();
+            best_success = action.success;
+            best_reward = action.reward;
+        }
+    }
+
+    if best_overlap < TOOL_USAGE_MIN_OVERLAP {
+        return None;
+    }
+
+    // For robotics actions with explicit reward, use the reward directly
+    let base_value = if let Some(reward) = best_reward {
+        reward * best_overlap
+    } else if best_success {
+        TOOL_USAGE_SUCCESS_SIGNAL * best_overlap
+    } else {
+        TOOL_USAGE_FAILURE_SIGNAL * best_overlap
+    };
+
+    let confidence = if best_overlap >= TOOL_USAGE_STRONG_THRESHOLD {
+        0.9
+    } else {
+        0.65
+    };
+
+    Some((base_value, confidence, best_tool, best_overlap))
 }
 
 /// Apply context pattern signals (repetition/topic change) to existing signals

--- a/src/zenoh_transport/handlers.rs
+++ b/src/zenoh_transport/handlers.rs
@@ -24,6 +24,7 @@ use crate::handlers::state::MultiUserMemoryManager;
 use crate::handlers::types::{
     MemoryEvent, RecallExperience, RecallFact, RecallMemory, RecallResponse, RecallTodo,
 };
+use crate::memory::feedback::{self, PendingFeedback, SurfacedMemoryInfo, ToolAction};
 use crate::memory::types::{ForgetCriteria, GeoFilter, MemoryId};
 use crate::memory::{
     Experience, MemorySystem, Query as MemoryQuery, RetrievalMode, SessionEvent, TodoStatus,
@@ -389,6 +390,74 @@ pub async fn handle_remember(sample: Sample, manager: Arc<MultiUserMemoryManager
         }
     };
 
+    // Tool-aware feedback attribution for robotics:
+    // If this remember() carries an action+reward, attribute it to the most recent recall.
+    // Pattern: robot recalls memories → acts → remembers outcome with action_type+reward.
+    // We take the PendingFeedback from the prior recall, attach the action as a ToolAction,
+    // then run the same signal processing + momentum update pipeline as HTTP proactive_context.
+    if req.action_type.is_some() && req.reward.is_some() {
+        let feedback_store = manager.feedback_store().clone();
+        let user_id_for_attr = req.user_id.clone();
+        let action_type = req.action_type.clone().unwrap_or_default();
+        let action_params = req.action_params.clone().unwrap_or_default();
+        let outcome_type = req.outcome_type.clone().unwrap_or_default();
+        let outcome_details = req.outcome_details.clone();
+        let reward = req.reward;
+
+        tokio::spawn(async move {
+            // Build ToolAction from robotics experience fields
+            let tool_action = ToolAction {
+                tool_name: action_type,
+                inputs: action_params,
+                success: matches!(outcome_type.as_str(), "success" | "partial"),
+                output_snippet: outcome_details.map(|s| s.chars().take(200).collect()),
+                reward,
+            };
+
+            // Phase 1: Take pending feedback under brief write lock
+            let pending = {
+                let mut store = feedback_store.write();
+                store.take_pending(&user_id_for_attr).map(|mut p| {
+                    p.tool_actions = vec![tool_action];
+                    p
+                })
+            };
+
+            if let Some(pending) = pending {
+                // Phase 2: Compute signals — no lock held
+                // For robotics, there's no "response text" — the tool action IS the response.
+                // Pass empty response so entity/semantic signals are minimal; tool signal dominates.
+                let signals =
+                    feedback::process_implicit_feedback_with_semantics(&pending, "", None, None);
+
+                if !signals.is_empty() {
+                    // Phase 3: Apply momentum updates under brief write lock
+                    let mut store = feedback_store.write();
+                    for (memory_id, signal) in &signals {
+                        let momentum = store.get_or_create_momentum(
+                            memory_id.clone(),
+                            crate::memory::types::ExperienceType::Context,
+                        );
+                        momentum.update(signal.clone());
+                        store.mark_dirty(memory_id);
+                    }
+                    if let Err(e) = store.flush() {
+                        debug!(
+                            "Failed to flush feedback store after robot attribution: {}",
+                            e
+                        );
+                    }
+
+                    debug!(
+                        user_id = %user_id_for_attr,
+                        signals = signals.len(),
+                        "Robotics tool-aware feedback attribution completed"
+                    );
+                }
+            }
+        });
+    }
+
     // Record metrics
     let duration = op_start.elapsed().as_secs_f64();
     metrics::MEMORY_STORE_DURATION.observe(duration);
@@ -737,6 +806,49 @@ pub async fn handle_recall(query: Query, manager: Arc<MultiUserMemoryManager>) {
             error!("Failed to serialize recall response: {}", e);
             reply_error(&query, "Serialization error").await;
         }
+    }
+
+    // Store PendingFeedback so subsequent remember() calls with action+reward
+    // can attribute outcomes to the memories we just surfaced.
+    if !recall_memories.is_empty() {
+        let memory_for_embed = memory.clone();
+        let query_for_embed = query_text.clone();
+        let user_id_for_fb = user_id.clone();
+        let feedback_store = manager.feedback_store().clone();
+
+        // Build surfaced memory info from recall results
+        let surfaced_infos: Vec<SurfacedMemoryInfo> = memories
+            .iter()
+            .map(|m| SurfacedMemoryInfo {
+                id: m.id.clone(),
+                entities: m.experience.entities.iter().cloned().collect(),
+                content_preview: m.experience.content.chars().take(200).collect(),
+                score: m.salience_score_with_access(),
+                embedding: Vec::new(), // Filled below if embedding succeeds
+            })
+            .collect();
+
+        // Compute context embedding in background for semantic feedback later
+        let context_for_pending = query_for_embed.clone();
+        tokio::spawn(async move {
+            let embedding = tokio::task::spawn_blocking(move || {
+                let guard = memory_for_embed.read();
+                guard
+                    .compute_embedding(&query_for_embed)
+                    .unwrap_or_default()
+            })
+            .await
+            .unwrap_or_default();
+
+            let pending = PendingFeedback::new(
+                user_id_for_fb,
+                context_for_pending,
+                embedding,
+                surfaced_infos,
+            );
+            let mut store = feedback_store.write();
+            store.set_pending(pending);
+        });
     }
 
     debug!(


### PR DESCRIPTION
## Summary

Closes #123. Adds causal feedback signal from tool/actuator actions to the implicit feedback pipeline.

- **ToolAction struct**: Unified abstraction covering Claude Code tools (`Read`, `Edit`, `Bash`) and robot actuators (`navigate`, `grasp`, `sense`) with inputs, success flag, output snippet, and optional reward
- **Jaccard token overlap**: `compute_tool_usage_signal()` tokenizes memory content and tool inputs, computes overlap to determine if a tool action was influenced by a surfaced memory
- **Signal blending**: Tool signal at 35% weight blended with existing entity+semantic signals; robotics reward passed through directly when present
- **Full pipeline**: Hook collects PostToolUse actions → MCP passes through → backend merges into PendingFeedback → attribution runs on next proactive_context call
- **Robotics bridge**: Zenoh `handle_recall()` stores PendingFeedback with surfaced memories; subsequent `handle_remember()` with action_type+reward triggers immediate attribution and momentum update

## Files Changed

| File | Changes |
|------|---------|
| `src/memory/feedback.rs` | ToolAction struct, ToolUsage signal variant, 5 constants, `compute_tool_usage_signal()`, integration into `process_implicit_feedback_with_semantics()`, PendingFeedback.tool_actions field |
| `src/handlers/recall.rs` | `tool_actions` on ProactiveContextRequest, wired into feedback processing |
| `hooks/memory-hook.ts` | Collect tool actions in PostToolUse, drain in surfaceProactiveContext |
| `mcp-server/index.ts` | Schema + destructuring + API pass-through for tool_actions |
| `src/zenoh_transport/handlers.rs` | PendingFeedback in handle_recall, robot action attribution in handle_remember |

## Test plan

- [x] `cargo check` — clean compile
- [x] `cargo clippy` — no new warnings
- [x] `cargo fmt` — formatted
- [x] `cargo test --lib` — 495 passed, 0 failed
- [ ] Manual: start shodh, use Claude Code with hooks, verify `feedback_processed` shows tool-attributed reinforcements
- [ ] Zenoh: recall → remember(action+reward) sequence, verify momentum updates