### PR TITLE
fix: reliability hardening — write retry, cache TTI, BM25 merge

### DIFF
--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -26,12 +26,17 @@ pub struct HealthResponse {
     pub users_in_cache: usize,
     pub user_evictions: usize,
     pub max_cache_size: usize,
+    pub write_failures: u64,
+    pub pending_retries: usize,
 }
 
 /// Main health check endpoint
 pub async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     let users_in_cache = state.users_in_cache();
     let user_evictions = state.user_evictions();
+
+    // Aggregate write failure metrics across all cached users
+    let (write_failures, pending_retries) = state.write_failure_metrics();
 
     Json(HealthResponse {
         status: "healthy".to_string(),
@@ -40,6 +45,8 @@ pub async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         users_in_cache,
         user_evictions,
         max_cache_size: state.server_config().max_users_in_memory,
+        write_failures,
+        pending_retries,
     })
 }
 

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -357,9 +357,29 @@ impl MultiUserMemoryManager {
         let max_cache = server_config.max_users_in_memory;
         let eviction_base_path = base_path.clone();
 
-        let user_memories = moka::sync::Cache::builder()
-            .max_capacity(server_config.max_users_in_memory as u64)
-            .time_to_idle(std::time::Duration::from_secs(3600))
+        // Configurable idle eviction timeout. Default: 0 (disabled).
+        // Single-user deployments (local Claude Code) should keep 0 — idle eviction
+        // causes persistent RocksDB lock contention when background tasks hold Arc
+        // references past the eviction point. Multi-user shared servers can set
+        // SHODH_CACHE_IDLE_SECS=3600 to reclaim memory from idle users.
+        let cache_idle_secs: u64 = std::env::var("SHODH_CACHE_IDLE_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+
+        let mut user_memories_builder =
+            moka::sync::Cache::builder().max_capacity(server_config.max_users_in_memory as u64);
+        if cache_idle_secs > 0 {
+            user_memories_builder =
+                user_memories_builder.time_to_idle(std::time::Duration::from_secs(cache_idle_secs));
+            info!(
+                "Cache idle eviction enabled: {}s (multi-user mode)",
+                cache_idle_secs
+            );
+        } else {
+            info!("Cache idle eviction disabled (single-user mode). Set SHODH_CACHE_IDLE_SECS to enable.");
+        }
+        let user_memories = user_memories_builder
             .eviction_listener(move |key: Arc<String>, value: Arc<parking_lot::RwLock<MemorySystem>>, cause| {
                 if matches!(cause, moka::notification::RemovalCause::Size | moka::notification::RemovalCause::Expired) {
                     evictions_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -414,9 +434,13 @@ impl MultiUserMemoryManager {
             })
             .build();
 
-        let graph_memories = moka::sync::Cache::builder()
-            .max_capacity(server_config.max_users_in_memory as u64)
-            .time_to_idle(std::time::Duration::from_secs(3600))
+        let mut graph_memories_builder =
+            moka::sync::Cache::builder().max_capacity(server_config.max_users_in_memory as u64);
+        if cache_idle_secs > 0 {
+            graph_memories_builder = graph_memories_builder
+                .time_to_idle(std::time::Duration::from_secs(cache_idle_secs));
+        }
+        let graph_memories = graph_memories_builder
             .eviction_listener(move |key: Arc<String>, _value, cause| {
                 let cause_label = if cause == moka::notification::RemovalCause::Expired {
                     "idle-timeout"
@@ -1534,6 +1558,20 @@ impl MultiUserMemoryManager {
                 }
             }
 
+            // Drain write retry buffer — re-attempt any failed writes from transient errors.
+            // Runs every cycle (not just heavy) since buffered memories are at risk of loss.
+            if let Ok(memory_lock) = self.get_user_memory(&user_id) {
+                let memory = memory_lock.read();
+                let retried = memory.drain_write_retries();
+                if retried > 0 {
+                    tracing::info!(
+                        user_id = %user_id,
+                        retried,
+                        "Drained write retry buffer"
+                    );
+                }
+            }
+
             // Direction 2: Lazy decay — flush opportunistic pruning queue
             // Instead of scanning all 34k+ edges (apply_decay), we queue edges found
             // below threshold during normal reads and batch-delete them here.
@@ -1633,6 +1671,36 @@ impl MultiUserMemoryManager {
                     }
                     _ => {}
                 }
+            }
+        }
+
+        // BM25 segment merge on heavy cycles — removes ghost state from upsert
+        // tombstones and reclaims disk space. Tantivy segments accumulate from
+        // per-memory commits; without periodic merging, search quality degrades
+        // and disk usage grows unboundedly.
+        if is_heavy {
+            let mut total_bm25_merged = 0usize;
+            for (user_id_arc, _) in self.user_memories.iter() {
+                let user_id = user_id_arc.as_ref();
+                if let Ok(memory_lock) = self.get_user_memory(user_id) {
+                    let memory = memory_lock.read();
+                    match memory.optimize_bm25() {
+                        Ok(merged) => total_bm25_merged += merged,
+                        Err(e) => {
+                            tracing::debug!(
+                                user_id = %user_id,
+                                error = %e,
+                                "BM25 optimize failed"
+                            );
+                        }
+                    }
+                }
+            }
+            if total_bm25_merged > 0 {
+                tracing::info!(
+                    "BM25 optimization: merged {} total segments across users",
+                    total_bm25_merged
+                );
             }
         }
 
@@ -1760,6 +1828,21 @@ impl MultiUserMemoryManager {
     /// Get users in cache count
     pub fn users_in_cache(&self) -> usize {
         self.user_memories.entry_count() as usize
+    }
+
+    /// Aggregate write failure metrics across all cached users.
+    /// Returns (total_failures, pending_retries).
+    pub fn write_failure_metrics(&self) -> (u64, usize) {
+        let mut total_failures = 0u64;
+        let mut total_pending = 0usize;
+        for (user_id, _) in self.user_memories.iter() {
+            if let Ok(memory_lock) = self.get_user_memory(user_id.as_ref()) {
+                let memory = memory_lock.read();
+                total_failures += memory.total_write_failures();
+                total_pending += memory.pending_write_retries();
+            }
+        }
+        (total_failures, total_pending)
     }
 
     /// Active reminder check: scan all users for due reminders, mark them triggered,

--- a/src/memory/hybrid_search.rs
+++ b/src/memory/hybrid_search.rs
@@ -410,6 +410,61 @@ impl BM25Index {
         self.reader.reload()?;
         Ok(())
     }
+
+    /// Merge all segments into a single segment.
+    ///
+    /// Tantivy accumulates segments from commits. Deleted documents (from upserts)
+    /// remain as tombstones until segments are merged. Without periodic merging:
+    /// - Ghost state from overwrites pollutes BM25 scoring
+    /// - Disk usage grows unboundedly
+    /// - Search latency increases with segment count
+    ///
+    /// This is expensive (rewrites entire index) so should only run on heavy
+    /// maintenance cycles, not per-request.
+    pub fn optimize(&self) -> Result<usize> {
+        let segment_count = {
+            let searcher = self.reader.searcher();
+            searcher.segment_readers().len()
+        };
+
+        if segment_count <= 1 {
+            return Ok(0);
+        }
+
+        let mut writer = self.writer.write();
+
+        // Collect all segment IDs for merging
+        let segment_ids: Vec<_> = self
+            .index
+            .searchable_segment_ids()
+            .context("Failed to get segment IDs")?;
+
+        if segment_ids.len() <= 1 {
+            return Ok(0);
+        }
+
+        let merged = segment_ids.len();
+        writer
+            .merge(&segment_ids)
+            .wait()
+            .context("Failed to merge BM25 segments")?;
+        writer
+            .commit()
+            .context("Failed to commit after BM25 merge")?;
+        drop(writer);
+
+        self.reader.reload()?;
+
+        tracing::info!("BM25 index optimized: merged {} segments into 1", merged);
+
+        Ok(merged)
+    }
+
+    /// Get the current number of segments (for health/metrics)
+    pub fn segment_count(&self) -> usize {
+        let searcher = self.reader.searcher();
+        searcher.segment_readers().len()
+    }
 }
 
 /// Reciprocal Rank Fusion (RRF) implementation
@@ -529,6 +584,17 @@ impl HybridSearchEngine {
     pub fn commit_and_reload(&self) -> Result<()> {
         self.bm25_index.commit()?;
         self.bm25_index.reload()
+    }
+
+    /// Merge BM25 segments to remove ghost state and reclaim space.
+    /// Returns the number of segments merged (0 if already optimal).
+    pub fn optimize_bm25(&self) -> Result<usize> {
+        self.bm25_index.optimize()
+    }
+
+    /// Get BM25 segment count for health metrics
+    pub fn bm25_segment_count(&self) -> usize {
+        self.bm25_index.segment_count()
     }
 
     /// Get BM25 index reference for direct searches

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -4843,6 +4843,35 @@ impl MemorySystem {
     pub fn save_vector_index(&self, _path: &Path) -> Result<()> {
         self.retriever.save()
     }
+
+    /// Merge BM25 index segments to remove ghost state from overwrites.
+    /// Should be called during heavy maintenance cycles only (expensive operation).
+    /// Returns the number of segments merged (0 if already optimal).
+    pub fn optimize_bm25(&self) -> Result<usize> {
+        self.hybrid_search.optimize_bm25()
+    }
+
+    /// Drain the write retry buffer, re-attempting any failed stores.
+    /// Returns the number of successfully retried writes.
+    pub fn drain_write_retries(&self) -> usize {
+        self.long_term_memory.drain_retry_buffer()
+    }
+
+    /// Number of writes pending retry
+    pub fn pending_write_retries(&self) -> usize {
+        self.long_term_memory.pending_retry_count()
+    }
+
+    /// Total write failures since server start
+    pub fn total_write_failures(&self) -> u64 {
+        self.long_term_memory.total_write_failures()
+    }
+
+    /// Get BM25 segment count for health metrics
+    pub fn bm25_segment_count(&self) -> usize {
+        self.hybrid_search.bm25_segment_count()
+    }
+
     /// Get vector index health information
     ///
     /// Returns metrics about the Vamana index including total vectors,

--- a/src/memory/storage.rs
+++ b/src/memory/storage.rs
@@ -999,12 +999,23 @@ const CF_INDEX: &str = "memory_index";
 /// Uses a single RocksDB instance with 2 column families:
 /// - default: main memory data (also shared by LearningHistoryStore, TemporalFactStore, etc. via key prefixes)
 /// - `memory_index`: secondary indices for tag/type/timestamp queries
+/// Maximum number of failed writes to buffer for retry.
+/// Small enough to bound memory usage (~100 memories × ~2KB ≈ 200KB)
+/// but large enough to absorb transient RocksDB contention bursts.
+const WRITE_RETRY_BUFFER_CAPACITY: usize = 100;
+
 pub struct MemoryStorage {
     db: Arc<DB>,
     /// Base storage path for all memory data
     storage_path: PathBuf,
     /// Write mode (sync vs async) - affects latency vs durability tradeoff
     write_mode: WriteMode,
+    /// Bounded retry buffer for failed writes.
+    /// Memories that fail to store (transient RocksDB lock contention, disk pressure)
+    /// are queued here and retried on the next maintenance tick or successful store.
+    write_retry_buffer: parking_lot::Mutex<std::collections::VecDeque<Memory>>,
+    /// Counter of total write failures (for /api/health metrics)
+    write_failure_count: std::sync::atomic::AtomicU64,
 }
 
 impl MemoryStorage {
@@ -1107,6 +1118,8 @@ impl MemoryStorage {
             db,
             storage_path: path.to_path_buf(),
             write_mode,
+            write_retry_buffer: parking_lot::Mutex::new(std::collections::VecDeque::new()),
+            write_failure_count: std::sync::atomic::AtomicU64::new(0),
         })
     }
 
@@ -1278,6 +1291,47 @@ impl MemoryStorage {
     /// For robotics/edge: Use async mode + periodic flush() calls for best latency.
     /// For compliance/critical: Set SHODH_WRITE_MODE=sync for full durability.
     pub fn store(&self, memory: &Memory) -> Result<()> {
+        // Opportunistically drain retry buffer on successful writes
+        self.drain_retry_buffer();
+
+        match self.store_inner(memory) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                let err_str = e.to_string();
+                // Buffer transient failures (lock contention, disk pressure)
+                // but not serialization errors (those are permanent)
+                if err_str.contains("lock")
+                    || err_str.contains("LOCK")
+                    || err_str.contains("disk")
+                    || err_str.contains("space")
+                    || err_str.contains("I/O")
+                {
+                    self.write_failure_count
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    let mut buffer = self.write_retry_buffer.lock();
+                    if buffer.len() < WRITE_RETRY_BUFFER_CAPACITY {
+                        tracing::warn!(
+                            memory_id = %memory.id.0,
+                            buffer_len = buffer.len() + 1,
+                            error = %e,
+                            "Write failed, buffered for retry"
+                        );
+                        buffer.push_back(memory.clone());
+                    } else {
+                        tracing::error!(
+                            memory_id = %memory.id.0,
+                            error = %e,
+                            "Write failed and retry buffer full — memory dropped"
+                        );
+                    }
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Internal store implementation (two-phase commit with rollback)
+    fn store_inner(&self, memory: &Memory) -> Result<()> {
         let key = memory.id.0.as_bytes();
 
         // Serialize memory
@@ -1309,6 +1363,66 @@ impl MemoryStorage {
         }
 
         Ok(())
+    }
+
+    /// Drain the retry buffer, re-attempting failed writes.
+    /// Called opportunistically on every successful store() and explicitly
+    /// from the maintenance cycle.
+    pub fn drain_retry_buffer(&self) -> usize {
+        let mut buffer = self.write_retry_buffer.lock();
+        if buffer.is_empty() {
+            return 0;
+        }
+
+        let count = buffer.len();
+        let mut succeeded = 0;
+        let mut still_failing = std::collections::VecDeque::new();
+
+        for memory in buffer.drain(..) {
+            match self.store_inner(&memory) {
+                Ok(()) => {
+                    succeeded += 1;
+                    tracing::info!(
+                        memory_id = %memory.id.0,
+                        "Retried write succeeded"
+                    );
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        memory_id = %memory.id.0,
+                        error = %e,
+                        "Retry write still failing"
+                    );
+                    if still_failing.len() < WRITE_RETRY_BUFFER_CAPACITY {
+                        still_failing.push_back(memory);
+                    }
+                }
+            }
+        }
+
+        *buffer = still_failing;
+
+        if succeeded > 0 || !buffer.is_empty() {
+            tracing::info!(
+                "Write retry drain: {}/{} succeeded, {} still pending",
+                succeeded,
+                count,
+                buffer.len()
+            );
+        }
+
+        succeeded
+    }
+
+    /// Number of writes currently buffered for retry
+    pub fn pending_retry_count(&self) -> usize {
+        self.write_retry_buffer.lock().len()
+    }
+
+    /// Total number of write failures since server start
+    pub fn total_write_failures(&self) -> u64 {
+        self.write_failure_count
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Update secondary indices for efficient retrieval


### PR DESCRIPTION
## Summary
Three reliability fixes to prevent data loss and performance degradation:

- **Write retry buffer (#132)**: Failed writes are now buffered (bounded at 100) and retried on next successful store or maintenance tick. Transient failures (lock contention, disk pressure) no longer permanently lose memories. Write failure metrics added to `/api/health`.

- **Configurable cache TTI (#126)**: `SHODH_CACHE_IDLE_SECS` env var (default: `0` = disabled). Eliminates persistent RocksDB lock contention in single-user deployments where background tasks hold `Arc` references past the moka eviction point. Multi-user servers can set `SHODH_CACHE_IDLE_SECS=3600`.

- **BM25 segment merge (#129)**: Tantivy index now merges segments on heavy maintenance cycles (~6h). Removes ghost state from upsert tombstones that degrade BM25 scoring quality and bloat disk usage.

## Files changed
- `src/memory/storage.rs` — write retry buffer, drain logic, failure metrics
- `src/handlers/state.rs` — configurable cache TTI, retry drain in maintenance, BM25 optimize in heavy cycle
- `src/memory/hybrid_search.rs` — `optimize()` and `segment_count()` on BM25Index
- `src/memory/mod.rs` — delegate methods for optimize/retry/metrics
- `src/handlers/health.rs` — write_failures + pending_retries in health response

## Verification
- `cargo check` — clean
- `cargo clippy --lib` — no new warnings
- Net: +305 / -6 lines

Closes #132, closes #126, closes #129