### PR TITLE
fix: resolve 7 audit bugs (#184-#190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3982,6 +3982,7 @@ dependencies = [
  "tokenizers",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tower 0.5.2",
  "tower-http",
  "tower_governor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ dotenvy = "0.15"  # Load .env files
 # Async runtime & web server
 tokio = { version = "1.48", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }  # SSE event streaming (sync for BroadcastStream)
+tokio-util = { version = "0.7", features = ["rt"] }  # TaskTracker for graceful shutdown of background tasks
 futures = "0.3"  # Stream utilities for SSE
 axum = { version = "0.8", features = ["json", "ws"] }
 tower = { version = "0.5", features = ["limit", "buffer", "load-shed"] }

--- a/hooks/memory-hook.ts
+++ b/hooks/memory-hook.ts
@@ -784,10 +784,30 @@ async function handleSubagentStop(input: HookInput): Promise<void> {
   );
 }
 
-async function handleStop(_input: HookInput): Promise<void> {
-  // Session end is tracked implicitly by memory timestamps and decay.
-  // Storing explicit "Session ended" memories creates noise in the activity log
-  // and gets re-ingested by proactive_context auto-ingest, causing duplicate events.
+async function handleStop(input: HookInput): Promise<void> {
+  // Store a lightweight session summary so handleSessionStart can surface
+  // continuity context in the next session. We keep it minimal to avoid
+  // noise — just the session boundary marker with lineage metadata.
+  const sessionId = input.session_id || currentEpisodeId || "unknown";
+  const stopReason = input.stop_reason || "unknown";
+  const cwd = input.cwd || process.cwd();
+
+  // Extract just the project directory name for context
+  const projectDir = cwd.split(/[/\\]/).pop() || cwd;
+
+  const content = `Session ended (${stopReason}) in ${projectDir}. Session ID: ${sessionId}`;
+
+  await callBrain("/api/remember", {
+    user_id: SHODH_USER_ID,
+    content,
+    type: "Context",
+    tags: ["session-summary", "source:stop-hook"],
+    source_type: "system",
+    importance: 0.3,
+    episode_id: sessionId,
+    preceding_memory_id: currentEpisodeId || undefined,
+    credibility: 1.0,
+  });
 }
 
 async function main(): Promise<void> {

--- a/src/embeddings/minilm.rs
+++ b/src/embeddings/minilm.rs
@@ -521,11 +521,14 @@ impl MiniLMEmbedder {
             // Distribute hash bits across embedding dimensions with positional offset
             for j in 0..self.dimension {
                 let index = (i.wrapping_mul(7) + j) % self.dimension;
-                if j < 64 {
-                    embedding[index] += ((hash >> j) & 1) as f32 * 0.1;
+                // For j >= 64, use a scattered bit index that varies with both word
+                // position (i) and dimension (j), avoiding reuse of the same bit pattern.
+                let bit_index = if j < 64 {
+                    j
                 } else {
-                    embedding[index] += ((hash >> (j % 64)) & 1) as f32 * 0.1;
-                }
+                    (i.wrapping_mul(7).wrapping_add(j)) % 64
+                };
+                embedding[index] += ((hash >> bit_index) & 1) as f32 * 0.1;
             }
         }
 

--- a/src/handlers/remember.rs
+++ b/src/handlers/remember.rs
@@ -86,12 +86,21 @@ pub struct BatchRememberRequest {
 }
 
 /// Options for batch remember
-#[derive(Debug, serde::Deserialize, Clone, Default)]
+#[derive(Debug, serde::Deserialize, Clone)]
 pub struct BatchRememberOptions {
     #[serde(default = "default_true")]
     pub extract_entities: bool,
     #[serde(default = "default_true")]
     pub create_edges: bool,
+}
+
+impl Default for BatchRememberOptions {
+    fn default() -> Self {
+        Self {
+            extract_entities: true,
+            create_edges: true,
+        }
+    }
 }
 
 fn default_true() -> bool {
@@ -371,12 +380,20 @@ pub async fn remember(
     let mut seen: HashSet<String> = merged_entities.iter().map(|t| t.to_lowercase()).collect();
     for record in &ner_entities {
         if seen.insert(record.text.to_lowercase()) {
-            merged_entities.push(record.text.clone());
+            if validation::validate_entity(&record.text).is_ok() {
+                merged_entities.push(record.text.clone());
+            } else {
+                tracing::debug!(entity = %record.text, "Skipping invalid NER entity (too long or invalid chars)");
+            }
         }
     }
     for keyword in extracted_keywords {
         if seen.insert(keyword.to_lowercase()) {
-            merged_entities.push(keyword);
+            if validation::validate_entity(&keyword).is_ok() {
+                merged_entities.push(keyword);
+            } else {
+                tracing::debug!(entity = %keyword, "Skipping invalid YAKE keyword (too long or invalid chars)");
+            }
         }
     }
     if merged_entities.len() > validation::MAX_ENTITIES_PER_MEMORY {
@@ -478,8 +495,10 @@ pub async fn remember(
     // caused 5-15s handler latency, exceeding the MCP client's 10s timeout and
     // triggering retries that created duplicate memories (31% duplication rate).
     // Now fire-and-forget: response returns in <200ms, post-tasks run in background.
+    // Use task_tracker.spawn() so shutdown can await in-flight graph writes.
     let response_id = memory_id.0.to_string();
     {
+        let tracker = state.task_tracker.clone();
         let state = state.clone();
         let memory = memory.clone();
         let user_id = req.user_id.clone();
@@ -488,7 +507,7 @@ pub async fn remember(
         let parent_id = req.parent_id.clone();
         let created_at = req.created_at;
 
-        tokio::spawn(async move {
+        tracker.spawn(async move {
             // Task 1: Build episodic graph (entities + episode + relationships)
             if let Err(e) = state.process_experience_into_graph(&user_id, &experience, &memory_id) {
                 tracing::debug!("Graph processing failed (non-fatal): {}", e);
@@ -846,12 +865,20 @@ pub async fn upsert_memory(
     let mut seen: HashSet<String> = merged_entities.iter().map(|t| t.to_lowercase()).collect();
     for record in &ner_entities {
         if seen.insert(record.text.to_lowercase()) {
-            merged_entities.push(record.text.clone());
+            if validation::validate_entity(&record.text).is_ok() {
+                merged_entities.push(record.text.clone());
+            } else {
+                tracing::debug!(entity = %record.text, "Skipping invalid NER entity in upsert (too long or invalid chars)");
+            }
         }
     }
     for keyword in extracted_keywords {
         if seen.insert(keyword.to_lowercase()) {
-            merged_entities.push(keyword);
+            if validation::validate_entity(&keyword).is_ok() {
+                merged_entities.push(keyword);
+            } else {
+                tracing::debug!(entity = %keyword, "Skipping invalid YAKE keyword in upsert (too long or invalid chars)");
+            }
         }
     }
     if merged_entities.len() > validation::MAX_ENTITIES_PER_MEMORY {
@@ -987,7 +1014,8 @@ pub async fn upsert_memory(
 /// edges, and strengthens corresponding knowledge graph connections. All failures
 /// are logged but never propagate — lineage is best-effort.
 fn spawn_lineage_inference(state: AppState, user_id: String, memory_id: crate::memory::MemoryId) {
-    tokio::spawn(async move {
+    let tracker = state.task_tracker.clone();
+    tracker.spawn(async move {
         let graph_arc = match state.get_user_graph(&user_id) {
             Ok(g) => g,
             Err(e) => {

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -281,6 +281,11 @@ pub struct MultiUserMemoryManager {
     /// applying logarithmic decay to prevent pathological repeated intrusions.
     /// See: Berntsen (2009), Thompson & Spencer (1966).
     pub habituation_tracker: Arc<HabituationTracker>,
+
+    /// Tracks background tasks (graph processing, lineage inference) spawned by
+    /// remember/upsert handlers. On shutdown, we close + await all tracked tasks
+    /// to prevent data loss from fire-and-forget graph writes.
+    pub task_tracker: tokio_util::task::TaskTracker,
 }
 
 impl MultiUserMemoryManager {
@@ -356,6 +361,8 @@ impl MultiUserMemoryManager {
         let evictions_clone = user_evictions.clone();
         let max_cache = server_config.max_users_in_memory;
         let eviction_base_path = base_path.clone();
+        let habituation_tracker: Arc<HabituationTracker> = Arc::new(DashMap::new());
+        let habituation_for_eviction = habituation_tracker.clone();
 
         // Configurable idle eviction timeout. Default: 0 (disabled).
         // Single-user deployments (local Claude Code) should keep 0 — idle eviction
@@ -396,7 +403,10 @@ impl MultiUserMemoryManager {
                     // while the lock is held, MemorySystem::new() fails with a lock error.
                     let index_path = eviction_base_path.join(key.as_str()).join("vector_index");
                     let user_key = key.clone();
+                    let hab_tracker = habituation_for_eviction.clone();
                     std::thread::spawn(move || {
+                        // Clean up habituation tracking for evicted user
+                        hab_tracker.remove(user_key.as_str());
                         // Scope the read guard so it drops before we drop the Arc.
                         // This ensures the RocksDB file lock is released promptly.
                         let save_result = {
@@ -599,7 +609,8 @@ impl MultiUserMemoryManager {
             user_memory_init_locks: DashMap::new(),
             user_graph_init_locks: DashMap::new(),
             shared_rocksdb_cache,
-            habituation_tracker: Arc::new(DashMap::new()),
+            habituation_tracker,
+            task_tracker: tokio_util::task::TaskTracker::new(),
         };
 
         info!("Running initial audit log rotation...");
@@ -924,6 +935,7 @@ impl MultiUserMemoryManager {
     pub fn evict_user(&self, user_id: &str) {
         self.user_memories.invalidate(user_id);
         self.graph_memories.invalidate(user_id);
+        self.habituation_tracker.remove(user_id);
         self.user_memories.run_pending_tasks();
         self.graph_memories.run_pending_tasks();
 
@@ -947,6 +959,7 @@ impl MultiUserMemoryManager {
     pub fn forget_user(&self, user_id: &str) -> Result<()> {
         self.user_memories.invalidate(user_id);
         self.graph_memories.invalidate(user_id);
+        self.habituation_tracker.remove(user_id);
 
         self.user_memories.run_pending_tasks();
         self.graph_memories.run_pending_tasks();
@@ -1004,7 +1017,7 @@ impl MultiUserMemoryManager {
     }
 
     /// Prefix-scan and batch-delete all keys starting with `{user_id}:` from a column family
-    fn delete_by_prefix(db: &rocksdb::DB, cf: &rocksdb::ColumnFamily, prefix: &[u8]) -> usize {
+    fn delete_by_prefix(db: &rocksdb::DB, cf: &rocksdb::ColumnFamily, prefix: &[u8]) -> Result<usize> {
         let mut batch = rocksdb::WriteBatch::default();
         let mut count = 0;
         let iter = db.prefix_iterator_cf(cf, prefix);
@@ -1017,9 +1030,9 @@ impl MultiUserMemoryManager {
             count += 1;
         }
         if count > 0 {
-            let _ = db.write(batch);
+            db.write(batch).map_err(|e| anyhow::anyhow!("RocksDB batch delete failed: {e}"))?;
         }
-        count
+        Ok(count)
     }
 
     /// Purge all user data from shared RocksDB (todos, reminders, files, feedback, audit)
@@ -1031,7 +1044,7 @@ impl MultiUserMemoryManager {
         let cf_names = ["todos", "projects", "prospective"];
         for name in &cf_names {
             if let Some(cf) = self.shared_db.cf_handle(name) {
-                let n = Self::delete_by_prefix(&self.shared_db, cf, prefix_bytes);
+                let n = Self::delete_by_prefix(&self.shared_db, cf, prefix_bytes)?;
                 if n > 0 {
                     tracing::debug!("GDPR: purged {n} entries from {name} CF for {user_id}");
                 }
@@ -1052,7 +1065,7 @@ impl MultiUserMemoryManager {
                 format!("todo_vector:{user_id}:"),
             ];
             for p in &prefixes {
-                Self::delete_by_prefix(&self.shared_db, cf, p.as_bytes());
+                Self::delete_by_prefix(&self.shared_db, cf, p.as_bytes())?;
             }
             // Priority and due/context keys also contain user_id but at varying positions.
             // Full scan of index CF to catch them all.
@@ -1066,7 +1079,7 @@ impl MultiUserMemoryManager {
                     }
                 }
             }
-            let _ = self.shared_db.write(batch);
+            self.shared_db.write(batch).map_err(|e| anyhow::anyhow!("GDPR todo_index purge failed: {e}"))?;
         }
 
         if let Some(cf) = self.shared_db.cf_handle("prospective_index") {
@@ -1077,7 +1090,7 @@ impl MultiUserMemoryManager {
                 format!("status:Dismissed:{user_id}:"),
             ];
             for p in &prefixes {
-                Self::delete_by_prefix(&self.shared_db, cf, p.as_bytes());
+                Self::delete_by_prefix(&self.shared_db, cf, p.as_bytes())?;
             }
             // Context keyword indices: `context:{keyword}:{user_id}:{id}`
             let mut batch = rocksdb::WriteBatch::default();
@@ -1090,16 +1103,16 @@ impl MultiUserMemoryManager {
                     }
                 }
             }
-            let _ = self.shared_db.write(batch);
+            self.shared_db.write(batch).map_err(|e| anyhow::anyhow!("GDPR prospective_index purge failed: {e}"))?;
         }
 
         // Files
         if let Some(cf) = self.shared_db.cf_handle("files") {
-            Self::delete_by_prefix(&self.shared_db, cf, prefix_bytes);
+            Self::delete_by_prefix(&self.shared_db, cf, prefix_bytes)?;
         }
         if let Some(cf) = self.shared_db.cf_handle("file_index") {
             let idx_prefix = format!("file_idx:{user_id}:");
-            Self::delete_by_prefix(&self.shared_db, cf, idx_prefix.as_bytes());
+            Self::delete_by_prefix(&self.shared_db, cf, idx_prefix.as_bytes())?;
             // Also catch other patterns
             let mut batch = rocksdb::WriteBatch::default();
             let iter = self.shared_db.iterator_cf(cf, rocksdb::IteratorMode::Start);
@@ -1111,18 +1124,19 @@ impl MultiUserMemoryManager {
                     }
                 }
             }
-            let _ = self.shared_db.write(batch);
+            self.shared_db.write(batch).map_err(|e| anyhow::anyhow!("GDPR file_index purge failed: {e}"))?;
         }
 
         // Feedback: `pending:{user_id}`
         if let Some(cf) = self.shared_db.cf_handle("feedback") {
             let pending_key = format!("pending:{user_id}");
-            let _ = self.shared_db.delete_cf(cf, pending_key.as_bytes());
+            self.shared_db.delete_cf(cf, pending_key.as_bytes())
+                .map_err(|e| anyhow::anyhow!("GDPR feedback purge failed: {e}"))?;
         }
 
         // Audit logs
         if let Some(cf) = self.shared_db.cf_handle("audit") {
-            Self::delete_by_prefix(&self.shared_db, cf, prefix_bytes);
+            Self::delete_by_prefix(&self.shared_db, cf, prefix_bytes)?;
         }
 
         // Clear in-memory audit log cache

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -1017,7 +1017,11 @@ impl MultiUserMemoryManager {
     }
 
     /// Prefix-scan and batch-delete all keys starting with `{user_id}:` from a column family
-    fn delete_by_prefix(db: &rocksdb::DB, cf: &rocksdb::ColumnFamily, prefix: &[u8]) -> Result<usize> {
+    fn delete_by_prefix(
+        db: &rocksdb::DB,
+        cf: &rocksdb::ColumnFamily,
+        prefix: &[u8],
+    ) -> Result<usize> {
         let mut batch = rocksdb::WriteBatch::default();
         let mut count = 0;
         let iter = db.prefix_iterator_cf(cf, prefix);
@@ -1030,7 +1034,8 @@ impl MultiUserMemoryManager {
             count += 1;
         }
         if count > 0 {
-            db.write(batch).map_err(|e| anyhow::anyhow!("RocksDB batch delete failed: {e}"))?;
+            db.write(batch)
+                .map_err(|e| anyhow::anyhow!("RocksDB batch delete failed: {e}"))?;
         }
         Ok(count)
     }
@@ -1079,7 +1084,9 @@ impl MultiUserMemoryManager {
                     }
                 }
             }
-            self.shared_db.write(batch).map_err(|e| anyhow::anyhow!("GDPR todo_index purge failed: {e}"))?;
+            self.shared_db
+                .write(batch)
+                .map_err(|e| anyhow::anyhow!("GDPR todo_index purge failed: {e}"))?;
         }
 
         if let Some(cf) = self.shared_db.cf_handle("prospective_index") {
@@ -1103,7 +1110,9 @@ impl MultiUserMemoryManager {
                     }
                 }
             }
-            self.shared_db.write(batch).map_err(|e| anyhow::anyhow!("GDPR prospective_index purge failed: {e}"))?;
+            self.shared_db
+                .write(batch)
+                .map_err(|e| anyhow::anyhow!("GDPR prospective_index purge failed: {e}"))?;
         }
 
         // Files
@@ -1124,13 +1133,16 @@ impl MultiUserMemoryManager {
                     }
                 }
             }
-            self.shared_db.write(batch).map_err(|e| anyhow::anyhow!("GDPR file_index purge failed: {e}"))?;
+            self.shared_db
+                .write(batch)
+                .map_err(|e| anyhow::anyhow!("GDPR file_index purge failed: {e}"))?;
         }
 
         // Feedback: `pending:{user_id}`
         if let Some(cf) = self.shared_db.cf_handle("feedback") {
             let pending_key = format!("pending:{user_id}");
-            self.shared_db.delete_cf(cf, pending_key.as_bytes())
+            self.shared_db
+                .delete_cf(cf, pending_key.as_bytes())
                 .map_err(|e| anyhow::anyhow!("GDPR feedback purge failed: {e}"))?;
         }
 

--- a/src/memory/lineage.rs
+++ b/src/memory/lineage.rs
@@ -753,6 +753,8 @@ impl LineageGraph {
             "start fresh",
             "start over",
             "complete rewrite",
+            "should rewrite",
+            "need to rewrite",
             "scrap this",
             "scrap the",
             "different strategy",

--- a/src/memory/todos.rs
+++ b/src/memory/todos.rs
@@ -511,28 +511,37 @@ impl TodoStore {
             batch.delete_cf(index_cf, parent_key.as_bytes());
         }
 
-        // Clean up vector index mapping: look up vector_id from reverse mapping
+        // Clean up vector index mapping: look up vector_id from reverse mapping.
+        // We capture the vector_id BEFORE the batch write so we can mark_deleted AFTER
+        // the batch commits — this ensures the index only reflects committed deletes.
         let rev_key = format!("todo_vector:{}:{}", todo.user_id, id_str);
-        if let Some(vid_bytes) = self.db.get_cf(index_cf, rev_key.as_bytes())? {
+        let pending_vector_delete = if let Some(vid_bytes) = self.db.get_cf(index_cf, rev_key.as_bytes())? {
             if vid_bytes.len() >= 4 {
                 let vector_id =
                     u32::from_le_bytes([vid_bytes[0], vid_bytes[1], vid_bytes[2], vid_bytes[3]]);
 
-                // Mark deleted in Vamana index
-                let indices = self.vector_indices.read();
-                if let Some(index) = indices.get(&todo.user_id) {
-                    index.mark_deleted(vector_id);
-                }
-
-                // Remove forward mapping
+                // Remove forward mapping in batch (will commit atomically)
                 let fwd_key = format!("vector_id:{}:{}", todo.user_id, vector_id);
                 batch.delete_cf(index_cf, fwd_key.as_bytes());
+                Some((todo.user_id.clone(), vector_id))
+            } else {
+                None
             }
-            // Remove reverse mapping
-            batch.delete_cf(index_cf, rev_key.as_bytes());
-        }
+        } else {
+            None
+        };
+        // Remove reverse mapping in batch
+        batch.delete_cf(index_cf, rev_key.as_bytes());
 
         self.db.write(batch)?;
+
+        // Mark deleted in Vamana index AFTER batch commit succeeds
+        if let Some((ref user_id, vector_id)) = pending_vector_delete {
+            let indices = self.vector_indices.read();
+            if let Some(index) = indices.get(user_id) {
+                index.mark_deleted(vector_id);
+            }
+        }
         Ok(())
     }
 

--- a/src/memory/todos.rs
+++ b/src/memory/todos.rs
@@ -515,7 +515,9 @@ impl TodoStore {
         // We capture the vector_id BEFORE the batch write so we can mark_deleted AFTER
         // the batch commits — this ensures the index only reflects committed deletes.
         let rev_key = format!("todo_vector:{}:{}", todo.user_id, id_str);
-        let pending_vector_delete = if let Some(vid_bytes) = self.db.get_cf(index_cf, rev_key.as_bytes())? {
+        let pending_vector_delete = if let Some(vid_bytes) =
+            self.db.get_cf(index_cf, rev_key.as_bytes())?
+        {
             if vid_bytes.len() >= 4 {
                 let vector_id =
                     u32::from_le_bytes([vid_bytes[0], vid_bytes[1], vid_bytes[2], vid_bytes[3]]);

--- a/src/server.rs
+++ b/src/server.rs
@@ -310,6 +310,17 @@ async fn async_main() -> Result<()> {
         }
     }
 
+    // Wait for tracked background tasks (graph processing, lineage inference)
+    // to complete before flushing databases, preventing data loss.
+    manager_for_shutdown.task_tracker.close();
+    let task_timeout = std::time::Duration::from_secs(10);
+    info!("Waiting up to {}s for background graph tasks...", task_timeout.as_secs());
+    if tokio::time::timeout(task_timeout, manager_for_shutdown.task_tracker.wait()).await.is_err() {
+        tracing::warn!("Background task drain timed out after {}s, proceeding with shutdown", task_timeout.as_secs());
+    } else {
+        info!("All background graph tasks completed");
+    }
+
     // Shut down Zenoh transport before flushing databases
     #[cfg(feature = "zenoh")]
     if let Some(handle) = zenoh_handle {
@@ -347,6 +358,25 @@ fn start_maintenance_scheduler(manager: AppState, interval_secs: u64) {
             let session_cleaned = manager.session_store().cleanup_stale_sessions();
             if session_cleaned > 0 {
                 tracing::debug!("Ended {} stale user sessions", session_cleaned);
+            }
+
+            // Prune stale habituation entries (> 24 hours since last surfaced)
+            {
+                let tracker = &manager.habituation_tracker;
+                let cutoff = chrono::Utc::now() - chrono::Duration::hours(24);
+                let mut pruned = 0usize;
+                // Outer map: user_id -> inner map
+                tracker.retain(|_user_id, inner| {
+                    inner.retain(|_mem_id, entry| {
+                        let keep = entry.last_surfaced > cutoff;
+                        if !keep { pruned += 1; }
+                        keep
+                    });
+                    !inner.is_empty()
+                });
+                if pruned > 0 {
+                    tracing::debug!("Pruned {} stale habituation entries (>24h)", pruned);
+                }
             }
 
             // Run maintenance in blocking thread pool

--- a/src/server.rs
+++ b/src/server.rs
@@ -314,9 +314,18 @@ async fn async_main() -> Result<()> {
     // to complete before flushing databases, preventing data loss.
     manager_for_shutdown.task_tracker.close();
     let task_timeout = std::time::Duration::from_secs(10);
-    info!("Waiting up to {}s for background graph tasks...", task_timeout.as_secs());
-    if tokio::time::timeout(task_timeout, manager_for_shutdown.task_tracker.wait()).await.is_err() {
-        tracing::warn!("Background task drain timed out after {}s, proceeding with shutdown", task_timeout.as_secs());
+    info!(
+        "Waiting up to {}s for background graph tasks...",
+        task_timeout.as_secs()
+    );
+    if tokio::time::timeout(task_timeout, manager_for_shutdown.task_tracker.wait())
+        .await
+        .is_err()
+    {
+        tracing::warn!(
+            "Background task drain timed out after {}s, proceeding with shutdown",
+            task_timeout.as_secs()
+        );
     } else {
         info!("All background graph tasks completed");
     }
@@ -369,7 +378,9 @@ fn start_maintenance_scheduler(manager: AppState, interval_secs: u64) {
                 tracker.retain(|_user_id, inner| {
                     inner.retain(|_mem_id, entry| {
                         let keep = entry.last_surfaced > cutoff;
-                        if !keep { pruned += 1; }
+                        if !keep {
+                            pruned += 1;
+                        }
                         keep
                     });
                     !inner.is_empty()


### PR DESCRIPTION
## Summary
- **#184** — GDPR `delete_by_prefix` now returns `Result<usize>`, propagates RocksDB write errors instead of silently swallowing them
- **#185** — Todo Vamana `mark_deleted()` moved after `db.write(batch)?` to ensure index only reflects committed deletes
- **#186** — NER/YAKE entities validated with `validate_entity()` before merging (both remember and upsert paths)
- **#187** — Fallback embedding bit reuse fixed: scattered bit index `(i*7+j) % 64` for dimensions >= 64
- **#188** — `tokio_util::TaskTracker` replaces `tokio::spawn` for graph/lineage tasks; shutdown awaits with 10s timeout
- **#189** — `handleStop()` stores lightweight session summary with `session-summary` tag for cross-session continuity
- **#190** — Habituation tracker cleanup on eviction, forget, user delete, and periodic pruning (>24h stale entries)

Also fixes:
- `BatchRememberOptions::default()` returning `false` instead of `true` (derived Default vs serde default mismatch)
- `detect_branch_signal` missing strong signals for "should rewrite" / "need to rewrite"
- Habituation tracker constructor wiring (eviction listener clone was disconnected from actual tracker)

## Test plan
- [x] `cargo check` — compiles clean
- [x] `cargo clippy` — no new warnings
- [x] `cargo test --lib` — 487 passed, 0 failed (was 485/2 before fixes)

Closes #184, #185, #186, #187, #188, #189, #190