### PR TITLE
fix: named constants for RRF K values and arousal thresholds

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -868,6 +868,36 @@ pub const ONTOLOGICAL_RERANK_BOOST: f32 = 0.08;
 pub const ONTOLOGICAL_RERANK_MAX: f32 = 0.25;
 
 // =============================================================================
+// RECIPROCAL RANK FUSION (RRF) CONSTANTS
+// Based on Cormack, Clarke & Büttcher (2009) — "Reciprocal Rank Fusion
+// outperforms Condorcet and individual Rank Learning Methods"
+// Standard RRF uses K=60. Lower K gives more weight to top-ranked results.
+// Two-stage fusion: inner pass (BM25+vector) and outer pass (graph+hybrid)
+// use different K values reflecting different rank distribution properties.
+// =============================================================================
+
+/// RRF K for inner BM25+vector fusion in HybridSearchEngine
+///
+/// Used in `hybrid_search.rs::search_with_dynamic_weights()` to fuse BM25
+/// keyword scores with vector similarity scores.
+///
+/// K=45 (vs standard K=60) slightly emphasizes top-ranked results from each
+/// signal. Both BM25 and vector produce well-calibrated rank orderings,
+/// so moderate top-weighting is appropriate.
+pub const RRF_K_HYBRID_FUSION: f32 = 45.0;
+
+/// RRF K for outer graph+hybrid fusion in Layer 4 of semantic_retrieve()
+///
+/// Used in `mod.rs::semantic_retrieve()` to fuse graph spreading activation
+/// results with the already-fused hybrid (BM25+vector) results.
+///
+/// K=30 (more aggressive than inner K=45) because graph results are pre-sorted
+/// by activation strength and the top graph results carry high signal — justified
+/// by ACT-R's spreading activation model where top-activated items have
+/// disproportionately stronger evidence (Anderson & Lebiere, 1998).
+pub const RRF_K_GRAPH_FUSION: f32 = 30.0;
+
+// =============================================================================
 // EDGE-TIER TRUST WEIGHTS FOR SPREADING ACTIVATION
 // Based on hippocampal-cortical consolidation: edges that survive decay are
 // more reliable for graph traversal. Dense graphs (L1) are noisy for search,
@@ -1722,6 +1752,18 @@ pub const HIGH_IMPORTANCE_THRESHOLD: f32 = 0.7;
 /// - Error/surprise events typically exceed this
 pub const HIGH_AROUSAL_THRESHOLD: f32 = 0.7;
 
+/// Lower arousal threshold for anticipatory prefetch relevance boosting
+///
+/// Two-tier arousal gating: prefetch uses a lower bar than salience spike detection.
+/// Prefetch asks "is this worth surfacing proactively?" while salience spike asks
+/// "is this exceptional enough to trigger replay?"
+///
+/// Justification:
+/// - 0.6 captures moderately arousing memories for prefetch (LaBar & Cabeza, 2006)
+/// - Distinct from HIGH_AROUSAL_THRESHOLD (0.7) which gates replay/salience spikes
+/// - Memories in [0.6, 0.7) get prefetch boost but don't trigger salience replay
+pub const PREFETCH_AROUSAL_THRESHOLD: f32 = 0.6;
+
 /// Surprise factor threshold for salience-triggered replay
 ///
 /// Deviation from running importance average that triggers surprise detection.
@@ -2007,5 +2049,17 @@ pub const TIER_LTP_THRESHOLD: f32 = 0.8;
 // | ONTOLOGICAL_MIN_CONFIDENCE    | memory/mod.rs             | semantic_retrieve() density gating  |
 // | ONTOLOGICAL_RERANK_BOOST      | memory/mod.rs             | semantic_retrieve() Layer 4.9       |
 // | ONTOLOGICAL_RERANK_MAX        | memory/mod.rs             | semantic_retrieve() Layer 4.9       |
+//
+// ## RRF Fusion Constants (Cormack et al. 2009, Anderson & Lebiere 1998)
+// | Constant                      | File                      | Function/Context                    |
+// |-------------------------------|---------------------------|-------------------------------------|
+// | RRF_K_HYBRID_FUSION           | memory/hybrid_search.rs   | search_with_dynamic_weights()       |
+// | RRF_K_GRAPH_FUSION            | memory/mod.rs             | semantic_retrieve() Layer 4         |
+//
+// ## Emotional Arousal Constants (LaBar & Cabeza 2006)
+// | Constant                      | File                      | Function/Context                    |
+// |-------------------------------|---------------------------|-------------------------------------|
+// | HIGH_AROUSAL_THRESHOLD        | memory/pattern_detection.rs| check_salience_spike()             |
+// | PREFETCH_AROUSAL_THRESHOLD    | memory/retrieval.rs       | PrefetchContext::relevance_score() |
 //
 // =============================================================================

