### PR TITLE
fix: remove dead reranker code, fix episode threading bugs

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -987,6 +987,21 @@ pub const AROUSAL_BOOST_SCALE: f32 = 0.15;
 /// - Previously hardcoded as additive (credibility - 0.5) * 0.1
 pub const CREDIBILITY_BOOST_SCALE: f32 = 0.2;
 
+/// Same-episode boost — additive score for memories sharing the current episode
+///
+/// When the query specifies an episode_id and a candidate belongs to the same
+/// episode, this boost surfaces co-occurring memories from the same work session.
+///
+/// Justification:
+/// - 0.3 is an additive constant in the contextual scoring layer (not the RRF
+///   multiplicative pipeline), matching the scale of other additive adjustments
+///   in `apply_context_scoring` (credibility +0.05, mood congruence +0.1)
+/// - Episode membership is a strong relevance signal — co-occurring memories
+///   share causal/temporal context that semantic similarity alone cannot capture
+///
+/// Reference: Tulving (1983) "Elements of Episodic Memory" — encoding specificity
+pub const SAME_EPISODE_BOOST: f32 = 0.3;
+
 /// Temporal match boost — maximum multiplicative boost for temporal date matching
 ///
 /// Three tiers:

--- a/src/handlers/remember.rs
+++ b/src/handlers/remember.rs
@@ -269,7 +269,6 @@ pub fn build_rich_context(
         episode_id,
         sequence_number,
         preceding_memory_id,
-        is_episode_start: sequence_number == Some(1),
         ..Default::default()
     };
 

--- a/src/memory/hybrid_search.rs
+++ b/src/memory/hybrid_search.rs
@@ -29,7 +29,6 @@ use tracing::{debug, info};
 
 use super::types::MemoryId;
 use crate::embeddings::minilm::MiniLMEmbedder;
