### PR TITLE
fix: wire disconnected feedback loop and replay boost

### DIFF
--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -191,6 +191,9 @@ function stripSystemNoise(text: string): string {
 // Track last proactive_context response for implicit feedback loop
 // The backend uses this to evaluate whether surfaced memories were helpful
 let lastProactiveResponse: string = "";
+// Track previous user context — the user's message that *followed* the last surfaced memories.
+// This is the true user_followup signal (their reaction to what we surfaced last time).
+let lastUserContext: string = "";
 
 // =============================================================================
 // STREAMING MEMORY INGESTION - Continuous background memory capture
@@ -2270,6 +2273,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           };
         }
 
+        // Capture current context as the user_followup for NEXT call
+        // (this message is the user's reaction to whatever we surfaced last time)
+        const previousUserContext = lastUserContext;
+        lastUserContext = cleanedContext;
+
         // Single API call to the full proactive context pipeline:
         // feedback loop, coactivation, segmented ingest, semantic todos, context reminders
         const result = await apiCall<ProactiveContextResponse>("/api/proactive_context", "POST", {
@@ -2283,7 +2291,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           auto_ingest,
           // Implicit feedback: send previous response so backend can evaluate which memories helped
           previous_response: lastProactiveResponse || undefined,
-          user_followup: lastProactiveResponse ? cleanedContext : undefined,
+          // user_followup is the PREVIOUS user message (their reaction to prior surfaced memories),
+          // not the current one. This avoids the self-referential signal bug where the same text
+          // that triggers recall is evaluated as feedback on the previous response.
+          user_followup: lastProactiveResponse ? (previousUserContext || undefined) : undefined,
           // Tool-aware feedback attribution: causal signal from tool/actuator actions
           ...(tool_actions.length > 0 ? { tool_actions } : {}),
         });
@@ -2446,8 +2457,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         const responseText = `${temporalHeader}${summary}:\n\n${formattedWithTime}${entitySummary}${factsBlock}${reminderBlock}${todoBlock}${feedbackNote}${ingestNote}\n\n[Latency: ${(result.latency_ms ?? 0).toFixed(1)}ms | Threshold: ${(semantic_threshold * 100).toFixed(0)}%]`;
 
-        // Store for implicit feedback on next call
-        lastProactiveResponse = responseText;
+        // Store clean semantic content for implicit feedback on next call.
+        // Strip display formatting (emoji borders, latency markers, entity summaries)
+        // that would add embedding noise and dilute the semantic signal.
+        const cleanContent = memories
+          .map((m: { content?: string }) => m.content || "")
+          .filter((c: string) => c.length > 0)
+          .join("\n");
+        lastProactiveResponse = cleanContent || responseText;
 
         return {
           content: [{ type: "text", text: responseText }],

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -3807,7 +3807,7 @@ impl GraphMemory {
         let mut strengthened = 0;
         let mut promotion_boosts = Vec::new();
 
-        for (from_id_str, to_id_str, _boost) in edge_boosts {
+        for (from_id_str, to_id_str, boost) in edge_boosts {
             // Parse UUIDs
             let from_uuid = match Uuid::parse_str(from_id_str) {
                 Ok(u) => u,
@@ -3867,13 +3867,15 @@ impl GraphMemory {
                 }
             } else {
                 // Create new ReplayStrengthened edge
-                // Replay edges start in L2 (episodic) since they represent consolidated associations
+                // Replay edges start in L2 (episodic) with replay boost applied to initial strength.
+                // Without this, the computed replay priority score was discarded and all new edges
+                // started at identical strength regardless of their consolidation importance.
                 let edge = RelationshipEdge {
                     uuid: Uuid::new_v4(),
                     from_entity: from_uuid,
                     to_entity: to_uuid,
                     relation_type: RelationType::CoRetrieved,
-                    strength: EdgeTier::L2Episodic.initial_weight(),
+                    strength: EdgeTier::L2Episodic.initial_weight() + boost,
                     created_at: Utc::now(),
                     valid_at: Utc::now(),
                     invalidated_at: None,

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -1070,11 +1070,14 @@ pub async fn proactive_context(
         .await
         .map_err(|e| AppError::Internal(anyhow::anyhow!("Feedback task panicked: {e}")))?;
 
-        // Apply reinforcement to memory system and graph based on feedback
+        // Apply reinforcement to memory system, graph, AND retrieval weights
         if !helpful_ids.is_empty() || !misleading_ids.is_empty() {
             let memory_sys_for_reinforce = memory_system.clone();
             let graph_for_reinforce = graph_memory.clone();
             let helpful_ids_for_graph = helpful_ids.clone();
+            let relevance_engine = state.relevance_engine.clone();
+            let helpful_count = helpful_ids.len();
+            let misleading_count = misleading_ids.len();
             tokio::task::spawn_blocking(move || {
                 let memory_guard = memory_sys_for_reinforce.read();
 
@@ -1121,6 +1124,18 @@ pub async fn proactive_context(
                             _ => {}
                         }
                     }
+                }
+
+                // Update adaptive retrieval weights via gradient descent (Rescorla-Wagner, 1972).
+                // proactive_context always uses semantic retrieval; entity matching contributes
+                // when entities were extracted. This closes the loop: feedback now adjusts
+                // how much weight semantic vs entity vs tag signals get in future retrievals.
+                let entity_contributed = helpful_count > 0; // entities always extracted in proactive_context
+                for _ in 0..helpful_count {
+                    relevance_engine.apply_feedback(true, entity_contributed, false, true);
+                }
+                for _ in 0..misleading_count {
+                    relevance_engine.apply_feedback(true, entity_contributed, false, false);
                 }
             })
             .await


### PR DESCRIPTION
Closes #146, closes #150

## Summary

### Feedback loop (#146)
- **LearnedWeights never updated**: `apply_feedback()` existed (relevance.rs:663) but was never called from proactive_context feedback path. Now wired after `reinforce_recall()` — retrieval weights update via gradient descent (Rescorla-Wagner, 1972) based on helpful/misleading classifications.
- **user_followup off-by-one**: MCP sent `cleanedContext` (current prompt) as `user_followup` — self-referential signal where the query that triggered recall was evaluated as feedback on the previous response. Fixed: track `lastUserContext` separately, send previous user message as followup.
- **previous_response display noise**: `lastProactiveResponse` stored formatted text with emoji borders, `[Latency: Xms]`, entity summaries. Now stores clean memory content only (`memories.map(m => m.content).join("\n")`).

### Replay boost (#150)
- **Boost value discarded**: `graph_memory.rs:3810` pattern-matched `_boost` and ignored it. New replay edges always started at `L2Episodic.initial_weight()` (0.5) regardless of consolidation priority. Fixed: initial strength = `L2_initial + boost`.

### Not addressed (deferred)
- EdgeSource enum for edge provenance — larger refactor, separate PR
- InterferenceEvent on RetrievalStats — design decision needed on whether retrieval-time interference should surface

## Files changed
- `src/handlers/recall.rs` — wire `relevance_engine.apply_feedback()` in feedback path
- `src/graph_memory.rs` — use replay boost value in new edge creation
- `mcp-server/index.ts` — fix user_followup tracking, strip response noise

## Test plan
- [x] `cargo check` — compiles
- [x] `cargo clippy` — no new warnings
- [x] `cargo fmt` — formatted
- [ ] Send 3 proactive_context calls in sequence, verify weight updates in logs
- [ ] Verify replay edges have strength > 0.5 (L2_initial + boost)