--- a/src/memory/hybrid_search.rs
+++ b/src/memory/hybrid_search.rs
@@ -82,7 +82,7 @@ fn default_graph_weight() -> f32 {
     0.25 // Graph spreading activation for associative retrieval (SHO-D4)
 }
 fn default_rrf_k() -> f32 {
-    45.0 // Lower k = more emphasis on top-ranked results
+    crate::constants::RRF_K_HYBRID_FUSION
 }
 fn default_candidate_count() -> usize {
     100 // Increased for better recall; slight latency tradeoff acceptable

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -760,7 +760,7 @@ impl MemorySystem {
                 .context
                 .as_ref()
                 .map(|c| c.emotional.arousal)
-                .unwrap_or(0.3);
+                .unwrap_or(0.0);
 
             let pattern_memory = pattern_detection::PatternMemory {
                 id: memory.id.0.to_string(),
@@ -2147,7 +2147,9 @@ impl MemorySystem {
             //
             // The density weights directly control the balance - no extra multipliers.
             // This follows ACT-R's additive activation model.
-            const K: f32 = 30.0;
+            // K value from constants.rs — see Cormack et al. (2009), Anderson & Lebiere (1998)
+            use crate::constants::RRF_K_GRAPH_FUSION;
+            let k = RRF_K_GRAPH_FUSION;
             let mut fused: std::collections::HashMap<MemoryId, f32> =
                 std::collections::HashMap::new();
             let mut heb: std::collections::HashMap<MemoryId, f32> =
@@ -2173,8 +2175,8 @@ impl MemorySystem {
 
             // Graph results: pure RRF with density weight
             for (r, (id, activation, h)) in graph_results.iter().enumerate() {
-                // Standard RRF: weight / (K + rank), rank is 1-indexed
-                let rrf_score = graph_w / (K + (r + 1) as f32);
+                // Standard RRF: weight / (k + rank), rank is 1-indexed
+                let rrf_score = graph_w / (k + (r + 1) as f32);
                 *fused.entry(id.clone()).or_insert(0.0) += rrf_score;
                 heb.insert(id.clone(), *h);
 
@@ -2186,7 +2188,7 @@ impl MemorySystem {
 
             // Hybrid (BM25+vector) results: pure RRF with density weight
             for (r, (id, _)) in hybrid_ids.iter().enumerate() {
-                *fused.entry(id.clone()).or_insert(0.0) += hybrid_w / (K + (r + 1) as f32);
+                *fused.entry(id.clone()).or_insert(0.0) += hybrid_w / (k + (r + 1) as f32);
             }
 
             // ===========================================================================

--- a/src/memory/retrieval.rs
+++ b/src/memory/retrieval.rs
@@ -2043,8 +2043,8 @@ impl AnticipatoryPrefetch {
         // SHO-104: Emotional arousal boost - high-arousal memories are more salient
         // Research: Emotionally arousing events are better remembered (LaBar & Cabeza, 2006)
         if let Some(ctx) = &memory.experience.context {
-            // High arousal memories get a relevance boost
-            if ctx.emotional.arousal > 0.6 {
+            // High arousal memories get a relevance boost (two-tier: prefetch uses lower bar)
+            if ctx.emotional.arousal > crate::constants::PREFETCH_AROUSAL_THRESHOLD {
                 score += 0.1 * ctx.emotional.arousal;
             }
 
@@ -2061,7 +2061,9 @@ impl AnticipatoryPrefetch {
             }
 
             // Mood-congruent retrieval: similar emotional valence boosts relevance
-            // Research: We recall happy memories when happy, sad when sad
+            // Research: Bower (1981) mood-congruent memory effect
+            // NOTE: Currently inert — Query struct has no emotional_valence field.
+            // Requires hook enrichment (#143) to populate emotional context on queries.
             if let Some(current_valence) = context.emotional_valence {
                 let valence_diff = (ctx.emotional.valence - current_valence).abs();
                 if valence_diff < 0.3 {


### PR DESCRIPTION
## Summary
- Add `PREFETCH_AROUSAL_THRESHOLD` (0.6) constant with LaBar & Cabeza 2006 citation — gates emotional prefetch at Layer 0.7
- Add `RRF_K_HYBRID_FUSION` (45.0) and `RRF_K_GRAPH_FUSION` (30.0) constants with Cormack et al. 2009 and Anderson & Lebiere 1998 citations
- Fix default arousal fallback from 0.3 → 0.0 (neutral baseline when hooks don't send emotion data)
- Replace all hardcoded RRF K values in `hybrid_search.rs` and `mod.rs` with named constants
- Annotate dead mood-congruent retrieval code with reference to #143 (hook enrichment)

Closes #145, closes #147