### PR TITLE
fix: word-boundary matching, consistent ontological filtering, edge dedup

### DIFF
--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -3113,7 +3113,9 @@ impl GraphMemory {
         // Sort entities by path score (decay_factor) descending
         all_entities.sort_by(|a, b| b.decay_factor.total_cmp(&a.decay_factor));
 
-        // Hebbian strengthening
+        // Hebbian strengthening (deduplicate: same edge may appear on multiple paths)
+        edges_to_strengthen.sort();
+        edges_to_strengthen.dedup();
         if !edges_to_strengthen.is_empty() {
             if let Err(e) = self.batch_strengthen_synapses(&edges_to_strengthen) {
                 tracing::debug!("Failed to strengthen synapses: {}", e);

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -687,6 +687,14 @@ pub fn spreading_activation_retrieve_with_stats(
                 let edges = graph
                     .get_entity_relationships_limited(&entity_uuid, Some(MAX_EDGES_PER_SPREAD))?;
 
+                // Degree normalization: prevent hub nodes from flooding the network.
+                // Matches bidirectional path (Anderson & Reder 1999 ACT-R).
+                let degree_norm = if SPREADING_DEGREE_NORMALIZATION {
+                    1.0 / (1.0 + edges.len() as f32).sqrt()
+                } else {
+                    1.0
+                };
+
                 for edge in edges {
                     // Spread activation to connected entity
                     let target_uuid = edge.to_entity;
@@ -707,7 +715,8 @@ pub fn spreading_activation_retrieve_with_stats(
                     let decay_rate = calculate_importance_weighted_decay(effective);
                     let decay = (-decay_rate * hop as f32).exp();
 
-                    let base_spread = source_activation * decay * effective * tier_trust;
+                    let base_spread =
+                        source_activation * decay * effective * tier_trust * degree_norm;
 
                     // Ontological type penalty (same as bidirectional path)
                     let spread_amount = if let Some(intent) = intent_ref {
@@ -733,7 +742,13 @@ pub fn spreading_activation_retrieve_with_stats(
                                         .map(|e| e.labels)
                                 });
                             if let Some(labels) = cached_labels {
-                                if !labels.iter().any(|l| intent.expected_labels.contains(l)) {
+                                let type_match = labels.iter().any(|l| {
+                                    intent
+                                        .expected_labels
+                                        .iter()
+                                        .any(|exp| l.matches_with_hierarchy(exp))
+                                });
+                                if !type_match {
                                     penalty *= ONTOLOGICAL_ENTITY_PENALTY;
                                 }
                             }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -278,6 +278,17 @@ fn build_ner_lookup(
         .collect()
 }
 
+/// Tokenize text into word-level tokens for boundary-safe matching.
+///
+/// Splits on non-alphanumeric characters (preserving apostrophes for contractions),
+/// filters tokens shorter than 3 characters. Returns borrowed slices to avoid allocation.
+/// Caller should lowercase the input first for case-insensitive matching.
+fn tokenize_words(text: &str) -> HashSet<&str> {
+    text.split(|c: char| !c.is_alphanumeric() && c != '\'')
+        .filter(|w| w.len() >= 3)
+        .collect()
+}
+
 impl MemorySystem {
     /// Create a new memory system.
     ///
@@ -1520,15 +1531,21 @@ impl MemorySystem {
                         });
 
                     if let Some(content) = content {
-                        // Must contain entity
-                        if !content.contains(&entity_lower) {
+                        let content_words = tokenize_words(&content);
+                        // Must contain all entity words (word-boundary safe)
+                        if !entity_lower
+                            .split_whitespace()
+                            .all(|w| content_words.contains(w))
+                        {
                             continue;
                         }
-                        // Must contain at least one attribute synonym
-                        let has_synonym = attr_query
-                            .attribute_synonyms
-                            .iter()
-                            .any(|syn| content.contains(&syn.to_lowercase()));
+                        // Must contain at least one attribute synonym (word-level)
+                        let has_synonym = attr_query.attribute_synonyms.iter().any(|syn| {
+                            let syn_lower = syn.to_lowercase();
+                            syn_lower
+                                .split_whitespace()
+                                .all(|w| content_words.contains(w))
+                        });
                         if has_synonym {
                             boosted_ids.insert(mem_id);
                         }
@@ -2312,9 +2329,10 @@ impl MemorySystem {
                         for id in &ids {
                             if let Some(content) = get_content(id) {
                                 let content_lower = content.to_lowercase();
+                                let content_words = tokenize_words(&content_lower);
                                 let match_count = signal_terms
                                     .iter()
-                                    .filter(|term| content_lower.contains(term.as_str()))
+                                    .filter(|term| content_words.contains(term.as_str()))
                                     .count();
 
                                 if match_count > 0 {


### PR DESCRIPTION
## Summary

- Replace substring `.contains()` with word-level `tokenize_words()` for prospective signal and attribute query matching — prevents false positives like "run" matching "runtime"
- Use `matches_with_hierarchy()` in unidirectional spreading activation to match bidirectional path behavior
- Add degree normalization to unidirectional spreading activation (was missing, bidirectional had it)
- Deduplicate edges before batch Hebbian strengthening

## Files changed

- `src/memory/mod.rs` — `tokenize_words()` helper, fixed prospective + attribute matching
- `src/memory/graph_retrieval.rs` — hierarchical label matching, degree normalization
- `src/graph_memory.rs` — edge dedup before batch strengthen

## Test plan

- [x] `cargo check` — compiles
- [x] `cargo clippy` — no new warnings
- [x] `cargo fmt` — formatted
- [x] `cargo test --lib` — 495 passed

Closes #139