-use crate::embeddings::Embedder;
 
 /// Configuration for hybrid search
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -56,14 +55,6 @@ pub struct HybridSearchConfig {
     #[serde(default = "default_candidate_count")]
     pub candidate_count: usize,
 
-    /// Number of top results to rerank with cross-encoder
-    #[serde(default = "default_rerank_count")]
-    pub rerank_count: usize,
-
-    /// Whether to use cross-encoder reranking
-    #[serde(default = "default_use_reranking")]
-    pub use_reranking: bool,
-
     /// Minimum BM25 score to consider (filters noise)
     #[serde(default = "default_min_bm25_score")]
     pub min_bm25_score: f32,
@@ -88,12 +79,6 @@ fn default_rrf_k() -> f32 {
 fn default_candidate_count() -> usize {
     100 // Increased for better recall; slight latency tradeoff acceptable
 }
-fn default_rerank_count() -> usize {
-    20
-}
-fn default_use_reranking() -> bool {
-    false // Disabled: current implementation is bi-encoder, not true cross-encoder
-}
 fn default_min_bm25_score() -> f32 {
     0.01 // Lower threshold to capture more keyword matches
 }
@@ -109,8 +94,6 @@ impl Default for HybridSearchConfig {
             graph_weight: default_graph_weight(),
             rrf_k: default_rrf_k(),
             candidate_count: default_candidate_count(),
-            rerank_count: default_rerank_count(),
-            use_reranking: default_use_reranking(),
             min_bm25_score: default_min_bm25_score(),
             min_graph_score: default_min_graph_score(),
         }
@@ -135,11 +118,8 @@ pub struct HybridSearchResult {
     /// Graph activation score from spreading activation (if matched) (SHO-D4)
     pub graph_score: Option<f32>,
 
-    /// RRF score before reranking
+    /// RRF score before post-processing
     pub rrf_score: f32,
-
-    /// Cross-encoder score (if reranked)
-    pub rerank_score: Option<f32>,
 
     /// Rank from BM25 (if matched)
     pub bm25_rank: Option<usize>,
@@ -499,108 +479,24 @@ impl RRFusion {
     }
 }
 
-/// Cross-encoder reranker using the same MiniLM model
-///
-/// For true cross-encoder reranking, you'd use a model trained for
-/// query-document scoring (e.g., cross-encoder/ms-marco-MiniLM-L-6-v2).
-/// This implementation uses cosine similarity as a proxy, which works
-/// but isn't as accurate as a dedicated cross-encoder.
-///
-/// Future: Replace with actual cross-encoder model for better accuracy.
-pub struct CrossEncoderReranker {
-    embedder: Arc<MiniLMEmbedder>,
-}
-
-impl CrossEncoderReranker {
-    /// Create reranker with shared embedder
-    pub fn new(embedder: Arc<MiniLMEmbedder>) -> Self {
-        Self { embedder }
-    }
-
-    /// Rerank candidates based on query-document similarity
-    ///
-    /// Takes (memory_id, content, current_score) and returns reranked scores.
-    ///
-    /// Note: This uses bi-encoder (separate query/doc embeddings) not true
-    /// cross-encoder (joint query+doc encoding). True cross-encoders are
-    /// more accurate but slower. This is a reasonable approximation.
-    pub fn rerank(
-        &self,
-        query: &str,
-        candidates: Vec<(MemoryId, String, f32)>,
-    ) -> Result<Vec<(MemoryId, f32)>> {
-        if candidates.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Encode query
-        let query_embedding = self.embedder.encode(query)?;
-
-        let mut results: Vec<(MemoryId, f32)> = Vec::with_capacity(candidates.len());
-
-        for (memory_id, content, _original_score) in candidates {
-            // Encode document
-            let doc_embedding = self.embedder.encode(&content)?;
-
-            // Cosine similarity
-            let similarity = cosine_similarity(&query_embedding, &doc_embedding);
-
-            results.push((memory_id, similarity));
-        }
-
-        // Sort by reranked score descending
-        results.sort_by(|a, b| b.1.total_cmp(&a.1));
-
-        Ok(results)
-    }
-}
-
-/// Compute cosine similarity between two vectors
-fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    if a.len() != b.len() || a.is_empty() {
-        return 0.0;
-    }
-
-    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
-    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
-    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
-
-    if norm_a == 0.0 || norm_b == 0.0 {
-        return 0.0;
-    }
-
-    dot / (norm_a * norm_b)
-}
-
 /// Unified hybrid search engine
 ///
-/// Combines BM25 + Vector + RRF + Cross-encoder + Cognitive signals
+/// Combines BM25 + Vector + RRF fusion + cognitive post-processing
 pub struct HybridSearchEngine {
     bm25_index: BM25Index,
     config: HybridSearchConfig,
-    reranker: Option<CrossEncoderReranker>,
 }
 
 impl HybridSearchEngine {
     /// Create hybrid search engine
     pub fn new(
         bm25_path: &Path,
-        embedder: Arc<MiniLMEmbedder>,
+        _embedder: Arc<MiniLMEmbedder>,
         config: HybridSearchConfig,
     ) -> Result<Self> {
         let bm25_index = BM25Index::new(bm25_path)?;
 
-        let reranker = if config.use_reranking {
-            Some(CrossEncoderReranker::new(embedder))
-        } else {
-            None
-        };
-
-        Ok(Self {
-            bm25_index,
-            config,
-            reranker,
-        })
+        Ok(Self { bm25_index, config })
     }
 
     /// Index a memory for BM25 search
@@ -733,7 +629,7 @@ impl HybridSearchEngine {
         &self,
         query: &str,
         vector_results: Vec<(MemoryId, f32)>,
-        get_content: F,
+        _get_content: F,
         term_weights: Option<&HashMap<String, f32>>,
         phrase_boosts: Option<&[(String, f32)]>,
         keyword_discriminativeness: Option<f32>,
@@ -811,113 +707,26 @@ impl HybridSearchEngine {
             .map(|(rank, (id, score))| (id.clone(), (*score, rank)))
             .collect();
 
-        // 3. Optional cross-encoder reranking
-        let final_results = if let Some(ref reranker) = self.reranker {
-            // Take top-k for reranking
-            let to_rerank: Vec<_> = fused
-                .iter()
-                .take(self.config.rerank_count)
-                .filter_map(|(id, _score)| {
-                    get_content(id).map(|content| (id.clone(), content, *_score))
-                })
-                .collect();
+        // 3. Build final results from RRF-fused scores
+        let final_results: Vec<HybridSearchResult> = fused
+            .into_iter()
+            .map(|(memory_id, rrf_score)| {
+                let bm25_info = bm25_map.get(&memory_id);
+                let vector_info = vector_map.get(&memory_id);
 
-            if !to_rerank.is_empty() {
-                let reranked = reranker.rerank(query, to_rerank)?;
-
-                // Build rerank map with cosine similarities (range [-1, 1])
-                let rerank_map: HashMap<MemoryId, f32> = reranked.into_iter().collect();
-
-                // Normalize rerank scores to [0, 1] for scale-compatible blending
-                // Cosine similarity ∈ [-1, 1] → shift to [0, 1]
-                let rerank_normalized: HashMap<MemoryId, f32> = rerank_map
-                    .iter()
-                    .map(|(id, s)| (id.clone(), (s + 1.0) / 2.0))
-                    .collect();
-
-                // Combine reranked results with non-reranked
-                // Blend: 0.6 * RRF + 0.4 * normalized_rerank (preserves RRF scale)
-                const RERANK_BLEND: f32 = 0.4;
-                let mut results: Vec<HybridSearchResult> = Vec::new();
-
-                for (memory_id, rrf_score) in fused {
-                    let bm25_info = bm25_map.get(&memory_id);
-                    let vector_info = vector_map.get(&memory_id);
-                    let rerank_score = rerank_map.get(&memory_id).copied();
-
-                    // Blend rerank with RRF to preserve score scale
-                    let final_score = if let Some(norm_rerank) =
-                        rerank_normalized.get(&memory_id).copied()
-                    {
-                        (1.0 - RERANK_BLEND) * rrf_score + RERANK_BLEND * norm_rerank * rrf_score
-                    } else {
-                        rrf_score
-                    };
-
-                    results.push(HybridSearchResult {
-                        memory_id,
-                        score: final_score,
-                        bm25_score: bm25_info.map(|(s, _)| *s),
-                        vector_score: vector_info.map(|(s, _)| *s),
-                        graph_score: None,
-                        rrf_score,
-                        rerank_score,
-                        bm25_rank: bm25_info.map(|(_, r)| *r),
-                        vector_rank: vector_info.map(|(_, r)| *r),
-                        graph_rank: None,
-                    });
+                HybridSearchResult {
+                    memory_id,
+                    score: rrf_score,
+                    bm25_score: bm25_info.map(|(s, _)| *s),
+                    vector_score: vector_info.map(|(s, _)| *s),
+                    graph_score: None,
+                    rrf_score,
+                    bm25_rank: bm25_info.map(|(_, r)| *r),
+                    vector_rank: vector_info.map(|(_, r)| *r),
+                    graph_rank: None,
                 }
-
-                // Re-sort by final score
-                results.sort_by(|a, b| b.score.total_cmp(&a.score));
-
-                results
-            } else {
-                // No content available for reranking, use RRF scores
-                fused
-                    .into_iter()
-                    .map(|(memory_id, rrf_score)| {
-                        let bm25_info = bm25_map.get(&memory_id);
-                        let vector_info = vector_map.get(&memory_id);
-
-                        HybridSearchResult {
-                            memory_id,
-                            score: rrf_score,
-                            bm25_score: bm25_info.map(|(s, _)| *s),
-                            vector_score: vector_info.map(|(s, _)| *s),
-                            graph_score: None,
-                            rrf_score,
-                            rerank_score: None,
-                            bm25_rank: bm25_info.map(|(_, r)| *r),
-                            vector_rank: vector_info.map(|(_, r)| *r),
-                            graph_rank: None,
-                        }
-                    })
-                    .collect()
-            }
-        } else {
-            // No reranking, use RRF scores directly
-            fused
-                .into_iter()
-                .map(|(memory_id, rrf_score)| {
-                    let bm25_info = bm25_map.get(&memory_id);
-                    let vector_info = vector_map.get(&memory_id);
-
-                    HybridSearchResult {
-                        memory_id,
-                        score: rrf_score,
-                        bm25_score: bm25_info.map(|(s, _)| *s),
-                        vector_score: vector_info.map(|(s, _)| *s),
-                        graph_score: None,
-                        rrf_score,
-                        rerank_score: None,
-                        bm25_rank: bm25_info.map(|(_, r)| *r),
-                        vector_rank: vector_info.map(|(_, r)| *r),
-                        graph_rank: None,
-                    }
-                })
-                .collect()
-        };
+            })
+            .collect();
 
         Ok(final_results)
     }
@@ -1044,19 +853,6 @@ mod tests {
     }
 
     #[test]
-    fn test_cosine_similarity() {
-        let a = vec![1.0, 0.0, 0.0];
-        let b = vec![1.0, 0.0, 0.0];
-        assert!((cosine_similarity(&a, &b) - 1.0).abs() < 0.001);
-
-        let c = vec![0.0, 1.0, 0.0];
-        assert!((cosine_similarity(&a, &c) - 0.0).abs() < 0.001);
-
-        let d = vec![-1.0, 0.0, 0.0];
-        assert!((cosine_similarity(&a, &d) - (-1.0)).abs() < 0.001);
-    }
-
-    #[test]
     fn test_hybrid_config_defaults() {
         let config = HybridSearchConfig::default();
         assert_eq!(config.bm25_weight, 0.35); // BM25 for keyword matching
@@ -1064,8 +860,6 @@ mod tests {
         assert_eq!(config.graph_weight, 0.25); // Graph for associative retrieval (SHO-D4)
         assert_eq!(config.rrf_k, 45.0); // Lower k for top-rank emphasis
         assert_eq!(config.candidate_count, 100); // Increased for better recall
-        assert_eq!(config.rerank_count, 20);
-        assert!(!config.use_reranking); // Disabled: bi-encoder, not cross-encoder
         assert_eq!(config.min_graph_score, 0.01); // Graph score threshold (SHO-D4)
     }
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -76,8 +76,7 @@ pub use crate::memory::graph_retrieval::{
     calculate_density_weights, spreading_activation_retrieve, ActivatedMemory,
 };
 pub use crate::memory::hybrid_search::{
-    BM25Index, CrossEncoderReranker, HybridSearchConfig, HybridSearchEngine, HybridSearchResult,
-    RRFusion,
+    BM25Index, HybridSearchConfig, HybridSearchEngine, HybridSearchResult, RRFusion,
 };
 pub use crate::memory::introspection::{
     AssociationChange, ConsolidationEvent, ConsolidationEventBuffer, ConsolidationReport,

--- a/src/memory/retrieval.rs
+++ b/src/memory/retrieval.rs
@@ -2056,7 +2056,7 @@ impl AnticipatoryPrefetch {
             // Episode context: same episode = highly relevant
             if let Some(current_episode) = &context.episode_id {
                 if ctx.episode.episode_id.as_ref() == Some(current_episode) {
-                    score += 0.3; // Strong boost for same-episode memories
+                    score += crate::constants::SAME_EPISODE_BOOST;
                 }
             }
 

--- a/src/memory/storage.rs
+++ b/src/memory/storage.rs
@@ -1364,7 +1364,9 @@ impl MemoryStorage {
 
                 // Also index by sequence within episode for temporal ordering
                 if let Some(seq) = ctx.episode.sequence_number {
-                    let seq_key = format!("episode_seq:{}:{}:{}", episode_id, seq, memory.id.0);
+                    // Zero-pad sequence number for correct lexicographic ordering in RocksDB
+                    // Without padding: 1, 10, 100, 2, 20... With {:010}: 0000000001, 0000000002...
+                    let seq_key = format!("episode_seq:{}:{:010}:{}", episode_id, seq, memory.id.0);
                     batch.put_cf(idx, seq_key.as_bytes(), b"1");
                 }
             }
@@ -1636,7 +1638,7 @@ impl MemoryStorage {
                 batch.delete_cf(idx, episode_key.as_bytes());
 
                 if let Some(seq) = ctx.episode.sequence_number {
-                    let seq_key = format!("episode_seq:{}:{}:{}", episode_id, seq, id.0);
+                    let seq_key = format!("episode_seq:{}:{:010}:{}", episode_id, seq, id.0);
                     batch.delete_cf(idx, seq_key.as_bytes());
                 }
             }

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -510,14 +510,6 @@ pub struct EpisodeContext {
     #[serde(default)]
     pub episode_start: Option<DateTime<Utc>>,
 
-    /// Is this the first memory in the episode?
-    #[serde(default)]
-    pub is_episode_start: bool,
-
-    /// Is this the last memory in the episode?
-    #[serde(default)]
-    pub is_episode_end: bool,
-
     /// Parent episode (for hierarchical episodes)
     /// E.g., a conversation within a larger task session
     #[serde(default)]


### PR DESCRIPTION
## Summary
- Remove `CrossEncoderReranker` (~220 LOC dead code) — bi-encoder proxy was never a true cross-encoder, disabled by default. The 9-layer retrieval pipeline already serves as the reranker.
- Fix episode sequence key ordering in RocksDB — unpadded integers caused wrong lexicographic sort (`1, 10, 100, 2...`). Zero-padded with `{:010}` in both write and delete paths.
- Extract `SAME_EPISODE_BOOST` constant from hardcoded `0.3` in contextual scoring, with Tulving (1983) citation.
- Remove dead `is_episode_start`/`is_episode_end` fields from `EpisodeContext` — set-but-never-read / never-used.

## Files changed
- `src/memory/hybrid_search.rs` — removed reranker struct, config, execution block, test (-199 lines)
- `src/memory/storage.rs` — zero-padded episode sequence keys
- `src/memory/retrieval.rs` — use `SAME_EPISODE_BOOST` constant
- `src/constants.rs` — new `SAME_EPISODE_BOOST` with citation
- `src/memory/types.rs` — removed dead episode fields
- `src/handlers/remember.rs` — removed dead `is_episode_start` assignment
- `src/memory/mod.rs` — removed `CrossEncoderReranker` re-export

## Verification
- `cargo check --all-targets` — clean
- `cargo clippy --lib` — no new warnings
- Net: +45 / -244 lines

Closes #144