### PR TITLE
fix(zenoh): forget user_id extraction, temporal fact timestamp, recall auth bypass

### DIFF
--- a/src/zenoh_transport/handlers.rs
+++ b/src/zenoh_transport/handlers.rs
@@ -431,6 +431,7 @@ pub async fn handle_remember(sample: Sample, manager: Arc<MultiUserMemoryManager
     let agent_id = req.agent_id.clone();
     let run_id = req.run_id.clone();
     let created_at = req.created_at;
+    let created_at_for_facts = created_at.unwrap_or_else(chrono::Utc::now);
 
     let memory_id = match tokio::task::spawn_blocking(move || {
         let guard = memory_clone.read();
@@ -593,7 +594,7 @@ pub async fn handle_remember(sample: Sample, manager: Arc<MultiUserMemoryManager
             let uid = user_id.clone();
             let content = experience.content.clone();
             let entities = experience.entities.clone();
-            let created_at = chrono::Utc::now();
+            let created_at = created_at_for_facts;
             let _ = tokio::task::spawn_blocking(move || {
                 let guard = mem.read();
                 guard.store_temporal_facts_for_memory(&uid, &mid, &content, &entities, created_at)
@@ -850,6 +851,8 @@ pub async fn handle_recall(query: Query, manager: Arc<MultiUserMemoryManager>) {
         Some(facts.len())
     };
 
+    let has_recall_memories = !recall_memories.is_empty();
+
     let response = RecallResponse {
         memories: recall_memories,
         count: total,
@@ -878,7 +881,7 @@ pub async fn handle_recall(query: Query, manager: Arc<MultiUserMemoryManager>) {
 
     // Store PendingFeedback so subsequent remember() calls with action+reward
     // can attribute outcomes to the memories we just surfaced.
-    if !recall_memories.is_empty() {
+    if has_recall_memories {
         let memory_for_embed = memory.clone();
         let query_for_embed = query_text.clone();
         let user_id_for_fb = user_id.clone();
@@ -933,7 +936,7 @@ pub async fn handle_recall(query: Query, manager: Arc<MultiUserMemoryManager>) {
 /// Handle a Zenoh DELETE/PUT on `{prefix}/{user_id}/forget`.
 ///
 /// Payload: `{ "memory_id": "uuid-string" }` or `{ "id": "uuid-string" }`
-pub async fn handle_forget(sample: Sample, manager: Arc<MultiUserMemoryManager>) {
+pub async fn handle_forget(sample: Sample, manager: Arc<MultiUserMemoryManager>, prefix: &str) {
     #[derive(serde::Deserialize)]
     struct ForgetRequest {
         #[serde(default)]
@@ -952,11 +955,11 @@ pub async fn handle_forget(sample: Sample, manager: Arc<MultiUserMemoryManager>)
         }
     };
 
-    // Extract user_id from key expression or payload
+    // Extract user_id from payload, falling back to key expression: {prefix}/{user_id}/forget
     let user_id = req.user_id.unwrap_or_else(|| {
-        // Try to extract from key expr: shodh/{user_id}/forget
-        // This will be the fallback since we parsed from payload first
-        String::new()
+        extract_user_id(&key, prefix)
+            .map(|s| s.to_string())
+            .unwrap_or_default()
     });
 
     if user_id.is_empty() {

--- a/src/zenoh_transport/mod.rs
+++ b/src/zenoh_transport/mod.rs
@@ -280,6 +280,7 @@ async fn register_forget_subscriber(
         .map_err(|e| anyhow::anyhow!("Failed to declare forget subscriber: {e}"))?;
 
     let mgr = Arc::clone(manager);
+    let prefix_owned = prefix.to_string();
 
     tokio::spawn(async move {
         loop {
@@ -291,8 +292,9 @@ async fn register_forget_subscriber(
                                 continue;
                             }
                             let mgr = Arc::clone(&mgr);
+                            let pfx = prefix_owned.clone();
                             tokio::spawn(async move {
-                                handlers::handle_forget(sample, mgr).await;
+                                handlers::handle_forget(sample, mgr, &pfx).await;
                             });
                         }
                         Err(e) => {
@@ -477,14 +479,24 @@ async fn register_recall_queryable(
                 query = queryable.recv_async() => {
                     match query {
                         Ok(query) => {
-                            if let Some(payload) = query.payload() {
-                                if !handlers::authenticate_payload(payload, api_key.as_deref()) {
-                                    let err = serde_json::json!({"error": "Unauthorized", "success": false});
+                            match query.payload() {
+                                Some(payload) => {
+                                    if !handlers::authenticate_payload(payload, api_key.as_deref()) {
+                                        let err = serde_json::json!({"error": "Unauthorized", "success": false});
+                                        if let Ok(bytes) = serde_json::to_vec(&err) {
+                                            let _ = query.reply(query.key_expr(), bytes).await;
+                                        }
+                                        continue;
+                                    }
+                                }
+                                None if api_key.is_some() => {
+                                    let err = serde_json::json!({"error": "Unauthorized: payload required when API key is configured", "success": false});
                                     if let Ok(bytes) = serde_json::to_vec(&err) {
                                         let _ = query.reply(query.key_expr(), bytes).await;
                                     }
                                     continue;
                                 }
+                                None => {} // No auth configured, pass through
                             }
                             let mgr = Arc::clone(&mgr);
                             tokio::spawn(async move {


### PR DESCRIPTION
## Summary

Four bugs fixed in the Zenoh transport module.

## Fixes

### 1. `handle_forget` user_id extraction (handlers.rs:956)
- **Bug:** When `user_id` was omitted from payload, handler returned `String::new()` instead of extracting from key expression `{prefix}/{user_id}/forget`
- **Fix:** Call `extract_user_id(&key, prefix)` as fallback — same pattern used by mission handlers
- **Impact:** Every payload-less forget operation silently failed

### 2. Temporal fact timestamp (handlers.rs:596)
- **Bug:** `store_temporal_facts_for_memory` used `Utc::now()` instead of `req.created_at`
- **Fix:** Use `req.created_at.unwrap_or_else(Utc::now)` — matches HTTP handler behavior
- **Impact:** Robots backfilling historical observations got wrong temporal fact timestamps

### 3. Recall auth bypass (mod.rs:480)
- **Bug:** When `api_key` is configured and a Zenoh client sends a recall query without payload, authentication was skipped entirely
- **Fix:** Added `None if api_key.is_some()` match arm to reject immediately
- **Impact:** Unauthenticated network peers could query memories when auth was enabled

### 4. Pre-existing compile error (handlers.rs:855)
- **Bug:** `recall_memories` moved into `RecallResponse` at line 855, then used again at line 882 — `cargo check --features zenoh` failed
- **Fix:** Capture `has_recall_memories` bool before the move

**Build:** `cargo check` + `cargo check --features zenoh` — zero errors