### PR TITLE
fix: connect disconnected scoring signals

### DIFF
--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -960,6 +960,15 @@ pub fn spreading_activation_retrieve_with_stats(
     traversed_edges.dedup();
     stats.traversed_edges = traversed_edges;
 
+    // Hebbian reinforcement: strengthen edges traversed during spreading activation
+    // Other traversal methods (traverse_from_entity, traverse_weighted, traverse_bidirectional)
+    // all call batch_strengthen_synapses — spreading activation should too
+    if !stats.traversed_edges.is_empty() {
+        if let Err(e) = graph.batch_strengthen_synapses(&stats.traversed_edges) {
+            tracing::debug!("Spreading activation edge strengthening failed: {}", e);
+        }
+    }
+
     tracing::info!(
         "🎯 Returning {} memories (top scores: {:?}), {} edges traversed",
         scored_memories.len(),

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -2542,18 +2542,15 @@ impl MemorySystem {
 
                 // FEEDBACK MOMENTUM (PIPE-9)
                 // Apply momentum from past feedback to consistently boost/suppress memories
-                // - Positive momentum (proven helpful) → boost score
-                // - Negative momentum (frequently ignored) → suppress up to 20%
+                // Symmetric 15% range: helpful memories boosted, misleading ones suppressed equally
                 // This ensures consistent feedback integration across ALL retrieval paths
                 let feedback_multiplier = if let Some(ref guard) = feedback_guard {
                     if let Some(fm) = guard.get_momentum(&mem.id) {
                         let momentum = fm.ema_with_decay();
                         if momentum < 0.0 {
-                            // Suppress: up to 20% penalty for highly negative momentum
-                            1.0 + (momentum * 0.2).max(-0.2)
+                            1.0 + (momentum * 0.15).max(-0.15)
                         } else {
-                            // Boost: up to 10% bonus for positive momentum
-                            1.0 + (momentum * 0.1).min(0.1)
+                            1.0 + (momentum * 0.15).min(0.15)
                         }
                     } else {
                         1.0 // No feedback history
@@ -2562,9 +2559,16 @@ impl MemorySystem {
                     1.0 // No feedback store configured
                 };
 
-                let final_score =
-                    (base + recency_boost + arousal_boost + credibility_boost + temporal_boost)
-                        * feedback_multiplier;
+                // Importance weighting: scale base score by learned importance (7 factors)
+                // Range 0.7-1.0: low-importance memories lose up to 30% of base score
+                let importance_factor = 0.7 + mem.importance() * 0.3;
+
+                let final_score = (base * importance_factor
+                    + recency_boost
+                    + arousal_boost
+                    + credibility_boost
+                    + temporal_boost)
+                    * feedback_multiplier;
 
                 let mut cloned: Memory = mem.as_ref().clone();
                 cloned.set_score(final_score);


### PR DESCRIPTION
Closes #137

## Summary
- **Importance factor in semantic retrieval**: `mem.importance()` (computed at remember-time via 7 factors) was ignored in the main semantic scoring path. Now scales base score multiplicatively (range 0.7-1.0), so low-importance memories lose up to 30% of base score while high-importance memories retain full score.
- **Spreading activation Hebbian reinforcement**: `batch_strengthen_synapses()` is called by all 3 traversal methods in `graph_memory.rs` but was missing from spreading activation in `graph_retrieval.rs`. Traversed edges were collected, deduped, logged — then discarded. Now reinforced.
- **Symmetric feedback momentum**: Negative momentum scaled by 0.2 (20% penalty), positive by 0.1 (10% bonus) — failures punished 2× harder than successes rewarded. Symmetrized both to 0.15 (range 0.85-1.15).

## Bug 2 (feedback → traversed edges) — deferred
`recall()` doesn't return `RetrievalStats` to the handler, so traversed edges aren't available at feedback time. The spreading activation fix (above) provides unconditional Hebbian strengthening. Feedback-selective strengthening requires changing the `recall()` return type — future scope.

## Test plan
- [x] `cargo check` — compiles
- [x] `cargo clippy` — no new warnings
- [x] `cargo fmt`
- [x] `cargo test --lib` — 495 passed