### PR TITLE
fix: temporal retrieval — unified parsing, pre-filter, session-scoped retrieval (#140)

### DIFF
--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -642,9 +642,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             mode: {
               type: "string",
-              enum: ["semantic", "associative", "hybrid"],
-              description: "Retrieval mode: 'semantic' for pure vector similarity, 'associative' for graph-based traversal (follows learned connections), 'hybrid' for density-dependent combination (default)",
+              enum: ["semantic", "associative", "temporal", "hybrid"],
+              description: "Retrieval mode: 'semantic' for pure vector similarity, 'associative' for graph-based traversal (follows learned connections), 'temporal' for time-based retrieval, 'hybrid' for density-dependent combination (default)",
               default: "hybrid",
+            },
+            session_id: {
+              type: "string",
+              description: "Session ID for session-scoped retrieval. When provided, retrieves memories from that session's time window. Forces temporal mode.",
             },
           },
           required: ["query"],
@@ -1508,7 +1512,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "recall": {
-        const { query, limit: rawLimit = 5, mode = "hybrid" } = args as { query: string; limit?: number; mode?: string };
+        const { query, limit: rawLimit = 5, mode = "hybrid", session_id } = args as { query: string; limit?: number; mode?: string; session_id?: string };
 
         if (!query || query.length === 0) {
           return { content: [{ type: "text", text: "Error: 'query' is required and cannot be empty" }], isError: true };
@@ -1516,7 +1520,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (query.length > MAX_QUERY_LENGTH) {
           return { content: [{ type: "text", text: `Error: 'query' exceeds maximum length of ${MAX_QUERY_LENGTH} characters` }], isError: true };
         }
-        const validModes = ["semantic", "associative", "hybrid"];
+        const validModes = ["semantic", "associative", "temporal", "hybrid"];
         if (!validModes.includes(mode)) {
           return { content: [{ type: "text", text: `Error: 'mode' must be one of: ${validModes.join(", ")}` }], isError: true };
         }
@@ -1567,6 +1571,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           query,
           limit,
           mode,
+          ...(session_id ? { session_id } : {}),
         });
 
         const memories = result.memories || [];

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1019,6 +1019,24 @@ pub const TEMPORAL_MATCH_BOOST_EXACT: f32 = 0.5;
 pub const TEMPORAL_MATCH_BOOST_WEEK: f32 = 0.3;
 pub const TEMPORAL_MATCH_BOOST_MONTH: f32 = 0.1;
 
+/// Temporal pre-filter boost — multiplicative boost for memories within the query's date range
+///
+/// When a query has parsed temporal references (e.g., "yesterday", "in March 2026"),
+/// we pre-fetch memories from that date range via SearchCriteria::ByDate and boost
+/// them in Layer 4.45 of the fusion pipeline. This ensures date-relevant memories
+/// rise above semantically similar but temporally wrong results.
+///
+/// 0.15 is conservative: a moderate nudge that won't override strong semantic matches
+/// but gives temporal-range memories a meaningful advantage.
+pub const TEMPORAL_PREFILTER_BOOST: f32 = 0.15;
+
+/// Minimum confidence for temporal prefix injection into query embeddings
+///
+/// Only inject a temporal context prefix (e.g., "[March 2026]") into the query
+/// embedding when parsed temporal refs have confidence >= this threshold.
+/// Prevents noisy prefix injection from low-confidence date parses.
+pub const TEMPORAL_PREFIX_MIN_CONFIDENCE: f32 = 0.8;
+
 /// Prospective signal boost — per-match multiplicative factor for goal-relevant memories
 ///
 /// Memories matching active goals/reminders get boosted to surface proactively.
@@ -2510,6 +2528,8 @@ pub const LINEAGE_CONFIRM_GRAPH_BOOST: f32 = 0.3;
 // | TEMPORAL_MATCH_BOOST_EXACT    | memory/mod.rs             | semantic_retrieve() Layer 5         |
 // | TEMPORAL_MATCH_BOOST_WEEK     | memory/mod.rs             | semantic_retrieve() Layer 5         |
 // | TEMPORAL_MATCH_BOOST_MONTH    | memory/mod.rs             | semantic_retrieve() Layer 5         |
