### PR TITLE
fix: MCP server ignores SHODH_HOST/SHODH_PORT for remote servers (#193)

### DIFF
--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -36,7 +36,20 @@ const __filename = (typeof import.meta !== "undefined" && import.meta.url) ? fil
 const __dirname = __filename ? path.dirname(__filename) : process.cwd();
 
 // Configuration
-const API_URL = process.env.SHODH_API_URL || "http://127.0.0.1:3030";
+// Priority: SHODH_API_URL (full URL) > SHODH_HOST+SHODH_PORT (constructed) > localhost default
+function resolveApiUrl(): string {
+  if (process.env.SHODH_API_URL) return process.env.SHODH_API_URL;
+  const host = process.env.SHODH_HOST;
+  const port = process.env.SHODH_PORT;
+  if (host) {
+    const scheme = port === "443" ? "https" : "http";
+    const portSuffix = (port && port !== "443" && port !== "80") ? `:${port}` : "";
+    return `${scheme}://${host}${portSuffix}`;
+  }
+  if (port) return `http://127.0.0.1:${port}`;
+  return "http://127.0.0.1:3030";
+}
+const API_URL = resolveApiUrl();
 const WS_URL = API_URL.replace(/^http/, "ws") + "/api/stream";
 const USER_ID = process.env.SHODH_USER_ID || "claude-code";
 


### PR DESCRIPTION
## Summary

Closes #193. The MCP TypeScript client only checked `SHODH_API_URL` for the backend address. Users setting `SHODH_HOST` and `SHODH_PORT` (the natural env vars for remote/production deployments) were silently ignored — the client always fell back to `http://127.0.0.1:3030`.

### Fix

Add `resolveApiUrl()` with priority chain:
1. `SHODH_API_URL` — full URL (e.g., `https://memory.example.com`), preferred
2. `SHODH_HOST` + `SHODH_PORT` — constructed URL, auto-detects `https` for port 443
3. `SHODH_PORT` only — localhost with custom port
4. Default `http://127.0.0.1:3030`

### User's config that now works

```json
{
  "env": {
    "SHODH_HOST": "memory.example.com",
    "SHODH_PORT": "443",
    "SHODH_API_KEY": "sk-..."
  }
}
```

Resolves to `https://memory.example.com` (port 443 implies HTTPS, no port suffix).

## Test plan

- [x] `SHODH_API_URL` set → uses it directly (unchanged behavior)
- [x] `SHODH_HOST=example.com SHODH_PORT=443` → `https://example.com`
- [x] `SHODH_HOST=example.com SHODH_PORT=8080` → `http://example.com:8080`
- [x] `SHODH_HOST=example.com` (no port) → `http://example.com`
- [x] `SHODH_PORT=5910` (no host) → `http://127.0.0.1:5910`
- [x] Nothing set → `http://127.0.0.1:3030` (default, unchanged)
- [x] Non-localhost HTTP triggers existing insecure URL warning