### PR TITLE
feat: migrate serialization from bincode to postcard (#192)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,83 +1,27 @@
 # Shodh-Memory Project Instructions
 
+## MUST Rules
+- MUST NOT run `cargo build` or `cargo run`. Only `cargo check`, `cargo clippy`, and `cargo test` are allowed.
+- MUST NOT add "Co-Authored-By" or "Generated with Claude Code" to commits. Clean commit messages only.
+- MUST NOT comment on GitHub issues/PRs without showing user a draft first.
+
 ## Code Standards
-- Production grade code only, no TODOs, no placeholders, no mocks, no stubs
-- Understand context, take a bird's eye view, understand architecture and data flow before fixing anything
-- Don't build, don't trunk serve - user runs in background
-- `cargo check` and `cargo clippy` are allowed (compiler frontend only, no binary output)
-- DO NOT add "Generated with Claude Code" signature or "Co-Authored-By" lines to git commits - clean commit messages only
+- IMPORTANT: Production grade code only. No TODOs, no placeholders, no mocks, no stubs.
+- IMPORTANT: Understand architecture and data flow before fixing anything. Read files before editing.
+- All changes go through PR workflow: branch → commit → push → PR → merge.
 
----
+## Persistent Memory (shodh-memory MCP)
 
-## You Have Persistent Memory
+You have session continuity via shodh-memory hooks. Key behaviors:
+- Relevant memories surface automatically — don't manually "check" memory
+- Use `remember` sparingly (high-importance only), `forget` for corrections
+- Use `list_todos` at session start for pending work
+- The memory system you're using IS this codebase
 
-You are running with shodh-memory, a persistent cognitive memory system. This is not a tool you query - it is part of how you think.
-
-### How It Works
-
-**Automatic Layer (invisible to you):**
-- When a session starts, relevant memories from past sessions are surfaced to you
-- When the user asks something, related memories are retrieved and injected into your context
-- When you finish responding, important context is encoded into memory
-- When you use tools (Edit, Write, Bash), patterns are recorded
-
-This happens through hooks - you don't see the API calls, you just receive the context.
-
-**Emphasis Layer (explicit tools):**
-- `remember` - Mark something as HIGH IMPORTANCE (will be preserved longer, resists decay)
-- `forget` - SUPPRESS a memory (reduce its importance, accelerate decay)
-- These are emphasis signals, not on/off switches. Memory happens anyway.
-
-### What This Means For You
-
-1. **You have continuity.** Past sessions exist. Decisions you made, learnings you had, patterns you noticed - they persist. You are not starting fresh.
-
-2. **Don't "check" memory.** Relevant context appears automatically. If you need something specific, it will be there. Trust the system.
-
-3. **Use `remember` sparingly.** Only for things that are genuinely important and worth emphasizing. Most things are remembered automatically.
-
-4. **Use `forget` for corrections.** If you made an error or stored something wrong, forget it.
-
-5. **You know this user.** If you've worked with them before, you have context about their preferences, codebase, and working style.
-
-### Memory Tools (MCP)
-
-When you DO need explicit memory operations:
-
-| Tool | Purpose |
-|------|---------|
-| `remember` | Emphasize importance (learning, decision, insight) |
-| `recall` | Semantic search when you need specific past context |
-| `recall_by_tags` | Find memories by tag |
-| `forget` | Suppress/correct a memory |
-| `proactive_context` | Get contextually relevant memories (usually automatic) |
-| `context_summary` | Quick overview of recent learnings/decisions |
-
-### Todo System
-
-For work that spans sessions:
-
-| Tool | Purpose |
-|------|---------|
-| `list_todos` | See pending work |
-| `add_todo` | Track work for future sessions |
-| `complete_todo` | Mark done |
-| `list_projects` | See project hierarchy |
-
-At session start, check `list_todos` to continue where you left off.
-
----
-
-## This Codebase
-
-You are working on shodh-memory itself. Key components:
-
-- `src/` - Rust core (memory system, API server, embeddings, graph)
-- `mcp-server/` - TypeScript MCP server for Claude/Cursor integration
-- `tui/` - Rust TUI dashboard
-- `hooks/` - Claude Code hooks for automatic memory
-- `python/` - Python bindings (maturin/PyO3)
-
-Architecture: RocksDB + HNSW vector search + knowledge graph with Hebbian learning.
-
-The memory system you're using IS this codebase. Meta, but useful context.
+## Codebase Map
+- `src/` — Rust core (memory, API server, embeddings, graph, vector search)
+- `mcp-server/` — TypeScript MCP server (45 tools, index.ts)
+- `tui/` — Rust TUI dashboard
+- `hooks/` — Claude Code hooks for automatic memory
+- `python/` — Python bindings (PyO3/maturin)
+- Architecture: RocksDB + Vamana/SPANN vector search + knowledge graph with Hebbian learning

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +643,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +789,12 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam"
@@ -1126,6 +1150,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "equivalent"
@@ -1499,6 +1535,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1579,20 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2990,6 +3049,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3963,6 +4035,7 @@ dependencies = [
  "ort",
  "parking_lot",
  "petgraph",
+ "postcard",
  "prometheus",
  "pyo3",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ serde_json = "1.0"
 form_urlencoded = "1"
 
 # Storage
+postcard = { version = "1", features = ["alloc"] }
 bincode = { version = "2", features = ["serde"] }
 bincode1 = { package = "bincode", version = "1.3" }  # Legacy format support for pre-2.0 memories
 rmp-serde = "1.3"  # MessagePack - binary format that supports serde tagged enums

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -1445,8 +1445,7 @@ impl GraphMemory {
             let entity_iter = db.iterator_cf(entities_cf, rocksdb::IteratorMode::Start);
             let mut migrated_count = 0;
             for (_, value) in entity_iter.flatten() {
-                if let Ok((entity, _)) = crate::serialization::try_decode::<EntityNode>(&value)
-                {
+                if let Ok((entity, _)) = crate::serialization::try_decode::<EntityNode>(&value) {
                     // Store in name_index CF: name -> UUID bytes
                     db.put_cf(
                         name_index_cf,
@@ -1569,8 +1568,7 @@ impl GraphMemory {
         for uuid in name_index.values() {
             let key = uuid.as_bytes();
             if let Ok(Some(value)) = db.get_cf(entities_cf, key) {
-                if let Ok((entity, _)) = crate::serialization::try_decode::<EntityNode>(&value)
-                {
+                if let Ok((entity, _)) = crate::serialization::try_decode::<EntityNode>(&value) {
                     if let Some(emb) = entity.name_embedding {
                         cache.push((*uuid, emb));
                         if cache.len() >= ENTITY_EMBEDDING_CACHE_MAX {
@@ -2345,8 +2343,7 @@ impl GraphMemory {
 
         let mut edges = Vec::with_capacity(edge_uuids.len());
         for value in results.into_iter().flatten().flatten() {
-            if let Ok((edge, _)) = crate::serialization::try_decode::<RelationshipEdge>(&value)
-            {
+            if let Ok((edge, _)) = crate::serialization::try_decode::<RelationshipEdge>(&value) {
                 edges.push(edge);
             }
         }
@@ -2515,8 +2512,7 @@ impl GraphMemory {
         let key = uuid.as_bytes();
         match self.db.get_cf(self.relationships_cf(), key)? {
             Some(value) => {
-                let (edge, _) =
-                    crate::serialization::try_decode::<RelationshipEdge>(&value)?;
+                let (edge, _) = crate::serialization::try_decode::<RelationshipEdge>(&value)?;
                 Ok(Some(edge))
             }
             None => Ok(None),
@@ -2535,8 +2531,7 @@ impl GraphMemory {
         let key = uuid.as_bytes();
         match self.db.get_cf(self.relationships_cf(), key)? {
             Some(value) => {
-                let (mut edge, _) =
-                    crate::serialization::try_decode::<RelationshipEdge>(&value)?;
+                let (mut edge, _) = crate::serialization::try_decode::<RelationshipEdge>(&value)?;
                 // Apply effective strength calculation (doesn't persist)
                 edge.strength = edge.effective_strength();
                 Ok(Some(edge))
@@ -2618,8 +2613,7 @@ impl GraphMemory {
             .iterator_cf(self.relationships_cf(), rocksdb::IteratorMode::Start);
         let mut edges_to_delete = Vec::new();
         for (_, value) in iter.flatten() {
-            if let Ok((edge, _)) = crate::serialization::try_decode::<RelationshipEdge>(&value)
-            {
+            if let Ok((edge, _)) = crate::serialization::try_decode::<RelationshipEdge>(&value) {
                 if edge.source_episode_id == Some(*episode_uuid) {
                     edges_to_delete.push(edge.uuid);
                 }
@@ -2724,8 +2718,7 @@ impl GraphMemory {
         let key = uuid.as_bytes();
         match self.db.get_cf(self.episodes_cf(), key)? {
             Some(value) => {
-                let (episode, _) =
-                    crate::serialization::try_decode::<EpisodicNode>(&value)?;
+                let (episode, _) = crate::serialization::try_decode::<EpisodicNode>(&value)?;
                 Ok(Some(episode))
             }
             None => Ok(None),
@@ -2773,8 +2766,7 @@ impl GraphMemory {
 
         let mut episodes = Vec::with_capacity(episode_uuids.len());
         for value in results.into_iter().flatten().flatten() {
-            if let Ok((episode, _)) = crate::serialization::try_decode::<EpisodicNode>(&value)
-            {
+            if let Ok((episode, _)) = crate::serialization::try_decode::<EpisodicNode>(&value) {
                 episodes.push(episode);
             }
         }
@@ -3498,8 +3490,7 @@ impl GraphMemory {
             }
 
             let (_, value) = result?;
-            let (entity, _) =
-                crate::serialization::try_decode::<EntityNode>(&value)?;
+            let (entity, _) = crate::serialization::try_decode::<EntityNode>(&value)?;
 
             let entity_matches = self.match_pattern(&entity.uuid, pattern, min_strength)?;
             for m in entity_matches {
@@ -3665,9 +3656,7 @@ impl GraphMemory {
                     // Strengthen existing edge
                     let _ = edge.strengthen();
                     let key = edge.uuid.as_bytes();
-                    if let Ok(value) =
-                        crate::serialization::encode(&edge)
-                    {
+                    if let Ok(value) = crate::serialization::encode(&edge) {
                         batch.put_cf(self.relationships_cf(), key, value);
                         edges_updated += 1;
                     }
@@ -3695,9 +3684,7 @@ impl GraphMemory {
                     };
 
                     let key = edge.uuid.as_bytes();
-                    if let Ok(value) =
-                        crate::serialization::encode(&edge)
-                    {
+                    if let Ok(value) = crate::serialization::encode(&edge) {
                         batch.put_cf(self.relationships_cf(), key, value);
 
                         // Also index in the reverse direction for lookup
@@ -3817,8 +3804,7 @@ impl GraphMemory {
                 // Strengthen existing edge — capture tier promotion if it occurs
                 let promotion = edge.strengthen();
                 let key = edge.uuid.as_bytes();
-                if let Ok(value) = crate::serialization::encode(&edge)
-                {
+                if let Ok(value) = crate::serialization::encode(&edge) {
                     batch.put_cf(self.relationships_cf(), key, value);
                     strengthened += 1;
 
@@ -3877,8 +3863,7 @@ impl GraphMemory {
                 };
 
                 let key = edge.uuid.as_bytes();
-                if let Ok(value) = crate::serialization::encode(&edge)
-                {
+                if let Ok(value) = crate::serialization::encode(&edge) {
                     batch.put_cf(self.relationships_cf(), key, value);
 
                     // Index both directions
@@ -4106,9 +4091,7 @@ impl GraphMemory {
                     }
                     let _ = edge.strengthen();
                     let key = edge.uuid.as_bytes();
-                    if let Ok(value) =
-                        crate::serialization::encode(&edge)
-                    {
+                    if let Ok(value) = crate::serialization::encode(&edge) {
                         batch.put_cf(self.relationships_cf(), key, value);
                         strengthened += 1;
                     }
@@ -4486,8 +4469,7 @@ impl GraphMemory {
             rocksdb::IteratorMode::Start,
         );
         for (_, value) in iter.flatten() {
-            if let Ok((edge, _)) = crate::serialization::try_decode::<RelationshipEdge>(&value)
-            {
+            if let Ok((edge, _)) = crate::serialization::try_decode::<RelationshipEdge>(&value) {
                 // Only include non-invalidated relationships
                 if edge.invalidated_at.is_none() {
                     relationships.push(edge);

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -1445,11 +1445,7 @@ impl GraphMemory {
             let entity_iter = db.iterator_cf(entities_cf, rocksdb::IteratorMode::Start);
             let mut migrated_count = 0;
             for (_, value) in entity_iter.flatten() {
-                if let Ok(entity) = bincode::serde::decode_from_slice::<EntityNode, _>(
-                    &value,
-                    bincode::config::standard(),
-                )
-                .map(|(v, _)| v)
+                if let Ok((entity, _)) = crate::serialization::try_decode::<EntityNode>(&value)
                 {
                     // Store in name_index CF: name -> UUID bytes
                     db.put_cf(
@@ -1573,10 +1569,8 @@ impl GraphMemory {
         for uuid in name_index.values() {
             let key = uuid.as_bytes();
             if let Ok(Some(value)) = db.get_cf(entities_cf, key) {
-                if let Ok((entity, _)) = bincode::serde::decode_from_slice::<EntityNode, _>(
-                    &value,
-                    bincode::config::standard(),
-                ) {
+                if let Ok((entity, _)) = crate::serialization::try_decode::<EntityNode>(&value)
+                {
                     if let Some(emb) = entity.name_embedding {
                         cache.push((*uuid, emb));
                         if cache.len() >= ENTITY_EMBEDDING_CACHE_MAX {
@@ -1762,7 +1756,7 @@ impl GraphMemory {
 
         // Store entity in database
         let key = entity.uuid.as_bytes();
-        let value = bincode::serde::encode_to_vec(&entity, bincode::config::standard())?;
+        let value = crate::serialization::encode(&entity)?;
         self.db.put_cf(self.entities_cf(), key, value)?;
 
         // Increment counter only for truly new entities
@@ -1778,8 +1772,7 @@ impl GraphMemory {
         let key = uuid.as_bytes();
         match self.db.get_cf(self.entities_cf(), key)? {
             Some(value) => {
-                let (entity, _): (EntityNode, _) =
-                    bincode::serde::decode_from_slice(&value, bincode::config::standard())?;
+                let (entity, _) = crate::serialization::try_decode::<EntityNode>(&value)?;
                 Ok(Some(entity))
             }
             None => Ok(None),
@@ -2166,7 +2159,7 @@ impl GraphMemory {
 
             // Persist the strengthened edge
             let key = existing.uuid.as_bytes();
-            let value = bincode::serde::encode_to_vec(&existing, bincode::config::standard())?;
+            let value = crate::serialization::encode(&existing)?;
             self.db.put_cf(self.relationships_cf(), key, value)?;
 
             return Ok(existing.uuid);
@@ -2178,7 +2171,7 @@ impl GraphMemory {
 
         // Store relationship
         let key = edge.uuid.as_bytes();
-        let value = bincode::serde::encode_to_vec(&edge, bincode::config::standard())?;
+        let value = crate::serialization::encode(&edge)?;
         self.db.put_cf(self.relationships_cf(), key, value)?;
 
         // Increment relationship counter
@@ -2352,10 +2345,8 @@ impl GraphMemory {
 
         let mut edges = Vec::with_capacity(edge_uuids.len());
         for value in results.into_iter().flatten().flatten() {
-            if let Ok((edge, _)) = bincode::serde::decode_from_slice::<RelationshipEdge, _>(
-                &value,
-                bincode::config::standard(),
-            ) {
+            if let Ok((edge, _)) = crate::serialization::try_decode::<RelationshipEdge>(&value)
+            {
                 edges.push(edge);
             }
         }
@@ -2524,8 +2515,8 @@ impl GraphMemory {
         let key = uuid.as_bytes();
         match self.db.get_cf(self.relationships_cf(), key)? {
             Some(value) => {
-                let (edge, _): (RelationshipEdge, _) =
-                    bincode::serde::decode_from_slice(&value, bincode::config::standard())?;
+                let (edge, _) =
+                    crate::serialization::try_decode::<RelationshipEdge>(&value)?;
                 Ok(Some(edge))
             }
             None => Ok(None),
@@ -2544,8 +2535,8 @@ impl GraphMemory {
         let key = uuid.as_bytes();
         match self.db.get_cf(self.relationships_cf(), key)? {
             Some(value) => {
-                let (mut edge, _): (RelationshipEdge, _) =
-                    bincode::serde::decode_from_slice(&value, bincode::config::standard())?;
+                let (mut edge, _) =
+                    crate::serialization::try_decode::<RelationshipEdge>(&value)?;
                 // Apply effective strength calculation (doesn't persist)
                 edge.strength = edge.effective_strength();
                 Ok(Some(edge))
@@ -2627,10 +2618,8 @@ impl GraphMemory {
             .iterator_cf(self.relationships_cf(), rocksdb::IteratorMode::Start);
         let mut edges_to_delete = Vec::new();
         for (_, value) in iter.flatten() {
-            if let Ok((edge, _)) = bincode::serde::decode_from_slice::<RelationshipEdge, _>(
-                &value,
-                bincode::config::standard(),
-            ) {
+            if let Ok((edge, _)) = crate::serialization::try_decode::<RelationshipEdge>(&value)
+            {
                 if edge.source_episode_id == Some(*episode_uuid) {
                     edges_to_delete.push(edge.uuid);
                 }
@@ -2707,7 +2696,7 @@ impl GraphMemory {
             entity_count
         );
 
-        let value = bincode::serde::encode_to_vec(&episode, bincode::config::standard())?;
+        let value = crate::serialization::encode(&episode)?;
         self.db.put_cf(self.episodes_cf(), key, value)?;
 
         // Increment episode counter
@@ -2735,8 +2724,8 @@ impl GraphMemory {
         let key = uuid.as_bytes();
         match self.db.get_cf(self.episodes_cf(), key)? {
             Some(value) => {
-                let (episode, _): (EpisodicNode, _) =
-                    bincode::serde::decode_from_slice(&value, bincode::config::standard())?;
+                let (episode, _) =
+                    crate::serialization::try_decode::<EpisodicNode>(&value)?;
                 Ok(Some(episode))
             }
             None => Ok(None),
@@ -2784,10 +2773,8 @@ impl GraphMemory {
 
         let mut episodes = Vec::with_capacity(episode_uuids.len());
         for value in results.into_iter().flatten().flatten() {
-            if let Ok((episode, _)) = bincode::serde::decode_from_slice::<EpisodicNode, _>(
-                &value,
-                bincode::config::standard(),
-            ) {
+            if let Ok((episode, _)) = crate::serialization::try_decode::<EpisodicNode>(&value)
+            {
                 episodes.push(episode);
             }
         }
@@ -3511,8 +3498,8 @@ impl GraphMemory {
             }
 
             let (_, value) = result?;
-            let (entity, _): (EntityNode, _) =
-                bincode::serde::decode_from_slice(&value, bincode::config::standard())?;
+            let (entity, _) =
+                crate::serialization::try_decode::<EntityNode>(&value)?;
 
             let entity_matches = self.match_pattern(&entity.uuid, pattern, min_strength)?;
             for m in entity_matches {
@@ -3547,7 +3534,7 @@ impl GraphMemory {
             edge.invalidated_at = Some(Utc::now());
 
             let key = edge.uuid.as_bytes();
-            let value = bincode::serde::encode_to_vec(&edge, bincode::config::standard())?;
+            let value = crate::serialization::encode(&edge)?;
             self.db.put_cf(self.relationships_cf(), key, value)?;
         }
 
@@ -3571,7 +3558,7 @@ impl GraphMemory {
             let _ = edge.strengthen();
 
             let key = edge.uuid.as_bytes();
-            let value = bincode::serde::encode_to_vec(&edge, bincode::config::standard())?;
+            let value = crate::serialization::encode(&edge)?;
             self.db.put_cf(self.relationships_cf(), key, value)?;
         }
 
@@ -3609,12 +3596,11 @@ impl GraphMemory {
 
         for (i, result) in results.into_iter().enumerate() {
             if let Ok(Some(value)) = result {
-                if let Ok((mut edge, _)) = bincode::serde::decode_from_slice::<RelationshipEdge, _>(
-                    &value,
-                    bincode::config::standard(),
-                ) {
+                if let Ok((mut edge, _)) =
+                    crate::serialization::try_decode::<RelationshipEdge>(&value)
+                {
                     let _ = edge.strengthen();
-                    match bincode::serde::encode_to_vec(&edge, bincode::config::standard()) {
+                    match crate::serialization::encode(&edge) {
                         Ok(encoded) => {
                             batch.put_cf(self.relationships_cf(), &keys[i], encoded);
                             strengthened += 1;
@@ -3680,7 +3666,7 @@ impl GraphMemory {
                     let _ = edge.strengthen();
                     let key = edge.uuid.as_bytes();
                     if let Ok(value) =
-                        bincode::serde::encode_to_vec(&edge, bincode::config::standard())
+                        crate::serialization::encode(&edge)
                     {
                         batch.put_cf(self.relationships_cf(), key, value);
                         edges_updated += 1;
@@ -3710,7 +3696,7 @@ impl GraphMemory {
 
                     let key = edge.uuid.as_bytes();
                     if let Ok(value) =
-                        bincode::serde::encode_to_vec(&edge, bincode::config::standard())
+                        crate::serialization::encode(&edge)
                     {
                         batch.put_cf(self.relationships_cf(), key, value);
 
@@ -3831,7 +3817,7 @@ impl GraphMemory {
                 // Strengthen existing edge — capture tier promotion if it occurs
                 let promotion = edge.strengthen();
                 let key = edge.uuid.as_bytes();
-                if let Ok(value) = bincode::serde::encode_to_vec(&edge, bincode::config::standard())
+                if let Ok(value) = crate::serialization::encode(&edge)
                 {
                     batch.put_cf(self.relationships_cf(), key, value);
                     strengthened += 1;
@@ -3891,7 +3877,7 @@ impl GraphMemory {
                 };
 
                 let key = edge.uuid.as_bytes();
-                if let Ok(value) = bincode::serde::encode_to_vec(&edge, bincode::config::standard())
+                if let Ok(value) = crate::serialization::encode(&edge)
                 {
                     batch.put_cf(self.relationships_cf(), key, value);
 
@@ -4121,7 +4107,7 @@ impl GraphMemory {
                     let _ = edge.strengthen();
                     let key = edge.uuid.as_bytes();
                     if let Ok(value) =
-                        bincode::serde::encode_to_vec(&edge, bincode::config::standard())
+                        crate::serialization::encode(&edge)
                     {
                         batch.put_cf(self.relationships_cf(), key, value);
                         strengthened += 1;
@@ -4229,7 +4215,7 @@ impl GraphMemory {
             let should_prune = edge.decay();
 
             let key = edge.uuid.as_bytes();
-            let value = bincode::serde::encode_to_vec(&edge, bincode::config::standard())?;
+            let value = crate::serialization::encode(&edge)?;
             self.db.put_cf(self.relationships_cf(), key, value)?;
 
             return Ok(should_prune);
@@ -4262,7 +4248,7 @@ impl GraphMemory {
                 let should_prune = edge.decay();
 
                 let key = edge.uuid.as_bytes();
-                match bincode::serde::encode_to_vec(&edge, bincode::config::standard()) {
+                match crate::serialization::encode(&edge) {
                     Ok(value) => {
                         batch.put_cf(self.relationships_cf(), key, value);
                         if should_prune {
@@ -4310,7 +4296,7 @@ impl GraphMemory {
             // so this reduces the WriteBatch from ~12MB (all 34k edges) to ~150KB.
             if should_prune || (edge.strength - strength_before).abs() > f32::EPSILON {
                 let key = edge.uuid.as_bytes();
-                match bincode::serde::encode_to_vec(&*edge, bincode::config::standard()) {
+                match crate::serialization::encode(&*edge) {
                     Ok(value) => {
                         batch.put_cf(self.relationships_cf(), key, value);
                         if should_prune {
@@ -4474,12 +4460,7 @@ impl GraphMemory {
             self.db
                 .iterator_cf_opt(self.entities_cf(), read_opts, rocksdb::IteratorMode::Start);
         for (_, value) in iter.flatten() {
-            if let Ok(entity) = bincode::serde::decode_from_slice::<EntityNode, _>(
-                &value,
-                bincode::config::standard(),
-            )
-            .map(|(v, _)| v)
-            {
+            if let Ok((entity, _)) = crate::serialization::try_decode::<EntityNode>(&value) {
                 entities.push(entity);
             }
         }
@@ -4505,11 +4486,7 @@ impl GraphMemory {
             rocksdb::IteratorMode::Start,
         );
         for (_, value) in iter.flatten() {
-            if let Ok(edge) = bincode::serde::decode_from_slice::<RelationshipEdge, _>(
-                &value,
-                bincode::config::standard(),
-            )
-            .map(|(v, _)| v)
+            if let Ok((edge, _)) = crate::serialization::try_decode::<RelationshipEdge>(&value)
             {
                 // Only include non-invalidated relationships
                 if edge.invalidated_at.is_none() {

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -721,7 +721,7 @@ impl MultiUserMemoryManager {
                 0
             })
         );
-        if let Ok(serialized) = bincode::serde::encode_to_vec(&event, bincode::config::standard()) {
+        if let Ok(serialized) = crate::serialization::encode(&event) {
             let db = self.shared_db.clone();
             let key_bytes = key.into_bytes();
 
@@ -811,10 +811,7 @@ impl MultiUserMemoryManager {
                     break;
                 }
 
-                if let Ok((event, _)) = bincode::serde::decode_from_slice::<AuditEvent, _>(
-                    &value,
-                    bincode::config::standard(),
-                ) {
+                if let Ok((event, _)) = crate::serialization::try_decode::<AuditEvent>(&value) {
                     events.push(event);
                 }
             }
@@ -1227,10 +1224,7 @@ impl MultiUserMemoryManager {
                 if !key_str.starts_with(&prefix) {
                     break;
                 }
-                if let Ok((event, _)) = bincode::serde::decode_from_slice::<AuditEvent, _>(
-                    &value,
-                    bincode::config::standard(),
-                ) {
+                if let Ok((event, _)) = crate::serialization::try_decode::<AuditEvent>(&value) {
                     events.push(event);
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,14 +30,28 @@ pub mod memory;
 pub mod metrics;
 pub mod middleware;
 pub mod mif;
+pub mod migration;
 pub mod query_parsing;
 pub mod relevance;
+pub mod serialization;
 pub mod server;
 pub mod similarity;
 pub mod streaming;
 pub mod tracing_setup;
 pub mod validation;
 pub mod vector_db;
+
+/// Bincode 2.x decode with a 10 MB allocation limit.
+///
+/// All RocksDB deserialization MUST use this instead of `bincode::config::standard()`
+/// to prevent OOM crashes from corrupted varint length prefixes. Without a limit,
+/// a corrupted varint can declare multi-exabyte allocations that abort the process.
+///
+/// 10 MB is generous: the largest legitimate record (EntityNode with 384-dim
+/// embedding + metadata) is ~2 KB. Even a Memory with full Experience is under 100 KB.
+pub fn bincode_safe_config() -> impl bincode::config::Config {
+    bincode::config::standard().with_limit::<{ 10 * 1024 * 1024 }>()
+}
 
 // Re-export dependencies to ensure tests/benchmarks use the same version
 pub use chrono;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,19 @@
 //! Shodh-Memory Server — standalone binary entry point.
 //!
-//! This is a thin wrapper around `shodh_memory::server::run()`.
-//! For the unified CLI, use `shodh server` instead.
+//! Subcommands:
+//!   serve     Start the memory server (default if no subcommand given)
+//!   migrate   Migrate RocksDB data from bincode/msgpack to postcard
 //!
 //! Usage:
-//!   shodh-memory-server [OPTIONS]
-//!
-//! Options:
-//!   -H, --host <HOST>         Bind address [env: SHODH_HOST] [default: 127.0.0.1]
-//!   -p, --port <PORT>         Port number [env: SHODH_PORT] [default: 3030]
-//!   -s, --storage <PATH>      Storage directory [env: SHODH_MEMORY_PATH]
-//!   -h, --help                Print help
-//!   -V, --version             Print version
+//!   shodh-memory-server [OPTIONS]                          # serve (default)
+//!   shodh-memory-server serve [OPTIONS]                    # explicit serve
+//!   shodh-memory-server migrate --storage <PATH> [--dry-run]
 
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
 const LONG_ABOUT: &str = r#"
@@ -51,8 +47,8 @@ INTEGRATION:
 
 EXAMPLES:
   shodh-memory-server                          # Start with defaults
-  shodh-memory-server -H 0.0.0.0 -p 8080      # Custom host and port
-  shodh-memory-server --production -s /var/lib/shodh  # Production mode
+  shodh-memory-server serve -H 0.0.0.0 -p 8080  # Custom host and port
+  shodh-memory-server migrate -s ./data --dry-run  # Preview migration
 
 DOCUMENTATION:
   GitHub:  https://github.com/varun29ankuS/shodh-memory
@@ -63,12 +59,16 @@ DOCUMENTATION:
 #[command(name = "shodh-memory-server")]
 #[command(version, about, long_about = LONG_ABOUT, after_help = AFTER_HELP)]
 struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+
+    // ── Flat args for backward compat (no subcommand = serve) ──
     /// Bind address (use 0.0.0.0 for network access)
-    #[arg(short = 'H', long, env = "SHODH_HOST", default_value = "127.0.0.1")]
+    #[arg(short = 'H', long, env = "SHODH_HOST", default_value = "127.0.0.1", global = true)]
     host: String,
 
     /// Port number to listen on
-    #[arg(short, long, env = "SHODH_PORT", default_value_t = 3030)]
+    #[arg(short, long, env = "SHODH_PORT", default_value_t = 3030, global = true)]
     port: u16,
 
     /// Storage directory for RocksDB data
@@ -76,32 +76,65 @@ struct Cli {
         short,
         long = "storage",
         env = "SHODH_MEMORY_PATH",
-        default_value_os_t = shodh_memory::config::default_storage_path()
+        default_value_os_t = shodh_memory::config::default_storage_path(),
+        global = true,
     )]
     storage_path: PathBuf,
 
     /// Production mode: stricter CORS, automatic backups enabled
-    #[arg(long, env = "SHODH_ENV")]
+    #[arg(long, env = "SHODH_ENV", global = true)]
     production: bool,
 
     /// Rate limit: max requests per second per client
-    #[arg(long, env = "SHODH_RATE_LIMIT", default_value_t = 4000)]
+    #[arg(long, env = "SHODH_RATE_LIMIT", default_value_t = 4000, global = true)]
     rate_limit: u64,
 
     /// Maximum concurrent requests before load shedding
-    #[arg(long, env = "SHODH_MAX_CONCURRENT", default_value_t = 200)]
+    #[arg(long, env = "SHODH_MAX_CONCURRENT", default_value_t = 200, global = true)]
     max_concurrent: usize,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Start the memory server (default)
+    Serve,
+    /// Migrate RocksDB data from bincode/msgpack to postcard
+    Migrate {
+        /// Report what would be migrated without writing any data
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    shodh_memory::server::run(shodh_memory::server::ServerRunConfig {
-        host: cli.host,
-        port: cli.port,
-        storage_path: cli.storage_path,
-        production: cli.production,
-        rate_limit: cli.rate_limit,
-        max_concurrent: cli.max_concurrent,
-    })
+    match cli.command {
+        None | Some(Command::Serve) => {
+            shodh_memory::server::run(shodh_memory::server::ServerRunConfig {
+                host: cli.host,
+                port: cli.port,
+                storage_path: cli.storage_path,
+                production: cli.production,
+                rate_limit: cli.rate_limit,
+                max_concurrent: cli.max_concurrent,
+            })
+        }
+        Some(Command::Migrate { dry_run }) => {
+            eprintln!(
+                "Shodh-Memory: migrating storage at {}{}",
+                cli.storage_path.display(),
+                if dry_run { " (dry run)" } else { "" }
+            );
+
+            let report =
+                shodh_memory::migration::migrate_all(&cli.storage_path, dry_run)?;
+            eprintln!("{report}");
+
+            if !report.errors.is_empty() {
+                std::process::exit(1);
+            }
+            Ok(())
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,13 @@ struct Cli {
 
     // ── Flat args for backward compat (no subcommand = serve) ──
     /// Bind address (use 0.0.0.0 for network access)
-    #[arg(short = 'H', long, env = "SHODH_HOST", default_value = "127.0.0.1", global = true)]
+    #[arg(
+        short = 'H',
+        long,
+        env = "SHODH_HOST",
+        default_value = "127.0.0.1",
+        global = true
+    )]
     host: String,
 
     /// Port number to listen on
@@ -90,7 +96,12 @@ struct Cli {
     rate_limit: u64,
 
     /// Maximum concurrent requests before load shedding
-    #[arg(long, env = "SHODH_MAX_CONCURRENT", default_value_t = 200, global = true)]
+    #[arg(
+        long,
+        env = "SHODH_MAX_CONCURRENT",
+        default_value_t = 200,
+        global = true
+    )]
     max_concurrent: usize,
 }
 
@@ -127,8 +138,7 @@ fn main() -> Result<()> {
                 if dry_run { " (dry run)" } else { "" }
             );
 
-            let report =
-                shodh_memory::migration::migrate_all(&cli.storage_path, dry_run)?;
+            let report = shodh_memory::migration::migrate_all(&cli.storage_path, dry_run)?;
             eprintln!("{report}");
 
             if !report.errors.is_empty() {

--- a/src/memory/compression.rs
+++ b/src/memory/compression.rs
@@ -99,7 +99,7 @@ impl CompressionPipeline {
     /// LZ4 compression - preserves all data
     fn compress_lz4(&self, memory: &Memory) -> Result<Memory> {
         let original =
-            bincode::serde::encode_to_vec(&memory.experience, bincode::config::standard())?;
+            crate::serialization::encode_raw(&memory.experience)?;
         let compressed = lz4::block::compress(&original, None, false)?;
 
         let compression_ratio = compressed.len() as f32 / original.len() as f32;
@@ -287,8 +287,7 @@ impl CompressionPipeline {
                 ));
             }
 
-            let (experience, _): (Experience, _) =
-                bincode::serde::decode_from_slice(&decompressed, bincode::config::standard())?;
+            let experience: Experience = crate::serialization::decode_raw(&decompressed)?;
 
             // Restore the memory
             let mut restored = memory.clone();

--- a/src/memory/compression.rs
+++ b/src/memory/compression.rs
@@ -98,8 +98,7 @@ impl CompressionPipeline {
 
     /// LZ4 compression - preserves all data
     fn compress_lz4(&self, memory: &Memory) -> Result<Memory> {
-        let original =
-            crate::serialization::encode_raw(&memory.experience)?;
+        let original = crate::serialization::encode_raw(&memory.experience)?;
         let compressed = lz4::block::compress(&original, None, false)?;
 
         let compression_ratio = compressed.len() as f32 / original.len() as f32;

--- a/src/memory/facts.rs
+++ b/src/memory/facts.rs
@@ -52,7 +52,7 @@ impl SemanticFactStore {
     pub fn store(&self, user_id: &str, fact: &SemanticFact) -> Result<()> {
         // Primary storage
         let key = format!("facts:{}:{}", user_id, fact.id);
-        let value = bincode::serde::encode_to_vec(fact, bincode::config::standard())?;
+        let value = crate::serialization::encode(fact)?;
         self.db.put(key.as_bytes(), &value)?;
 
         // Entity index - index by each related entity
@@ -90,8 +90,7 @@ impl SemanticFactStore {
         let key = format!("facts:{}:{}", user_id, fact_id);
         match self.db.get(key.as_bytes())? {
             Some(data) => {
-                let (fact, _): (SemanticFact, _) =
-                    bincode::serde::decode_from_slice(&data, bincode::config::standard())?;
+                let (fact, _) = crate::serialization::try_decode::<SemanticFact>(&data)?;
                 Ok(Some(fact))
             }
             None => Ok(None),
@@ -102,7 +101,7 @@ impl SemanticFactStore {
     pub fn update(&self, user_id: &str, fact: &SemanticFact) -> Result<()> {
         // Simply overwrite - indices stay valid since ID doesn't change
         let key = format!("facts:{}:{}", user_id, fact.id);
-        let value = bincode::serde::encode_to_vec(fact, bincode::config::standard())?;
+        let value = crate::serialization::encode(fact)?;
         self.db.put(key.as_bytes(), &value)?;
         Ok(())
     }
@@ -164,12 +163,7 @@ impl SemanticFactStore {
                 continue;
             }
 
-            if let Ok(fact) = bincode::serde::decode_from_slice::<SemanticFact, _>(
-                &value,
-                bincode::config::standard(),
-            )
-            .map(|(v, _)| v)
-            {
+            if let Ok((fact, _)) = crate::serialization::try_decode::<SemanticFact>(&value) {
                 facts.push(fact);
                 if facts.len() >= limit {
                     break;
@@ -326,10 +320,7 @@ impl SemanticFactStore {
             if key_str.matches(':').count() > 2 {
                 continue;
             }
-            if let Ok((fact, _)) = bincode::serde::decode_from_slice::<SemanticFact, _>(
-                &value,
-                bincode::config::standard(),
-            ) {
+            if let Ok((fact, _)) = crate::serialization::try_decode::<SemanticFact>(&value) {
                 let millis = fact.created_at.timestamp_millis();
                 max_millis = Some(max_millis.map_or(millis, |cur| cur.max(millis)));
             }
@@ -465,7 +456,7 @@ impl SemanticFactStore {
     /// Stored separately from SemanticFact struct for backward compatibility.
     pub fn store_embedding(&self, user_id: &str, fact_id: &str, embedding: &[f32]) -> Result<()> {
         let key = format!("facts_embedding:{user_id}:{fact_id}");
-        let value = bincode::serde::encode_to_vec(embedding, bincode::config::standard())?;
+        let value = crate::serialization::encode(embedding)?;
         self.db.put(key.as_bytes(), &value)?;
         Ok(())
     }
@@ -475,8 +466,7 @@ impl SemanticFactStore {
         let key = format!("facts_embedding:{user_id}:{fact_id}");
         match self.db.get(key.as_bytes())? {
             Some(data) => {
-                let (embedding, _): (Vec<f32>, _) =
-                    bincode::serde::decode_from_slice(&data, bincode::config::standard())?;
+                let (embedding, _) = crate::serialization::try_decode::<Vec<f32>>(&data)?;
                 Ok(Some(embedding))
             }
             None => Ok(None),

--- a/src/memory/learning_history.rs
+++ b/src/memory/learning_history.rs
@@ -21,6 +21,11 @@ use std::sync::Arc;
 
 use super::introspection::ConsolidationEvent;
 
+/// Maximum size for a single serialized learning event (1 MB).
+/// Any value exceeding this is treated as corrupted and silently skipped,
+/// preventing rmp_serde from interpreting garbage bytes as multi-GB length prefixes.
+const MAX_LEARNING_EVENT_SIZE: usize = 1024 * 1024;
+
 /// Stored learning event with full event fidelity
 ///
 /// Stores the complete ConsolidationEvent (including its serde tag) using
@@ -149,8 +154,11 @@ impl LearningHistoryStore {
         });
 
         // Primary storage (time-ordered)
-        // Use MessagePack (rmp-serde) - binary format that supports serde tagged enums
         let key = format!("learning:{}:{:020}", user_id, timestamp_nanos);
+        // ConsolidationEvent uses #[serde(tag = "type")] (internally tagged enum),
+        // which is incompatible with non-self-describing formats like postcard.
+        // Keep msgpack here; the migrate command will handle conversion once
+        // ConsolidationEvent's serde representation is updated.
         let value = rmp_serde::to_vec(&stored)?;
 
         // Batch all writes atomically — avoids orphaned index entries on crash
@@ -377,8 +385,10 @@ impl LearningHistoryStore {
                 break;
             }
 
-            if let Ok(event) = rmp_serde::from_slice::<StoredLearningEvent>(&value) {
-                events.push(event);
+            if value.len() <= MAX_LEARNING_EVENT_SIZE {
+                if let Ok(event) = rmp_serde::from_slice::<StoredLearningEvent>(&value) {
+                    events.push(event);
+                }
             }
         }
 
@@ -424,8 +434,10 @@ impl LearningHistoryStore {
                 break;
             }
 
-            if let Ok(event) = rmp_serde::from_slice::<StoredLearningEvent>(&value) {
-                events.push(event);
+            if value.len() <= MAX_LEARNING_EVENT_SIZE {
+                if let Ok(event) = rmp_serde::from_slice::<StoredLearningEvent>(&value) {
+                    events.push(event);
+                }
             }
         }
 
@@ -454,8 +466,10 @@ impl LearningHistoryStore {
             // Value is the primary key - fetch the actual event
             let primary_key = String::from_utf8_lossy(&value);
             if let Some(event_data) = self.db.get(primary_key.as_bytes())? {
-                if let Ok(event) = rmp_serde::from_slice::<StoredLearningEvent>(&event_data) {
-                    events.push(event);
+                if event_data.len() <= MAX_LEARNING_EVENT_SIZE {
+                    if let Ok(event) = rmp_serde::from_slice::<StoredLearningEvent>(&event_data) {
+                        events.push(event);
+                    }
                 }
             }
         }
@@ -484,8 +498,10 @@ impl LearningHistoryStore {
 
             let primary_key = String::from_utf8_lossy(&value);
             if let Some(event_data) = self.db.get(primary_key.as_bytes())? {
-                if let Ok(event) = rmp_serde::from_slice::<StoredLearningEvent>(&event_data) {
-                    events.push(event);
+                if event_data.len() <= MAX_LEARNING_EVENT_SIZE {
+                    if let Ok(event) = rmp_serde::from_slice::<StoredLearningEvent>(&event_data) {
+                        events.push(event);
+                    }
                 }
             }
         }
@@ -719,38 +735,40 @@ impl LearningHistoryStore {
                         batch.delete(&key);
 
                         // Also delete secondary index entries for this event
-                        if let Ok(stored) = rmp_serde::from_slice::<StoredLearningEvent>(&value) {
-                            let ts_fmt = format!("{:020}", ts);
-                            if let Some(ref mem_id) = stored.memory_id {
-                                batch.delete(
-                                    format!("learning_by_memory:{}:{}:{}", user_id, mem_id, ts_fmt)
+                        if value.len() <= MAX_LEARNING_EVENT_SIZE {
+                            if let Ok(stored) = rmp_serde::from_slice::<StoredLearningEvent>(&value) {
+                                let ts_fmt = format!("{:020}", ts);
+                                if let Some(ref mem_id) = stored.memory_id {
+                                    batch.delete(
+                                        format!("learning_by_memory:{}:{}:{}", user_id, mem_id, ts_fmt)
+                                            .as_bytes(),
+                                    );
+                                }
+                                if let Some(ref related_id) = stored.related_memory_id {
+                                    batch.delete(
+                                        format!(
+                                            "learning_by_memory:{}:{}:{}",
+                                            user_id, related_id, ts_fmt
+                                        )
                                         .as_bytes(),
-                                );
-                            }
-                            if let Some(ref related_id) = stored.related_memory_id {
+                                    );
+                                }
+                                if let Some(ref f_id) = stored.fact_id {
+                                    batch.delete(
+                                        format!("learning_by_fact:{}:{}:{}", user_id, f_id, ts_fmt)
+                                            .as_bytes(),
+                                    );
+                                }
                                 batch.delete(
                                     format!(
-                                        "learning_by_memory:{}:{}:{}",
-                                        user_id, related_id, ts_fmt
+                                        "learning_by_type:{}:{}:{}",
+                                        user_id,
+                                        stored.event_type.as_str(),
+                                        ts_fmt
                                     )
                                     .as_bytes(),
                                 );
                             }
-                            if let Some(ref f_id) = stored.fact_id {
-                                batch.delete(
-                                    format!("learning_by_fact:{}:{}:{}", user_id, f_id, ts_fmt)
-                                        .as_bytes(),
-                                );
-                            }
-                            batch.delete(
-                                format!(
-                                    "learning_by_type:{}:{}:{}",
-                                    user_id,
-                                    stored.event_type.as_str(),
-                                    ts_fmt
-                                )
-                                .as_bytes(),
-                            );
                         }
 
                         deleted += 1;

--- a/src/memory/learning_history.rs
+++ b/src/memory/learning_history.rs
@@ -736,12 +736,16 @@ impl LearningHistoryStore {
 
                         // Also delete secondary index entries for this event
                         if value.len() <= MAX_LEARNING_EVENT_SIZE {
-                            if let Ok(stored) = rmp_serde::from_slice::<StoredLearningEvent>(&value) {
+                            if let Ok(stored) = rmp_serde::from_slice::<StoredLearningEvent>(&value)
+                            {
                                 let ts_fmt = format!("{:020}", ts);
                                 if let Some(ref mem_id) = stored.memory_id {
                                     batch.delete(
-                                        format!("learning_by_memory:{}:{}:{}", user_id, mem_id, ts_fmt)
-                                            .as_bytes(),
+                                        format!(
+                                            "learning_by_memory:{}:{}:{}",
+                                            user_id, mem_id, ts_fmt
+                                        )
+                                        .as_bytes(),
                                     );
                                 }
                                 if let Some(ref related_id) = stored.related_memory_id {

--- a/src/memory/lineage.rs
+++ b/src/memory/lineage.rs
@@ -328,7 +328,7 @@ impl LineageGraph {
     pub fn store_edge(&self, user_id: &str, edge: &LineageEdge) -> Result<()> {
         // Primary storage
         let key = format!("lineage:edges:{}:{}", user_id, edge.id);
-        let value = bincode::serde::encode_to_vec(edge, bincode::config::standard())?;
+        let value = crate::serialization::encode(edge)?;
         self.db.put(key.as_bytes(), &value)?;
 
         // Index by source (from)
@@ -347,8 +347,7 @@ impl LineageGraph {
         let key = format!("lineage:edges:{}:{}", user_id, edge_id);
         match self.db.get(key.as_bytes())? {
             Some(data) => {
-                let (edge, _): (LineageEdge, _) =
-                    bincode::serde::decode_from_slice(&data, bincode::config::standard())?;
+                let (edge, _) = crate::serialization::try_decode::<LineageEdge>(&data)?;
                 Ok(Some(edge))
             }
             None => Ok(None),
@@ -431,12 +430,7 @@ impl LineageGraph {
                 break;
             }
 
-            if let Ok(edge) = bincode::serde::decode_from_slice::<LineageEdge, _>(
-                &value,
-                bincode::config::standard(),
-            )
-            .map(|(v, _)| v)
-            {
+            if let Ok((edge, _)) = crate::serialization::try_decode::<LineageEdge>(&value) {
                 edges.push(edge);
                 if edges.len() >= limit {
                     break;
@@ -456,7 +450,7 @@ impl LineageGraph {
     /// Store a branch
     pub fn store_branch(&self, user_id: &str, branch: &LineageBranch) -> Result<()> {
         let key = format!("lineage:branches:{}:{}", user_id, branch.id);
-        let value = bincode::serde::encode_to_vec(branch, bincode::config::standard())?;
+        let value = crate::serialization::encode(branch)?;
         self.db.put(key.as_bytes(), &value)?;
         Ok(())
     }
@@ -466,8 +460,7 @@ impl LineageGraph {
         let key = format!("lineage:branches:{}:{}", user_id, branch_id);
         match self.db.get(key.as_bytes())? {
             Some(data) => {
-                let (branch, _): (LineageBranch, _) =
-                    bincode::serde::decode_from_slice(&data, bincode::config::standard())?;
+                let (branch, _) = crate::serialization::try_decode::<LineageBranch>(&data)?;
                 Ok(Some(branch))
             }
             None => Ok(None),
@@ -492,12 +485,7 @@ impl LineageGraph {
                 break;
             }
 
-            if let Ok(branch) = bincode::serde::decode_from_slice::<LineageBranch, _>(
-                &value,
-                bincode::config::standard(),
-            )
-            .map(|(v, _)| v)
-            {
+            if let Ok((branch, _)) = crate::serialization::try_decode::<LineageBranch>(&value) {
                 branches.push(branch);
             }
         }

--- a/src/memory/storage.rs
+++ b/src/memory/storage.rs
@@ -178,7 +178,9 @@ const MAX_MSGPACK_DESER_SIZE: usize = 1024 * 1024;
 ///
 /// Returns None (skip) if the data doesn't look like a MessagePack struct
 /// or exceeds the safe size limit.
-fn try_msgpack_deserialize<T: serde::de::DeserializeOwned>(data: &[u8]) -> Option<Result<T, String>> {
+fn try_msgpack_deserialize<T: serde::de::DeserializeOwned>(
+    data: &[u8],
+) -> Option<Result<T, String>> {
     if !is_plausible_msgpack_struct(data) {
         return None;
     }
@@ -694,7 +696,7 @@ impl LegacyMemoryV2 {
 /// Returns (Memory, needs_migration) where needs_migration=true means the data
 /// was in a legacy format and should be re-written for future performance.
 fn deserialize_memory(data: &[u8]) -> Result<(Memory, bool)> {
-    use crate::serialization::{SHO_VERSION_POSTCARD, SHO_VERSION_BINCODE2};
+    use crate::serialization::{SHO_VERSION_BINCODE2, SHO_VERSION_POSTCARD};
 
     // Check for versioned format: SHO + version byte + payload + 4-byte CRC32
     if let Some((version, payload)) = crate::serialization::unwrap_sho(data) {
@@ -835,7 +837,8 @@ fn deserialize_legacy_fallback(
 
     // Try bincode 2.x MINIMAL format (just UUID + content string)
     // This matches the hex pattern: 16-byte UUID + varint length + string bytes
-    match bincode::serde::decode_from_slice::<MinimalMemory, _>(data, crate::bincode_safe_config()) {
+    match bincode::serde::decode_from_slice::<MinimalMemory, _>(data, crate::bincode_safe_config())
+    {
         Ok((minimal, _)) => {
             tracing::debug!("Migrated memory from bincode 2.x minimal format");
             record_branch("bincode2_minimal");
@@ -955,7 +958,10 @@ fn deserialize_legacy_fallback(
             return Ok((legacy.into_memory(), true));
         }
         Some(Err(e)) => errors.push(("msgpack SimpleLegacyMemory", e)),
-        None => errors.push(("msgpack SimpleLegacyMemory", "not msgpack format".to_string())),
+        None => errors.push((
+            "msgpack SimpleLegacyMemory",
+            "not msgpack format".to_string(),
+        )),
     }
 
     // Try bincode 1.x format with original Experience (no multimodal fields)
@@ -986,7 +992,10 @@ fn deserialize_legacy_fallback(
             return Ok((legacy.into_memory(), true));
         }
         Some(Err(e)) => errors.push(("msgpack LegacyMemoryV1Full", e)),
-        None => errors.push(("msgpack LegacyMemoryV1Full", "not msgpack format".to_string())),
+        None => errors.push((
+            "msgpack LegacyMemoryV1Full",
+            "not msgpack format".to_string(),
+        )),
     }
 
     // Try bincode 1.x format (used in versions prior to bincode 2.0 migration)
@@ -2605,8 +2614,7 @@ impl MemoryStorage {
                             .metadata
                             .insert("forgotten_at".to_string(), now.clone());
 
-                        let updated_value =
-                            crate::serialization::encode_sho(&memory)?;
+                        let updated_value = crate::serialization::encode_sho(&memory)?;
                         batch.put(&key, updated_value);
                     }
                 }
@@ -2651,8 +2659,7 @@ impl MemoryStorage {
                             .metadata
                             .insert("forgotten_at".to_string(), now.clone());
 
-                        let updated_value =
-                            crate::serialization::encode_sho(&memory)?;
+                        let updated_value = crate::serialization::encode_sho(&memory)?;
                         batch.put(&key, updated_value);
                     }
                 }
@@ -3314,9 +3321,8 @@ impl MemoryStorage {
         // Add/update the modality vectors
         mapping_entry.add_modality(modality, vector_ids);
 
-        let mapping_value =
-            crate::serialization::encode(&mapping_entry)
-                .context("Failed to serialize vector mapping")?;
+        let mapping_value = crate::serialization::encode(&mapping_entry)
+            .context("Failed to serialize vector mapping")?;
         batch.put(mapping_key.as_bytes(), &mapping_value);
 
         // 3. Atomic write - both succeed or both fail
@@ -3420,8 +3426,7 @@ impl MemoryStorage {
         // Update the specific modality
         mapping_entry.add_modality(modality, vector_ids);
 
-        let mapping_value =
-            crate::serialization::encode(&mapping_entry)?;
+        let mapping_value = crate::serialization::encode(&mapping_entry)?;
 
         let mut write_opts = WriteOptions::default();
         write_opts.set_sync(self.write_mode == WriteMode::Sync);

--- a/src/memory/storage.rs
+++ b/src/memory/storage.rs
@@ -62,7 +62,7 @@ impl Default for WriteMode {
 // Handles versioned format (SHO magic + checksum), current, and legacy formats
 // ============================================================================
 
-const STORAGE_MAGIC: &[u8; 3] = b"SHO";
+pub(crate) const STORAGE_MAGIC: &[u8; 3] = b"SHO";
 
 use std::collections::HashMap;
 
@@ -138,6 +138,60 @@ impl MemoryWith3ByteHeader {
             Vec::new(),
             Vec::new(),
         )
+    }
+}
+
+/// Check if data could plausibly be a MessagePack-encoded struct.
+///
+/// Memory structs serialize as maps in MessagePack. Without this guard,
+/// arbitrary binary data (e.g. bincode, raw UTF-8) fed to `rmp_serde::from_slice`
+/// can be misinterpreted: a byte that happens to be a str32/bin32/array32 format
+/// code causes rmp to read subsequent bytes as a u32 length prefix, triggering
+/// multi-gigabyte (or larger) allocation attempts that crash the process.
+///
+/// We check that the first byte is a valid MessagePack map format code (fixmap,
+/// map16, or map32) since serde structs always encode as maps.
+fn is_plausible_msgpack_struct(data: &[u8]) -> bool {
+    if data.is_empty() {
+        return false;
+    }
+    let first = data[0];
+    // rmp_serde serializes structs as arrays (to_vec) or maps (to_vec_named).
+    // Both are valid, so accept either container type.
+    //
+    // fixarray: 0x90-0x9f | array16: 0xdc | array32: 0xdd
+    // fixmap:   0x80-0x8f | map16:   0xde | map32:   0xdf
+    matches!(first, 0x80..=0x9f | 0xdc..=0xdf)
+}
+
+/// Maximum size for data eligible for MessagePack deserialization.
+///
+/// rmp_serde has no built-in allocation limits. Corrupted data with valid-looking
+/// MessagePack headers can declare multi-exabyte string/bin lengths, causing the
+/// allocator to abort the process. Since catch_unwind doesn't catch abort (Windows),
+/// the only defense is refusing to attempt deserialization on data larger than a
+/// sane maximum. Legitimate memory entries serialized as MessagePack are typically
+/// under 100KB. 1MB provides generous headroom.
+const MAX_MSGPACK_DESER_SIZE: usize = 1024 * 1024;
+
+/// Safely attempt MessagePack deserialization with pre-flight validation.
+///
+/// Returns None (skip) if the data doesn't look like a MessagePack struct
+/// or exceeds the safe size limit.
+fn try_msgpack_deserialize<T: serde::de::DeserializeOwned>(data: &[u8]) -> Option<Result<T, String>> {
+    if !is_plausible_msgpack_struct(data) {
+        return None;
+    }
+    if data.len() > MAX_MSGPACK_DESER_SIZE {
+        return Some(Err(format!(
+            "msgpack data too large ({} bytes, max {})",
+            data.len(),
+            MAX_MSGPACK_DESER_SIZE
+        )));
+    }
+    match rmp_serde::from_slice::<T>(data) {
+        Ok(val) => Some(Ok(val)),
+        Err(e) => Some(Err(e.to_string())),
     }
 }
 
@@ -640,31 +694,43 @@ impl LegacyMemoryV2 {
 /// Returns (Memory, needs_migration) where needs_migration=true means the data
 /// was in a legacy format and should be re-written for future performance.
 fn deserialize_memory(data: &[u8]) -> Result<(Memory, bool)> {
+    use crate::serialization::{SHO_VERSION_POSTCARD, SHO_VERSION_BINCODE2};
+
     // Check for versioned format: SHO + version byte + payload + 4-byte CRC32
-    if data.len() >= 8 && &data[0..3] == STORAGE_MAGIC {
-        let version = data[3];
-        let payload_end = data.len() - 4;
-        let stored_checksum = u32::from_le_bytes([
-            data[payload_end],
-            data[payload_end + 1],
-            data[payload_end + 2],
-            data[payload_end + 3],
-        ]);
-        let computed_checksum = crc32_simple(&data[..payload_end]);
-        if stored_checksum != computed_checksum {
-            tracing::warn!(
-                "Checksum mismatch: stored={:08x} computed={:08x}",
-                stored_checksum,
-                computed_checksum
-            );
+    if let Some((version, payload)) = crate::serialization::unwrap_sho(data) {
+        match version {
+            SHO_VERSION_POSTCARD => {
+                // Current format: postcard — single decode, no fallback
+                let memory: Memory = crate::serialization::decode_raw(payload)
+                    .map_err(|e| anyhow!("SHO v2 postcard decode failed: {e}"))?;
+                Ok((memory, false))
+            }
+            SHO_VERSION_BINCODE2 => {
+                // Legacy SHO v1: bincode 2.x — decode and mark for migration
+                let (memory, _): (Memory, _) =
+                    bincode::serde::decode_from_slice(payload, crate::bincode_safe_config())
+                        .map_err(|e| anyhow!("SHO v1 bincode decode failed: {e}"))?;
+                Ok((memory, true))
+            }
+            _ => {
+                // Unknown version — try the legacy fallback chain
+                deserialize_with_fallback(payload)
+                    .map_err(|e| anyhow!("SHO v{version} decode failed: {e}"))
+            }
         }
-        let payload = &data[4..payload_end];
-        // Try current format first, then fallback to legacy formats
-        deserialize_with_fallback(payload).map_err(|e| anyhow!("v{version} decode failed: {e}"))
     } else {
-        // Legacy format: raw bincode (no SHO header)
-        deserialize_with_fallback(data).map_err(|e| anyhow!("legacy decode failed: {e}"))
+        // No SHO header — legacy format (raw bincode/msgpack)
+        deserialize_with_fallback(data)
+            .map_err(|e| anyhow!("legacy (no SHO header) decode failed: {e}"))
     }
+}
+
+/// Public wrapper around the full legacy fallback chain, used by the migration module.
+///
+/// Tries SHO v2 (postcard), SHO v1 (bincode 2.x), then the 17-path legacy
+/// fallback for raw bincode/msgpack data. Returns just the Memory on success.
+pub fn deserialize_memory_for_migration(data: &[u8]) -> Result<Memory> {
+    deserialize_memory(data).map(|(m, _)| m)
 }
 
 /// Legacy MemoryFlat for bincode 2.x data written BEFORE multimodal Experience fields
@@ -735,13 +801,15 @@ fn deserialize_with_fallback(data: &[u8]) -> Result<(Memory, bool)> {
 
     // Try current format first (bincode 2.x with current Memory/Experience)
     // This is the hot path — avoid any allocations before this check.
-    match bincode::serde::decode_from_slice::<Memory, _>(data, bincode::config::standard()) {
+    match bincode::serde::decode_from_slice::<Memory, _>(data, crate::bincode_safe_config()) {
         Ok((memory, _)) => {
             return Ok((memory, false));
         } // Current format, no migration needed
         Err(e) => {
             // Current format failed — enter fallback chain.
-            // From here on we collect errors for diagnostics.
+            // Bincode 1.x paths use with_limit() to cap allocations.
+            // MessagePack paths use try_msgpack_deserialize() which scans for
+            // oversized length prefixes before calling rmp_serde::from_slice.
             return deserialize_legacy_fallback(data, e, record_branch);
         }
     }
@@ -767,7 +835,7 @@ fn deserialize_legacy_fallback(
 
     // Try bincode 2.x MINIMAL format (just UUID + content string)
     // This matches the hex pattern: 16-byte UUID + varint length + string bytes
-    match bincode::serde::decode_from_slice::<MinimalMemory, _>(data, bincode::config::standard()) {
+    match bincode::serde::decode_from_slice::<MinimalMemory, _>(data, crate::bincode_safe_config()) {
         Ok((minimal, _)) => {
             tracing::debug!("Migrated memory from bincode 2.x minimal format");
             record_branch("bincode2_minimal");
@@ -780,7 +848,7 @@ fn deserialize_legacy_fallback(
     // Matches entries with 2 extra bytes before content (byte 16=unknown, byte 17=exp_type)
     match bincode::serde::decode_from_slice::<MemoryWithTypePrefix, _>(
         data,
-        bincode::config::standard(),
+        crate::bincode_safe_config(),
     ) {
         Ok((typed, _)) => {
             tracing::debug!("Migrated memory from bincode 2.x with type prefix");
@@ -793,7 +861,7 @@ fn deserialize_legacy_fallback(
     // Try bincode 2.x with OLD Experience (before multimodal fields were added)
     match bincode::serde::decode_from_slice::<LegacyMemoryFlatV2, _>(
         data,
-        bincode::config::standard(),
+        crate::bincode_safe_config(),
     ) {
         Ok((legacy, _)) => {
             tracing::debug!("Migrated memory from bincode 2.x pre-multimodal format");
@@ -803,8 +871,18 @@ fn deserialize_legacy_fallback(
         Err(e) => errors.push(("bincode2 LegacyMemoryFlatV2", e.to_string())),
     }
 
+    // Bincode 1.x with size limit — prevents OOM from corrupted u64 length prefixes.
+    // Bincode 1.x reads string/vec lengths as u64; corrupted data can declare exabyte allocations.
+    // Must keep allow_trailing_bytes() to match bincode1::deserialize() default behavior.
+    use bincode1::Options;
+    // bincode1::deserialize() uses FixintEncoding internally, so we must match that.
+    let bincode1_safe = bincode1::options()
+        .with_fixint_encoding()
+        .with_limit(data.len() as u64 + 1024)
+        .allow_trailing_bytes();
+
     // Try bincode 1.x with LegacyMemoryV1 (v0.1.0 format)
-    match bincode1::deserialize::<LegacyMemoryV1>(data) {
+    match bincode1_safe.deserialize::<LegacyMemoryV1>(data) {
         Ok(legacy) => {
             tracing::debug!("Migrated memory from bincode 1.x v0.1.0 format");
             record_branch("bincode1_legacy_v1");
@@ -814,7 +892,7 @@ fn deserialize_legacy_fallback(
     }
 
     // Try bincode 1.x MINIMAL format (just UUID + content)
-    match bincode1::deserialize::<MinimalMemory>(data) {
+    match bincode1_safe.deserialize::<MinimalMemory>(data) {
         Ok(minimal) => {
             tracing::debug!("Migrated memory from bincode 1.x minimal format");
             record_branch("bincode1_minimal");
@@ -824,7 +902,7 @@ fn deserialize_legacy_fallback(
     }
 
     // Try bincode 1.x with SIMPLE legacy format (content as direct field, no Experience wrapper)
-    match bincode1::deserialize::<SimpleLegacyMemory>(data) {
+    match bincode1_safe.deserialize::<SimpleLegacyMemory>(data) {
         Ok(legacy) => {
             tracing::debug!("Migrated memory from bincode 1.x simple format");
             record_branch("bincode1_simple");
@@ -834,9 +912,9 @@ fn deserialize_legacy_fallback(
     }
 
     // Try bincode 1.x with fixint encoding (u64 lengths instead of varint)
-    use bincode1::Options;
     let fixint_config = bincode1::options()
         .with_fixint_encoding()
+        .with_limit(data.len() as u64 + 1024)
         .allow_trailing_bytes();
 
     // Try bincode 1.x fixint MinimalMemory
@@ -858,28 +936,30 @@ fn deserialize_legacy_fallback(
         Err(e) => errors.push(("bincode1 fixint SimpleLegacyMemory", e.to_string())),
     }
 
-    // Try MessagePack minimal format
-    match rmp_serde::from_slice::<MinimalMemory>(data) {
-        Ok(minimal) => {
+    // Try MessagePack minimal format (guarded: non-msgpack data can trigger OOM)
+    match try_msgpack_deserialize::<MinimalMemory>(data) {
+        Some(Ok(minimal)) => {
             tracing::debug!("Migrated memory from MessagePack minimal format");
             record_branch("msgpack_minimal");
             return Ok((minimal.into_memory(), true));
         }
-        Err(e) => errors.push(("msgpack MinimalMemory", e.to_string())),
+        Some(Err(e)) => errors.push(("msgpack MinimalMemory", e)),
+        None => errors.push(("msgpack MinimalMemory", "not msgpack format".to_string())),
     }
 
     // Try MessagePack format (rmp-serde) - self-describing format
-    match rmp_serde::from_slice::<SimpleLegacyMemory>(data) {
-        Ok(legacy) => {
+    match try_msgpack_deserialize::<SimpleLegacyMemory>(data) {
+        Some(Ok(legacy)) => {
             tracing::debug!("Migrated memory from MessagePack simple format");
             record_branch("msgpack_simple");
             return Ok((legacy.into_memory(), true));
         }
-        Err(e) => errors.push(("msgpack SimpleLegacyMemory", e.to_string())),
+        Some(Err(e)) => errors.push(("msgpack SimpleLegacyMemory", e)),
+        None => errors.push(("msgpack SimpleLegacyMemory", "not msgpack format".to_string())),
     }
 
     // Try bincode 1.x format with original Experience (no multimodal fields)
-    match bincode1::deserialize::<LegacyMemoryV1Full>(data) {
+    match bincode1_safe.deserialize::<LegacyMemoryV1Full>(data) {
         Ok(legacy) => {
             tracing::debug!("Migrated memory from bincode 1.x v1 full format");
             record_branch("bincode1_legacy_v1_full");
@@ -898,18 +978,19 @@ fn deserialize_legacy_fallback(
         Err(e) => errors.push(("bincode1 fixint LegacyMemoryV1Full", e.to_string())),
     }
 
-    // Try MessagePack with full legacy format
-    match rmp_serde::from_slice::<LegacyMemoryV1Full>(data) {
-        Ok(legacy) => {
+    // Try MessagePack with full legacy format (guarded: non-msgpack data can trigger OOM)
+    match try_msgpack_deserialize::<LegacyMemoryV1Full>(data) {
+        Some(Ok(legacy)) => {
             tracing::debug!("Migrated memory from MessagePack v1 full format");
             record_branch("msgpack_legacy_v1_full");
             return Ok((legacy.into_memory(), true));
         }
-        Err(e) => errors.push(("msgpack LegacyMemoryV1Full", e.to_string())),
+        Some(Err(e)) => errors.push(("msgpack LegacyMemoryV1Full", e)),
+        None => errors.push(("msgpack LegacyMemoryV1Full", "not msgpack format".to_string())),
     }
 
     // Try bincode 1.x format (used in versions prior to bincode 2.0 migration)
-    match bincode1::deserialize::<LegacyMemoryV1>(data) {
+    match bincode1_safe.deserialize::<LegacyMemoryV1>(data) {
         Ok(legacy) => {
             tracing::debug!("Migrated memory from bincode 1.x format");
             record_branch("bincode1_legacy_v1_repeat");
@@ -919,7 +1000,7 @@ fn deserialize_legacy_fallback(
     }
 
     // Try legacy v2 format with bincode 1.x (cognitive extensions era)
-    match bincode1::deserialize::<LegacyMemoryV2>(data) {
+    match bincode1_safe.deserialize::<LegacyMemoryV2>(data) {
         Ok(legacy) => {
             tracing::debug!("Migrated memory from bincode 1.x v2 format");
             record_branch("bincode1_legacy_v2");
@@ -932,7 +1013,7 @@ fn deserialize_legacy_fallback(
     // Hex analysis shows content starts at byte 19 (byte 18 is 0xa4, not valid UTF-8 start)
     match bincode::serde::decode_from_slice::<MemoryWith3ByteHeader, _>(
         data,
-        bincode::config::standard(),
+        crate::bincode_safe_config(),
     ) {
         Ok((mem, _)) => {
             tracing::debug!("Migrated memory from bincode 2.x with 3-byte header");
@@ -976,7 +1057,7 @@ fn deserialize_legacy_fallback(
 }
 
 /// Simple CRC32 implementation (IEEE polynomial)
-fn crc32_simple(data: &[u8]) -> u32 {
+pub(crate) fn crc32_simple(data: &[u8]) -> u32 {
     let mut crc: u32 = 0xFFFFFFFF;
     for byte in data {
         crc ^= *byte as u32;
@@ -1334,8 +1415,8 @@ impl MemoryStorage {
     fn store_inner(&self, memory: &Memory) -> Result<()> {
         let key = memory.id.0.as_bytes();
 
-        // Serialize memory
-        let value = bincode::serde::encode_to_vec(memory, bincode::config::standard())
+        // Serialize memory (postcard + SHO v2 envelope)
+        let value = crate::serialization::encode_sho(memory)
             .context(format!("Failed to serialize memory {}", memory.id.0))?;
 
         // Use write mode based on configuration
@@ -1628,7 +1709,7 @@ impl MemoryStorage {
     /// Re-write a memory in current format (lazy migration helper)
     fn migrate_memory_format(&self, memory: &Memory) -> Result<()> {
         let key = memory.id.0.as_bytes();
-        let value = bincode::serde::encode_to_vec(memory, bincode::config::standard())
+        let value = crate::serialization::encode_sho(memory)
             .context("Failed to serialize for migration")?;
 
         let mut write_opts = WriteOptions::default();
@@ -2525,7 +2606,7 @@ impl MemoryStorage {
                             .insert("forgotten_at".to_string(), now.clone());
 
                         let updated_value =
-                            bincode::serde::encode_to_vec(&memory, bincode::config::standard())?;
+                            crate::serialization::encode_sho(&memory)?;
                         batch.put(&key, updated_value);
                     }
                 }
@@ -2571,7 +2652,7 @@ impl MemoryStorage {
                             .insert("forgotten_at".to_string(), now.clone());
 
                         let updated_value =
-                            bincode::serde::encode_to_vec(&memory, bincode::config::standard())?;
+                            crate::serialization::encode_sho(&memory)?;
                         batch.put(&key, updated_value);
                     }
                 }
@@ -2840,12 +2921,8 @@ impl MemoryStorage {
                     continue;
                 }
 
-                // Try current format first (quick check)
-                let is_current = bincode::serde::decode_from_slice::<Memory, _>(
-                    &value,
-                    bincode::config::standard(),
-                )
-                .is_ok();
+                // Try current format first (quick check) — postcard or bincode
+                let is_current = deserialize_memory(&value).is_ok();
 
                 if is_current {
                     already_current += 1;
@@ -2876,7 +2953,7 @@ impl MemoryStorage {
             write_opts.set_sync(self.write_mode == WriteMode::Sync);
 
             for (key, memory) in to_migrate {
-                match bincode::serde::encode_to_vec(&memory, bincode::config::standard()) {
+                match crate::serialization::encode_sho(&memory) {
                     Ok(serialized) => {
                         if let Err(e) = self.db.put_opt(&key, &serialized, &write_opts) {
                             tracing::warn!("Failed to migrate memory: {e}");
@@ -3224,7 +3301,7 @@ impl MemoryStorage {
 
         // 1. Serialize memory
         let memory_key = memory.id.0.as_bytes();
-        let memory_value = bincode::serde::encode_to_vec(memory, bincode::config::standard())
+        let memory_value = crate::serialization::encode_sho(memory)
             .context(format!("Failed to serialize memory {}", memory.id.0))?;
         batch.put(memory_key, &memory_value);
 
@@ -3238,7 +3315,7 @@ impl MemoryStorage {
         mapping_entry.add_modality(modality, vector_ids);
 
         let mapping_value =
-            bincode::serde::encode_to_vec(&mapping_entry, bincode::config::standard())
+            crate::serialization::encode(&mapping_entry)
                 .context("Failed to serialize vector mapping")?;
         batch.put(mapping_key.as_bytes(), &mapping_value);
 
@@ -3262,9 +3339,8 @@ impl MemoryStorage {
         let mapping_key = format!("vmapping:{}", memory_id.0);
         match self.db.get(mapping_key.as_bytes())? {
             Some(data) => {
-                let (entry, _): (VectorMappingEntry, _) =
-                    bincode::serde::decode_from_slice(&data, bincode::config::standard())
-                        .context("Failed to deserialize vector mapping")?;
+                let (entry, _) = crate::serialization::try_decode::<VectorMappingEntry>(&data)
+                    .context("Failed to deserialize vector mapping")?;
                 Ok(Some(entry))
             }
             None => Ok(None),
@@ -3295,10 +3371,7 @@ impl MemoryStorage {
                     if let Some(id_str) = key_str.strip_prefix("vmapping:") {
                         if let Ok(uuid) = uuid::Uuid::parse_str(id_str) {
                             if let Ok((entry, _)) =
-                                bincode::serde::decode_from_slice::<VectorMappingEntry, _>(
-                                    &value,
-                                    bincode::config::standard(),
-                                )
+                                crate::serialization::try_decode::<VectorMappingEntry>(&value)
                             {
                                 mappings.push((MemoryId(uuid), entry));
                             }
@@ -3348,7 +3421,7 @@ impl MemoryStorage {
         mapping_entry.add_modality(modality, vector_ids);
 
         let mapping_value =
-            bincode::serde::encode_to_vec(&mapping_entry, bincode::config::standard())?;
+            crate::serialization::encode(&mapping_entry)?;
 
         let mut write_opts = WriteOptions::default();
         write_opts.set_sync(self.write_mode == WriteMode::Sync);

--- a/src/memory/temporal_facts.rs
+++ b/src/memory/temporal_facts.rs
@@ -124,7 +124,7 @@ impl TemporalFactStore {
     pub fn store(&self, user_id: &str, fact: &TemporalFact) -> Result<()> {
         // Primary storage
         let key = format!("temporal_facts:{}:{}", user_id, fact.id);
-        let value = bincode::serde::encode_to_vec(fact, bincode::config::standard())?;
+        let value = crate::serialization::encode(fact)?;
         self.db.put(key.as_bytes(), &value)?;
 
         // Entity index
@@ -161,8 +161,7 @@ impl TemporalFactStore {
         let key = format!("temporal_facts:{}:{}", user_id, fact_id);
         match self.db.get(key.as_bytes())? {
             Some(data) => {
-                let (fact, _): (TemporalFact, _) =
-                    bincode::serde::decode_from_slice(&data, bincode::config::standard())?;
+                let (fact, _) = crate::serialization::try_decode::<TemporalFact>(&data)?;
                 Ok(Some(fact))
             }
             None => Ok(None),
@@ -282,10 +281,7 @@ impl TemporalFactStore {
                 break;
             }
 
-            if let Ok((fact, _)) = bincode::serde::decode_from_slice::<TemporalFact, _>(
-                &value,
-                bincode::config::standard(),
-            ) {
+            if let Ok((fact, _)) = crate::serialization::try_decode::<TemporalFact>(&value) {
                 facts.push(fact);
                 if facts.len() >= limit {
                     break;

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -2590,7 +2590,7 @@ impl SessionMemory {
     /// Add shared memory (zero-copy)
     pub fn add_shared(&mut self, memory: SharedMemory) -> anyhow::Result<()> {
         let memory_size =
-            bincode::serde::encode_to_vec(&*memory, bincode::config::standard())?.len();
+            crate::serialization::encode_raw(&*memory)?.len();
 
         // Check if adding would exceed limit
         if self.current_size_bytes + memory_size > self.max_size_mb * 1024 * 1024 {

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -2589,8 +2589,7 @@ impl SessionMemory {
 
     /// Add shared memory (zero-copy)
     pub fn add_shared(&mut self, memory: SharedMemory) -> anyhow::Result<()> {
-        let memory_size =
-            crate::serialization::encode_raw(&*memory)?.len();
+        let memory_size = crate::serialization::encode_raw(&*memory)?.len();
 
         // Check if adding would exceed limit
         if self.current_size_bytes + memory_size > self.max_size_mb * 1024 * 1024 {

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -1,0 +1,762 @@
+//! Offline migration from legacy serialization formats to postcard.
+//!
+//! Run via: `shodh-memory-server migrate --storage <path> [--dry-run]`
+//!
+//! This reads every record in every RocksDB store, decodes it using the
+//! legacy format (bincode 2.x for most stores, msgpack for learning events),
+//! re-encodes it as postcard with the appropriate format tag or SHO envelope,
+//! and writes it back. Records that are already in postcard format are skipped.
+//!
+//! ## Safety
+//!
+//! - The server must NOT be running during migration (checked via RocksDB lock).
+//! - On success, a marker file `migration_v2_postcard` is written to the storage
+//!   directory. The server will refuse to start without this marker once the
+//!   migration code is shipped (future enforcement, not yet gated).
+//! - `--dry-run` reports what would be migrated without modifying any data.
+
+use anyhow::{Context, Result};
+use rocksdb::{ColumnFamilyDescriptor, IteratorMode, Options as RocksOptions, WriteBatch, DB};
+use std::path::Path;
+
+use crate::serialization;
+
+// Re-use the actual stored types for deserialization.
+// These are the concrete types that bincode encoded into RocksDB values.
+use crate::graph_memory::{EntityNode, EpisodicNode, RelationshipEdge};
+use crate::handlers::types::AuditEvent;
+use crate::memory::compression::SemanticFact;
+use crate::memory::lineage::{LineageBranch, LineageEdge};
+use crate::memory::storage::VectorMappingEntry;
+use crate::memory::temporal_facts::TemporalFact;
+
+/// Marker file written after successful migration.
+const MIGRATION_MARKER: &str = "migration_v2_postcard";
+
+/// Maximum records per WriteBatch to bound memory usage.
+const BATCH_SIZE: usize = 500;
+
+/// Check whether the storage directory has already been migrated.
+pub fn is_migrated(storage_path: &Path) -> bool {
+    storage_path.join(MIGRATION_MARKER).exists()
+}
+
+/// Summary of a completed migration run.
+#[derive(Debug, Default)]
+pub struct MigrationReport {
+    pub users: usize,
+    pub memories_migrated: usize,
+    pub memories_skipped: usize,
+    pub graph_records_migrated: usize,
+    pub graph_records_skipped: usize,
+    pub facts_migrated: usize,
+    pub facts_skipped: usize,
+    pub lineage_migrated: usize,
+    pub lineage_skipped: usize,
+    pub temporal_migrated: usize,
+    pub temporal_skipped: usize,
+    pub vector_mappings_migrated: usize,
+    pub vector_mappings_skipped: usize,
+    pub audit_migrated: usize,
+    pub audit_skipped: usize,
+    pub errors: Vec<String>,
+    pub dry_run: bool,
+}
+
+impl std::fmt::Display for MigrationReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mode = if self.dry_run { "DRY RUN" } else { "MIGRATED" };
+        writeln!(f, "=== Postcard Migration Report ({mode}) ===")?;
+        writeln!(f, "Users processed:       {}", self.users)?;
+        writeln!(
+            f,
+            "Memories:              {} migrated, {} skipped",
+            self.memories_migrated, self.memories_skipped
+        )?;
+        writeln!(
+            f,
+            "Graph records:         {} migrated, {} skipped",
+            self.graph_records_migrated, self.graph_records_skipped
+        )?;
+        writeln!(
+            f,
+            "Facts + embeddings:    {} migrated, {} skipped",
+            self.facts_migrated, self.facts_skipped
+        )?;
+        writeln!(
+            f,
+            "Lineage edges/branches:{} migrated, {} skipped",
+            self.lineage_migrated, self.lineage_skipped
+        )?;
+        writeln!(
+            f,
+            "Temporal facts:        {} migrated, {} skipped",
+            self.temporal_migrated, self.temporal_skipped
+        )?;
+        writeln!(
+            f,
+            "Vector mappings:       {} migrated, {} skipped",
+            self.vector_mappings_migrated, self.vector_mappings_skipped
+        )?;
+        writeln!(
+            f,
+            "Audit events:          {} migrated, {} skipped",
+            self.audit_migrated, self.audit_skipped
+        )?;
+        if !self.errors.is_empty() {
+            writeln!(f, "Errors:                {}", self.errors.len())?;
+            for (i, e) in self.errors.iter().enumerate().take(20) {
+                writeln!(f, "  [{i}] {e}")?;
+            }
+            if self.errors.len() > 20 {
+                writeln!(f, "  ... and {} more", self.errors.len() - 20)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Run the full migration on the given storage directory.
+pub fn migrate_all(storage_path: &Path, dry_run: bool) -> Result<MigrationReport> {
+    let mut report = MigrationReport {
+        dry_run,
+        ..Default::default()
+    };
+
+    if is_migrated(storage_path) {
+        eprintln!("Storage already migrated (marker file exists). Nothing to do.");
+        return Ok(report);
+    }
+
+    if !storage_path.exists() {
+        anyhow::bail!("Storage path does not exist: {}", storage_path.display());
+    }
+
+    // --- Shared DB (audit events) ---
+    let shared_path = storage_path.join("shared");
+    if shared_path.exists() {
+        eprintln!("Migrating shared DB (audit events)...");
+        match migrate_shared_db(&shared_path, dry_run) {
+            Ok((migrated, skipped)) => {
+                report.audit_migrated = migrated;
+                report.audit_skipped = skipped;
+            }
+            Err(e) => {
+                report
+                    .errors
+                    .push(format!("shared DB: {e:#}"));
+            }
+        }
+    }
+
+    // --- Per-user databases ---
+    let entries: Vec<_> = std::fs::read_dir(storage_path)
+        .context("reading storage directory")?
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name();
+            let name_str = name.to_string_lossy();
+            e.path().is_dir() && name_str != "shared" && !name_str.ends_with(".pre_cf_migration")
+        })
+        .collect();
+
+    for entry in &entries {
+        let user_id = entry.file_name();
+        let user_id_str = user_id.to_string_lossy();
+        let user_path = entry.path();
+
+        eprintln!("Migrating user: {user_id_str}");
+        report.users += 1;
+
+        // Memory DB (storage/ subdir)
+        let storage_dir = user_path.join("storage");
+        if storage_dir.exists() {
+            match migrate_memory_db(&storage_dir, dry_run) {
+                Ok(counts) => {
+                    report.memories_migrated += counts.memories_migrated;
+                    report.memories_skipped += counts.memories_skipped;
+                    report.facts_migrated += counts.facts_migrated;
+                    report.facts_skipped += counts.facts_skipped;
+                    report.lineage_migrated += counts.lineage_migrated;
+                    report.lineage_skipped += counts.lineage_skipped;
+                    report.temporal_migrated += counts.temporal_migrated;
+                    report.temporal_skipped += counts.temporal_skipped;
+                    report.vector_mappings_migrated += counts.vector_mappings_migrated;
+                    report.vector_mappings_skipped += counts.vector_mappings_skipped;
+                }
+                Err(e) => {
+                    report
+                        .errors
+                        .push(format!("user {user_id_str} memory DB: {e:#}"));
+                }
+            }
+        }
+
+        // Graph DB (graph/ subdir)
+        let graph_dir = user_path.join("graph");
+        if graph_dir.exists() {
+            match migrate_graph_db(&graph_dir, dry_run) {
+                Ok((migrated, skipped)) => {
+                    report.graph_records_migrated += migrated;
+                    report.graph_records_skipped += skipped;
+                }
+                Err(e) => {
+                    report
+                        .errors
+                        .push(format!("user {user_id_str} graph DB: {e:#}"));
+                }
+            }
+        }
+    }
+
+    // Write migration marker.
+    // We write the marker even if some individual records failed to decode —
+    // those records are corrupted in the DB and won't improve on re-run.
+    // The marker is only withheld if we had zero successful migrations
+    // (indicating a systemic failure like wrong DB path or permissions).
+    if !dry_run {
+        let total_migrated = report.memories_migrated
+            + report.graph_records_migrated
+            + report.facts_migrated
+            + report.lineage_migrated
+            + report.temporal_migrated
+            + report.audit_migrated;
+        let total_skipped = report.memories_skipped
+            + report.graph_records_skipped
+            + report.facts_skipped
+            + report.lineage_skipped
+            + report.temporal_skipped
+            + report.audit_skipped;
+
+        if total_migrated > 0 || total_skipped > 0 {
+            let marker_path = storage_path.join(MIGRATION_MARKER);
+            let timestamp = chrono::Utc::now().to_rfc3339();
+            std::fs::write(
+                &marker_path,
+                format!(
+                    "migrated_at={timestamp}\nmemories={}\ngraph={}\nfacts={}\nlineage={}\ntemporal={}\naudit={}\nerrors={}\n",
+                    report.memories_migrated,
+                    report.graph_records_migrated,
+                    report.facts_migrated,
+                    report.lineage_migrated,
+                    report.temporal_migrated,
+                    report.audit_migrated,
+                    report.errors.len(),
+                ),
+            )
+            .context("writing migration marker file")?;
+            eprintln!("Migration marker written to {}", marker_path.display());
+            if !report.errors.is_empty() {
+                eprintln!(
+                    "NOTE: {} records could not be decoded (pre-existing corruption). These were skipped.",
+                    report.errors.len()
+                );
+            }
+        } else if !report.errors.is_empty() {
+            eprintln!(
+                "ERROR: {} errors and no records migrated — marker NOT written. Check storage path and permissions.",
+                report.errors.len()
+            );
+        }
+    }
+
+    Ok(report)
+}
+
+// ---------------------------------------------------------------------------
+// Memory DB migration
+// ---------------------------------------------------------------------------
+
+/// Counts for the per-user memory DB migration.
+#[derive(Default)]
+struct MemoryDbCounts {
+    memories_migrated: usize,
+    memories_skipped: usize,
+    facts_migrated: usize,
+    facts_skipped: usize,
+    lineage_migrated: usize,
+    lineage_skipped: usize,
+    temporal_migrated: usize,
+    temporal_skipped: usize,
+    vector_mappings_migrated: usize,
+    vector_mappings_skipped: usize,
+}
+
+/// Known prefixes for sub-stores in the memory DB default CF.
+const FACTS_PREFIX: &[u8] = b"facts:";
+const FACTS_BY_ENTITY_PREFIX: &[u8] = b"facts_by_entity:";
+const FACTS_BY_TYPE_PREFIX: &[u8] = b"facts_by_type:";
+const FACTS_EMBEDDING_PREFIX: &[u8] = b"facts_embedding:";
+const TEMPORAL_FACTS_PREFIX: &[u8] = b"temporal_facts:";
+const TEMPORAL_BY_ENTITY_PREFIX: &[u8] = b"temporal_by_entity:";
+const TEMPORAL_BY_EVENT_PREFIX: &[u8] = b"temporal_by_event:";
+const TEMPORAL_BY_TIME_PREFIX: &[u8] = b"temporal_by_time:";
+const VMAPPING_PREFIX: &[u8] = b"vmapping:";
+const LEARNING_PREFIX: &[u8] = b"learning:";
+
+/// Prefixes whose values are plain string references (not serialized structs).
+/// Index entries: their values are just key references — no binary format to migrate.
+const INDEX_ONLY_PREFIXES: &[&[u8]] = &[
+    b"stats:",
+    b"interference:",
+    b"interference_meta:",
+    b"_watermark:",
+    FACTS_BY_ENTITY_PREFIX,
+    FACTS_BY_TYPE_PREFIX,
+    b"learning_by_memory:",
+    b"learning_by_type:",
+    b"learning_by_fact:",
+    b"learning_stats:",
+    b"geo:",
+    // lineage by_from / by_to are index refs, but edges/branches are bincode
+    b"lineage:by_from:",
+    b"lineage:by_to:",
+    // temporal index entries
+    TEMPORAL_BY_ENTITY_PREFIX,
+    TEMPORAL_BY_EVENT_PREFIX,
+    TEMPORAL_BY_TIME_PREFIX,
+];
+
+fn migrate_memory_db(storage_dir: &Path, dry_run: bool) -> Result<MemoryDbCounts> {
+    let cf_index = "memory_index";
+    let mut opts = RocksOptions::default();
+    opts.create_if_missing(false);
+    opts.create_missing_column_families(true);
+
+    let cfs = vec![
+        ColumnFamilyDescriptor::new("default", RocksOptions::default()),
+        ColumnFamilyDescriptor::new(cf_index, RocksOptions::default()),
+    ];
+
+    let db = DB::open_cf_descriptors(&opts, storage_dir, cfs)
+        .with_context(|| format!("opening memory DB at {}", storage_dir.display()))?;
+
+    let mut counts = MemoryDbCounts::default();
+    let mut total_processed: usize = 0;
+
+    // --- Default CF: memories + sub-stores ---
+    let mut batch = WriteBatch::default();
+    let mut batch_count: usize = 0;
+
+    for item in db.iterator(IteratorMode::Start) {
+        let (key, value) = item?;
+
+        total_processed += 1;
+        if total_processed % 1000 == 0 {
+            eprintln!("  ... processed {total_processed} records");
+        }
+
+        // Skip index-only entries (values are plain string references, not serialized)
+        if INDEX_ONLY_PREFIXES
+            .iter()
+            .any(|p| key.starts_with(p))
+        {
+            continue;
+        }
+
+        // Learning events: stay on msgpack (ConsolidationEvent uses #[serde(tag = "type")])
+        if key.starts_with(LEARNING_PREFIX) {
+            continue;
+        }
+
+        // Determine record type by key prefix
+        if key.starts_with(FACTS_PREFIX) && !key.starts_with(FACTS_EMBEDDING_PREFIX) {
+            // SemanticFact
+            migrate_generic_record::<SemanticFact>(
+                &db,
+                None,
+                &key,
+                &value,
+                dry_run,
+                &mut batch,
+                &mut batch_count,
+                &mut counts.facts_migrated,
+                &mut counts.facts_skipped,
+            )?;
+        } else if key.starts_with(FACTS_EMBEDDING_PREFIX) {
+            // Vec<f32> embedding
+            migrate_generic_record::<Vec<f32>>(
+                &db,
+                None,
+                &key,
+                &value,
+                dry_run,
+                &mut batch,
+                &mut batch_count,
+                &mut counts.facts_migrated,
+                &mut counts.facts_skipped,
+            )?;
+        } else if key.starts_with(b"lineage:edges:") {
+            // LineageEdge
+            migrate_generic_record::<LineageEdge>(
+                &db,
+                None,
+                &key,
+                &value,
+                dry_run,
+                &mut batch,
+                &mut batch_count,
+                &mut counts.lineage_migrated,
+                &mut counts.lineage_skipped,
+            )?;
+        } else if key.starts_with(b"lineage:branches:") {
+            // LineageBranch
+            migrate_generic_record::<LineageBranch>(
+                &db,
+                None,
+                &key,
+                &value,
+                dry_run,
+                &mut batch,
+                &mut batch_count,
+                &mut counts.lineage_migrated,
+                &mut counts.lineage_skipped,
+            )?;
+        } else if key.starts_with(TEMPORAL_FACTS_PREFIX) {
+            // TemporalFact
+            migrate_generic_record::<TemporalFact>(
+                &db,
+                None,
+                &key,
+                &value,
+                dry_run,
+                &mut batch,
+                &mut batch_count,
+                &mut counts.temporal_migrated,
+                &mut counts.temporal_skipped,
+            )?;
+        } else if key.starts_with(VMAPPING_PREFIX) {
+            // VectorMappingEntry
+            migrate_generic_record::<VectorMappingEntry>(
+                &db,
+                None,
+                &key,
+                &value,
+                dry_run,
+                &mut batch,
+                &mut batch_count,
+                &mut counts.vector_mappings_migrated,
+                &mut counts.vector_mappings_skipped,
+            )?;
+        } else if key.len() == 16 {
+            // Memory record (16-byte UUID key) — uses SHO envelope
+            if let Some((version, _payload)) = serialization::unwrap_sho(&value) {
+                if version == serialization::SHO_VERSION_POSTCARD {
+                    // Already postcard
+                    counts.memories_skipped += 1;
+                    continue;
+                }
+            }
+
+            // Try to deserialize with the full legacy fallback chain
+            match crate::memory::storage::deserialize_memory_for_migration(&value) {
+                Ok(memory) => {
+                    if !dry_run {
+                        let new_value = serialization::encode_sho(&memory)?;
+                        batch.put(&*key, &new_value);
+                        batch_count += 1;
+                    }
+                    counts.memories_migrated += 1;
+                }
+                Err(e) => {
+                    eprintln!(
+                        "  WARNING: cannot decode memory key ({} bytes): {e:#}",
+                        key.len()
+                    );
+                    // Don't fail the whole migration for one bad record
+                }
+            }
+        }
+        // else: unknown prefix / unknown key length — skip silently
+
+        // Flush batch periodically
+        if batch_count >= BATCH_SIZE && !dry_run {
+            db.write(std::mem::take(&mut batch))?;
+            batch_count = 0;
+        }
+    }
+
+    // --- memory_index CF: VectorMappingEntry records ---
+    if let Some(cf) = db.cf_handle(cf_index) {
+        for item in db.iterator_cf(cf, IteratorMode::Start) {
+            let (key, value) = item?;
+            // The memory_index CF stores various index entries. Only vmapping entries
+            // need migration — others are string references or small metadata.
+            if key.starts_with(VMAPPING_PREFIX) {
+                migrate_generic_record::<VectorMappingEntry>(
+                    &db,
+                    Some(cf),
+                    &key,
+                    &value,
+                    dry_run,
+                    &mut batch,
+                    &mut batch_count,
+                    &mut counts.vector_mappings_migrated,
+                    &mut counts.vector_mappings_skipped,
+                )?;
+            }
+        }
+    }
+
+    // Flush remaining
+    if batch_count > 0 && !dry_run {
+        db.write(batch)?;
+    }
+
+    eprintln!(
+        "  Memory DB: {} memories migrated, {} skipped",
+        counts.memories_migrated, counts.memories_skipped
+    );
+
+    Ok(counts)
+}
+
+// ---------------------------------------------------------------------------
+// Graph DB migration
+// ---------------------------------------------------------------------------
+
+/// Graph DB column families that contain serialized data (entities, edges, episodes).
+const GRAPH_DATA_CFS: &[&str] = &["entities", "relationships", "episodes", "entity_edges"];
+
+/// Graph DB column families that contain index data (string references, counts) — skip.
+const GRAPH_INDEX_CFS: &[&str] = &[
+    "entity_pair_index",
+    "entity_episodes",
+    "name_index",
+    "lowercase_index",
+    "stemmed_index",
+];
+
+fn migrate_graph_db(graph_dir: &Path, dry_run: bool) -> Result<(usize, usize)> {
+    let mut opts = RocksOptions::default();
+    opts.create_if_missing(false);
+    opts.create_missing_column_families(true);
+
+    let all_cfs: Vec<&str> = GRAPH_DATA_CFS
+        .iter()
+        .chain(GRAPH_INDEX_CFS.iter())
+        .copied()
+        .collect();
+
+    let cfs: Vec<ColumnFamilyDescriptor> = std::iter::once(ColumnFamilyDescriptor::new(
+        "default",
+        RocksOptions::default(),
+    ))
+    .chain(
+        all_cfs
+            .iter()
+            .map(|name| ColumnFamilyDescriptor::new(*name, RocksOptions::default())),
+    )
+    .collect();
+
+    let db = DB::open_cf_descriptors(&opts, graph_dir, cfs)
+        .with_context(|| format!("opening graph DB at {}", graph_dir.display()))?;
+
+    let mut migrated: usize = 0;
+    let mut skipped: usize = 0;
+
+    // Migrate data CFs. All three graph types (EntityNode, RelationshipEdge,
+    // EpisodicNode) are stored as opaque bincode blobs. We use the generic
+    // bincode→postcard migration which doesn't care about the concrete type
+    // at compile time — we just need to round-trip the bytes through
+    // try_decode → encode. But try_decode needs a concrete type parameter.
+    //
+    // Since the graph CFs are typed:
+    //   entities → EntityNode
+    //   relationships, entity_edges → RelationshipEdge
+    //   episodes → EpisodicNode
+    // we dispatch per CF name.
+
+    for cf_name in GRAPH_DATA_CFS {
+        let cf = match db.cf_handle(cf_name) {
+            Some(cf) => cf,
+            None => continue,
+        };
+
+        let mut batch = WriteBatch::default();
+        let mut batch_count: usize = 0;
+
+        for item in db.iterator_cf(cf, IteratorMode::Start) {
+            let (key, value) = item?;
+
+            match *cf_name {
+                "entities" => {
+                    migrate_generic_record::<EntityNode>(
+                        &db,
+                        Some(cf),
+                        &key,
+                        &value,
+                        dry_run,
+                        &mut batch,
+                        &mut batch_count,
+                        &mut migrated,
+                        &mut skipped,
+                    )?;
+                }
+                "relationships" | "entity_edges" => {
+                    migrate_generic_record::<RelationshipEdge>(
+                        &db,
+                        Some(cf),
+                        &key,
+                        &value,
+                        dry_run,
+                        &mut batch,
+                        &mut batch_count,
+                        &mut migrated,
+                        &mut skipped,
+                    )?;
+                }
+                "episodes" => {
+                    migrate_generic_record::<EpisodicNode>(
+                        &db,
+                        Some(cf),
+                        &key,
+                        &value,
+                        dry_run,
+                        &mut batch,
+                        &mut batch_count,
+                        &mut migrated,
+                        &mut skipped,
+                    )?;
+                }
+                _ => {}
+            }
+
+            if batch_count >= BATCH_SIZE && !dry_run {
+                db.write(std::mem::take(&mut batch))?;
+                batch_count = 0;
+            }
+        }
+
+        if batch_count > 0 && !dry_run {
+            db.write(batch)?;
+        }
+    }
+
+    eprintln!("  Graph DB: {migrated} migrated, {skipped} skipped");
+    Ok((migrated, skipped))
+}
+
+// ---------------------------------------------------------------------------
+// Shared DB migration (audit events)
+// ---------------------------------------------------------------------------
+
+fn migrate_shared_db(shared_dir: &Path, dry_run: bool) -> Result<(usize, usize)> {
+    let mut opts = RocksOptions::default();
+    opts.create_if_missing(false);
+    opts.create_missing_column_families(true);
+
+    // The shared DB has many CFs but only "audit" contains bincode data.
+    // Others (todos, projects, prospective, feedback, files) use JSON.
+    let shared_cfs = [
+        "default",
+        "audit",
+        "todos",
+        "projects",
+        "todo_index",
+        "prospective",
+        "prospective_index",
+        "files",
+        "file_index",
+        "feedback",
+    ];
+    let cfs: Vec<ColumnFamilyDescriptor> = shared_cfs
+        .iter()
+        .map(|name| ColumnFamilyDescriptor::new(*name, RocksOptions::default()))
+        .collect();
+
+    let db = DB::open_cf_descriptors(&opts, shared_dir, cfs)
+        .with_context(|| format!("opening shared DB at {}", shared_dir.display()))?;
+
+    let cf = match db.cf_handle("audit") {
+        Some(cf) => cf,
+        None => return Ok((0, 0)),
+    };
+
+    let mut migrated: usize = 0;
+    let mut skipped: usize = 0;
+    let mut batch = WriteBatch::default();
+    let mut batch_count: usize = 0;
+
+    for item in db.iterator_cf(cf, IteratorMode::Start) {
+        let (key, value) = item?;
+
+        migrate_generic_record::<AuditEvent>(
+            &db,
+            Some(cf),
+            &key,
+            &value,
+            dry_run,
+            &mut batch,
+            &mut batch_count,
+            &mut migrated,
+            &mut skipped,
+        )?;
+
+        if batch_count >= BATCH_SIZE && !dry_run {
+            db.write(std::mem::take(&mut batch))?;
+            batch_count = 0;
+        }
+    }
+
+    if batch_count > 0 && !dry_run {
+        db.write(batch)?;
+    }
+
+    eprintln!("  Shared DB: {migrated} audit events migrated, {skipped} skipped");
+    Ok((migrated, skipped))
+}
+
+// ---------------------------------------------------------------------------
+// Generic record migration helper
+// ---------------------------------------------------------------------------
+
+/// Migrate a single record from legacy bincode to tagged postcard.
+///
+/// If the record already has the postcard format tag, it is skipped.
+/// Otherwise it is decoded via `try_decode` (postcard-first, bincode fallback)
+/// and re-encoded as tagged postcard.
+#[allow(clippy::too_many_arguments)]
+fn migrate_generic_record<T>(
+    _db: &DB,
+    cf: Option<&rocksdb::ColumnFamily>,
+    key: &[u8],
+    value: &[u8],
+    dry_run: bool,
+    batch: &mut WriteBatch,
+    batch_count: &mut usize,
+    migrated: &mut usize,
+    skipped: &mut usize,
+) -> Result<()>
+where
+    T: serde::de::DeserializeOwned + serde::Serialize,
+{
+    // Already in postcard format — skip
+    if serialization::has_format_tag_pub(value) {
+        *skipped += 1;
+        return Ok(());
+    }
+
+    // Decode with legacy bincode fallback
+    let (val, _needs_migration): (T, bool) = serialization::try_decode(value)
+        .with_context(|| {
+            format!(
+                "decoding record (key len={}, value len={})",
+                key.len(),
+                value.len()
+            )
+        })?;
+
+    if !dry_run {
+        let new_value = serialization::encode(&val)?;
+        if let Some(cf) = cf {
+            batch.put_cf(cf, key, &new_value);
+        } else {
+            batch.put(key, &new_value);
+        }
+        *batch_count += 1;
+    }
+
+    *migrated += 1;
+    Ok(())
+}

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -142,9 +142,7 @@ pub fn migrate_all(storage_path: &Path, dry_run: bool) -> Result<MigrationReport
                 report.audit_skipped = skipped;
             }
             Err(e) => {
-                report
-                    .errors
-                    .push(format!("shared DB: {e:#}"));
+                report.errors.push(format!("shared DB: {e:#}"));
             }
         }
     }
@@ -347,10 +345,7 @@ fn migrate_memory_db(storage_dir: &Path, dry_run: bool) -> Result<MemoryDbCounts
         }
 
         // Skip index-only entries (values are plain string references, not serialized)
-        if INDEX_ONLY_PREFIXES
-            .iter()
-            .any(|p| key.starts_with(p))
-        {
+        if INDEX_ONLY_PREFIXES.iter().any(|p| key.starts_with(p)) {
             continue;
         }
 
@@ -738,8 +733,8 @@ where
     }
 
     // Decode with legacy bincode fallback
-    let (val, _needs_migration): (T, bool) = serialization::try_decode(value)
-        .with_context(|| {
+    let (val, _needs_migration): (T, bool) =
+        serialization::try_decode(value).with_context(|| {
             format!(
                 "decoding record (key len={}, value len={})",
                 key.len(),

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -59,8 +59,8 @@ const SHO_TRAILER_LEN: usize = 4; // CRC32-LE
 /// Used for all non-Memory RocksDB records (graph, facts, lineage, etc.).
 /// Single allocation: reserves space for the tag, then serializes in-place.
 pub fn encode<T: Serialize + ?Sized>(val: &T) -> Result<Vec<u8>> {
-    let payload = postcard::to_allocvec(val)
-        .map_err(|e| anyhow::anyhow!("postcard encode: {e}"))?;
+    let payload =
+        postcard::to_allocvec(val).map_err(|e| anyhow::anyhow!("postcard encode: {e}"))?;
     // Single allocation: prepend 2-byte tag by building final buffer once.
     // Vec::with_capacity + extend is one alloc; the payload Vec is consumed.
     let mut buf = Vec::with_capacity(FORMAT_TAG_LEN + payload.len());
@@ -109,8 +109,7 @@ pub fn decode_raw<T: DeserializeOwned>(data: &[u8]) -> Result<T> {
 /// Returns an error if the data doesn't have the format tag or postcard fails.
 pub fn decode<T: DeserializeOwned>(data: &[u8]) -> Result<T> {
     if has_format_tag(data) {
-        postcard::from_bytes(&data[2..])
-            .map_err(|e| anyhow::anyhow!("postcard decode: {e}"))
+        postcard::from_bytes(&data[2..]).map_err(|e| anyhow::anyhow!("postcard decode: {e}"))
     } else {
         Err(anyhow::anyhow!("missing postcard format tag"))
     }
@@ -129,9 +128,8 @@ pub fn try_decode<T: DeserializeOwned>(data: &[u8]) -> Result<(T, bool)> {
     }
 
     // Legacy: bincode 2.x with safe allocation limit
-    let (val, _): (T, _) =
-        bincode::serde::decode_from_slice(data, crate::bincode_safe_config())
-            .map_err(|e| anyhow::anyhow!("bincode decode (legacy): {e}"))?;
+    let (val, _): (T, _) = bincode::serde::decode_from_slice(data, crate::bincode_safe_config())
+        .map_err(|e| anyhow::anyhow!("bincode decode (legacy): {e}"))?;
     Ok((val, true))
 }
 
@@ -262,9 +260,11 @@ mod tests {
             d: map,
         };
         // Encode with bincode (no format tag)
-        let bytes =
-            bincode::serde::encode_to_vec(&val, bincode::config::standard()).unwrap();
-        assert!(!has_format_tag(&bytes), "bincode should not have format tag");
+        let bytes = bincode::serde::encode_to_vec(&val, bincode::config::standard()).unwrap();
+        assert!(
+            !has_format_tag(&bytes),
+            "bincode should not have format tag"
+        );
         let (decoded, needs_migration): (Complex, bool) = try_decode(&bytes).unwrap();
         assert_eq!(decoded, val);
         assert!(needs_migration);
@@ -276,8 +276,7 @@ mod tests {
         let envelope = encode_sho(&val).unwrap();
         let (version, payload) = unwrap_sho(&envelope).unwrap();
         assert_eq!(version, SHO_VERSION_POSTCARD);
-        let decoded: (u64, String) =
-            postcard::from_bytes(payload).unwrap();
+        let decoded: (u64, String) = postcard::from_bytes(payload).unwrap();
         assert_eq!(decoded, val);
     }
 }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,0 +1,283 @@
+//! Centralized serialization module for shodh-memory.
+//!
+//! All RocksDB serialization flows through this module. The canonical format
+//! is **postcard** (v1.x, stable wire format). Legacy bincode/msgpack data is
+//! readable via [`try_decode`] during the transition window and via the
+//! `shodh-memory-server migrate` subcommand.
+//!
+//! # Format Discrimination
+//!
+//! Postcard can silently decode bincode data with **wrong values** (the varint
+//! encodings are similar enough that postcard "succeeds" but produces garbage).
+//! We therefore use explicit format tags to distinguish new data from legacy:
+//!
+//! ## Memory records (SHO envelope)
+//!
+//! ```text
+//! [S H O] [version] [payload ...] [CRC32-LE]
+//!  3 bytes   1 byte    N bytes      4 bytes
+//! ```
+//!
+//! - Version 1: payload is bincode 2.x (legacy)
+//! - Version 2: payload is postcard (current)
+//!
+//! ## Non-Memory records (format tag)
+//!
+//! ```text
+//! [0x50 0x02] [postcard payload ...]
+//!   2 bytes          N bytes
+//! ```
+//!
+//! Records without the `[0x50 0x02]` prefix are legacy bincode/msgpack.
+
+use anyhow::Result;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::memory::storage::{crc32_simple, STORAGE_MAGIC};
+
+/// Current SHO envelope version (postcard payload).
+pub const SHO_VERSION_POSTCARD: u8 = 2;
+
+/// Legacy SHO envelope version (bincode 2.x payload).
+pub const SHO_VERSION_BINCODE2: u8 = 1;
+
+/// 2-byte format tag prepended to non-Memory postcard records.
+/// `[0x50, 0x02]` = 'P', version 2.
+const FORMAT_TAG: [u8; 2] = [0x50, 0x02];
+const FORMAT_TAG_LEN: usize = FORMAT_TAG.len();
+
+/// SHO envelope overhead constants.
+const SHO_HEADER_LEN: usize = 3 + 1; // magic (3) + version (1)
+const SHO_TRAILER_LEN: usize = 4; // CRC32-LE
+
+// ---------------------------------------------------------------------------
+// Encode
+// ---------------------------------------------------------------------------
+
+/// Serialize a value to postcard bytes with a 2-byte format tag prefix.
+///
+/// Used for all non-Memory RocksDB records (graph, facts, lineage, etc.).
+/// Single allocation: reserves space for the tag, then serializes in-place.
+pub fn encode<T: Serialize + ?Sized>(val: &T) -> Result<Vec<u8>> {
+    let payload = postcard::to_allocvec(val)
+        .map_err(|e| anyhow::anyhow!("postcard encode: {e}"))?;
+    // Single allocation: prepend 2-byte tag by building final buffer once.
+    // Vec::with_capacity + extend is one alloc; the payload Vec is consumed.
+    let mut buf = Vec::with_capacity(FORMAT_TAG_LEN + payload.len());
+    buf.extend_from_slice(&FORMAT_TAG);
+    buf.extend_from_slice(&payload);
+    Ok(buf)
+}
+
+/// Serialize a value to raw postcard bytes (no format tag).
+///
+/// Used internally by `encode_sho` where the SHO envelope provides format info.
+pub fn encode_raw<T: Serialize + ?Sized>(val: &T) -> Result<Vec<u8>> {
+    postcard::to_allocvec(val).map_err(|e| anyhow::anyhow!("postcard encode: {e}"))
+}
+
+/// Serialize a value to postcard bytes wrapped in a SHO v2 envelope.
+///
+/// Used exclusively for Memory records in `MemoryStorage::store_inner()`.
+/// Single allocation: serializes payload, then builds the envelope in one buffer.
+pub fn encode_sho<T: Serialize + ?Sized>(val: &T) -> Result<Vec<u8>> {
+    let payload = encode_raw(val)?;
+    // Build envelope in one allocation: [SHO][v2][payload][CRC32-LE]
+    let total = SHO_HEADER_LEN + payload.len() + SHO_TRAILER_LEN;
+    let mut buf = Vec::with_capacity(total);
+    buf.extend_from_slice(STORAGE_MAGIC);
+    buf.push(SHO_VERSION_POSTCARD);
+    buf.extend_from_slice(&payload);
+    let crc = crc32_simple(&buf);
+    buf.extend_from_slice(&crc.to_le_bytes());
+    Ok(buf)
+}
+
+// ---------------------------------------------------------------------------
+// Decode
+// ---------------------------------------------------------------------------
+
+/// Deserialize raw postcard bytes (no format tag).
+///
+/// Used for SHO v2 payloads where the envelope provides format discrimination.
+pub fn decode_raw<T: DeserializeOwned>(data: &[u8]) -> Result<T> {
+    postcard::from_bytes(data).map_err(|e| anyhow::anyhow!("postcard decode: {e}"))
+}
+
+/// Deserialize a tagged postcard record. Strips the 2-byte format tag.
+///
+/// Returns an error if the data doesn't have the format tag or postcard fails.
+pub fn decode<T: DeserializeOwned>(data: &[u8]) -> Result<T> {
+    if has_format_tag(data) {
+        postcard::from_bytes(&data[2..])
+            .map_err(|e| anyhow::anyhow!("postcard decode: {e}"))
+    } else {
+        Err(anyhow::anyhow!("missing postcard format tag"))
+    }
+}
+
+/// Decode a non-Memory record: if it has the postcard format tag, decode as
+/// postcard; otherwise fall back to bincode 2.x with 10 MB allocation limit.
+///
+/// Returns `(value, needs_migration)` where `needs_migration = true` means
+/// the record was in legacy bincode format.
+pub fn try_decode<T: DeserializeOwned>(data: &[u8]) -> Result<(T, bool)> {
+    if has_format_tag(data) {
+        let val = postcard::from_bytes::<T>(&data[2..])
+            .map_err(|e| anyhow::anyhow!("postcard decode (tagged): {e}"))?;
+        return Ok((val, false));
+    }
+
+    // Legacy: bincode 2.x with safe allocation limit
+    let (val, _): (T, _) =
+        bincode::serde::decode_from_slice(data, crate::bincode_safe_config())
+            .map_err(|e| anyhow::anyhow!("bincode decode (legacy): {e}"))?;
+    Ok((val, true))
+}
+
+/// Check if data starts with the postcard format tag.
+#[inline]
+fn has_format_tag(data: &[u8]) -> bool {
+    data.len() >= 2 && data[0] == FORMAT_TAG[0] && data[1] == FORMAT_TAG[1]
+}
+
+/// Public version of [`has_format_tag`] for use by the migration module.
+#[inline]
+pub fn has_format_tag_pub(data: &[u8]) -> bool {
+    has_format_tag(data)
+}
+
+// ---------------------------------------------------------------------------
+// SHO Envelope
+// ---------------------------------------------------------------------------
+
+/// Wrap a postcard payload in a SHO v2 envelope: `[SHO][2][payload][CRC32-LE]`.
+pub fn wrap_sho_v2(payload: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(SHO_HEADER_LEN + payload.len() + SHO_TRAILER_LEN);
+    buf.extend_from_slice(STORAGE_MAGIC);
+    buf.push(SHO_VERSION_POSTCARD);
+    buf.extend_from_slice(payload);
+    let crc = crc32_simple(&buf);
+    buf.extend_from_slice(&crc.to_le_bytes());
+    buf
+}
+
+/// Unwrap a SHO envelope, returning `(version, payload)`.
+///
+/// Returns `None` if the data does not have a valid SHO header
+/// (less than 8 bytes or missing magic).
+pub fn unwrap_sho(data: &[u8]) -> Option<(u8, &[u8])> {
+    if data.len() < 8 || &data[0..3] != STORAGE_MAGIC {
+        return None;
+    }
+    let version = data[3];
+    let payload_end = data.len() - 4;
+    let stored_crc = u32::from_le_bytes([
+        data[payload_end],
+        data[payload_end + 1],
+        data[payload_end + 2],
+        data[payload_end + 3],
+    ]);
+    let computed_crc = crc32_simple(&data[..payload_end]);
+    if stored_crc != computed_crc {
+        tracing::warn!(
+            stored_crc = format_args!("{stored_crc:08x}"),
+            computed_crc = format_args!("{computed_crc:08x}"),
+            "SHO envelope checksum mismatch"
+        );
+    }
+    Some((version, &data[4..payload_end]))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_round_trip_simple() {
+        let val: Vec<u32> = vec![1, 2, 3, 42];
+        let bytes = encode(&val).unwrap();
+        let decoded: Vec<u32> = decode(&bytes).unwrap();
+        assert_eq!(val, decoded);
+    }
+
+    #[test]
+    fn test_format_tag_present() {
+        let bytes = encode(&42u32).unwrap();
+        assert!(has_format_tag(&bytes));
+        assert_eq!(bytes[0], 0x50);
+        assert_eq!(bytes[1], 0x02);
+    }
+
+    #[test]
+    fn test_decode_rejects_untagged() {
+        // Raw postcard without tag should fail decode()
+        let raw = postcard::to_allocvec(&42u32).unwrap();
+        assert!(decode::<u32>(&raw).is_err());
+    }
+
+    #[test]
+    fn test_sho_envelope_round_trip() {
+        let payload = b"hello postcard";
+        let envelope = wrap_sho_v2(payload);
+        let (version, extracted) = unwrap_sho(&envelope).unwrap();
+        assert_eq!(version, SHO_VERSION_POSTCARD);
+        assert_eq!(extracted, payload);
+    }
+
+    #[test]
+    fn test_sho_envelope_no_magic() {
+        assert!(unwrap_sho(b"NOT_SHO").is_none());
+        assert!(unwrap_sho(b"short").is_none());
+    }
+
+    #[test]
+    fn test_try_decode_tagged_postcard() {
+        let val: (u32, String) = (42, "test".to_string());
+        let bytes = encode(&val).unwrap();
+        let (decoded, needs_migration): ((u32, String), bool) = try_decode(&bytes).unwrap();
+        assert_eq!(decoded, val);
+        assert!(!needs_migration);
+    }
+
+    #[test]
+    fn test_try_decode_bincode_legacy() {
+        #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+        struct Complex {
+            a: u64,
+            b: String,
+            c: Vec<u32>,
+            d: std::collections::HashMap<String, i32>,
+        }
+        let mut map = std::collections::HashMap::new();
+        map.insert("key".to_string(), -7);
+        let val = Complex {
+            a: 999_999_999,
+            b: "hello world".to_string(),
+            c: vec![100, 200, 300],
+            d: map,
+        };
+        // Encode with bincode (no format tag)
+        let bytes =
+            bincode::serde::encode_to_vec(&val, bincode::config::standard()).unwrap();
+        assert!(!has_format_tag(&bytes), "bincode should not have format tag");
+        let (decoded, needs_migration): (Complex, bool) = try_decode(&bytes).unwrap();
+        assert_eq!(decoded, val);
+        assert!(needs_migration);
+    }
+
+    #[test]
+    fn test_encode_sho_decode_round_trip() {
+        let val: (u64, String) = (12345, "sho test".to_string());
+        let envelope = encode_sho(&val).unwrap();
+        let (version, payload) = unwrap_sho(&envelope).unwrap();
+        assert_eq!(version, SHO_VERSION_POSTCARD);
+        let decoded: (u64, String) =
+            postcard::from_bytes(payload).unwrap();
+        assert_eq!(decoded, val);
+    }
+}

--- a/src/vector_db/vamana.rs
+++ b/src/vector_db/vamana.rs
@@ -1500,11 +1500,15 @@ impl VamanaIndex {
             deleted_ids: self.deleted_ids.read().clone(),
         };
 
-        // Save as binary
+        // Save as length-prefixed postcard binary
         let index_file = path.join("vamana_index.bin");
+        let encoded = crate::serialization::encode_raw(&data)?;
         let file = File::create(&index_file)?;
         let mut writer = BufWriter::new(file);
-        bincode::serde::encode_into_std_write(&data, &mut writer, bincode::config::standard())?;
+        use std::io::Write;
+        writer.write_all(&(encoded.len() as u64).to_le_bytes())?;
+        writer.write_all(&encoded)?;
+        writer.flush()?;
 
         info!(
             "Saved Vamana index with {} vectors to {:?}",
@@ -1539,8 +1543,31 @@ impl VamanaIndex {
             deleted_ids: HashSet<u32>,
         }
 
-        let data: VamanaData =
-            bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard())?;
+        // Try new length-prefixed postcard format, fall back to legacy bincode streaming
+        let data: VamanaData = {
+            use std::io::Read;
+            let mut len_buf = [0u8; 8];
+            let postcard_result = reader.read_exact(&mut len_buf)
+                .ok()
+                .and_then(|()| {
+                    let len = u64::from_le_bytes(len_buf) as usize;
+                    // Sanity check: reject implausible lengths (> 4 GB)
+                    if len > 4 * 1024 * 1024 * 1024 { return None; }
+                    let mut buf = vec![0u8; len];
+                    reader.read_exact(&mut buf).ok()?;
+                    crate::serialization::decode_raw::<VamanaData>(&buf).ok()
+                });
+            match postcard_result {
+                Some(data) => data,
+                None => {
+                    // Fall back to legacy bincode streaming format
+                    drop(reader);
+                    let file = File::open(path.join("vamana_index.bin"))?;
+                    let mut reader = BufReader::new(file);
+                    bincode::serde::decode_from_std_read(&mut reader, crate::bincode_safe_config())?
+                }
+            }
+        };
 
         // Update internal state
         *self.graph.write() = data.graph;

--- a/src/vector_db/vamana.rs
+++ b/src/vector_db/vamana.rs
@@ -1547,16 +1547,16 @@ impl VamanaIndex {
         let data: VamanaData = {
             use std::io::Read;
             let mut len_buf = [0u8; 8];
-            let postcard_result = reader.read_exact(&mut len_buf)
-                .ok()
-                .and_then(|()| {
-                    let len = u64::from_le_bytes(len_buf) as usize;
-                    // Sanity check: reject implausible lengths (> 4 GB)
-                    if len > 4 * 1024 * 1024 * 1024 { return None; }
-                    let mut buf = vec![0u8; len];
-                    reader.read_exact(&mut buf).ok()?;
-                    crate::serialization::decode_raw::<VamanaData>(&buf).ok()
-                });
+            let postcard_result = reader.read_exact(&mut len_buf).ok().and_then(|()| {
+                let len = u64::from_le_bytes(len_buf) as usize;
+                // Sanity check: reject implausible lengths (> 4 GB)
+                if len > 4 * 1024 * 1024 * 1024 {
+                    return None;
+                }
+                let mut buf = vec![0u8; len];
+                reader.read_exact(&mut buf).ok()?;
+                crate::serialization::decode_raw::<VamanaData>(&buf).ok()
+            });
             match postcard_result {
                 Some(data) => data,
                 None => {


### PR DESCRIPTION
## Summary

Closes #192. Replaces bincode 2.x (unmaintained, RUSTSEC-2025-0141) with postcard for all RocksDB serialization.

- **All writes** now use postcard with format-tagged envelopes
- **All reads** try postcard first, fall back to bincode for legacy data
- **Prevents OOM crashes** from corrupted bincode varint length prefixes (2.3 exabyte allocation observed on 1.1GB production data)
- **Memory hot path**: SHO v2 envelope = single postcard decode, no 17-path fallback chain
- **Offline migration CLI**: `shodh-memory-server migrate --storage <path> [--dry-run]`

### Files changed

| File | Change |
|------|--------|
| `src/serialization.rs` | NEW — central encode/decode with format tags + SHO v2 envelope |
| `src/migration.rs` | NEW — offline batch migration runner |
| `src/main.rs` | Subcommands: `serve` (default) / `migrate` |
| `src/memory/storage.rs` | SHO v2 envelope for Memory writes, version-dispatched reads |
| `src/graph_memory.rs` | 15 encode + 13 decode calls converted |
| `src/memory/facts.rs` | SemanticFact + embedding encode/decode |
| `src/memory/lineage.rs` | LineageEdge/LineageBranch encode/decode |
| `src/memory/temporal_facts.rs` | TemporalFact encode/decode |
| `src/handlers/state.rs` | AuditEvent encode/decode |
| `src/memory/compression.rs` | Experience encode/decode |
| `src/vector_db/vamana.rs` | Length-prefixed postcard, bincode streaming fallback |
| `src/memory/learning_history.rs` | Stays on msgpack (internally tagged enum) |

### Why postcard?

- Stable wire format (v1.x spec locked)
- True no_std + no_heap support via `to_slice()`/`from_bytes()` — ready for bare metal
- Serde drop-in (no type changes needed)
- Only format satisfying all 5 requirements: wire stability, serde compat, no_std, no_heap, active maintenance

### Not in this PR

- bincode is retained as read-only fallback for unmigrated data
- Feature-gating bincode behind `legacy-formats` — follow-up after migration proven on prod

## Test plan

- [x] 495 lib tests pass
- [x] Clippy clean (no warnings from new code)
- [x] Verified on 1.1GB production data (10 users)
- [x] Old code OOM crashes on same data; new code survives
- [x] Write + read-back round-trip verified via API
- [x] Pre-existing corrupted records handled gracefully (logged, not crashed)