+// | TEMPORAL_PREFILTER_BOOST      | memory/mod.rs             | semantic_retrieve() Layer 4.45      |
+// | TEMPORAL_PREFIX_MIN_CONFIDENCE| memory/mod.rs             | semantic_retrieve() embedding       |
 // | HEBBIAN_ASSOCIATION_WEIGHT    | memory/mod.rs             | semantic_retrieve() Layer 5         |
 // | SCORING_IMPORTANCE_FLOOR      | memory/mod.rs             | semantic_retrieve() Layer 5         |
 // | SCORING_IMPORTANCE_RANGE      | memory/mod.rs             | semantic_retrieve() Layer 5         |

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -338,6 +338,23 @@ pub async fn recall(
     let mode = req.mode.clone();
     let retrieval_mode_for_recall = parse_retrieval_mode(&mode);
 
+    // SESSION-SCOPED RETRIEVAL: resolve session_id → time_range before spawn_blocking.
+    // When session_id is provided, look up the session's time window and set
+    // retrieval_mode to Temporal so temporal_search() uses the date range.
+    let session_time_range = req.session_id.as_ref().and_then(|sid| {
+        use crate::memory::sessions::SessionId;
+        let session_id = SessionId(uuid::Uuid::parse_str(sid).ok()?);
+        state.session_store().get_session_time_range(&session_id)
+    });
+    let session_id_for_recall = req.session_id.clone();
+
+    // If session_id resolved to a time range, force Temporal mode
+    let retrieval_mode_for_recall = if session_time_range.is_some() {
+        RetrievalMode::Temporal
+    } else {
+        retrieval_mode_for_recall
+    };
+
     // PROSPECTIVE MEMORY + RECALL: Run inside a single spawn_blocking to share
     // the computed query embedding between prospective semantic matching and recall.
     // This fixes C5 (keyword-only → semantic) and sets up prospective_signals for boosting.
@@ -420,6 +437,8 @@ pub async fn recall(
                 max_results: limit,
                 retrieval_mode: retrieval_mode_for_recall,
                 prospective_signals: prospective_signals.clone(),
+                session_id: session_id_for_recall,
+                time_range: session_time_range,
                 ..Default::default()
             };
 

--- a/src/handlers/types.rs
+++ b/src/handlers/types.rs
@@ -93,9 +93,12 @@ pub struct RecallRequest {
     pub query: String,
     #[serde(default = "default_recall_limit")]
     pub limit: usize,
-    /// Retrieval mode: "semantic", "associative", or "hybrid" (default)
+    /// Retrieval mode: "semantic", "associative", "temporal", or "hybrid" (default)
     #[serde(default = "default_recall_mode")]
     pub mode: String,
+    /// Session ID for session-scoped retrieval (used with mode="temporal")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
 }
 
 pub fn default_recall_limit() -> usize {

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1411,25 +1411,79 @@ impl MemorySystem {
         let recall_start = std::time::Instant::now();
 
         // ===========================================================================
-        // TEMPORAL EXTRACTION (TEMPR approach from Hindsight - 89.6% on LoCoMo)
+        // TEMPORAL ANALYSIS (unified intent + date parsing)
         // ===========================================================================
-        // Key insight: Temporal filtering is critical for multi-hop retrieval accuracy.
-        // Extract temporal constraints from query and use them to boost/filter results.
-        let query_temporal = query_parser::extract_temporal_refs(query_text);
-        let has_temporal_query = query_parser::requires_temporal_filtering(query_text);
+        // Replaces independent calls to extract_temporal_refs() and detect_temporal_intent().
+        // analyze_temporal() parses dates first, then derives intent from parsed structure,
+        // falling back to keyword detection only when dateparser finds nothing.
+        let temporal_ctx = query_parser::analyze_temporal(query_text);
+        let has_temporal_query = temporal_ctx.intent != query_parser::TemporalIntent::None;
 
         if has_temporal_query {
-            let temporal_intent = query_parser::detect_temporal_intent(query_text);
             tracing::debug!(
-                "Temporal query detected: intent={:?}, refs={:?}",
-                temporal_intent,
-                query_temporal
+                "Temporal query detected: intent={:?}, filtering={}, seeking={}, date_range={:?}, refs={:?}",
+                temporal_ctx.intent,
+                temporal_ctx.is_filtering_query,
+                temporal_ctx.is_seeking_query,
+                temporal_ctx.date_range,
+                temporal_ctx.extraction
                     .refs
                     .iter()
                     .map(|r| r.date.to_string())
                     .collect::<Vec<_>>()
             );
         }
+
+        // ===========================================================================
+        // LAYER 0.4: TEMPORAL PRE-FILTER (Date-Range Candidate Prefetch)
+        // ===========================================================================
+        // When the query has parsed temporal references (e.g., "yesterday", "March 2026"),
+        // pre-fetch memories from the matching date range via SearchCriteria::ByDate.
+        // These IDs are collected as candidates for boosting at Layer 4.45.
+        // NOT exclusive — memories outside the range still enter via Vamana/BM25.
+        let temporal_prefilter_ids: HashSet<MemoryId> = if temporal_ctx.is_filtering_query {
+            if let Some((start_date, end_date)) = temporal_ctx.date_range {
+                // Convert NaiveDate to DateTime<Utc> (start of first day, end of last day)
+                let start_dt = start_date
+                    .and_hms_opt(0, 0, 0)
+                    .map(|dt| {
+                        chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(dt, chrono::Utc)
+                    })
+                    .unwrap_or_else(chrono::Utc::now);
+                let end_dt = end_date
+                    .and_hms_opt(23, 59, 59)
+                    .map(|dt| {
+                        chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(dt, chrono::Utc)
+                    })
+                    .unwrap_or_else(chrono::Utc::now);
+
+                match self.advanced_search(storage::SearchCriteria::ByDate {
+                    start: start_dt,
+                    end: end_dt,
+                }) {
+                    Ok(memories) => {
+                        let ids: HashSet<_> = memories.iter().map(|m| m.id.clone()).collect();
+                        if !ids.is_empty() {
+                            tracing::info!(
+                                    "Layer 0.4: Temporal pre-filter found {} memories in date range {:?} to {:?}",
+                                    ids.len(),
+                                    start_date,
+                                    end_date
+                                );
+                        }
+                        ids
+                    }
+                    Err(e) => {
+                        tracing::warn!("Layer 0.4: Temporal pre-filter search failed: {}", e);
+                        HashSet::new()
+                    }
+                }
+            } else {
+                HashSet::new()
+            }
+        } else {
+            HashSet::new()
+        };
 
         // ===========================================================================
         // LAYER 0.5: ATTRIBUTE QUERY DETECTION (Fact-First Retrieval)
@@ -1718,6 +1772,32 @@ impl MemorySystem {
             "recall [layer:0.5-0.7] query analysis + attribute + temporal fact + fact source lookup"
         );
 
+        // TEMPORAL PREFIX INJECTION: When the query has high-confidence temporal
+        // references, prepend a temporal context string to give MiniLM textual
+        // overlap with memory content mentioning the same time period.
+        // Only applied for filtering queries (not "when did X happen?" seeking queries).
+        let embedding_query_text: std::borrow::Cow<'_, str> = if temporal_ctx.is_filtering_query
+            && temporal_ctx
+                .extraction
+                .refs
+                .iter()
+                .any(|r| r.confidence >= crate::constants::TEMPORAL_PREFIX_MIN_CONFIDENCE)
+        {
+            // Build prefix from the original temporal text (e.g., "March 2026", "yesterday")
+            let temporal_labels: Vec<&str> = temporal_ctx
+                .extraction
+                .refs
+                .iter()
+                .filter(|r| r.confidence >= crate::constants::TEMPORAL_PREFIX_MIN_CONFIDENCE)
+                .map(|r| r.original_text.as_str())
+                .collect();
+            let prefix = format!("[{}] ", temporal_labels.join(", "));
+            tracing::debug!("Temporal prefix injection: \"{}\"", prefix);
+            std::borrow::Cow::Owned(format!("{}{}", prefix, query_text))
+        } else {
+            std::borrow::Cow::Borrowed(query_text)
+        };
+
         // PERFORMANCE: Use pre-computed embedding if caller provided one,
         // otherwise fall back to SHA256-keyed cache (80ms → <1μs for repeated queries)
         let query_embedding =
@@ -1728,21 +1808,21 @@ impl MemorySystem {
                 tracing::debug!("Query embedding PRECOMPUTED by caller — skipping encode");
                 pre.clone()
             } else {
-                let query_hash = Self::sha256_hash(query_text);
+                let query_hash = Self::sha256_hash(&embedding_query_text);
                 if let Some(cached_embedding) = self.query_cache.get(&query_hash) {
                     EMBEDDING_CACHE_QUERY.with_label_values(&["hit"]).inc();
-                    tracing::debug!("Query embedding cache HIT for: {}", query_text);
+                    tracing::debug!("Query embedding cache HIT for: {}", &*embedding_query_text);
                     cached_embedding.clone()
                 } else {
                     EMBEDDING_CACHE_QUERY.with_label_values(&["miss"]).inc();
                     tracing::debug!(
                         "Query embedding cache MISS - generating for: {}",
-                        query_text
+                        &*embedding_query_text
                     );
                     let embedding = self
                         .embedder
                         .as_ref()
-                        .encode(query_text)
+                        .encode(&embedding_query_text)
                         .context("Failed to generate query embedding")?;
 
                     self.query_cache.insert(query_hash, embedding.clone());
@@ -2058,6 +2138,7 @@ impl MemorySystem {
             confidence_range: query.confidence_range,
             offset: query.offset,
             episode_id: query.episode_id.clone(),
+            session_id: query.session_id.clone(),
             prospective_signals: query.prospective_signals.clone(),
             recency_weight: query.recency_weight,
         };
@@ -2219,6 +2300,30 @@ impl MemorySystem {
                 if boosted_count > 0 {
                     tracing::info!(
                         "Layer 4.5: Boosted {} memories for attribute query",
+                        boosted_count
+                    );
+                }
+            }
+
+            // ===========================================================================
+            // LAYER 4.45: TEMPORAL PRE-FILTER BOOST
+            // ===========================================================================
+            // Memories that fell within the query's parsed date range (Layer 0.4)
+            // get a multiplicative boost. This ensures date-relevant memories rise
+            // above semantically similar but temporally wrong results.
+            if !temporal_prefilter_ids.is_empty() {
+                let mut boosted_count = 0;
+                for id in &temporal_prefilter_ids {
+                    if let Some(score) = fused.get_mut(id) {
+                        *score *= 1.0 + crate::constants::TEMPORAL_PREFILTER_BOOST;
+                        boosted_count += 1;
+                    }
+                    // Don't insert memories absent from fusion — date range alone
+                    // without semantic/graph support is insufficient evidence
+                }
+                if boosted_count > 0 {
+                    tracing::info!(
+                        "Layer 4.45: Boosted {} memories from temporal pre-filter",
                         boosted_count
                     );
                 }
@@ -2515,11 +2620,18 @@ impl MemorySystem {
                     .unwrap_or(0.0);
 
                 // TEMPORAL MATCH (TEMPR approach for multi-hop temporal retrieval)
-                let temporal_factor =
-                    if has_temporal_query && !mem.experience.temporal_refs.is_empty() {
-                        let mut best_match = 0.0_f32;
+                //
+                // Three-tier strategy:
+                // 1. If memory has explicit temporal_refs → match against query refs (highest signal)
+                // 2. If query is filtering BY date → use created_at proximity as fallback
+                // 3. If query is seeking FOR a date (WhenQuestion) → skip boost entirely
+                let temporal_factor = if has_temporal_query && !temporal_ctx.is_seeking_query {
+                    let mut best_match = 0.0_f32;
+
+                    // Tier 1: Explicit temporal_refs on the memory
+                    if !mem.experience.temporal_refs.is_empty() {
                         for mem_ref in &mem.experience.temporal_refs {
-                            for query_ref in &query_temporal.refs {
+                            for query_ref in &temporal_ctx.extraction.refs {
                                 if mem_ref == &query_ref.date.to_string() {
                                     best_match = best_match.max(TEMPORAL_MATCH_BOOST_EXACT);
                                 } else if let Ok(mem_date) =
@@ -2538,10 +2650,39 @@ impl MemorySystem {
                                 }
                             }
                         }
-                        best_match
-                    } else {
-                        0.0
-                    };
+                    }
+
+                    // Tier 2: created_at proximity fallback for filtering queries
+                    // Most memories don't have temporal_refs, so use created_at as proxy
+                    if best_match == 0.0 && temporal_ctx.is_filtering_query {
+                        if let Some((range_start, range_end)) = temporal_ctx.date_range {
+                            let created_date = mem.created_at.date_naive();
+                            let range_mid = range_start
+                                + chrono::Duration::days((range_end - range_start).num_days() / 2);
+                            let days_off = (created_date - range_mid).num_days().abs();
+                            let range_half = ((range_end - range_start).num_days() / 2).max(1);
+
+                            if days_off <= range_half {
+                                // Within range: full boost
+                                best_match = TEMPORAL_MATCH_BOOST_EXACT;
+                            } else if days_off <= range_half + 7 {
+                                // Near range: decaying week boost
+                                let proximity = TEMPORAL_MATCH_BOOST_WEEK
+                                    * (1.0 - (days_off - range_half) as f32 / 7.0);
+                                best_match = best_match.max(proximity);
+                            } else if days_off <= range_half + 30 {
+                                // Further out: decaying month boost
+                                let proximity = TEMPORAL_MATCH_BOOST_MONTH
+                                    * (1.0 - (days_off - range_half) as f32 / 30.0);
+                                best_match = best_match.max(proximity);
+                            }
+                        }
+                    }
+
+                    best_match
+                } else {
+                    0.0
+                };
 
                 // FEEDBACK MOMENTUM (PIPE-9)
                 // Symmetric ±15% multiplicative adjustment

--- a/src/memory/query_parser.rs
+++ b/src/memory/query_parser.rs
@@ -301,6 +301,44 @@ pub fn extract_temporal_refs(text: &str) -> TemporalExtraction {
         update_bounds(&mut earliest, &mut latest, date);
     }
 
+    // Extract relative temporal keywords ("yesterday", "last week", "3 days ago")
+    let relative_dates = extract_relative_dates(text, &now);
+    for (date, original, pos, ref_type) in relative_dates {
+        if !is_valid_date(&date) {
+            continue;
+        }
+        if refs.iter().any(|r| r.date == date) {
+            continue;
+        }
+        refs.push(TemporalRef {
+            date,
+            original_text: original,
+            confidence: 0.85,
+            position: pos,
+            ref_type,
+        });
+        update_bounds(&mut earliest, &mut latest, date);
+    }
+
+    // Extract "Month Year" patterns without day (e.g., "March 2026", "in May 2023")
+    let month_year_dates = extract_month_year_dates(text);
+    for (date, original, pos) in month_year_dates {
+        if !is_valid_date(&date) {
+            continue;
+        }
+        if refs.iter().any(|r| r.date == date) {
+            continue;
+        }
+        refs.push(TemporalRef {
+            date,
+            original_text: original,
+            confidence: 0.85,
+            position: pos,
+            ref_type: TemporalRefType::Month,
+        });
+        update_bounds(&mut earliest, &mut latest, date);
+    }
+
     // Sort by position in text
     refs.sort_by_key(|r| r.position);
 
@@ -458,6 +496,113 @@ fn extract_explicit_dates(text: &str) -> Vec<(NaiveDate, String, usize)> {
         let year: i32 = cap[3].parse().unwrap_or(2000);
 
         if let Some(date) = NaiveDate::from_ymd_opt(year, month, day) {
+            let pos = cap.get(0).map(|m| m.start()).unwrap_or(0);
+            results.push((date, cap[0].to_string(), pos));
+        }
+    }
+
+    results
+}
+
+/// Extract relative temporal keywords from text.
+///
+/// Handles patterns that dateparser misses when embedded in longer text:
+/// "yesterday", "today", "last week/month/year", "N days/weeks/months ago",
+/// "this week/month", day-of-week references.
+fn extract_relative_dates(
+    text: &str,
+    now: &DateTime<Utc>,
+) -> Vec<(NaiveDate, String, usize, TemporalRefType)> {
+    use regex::Regex;
+
+    let text_lower = text.to_lowercase();
+    let today = now.date_naive();
+    let mut results = Vec::new();
+
+    // "yesterday"
+    if let Some(pos) = text_lower.find("yesterday") {
+        let date = today - chrono::Duration::days(1);
+        results.push((
+            date,
+            "yesterday".to_string(),
+            pos,
+            TemporalRefType::Relative,
+        ));
+    }
+
+    // "today"
+    if let Some(pos) = text_lower.find("today") {
+        results.push((today, "today".to_string(), pos, TemporalRefType::Relative));
+    }
+
+    // "N days/weeks/months ago"
+    let ago_re = Regex::new(r"(?i)(\d+)\s+(day|week|month|year)s?\s+ago").unwrap();
+    for cap in ago_re.captures_iter(text) {
+        let n: i64 = cap[1].parse().unwrap_or(1);
+        let unit = cap[2].to_lowercase();
+        let date = match unit.as_str() {
+            "day" => today - chrono::Duration::days(n),
+            "week" => today - chrono::Duration::weeks(n),
+            "month" => {
+                // Approximate: 30 days per month
+                today - chrono::Duration::days(n * 30)
+            }
+            "year" => today - chrono::Duration::days(n * 365),
+            _ => continue,
+        };
+        let pos = cap.get(0).map(|m| m.start()).unwrap_or(0);
+        results.push((date, cap[0].to_string(), pos, TemporalRefType::Relative));
+    }
+
+    // "last week/month/year"
+    let last_re = Regex::new(r"(?i)last\s+(week|month|year)").unwrap();
+    for cap in last_re.captures_iter(text) {
+        let unit = cap[1].to_lowercase();
+        let date = match unit.as_str() {
+            "week" => today - chrono::Duration::weeks(1),
+            "month" => today - chrono::Duration::days(30),
+            "year" => today - chrono::Duration::days(365),
+            _ => continue,
+        };
+        let pos = cap.get(0).map(|m| m.start()).unwrap_or(0);
+        // Skip if we already have a date from "N weeks ago" at similar position
+        if results.iter().any(|r| r.0 == date) {
+            continue;
+        }
+        results.push((date, cap[0].to_string(), pos, TemporalRefType::Relative));
+    }
+
+    // "this week/month/year"
+    let this_re = Regex::new(r"(?i)this\s+(week|month|year)").unwrap();
+    for cap in this_re.captures_iter(text) {
+        let pos = cap.get(0).map(|m| m.start()).unwrap_or(0);
+        if results.iter().any(|r| r.0 == today) {
+            continue;
+        }
+        results.push((today, cap[0].to_string(), pos, TemporalRefType::Relative));
+    }
+
+    results
+}
+
+/// Extract "Month Year" patterns without a day number.
+///
+/// Handles: "March 2026", "in May 2023", "last March"
+/// Returns the first day of the month as the date.
+fn extract_month_year_dates(text: &str) -> Vec<(NaiveDate, String, usize)> {
+    use regex::Regex;
+
+    let mut results = Vec::new();
+
+    // "Month Year" (e.g., "March 2026", "in September 2025")
+    let month_year_re = Regex::new(
+        r"(?i)(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{4})"
+    ).unwrap();
+
+    for cap in month_year_re.captures_iter(text) {
+        let month = month_to_num(&cap[1]);
+        let year: i32 = cap[2].parse().unwrap_or(2000);
+        if let Some(date) = NaiveDate::from_ymd_opt(year, month, 1) {
             let pos = cap.get(0).map(|m| m.start()).unwrap_or(0);
             results.push((date, cap[0].to_string(), pos));
         }
@@ -632,6 +777,136 @@ pub fn requires_temporal_filtering(query: &str) -> bool {
 /// the date from the retrieved content.
 pub fn asks_for_temporal_answer(query: &str) -> bool {
     matches!(detect_temporal_intent(query), TemporalIntent::WhenQuestion)
+}
+
+// ============================================================================
+// UNIFIED TEMPORAL ANALYSIS
+// ============================================================================
+// Combines intent detection with parsed date extraction into a single context
+// object. Fixes the gap where `detect_temporal_intent()` uses keyword matching
+// independently of `extract_temporal_refs()` which does real date parsing.
+
+/// Unified temporal query context combining intent, parsed dates, and date range.
+///
+/// Replaces the pattern of calling `extract_temporal_refs()` and
+/// `detect_temporal_intent()` independently. The parsed dates now inform
+/// intent detection, and the date range is computed with appropriate padding
+/// based on the temporal ref type.
+#[derive(Debug, Clone)]
+pub struct TemporalQueryContext {
+    /// The detected temporal intent
+    pub intent: TemporalIntent,
+    /// Parsed temporal references from the query text
+    pub extraction: TemporalExtraction,
+    /// Computed date range for filtering (with padding based on ref type)
+    pub date_range: Option<(NaiveDate, NaiveDate)>,
+    /// True when query has parsed dates to filter BY (SpecificTime, TimeRange)
+    pub is_filtering_query: bool,
+    /// True when query asks FOR a date (WhenQuestion, Ordering, Duration)
+    pub is_seeking_query: bool,
+}
+
+/// Analyze a query for temporal signals, unifying parsing and intent detection.
+///
+/// Strategy:
+/// 1. Parse dates first via `extract_temporal_refs()` (dateparser + regex)
+/// 2. If dates found → derive intent from ref types (no keyword matching needed)
+/// 3. If no dates → fall back to `detect_temporal_intent()` for intent-only
+///    queries like "when did X happen"
+/// 4. Compute padded date range based on ref types
+pub fn analyze_temporal(query: &str) -> TemporalQueryContext {
+    let extraction = extract_temporal_refs(query);
+    let query_lower = query.to_lowercase();
+
+    // Detect "when" prefix — this is asking FOR a date, not filtering BY one
+    let is_when_question = query_lower.starts_with("when")
+        || query_lower.contains(" when ")
+        || query_lower.contains("what date")
+        || query_lower.contains("what day")
+        || query_lower.contains("what time");
+
+    let intent = if extraction.has_temporal_refs() {
+        // Parsed dates found — derive intent from structure
+        if is_when_question {
+            // "When in March did X happen?" — has dates but asking for specifics
+            TemporalIntent::WhenQuestion
+        } else {
+            TemporalIntent::SpecificTime
+        }
+    } else {
+        // No parsed dates — fall back to keyword-based intent detection
+        detect_temporal_intent(query)
+    };
+
+    // Compute date range with padding based on ref types
+    let date_range = compute_padded_date_range(&extraction);
+
+    let is_filtering_query = matches!(
+        intent,
+        TemporalIntent::SpecificTime | TemporalIntent::Ordering
+    ) && date_range.is_some();
+
+    let is_seeking_query = matches!(
+        intent,
+        TemporalIntent::WhenQuestion | TemporalIntent::Duration
+    );
+
+    TemporalQueryContext {
+        intent,
+        extraction,
+        date_range,
+        is_filtering_query,
+        is_seeking_query,
+    }
+}
+
+/// Compute a padded date range from temporal extraction results.
+///
+/// Padding strategy based on the most specific ref type:
+/// - Absolute/DayOfWeek: ±1 day (3-day window)
+/// - Relative: ±1 day
+/// - Month: full calendar month
+/// - Year: full calendar year
+/// - Mixed refs: use extraction bounds directly (already encompass the range)
+fn compute_padded_date_range(extraction: &TemporalExtraction) -> Option<(NaiveDate, NaiveDate)> {
+    let (earliest, latest) = extraction.date_range()?;
+
+    if extraction.refs.len() == 1 {
+        // Single ref — pad based on type
+        let ref_type = extraction.refs[0].ref_type;
+        match ref_type {
+            TemporalRefType::Month => {
+                // Expand to full calendar month
+                let start = NaiveDate::from_ymd_opt(earliest.year(), earliest.month(), 1)?;
+                let end = if earliest.month() == 12 {
+                    NaiveDate::from_ymd_opt(earliest.year() + 1, 1, 1)?
+                        .pred_opt()
+                        .unwrap_or(start)
+                } else {
+                    NaiveDate::from_ymd_opt(earliest.year(), earliest.month() + 1, 1)?
+                        .pred_opt()
+                        .unwrap_or(start)
+                };
+                Some((start, end))
+            }
+            TemporalRefType::Year => {
+                let start = NaiveDate::from_ymd_opt(earliest.year(), 1, 1)?;
+                let end = NaiveDate::from_ymd_opt(earliest.year(), 12, 31)?;
+                Some((start, end))
+            }
+            TemporalRefType::Absolute | TemporalRefType::DayOfWeek | TemporalRefType::Relative => {
+                // ±1 day padding
+                let start = earliest - chrono::Duration::days(1);
+                let end = latest + chrono::Duration::days(1);
+                Some((start, end))
+            }
+        }
+    } else {
+        // Multiple refs — use bounds directly with ±1 day padding
+        let start = earliest - chrono::Duration::days(1);
+        let end = latest + chrono::Duration::days(1);
+        Some((start, end))
+    }
 }
 
 // ============================================================================
@@ -4052,5 +4327,83 @@ mod tests {
             "Should detect 'support group' as phrase. Found: {:?}",
             phrases
         );
+    }
+
+    // ========================================================================
+    // TemporalQueryContext / analyze_temporal tests
+    // ========================================================================
+
+    #[test]
+    fn test_analyze_temporal_specific_month() {
+        let ctx = analyze_temporal("what happened in March 2026");
+        assert_eq!(ctx.intent, TemporalIntent::SpecificTime);
+        assert!(ctx.is_filtering_query, "should be filtering query");
+        assert!(!ctx.is_seeking_query);
+        assert!(ctx.date_range.is_some());
+        let (start, end) = ctx.date_range.unwrap();
+        assert_eq!(start.month(), 3);
+        assert_eq!(start.day(), 1);
+        assert_eq!(end.month(), 3);
+        assert_eq!(end.day(), 31);
+    }
+
+    #[test]
+    fn test_analyze_temporal_when_question() {
+        let ctx = analyze_temporal("when did the deployment happen");
+        assert_eq!(ctx.intent, TemporalIntent::WhenQuestion);
+        assert!(ctx.is_seeking_query, "WhenQuestion should be seeking");
+        assert!(!ctx.is_filtering_query);
+    }
+
+    #[test]
+    fn test_analyze_temporal_yesterday() {
+        let ctx = analyze_temporal("what did we discuss yesterday");
+        assert_eq!(ctx.intent, TemporalIntent::SpecificTime);
+        assert!(ctx.is_filtering_query);
+        assert!(ctx.date_range.is_some());
+    }
+
+    #[test]
+    fn test_analyze_temporal_no_temporal() {
+        let ctx = analyze_temporal("tell me about the robot architecture");
+        assert_eq!(ctx.intent, TemporalIntent::None);
+        assert!(!ctx.is_filtering_query);
+        assert!(!ctx.is_seeking_query);
+        assert!(ctx.date_range.is_none());
+    }
+
+    #[test]
+    fn test_analyze_temporal_iso_date() {
+        let ctx = analyze_temporal("what happened on 2026-03-15");
+        assert_eq!(ctx.intent, TemporalIntent::SpecificTime);
+        assert!(ctx.is_filtering_query);
+        let (start, end) = ctx.date_range.unwrap();
+        // Single absolute date → ±1 day padding
+        assert_eq!(start, NaiveDate::from_ymd_opt(2026, 3, 14).unwrap());
+        assert_eq!(end, NaiveDate::from_ymd_opt(2026, 3, 16).unwrap());
+    }
+
+    #[test]
+    fn test_analyze_temporal_when_with_date() {
+        // "When in March 2026 did X happen" — has dates but asking for specifics
+        let ctx = analyze_temporal("when in March 2026 did the incident happen");
+        assert_eq!(ctx.intent, TemporalIntent::WhenQuestion);
+        assert!(ctx.is_seeking_query);
+        // Has parsed dates but intent is WhenQuestion, so not a filtering query
+        assert!(!ctx.is_filtering_query);
+    }
+
+    #[test]
+    fn test_analyze_temporal_duration() {
+        let ctx = analyze_temporal("how long ago did we fix the bug");
+        assert_eq!(ctx.intent, TemporalIntent::Duration);
+        assert!(ctx.is_seeking_query);
+        assert!(!ctx.is_filtering_query);
+    }
+
+    #[test]
+    fn test_compute_padded_date_range_empty() {
+        let extraction = TemporalExtraction::default();
+        assert!(compute_padded_date_range(&extraction).is_none());
     }
 }

--- a/src/memory/sessions.rs
+++ b/src/memory/sessions.rs
@@ -636,6 +636,20 @@ impl SessionStore {
         }
     }
 
+    /// Get session time range (start, end) for date-based retrieval.
+    ///
+    /// For active sessions, `end` is the current time.
+    /// For completed sessions, `end` is the session's `ended_at` timestamp.
+    pub fn get_session_time_range(
+        &self,
+        session_id: &SessionId,
+    ) -> Option<(DateTime<Utc>, DateTime<Utc>)> {
+        self.get_session(session_id).map(|session| {
+            let end = session.ended_at.unwrap_or_else(Utc::now);
+            (session.started_at, end)
+        })
+    }
+
     /// Get session by ID
     pub fn get_session(&self, session_id: &SessionId) -> Option<Session> {
         // Check active first

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -1976,6 +1976,13 @@ pub struct Query {
     /// This prevents episode bleeding where unrelated memories mix in results
     pub episode_id: Option<String>,
 
+    // === Session Context ===
+    /// Session ID for session-scoped retrieval
+    /// When set with Temporal retrieval mode, retrieves memories stored during
+    /// the specified session's time window. Enables "what did we discuss in
+    /// yesterday's session?" queries.
+    pub session_id: Option<String>,
+
     // === Scoring Parameters ===
     /// Weight for recency boost in unified scoring (0.0-1.0)
     /// When None, uses hardcoded default (0.1 = 10% contribution)
@@ -2064,6 +2071,7 @@ impl Default for Query {
             confidence_range: None,
             prospective_signals: None,
             episode_id: None,
+            session_id: None,
             recency_weight: None,
             max_results: DEFAULT_MAX_RESULTS,
             retrieval_mode: RetrievalMode::Hybrid,


### PR DESCRIPTION
## Summary

Fixes #140 — four structural weaknesses in temporal retrieval:

- **Unified temporal analysis**: `analyze_temporal()` parses dates first (dateparser + regex), derives intent from structure. Falls back to keyword matching only when no dates found. New extractors for "yesterday"/"3 days ago" and "March 2026" patterns
- **Layer 0.4 pre-filter**: pre-fetches memories from parsed date range via `SearchCriteria::ByDate`, boosts at Layer 4.45 in RRF fusion (`TEMPORAL_PREFILTER_BOOST = 0.15`)
- **Layer 5 `created_at` proximity**: fallback when memory lacks `temporal_refs` (most don't). Scores distance from query's target date range. `WhenQuestion` seeking queries skip boost entirely
- **Session-scoped retrieval**: `session_id` on Query/RecallRequest resolves to session time window, forces Temporal mode. MCP recall tool updated
- **Temporal prefix injection**: high-confidence refs prepended to query embedding text

## Files changed

| File | Changes |
|------|---------|
| `query_parser.rs` | `TemporalQueryContext`, `analyze_temporal()`, `extract_relative_dates()`, `extract_month_year_dates()`, `compute_padded_date_range()`, 8 tests |
| `mod.rs` | Layer 0.4 pre-filter, Layer 4.45 boost, Layer 5 created_at proximity, temporal prefix injection |
| `types.rs` | `session_id` field on `Query` |
| `sessions.rs` | `get_session_time_range()` |
| `recall.rs` | session_id resolution → time_range, wired to MemoryQuery |
| `types.rs` (handlers) | `session_id` on `RecallRequest` |
| `constants.rs` | `TEMPORAL_PREFILTER_BOOST`, `TEMPORAL_PREFIX_MIN_CONFIDENCE` |
| `index.ts` | `session_id` param, `temporal` mode on recall tool |

## Test plan

- [x] All 503 existing tests pass
- [x] 8 new `analyze_temporal` unit tests (specific month, yesterday, ISO date, when question, duration, no temporal, when+date, empty range)
- [x] `cargo clippy` clean on changed files
- [ ] Manual: start server, recall with temporal queries, verify Layer 0.4 log