### PR TITLE
fix: numeric stability + serialization hardening (audit P0/P1)

### DIFF
--- a/src/ab_testing.rs
+++ b/src/ab_testing.rs
@@ -803,12 +803,12 @@ impl ABTestAnalyzer {
             // Interpolate between 0.001 and 0.0001
             let ratio = (chi_squared - CHI_SQUARED_CRITICAL_001)
                 / (CHI_SQUARED_CRITICAL_0001 - CHI_SQUARED_CRITICAL_001);
-            0.001 - ratio * 0.0009
+            (0.001 - ratio * 0.0009).max(0.0)
         } else if chi_squared >= CHI_SQUARED_CRITICAL_005 {
             // Interpolate between 0.05 and 0.001
             let ratio = (chi_squared - CHI_SQUARED_CRITICAL_005)
                 / (CHI_SQUARED_CRITICAL_001 - CHI_SQUARED_CRITICAL_005);
-            0.05 - ratio * 0.049
+            (0.05 - ratio * 0.049).max(0.0)
         } else {
             // Below 0.05 significance
             // Rough approximation: p ≈ exp(-chi_squared/2) for small values
@@ -1113,7 +1113,11 @@ impl ABTestAnalyzer {
         // Use ratio of gamma samples for Beta
         let gamma_a = Self::gamma_sample(alpha, seed, lcg);
         let gamma_b = Self::gamma_sample(beta, seed, lcg);
-        gamma_a / (gamma_a + gamma_b)
+        let denom = gamma_a + gamma_b;
+        if denom == 0.0 {
+            return 0.5; // Uninformative midpoint when both gamma samples are zero
+        }
+        gamma_a / denom
     }
 
     /// Sample from Gamma distribution using Marsaglia and Tsang's method
@@ -1141,7 +1145,8 @@ impl ABTestAnalyzer {
 
     /// Sample from standard normal using Box-Muller transform
     fn normal_sample(seed: &mut u64, lcg: &impl Fn(&mut u64) -> f64) -> f64 {
-        let u1 = lcg(seed);
+        // Clamp u1 away from zero to prevent ln(0) = -inf → NaN propagation
+        let u1 = lcg(seed).max(f64::MIN_POSITIVE);
         let u2 = lcg(seed);
         (-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos()
     }
@@ -1261,6 +1266,16 @@ impl ABTestAnalyzer {
         analysis_number: u32,
         planned_analyses: u32,
     ) -> SequentialTest {
+        if planned_analyses == 0 || analysis_number == 0 {
+            return SequentialTest {
+                analysis_number,
+                planned_analyses,
+                alpha_spent: 0.0,
+                current_alpha: test.config.significance_level,
+                can_stop_early: false,
+                stop_reason: None,
+            };
+        }
         let fraction = analysis_number as f64 / planned_analyses as f64;
 
         // O'Brien-Fleming alpha spending function

--- a/src/decay.rs
+++ b/src/decay.rs
@@ -231,7 +231,7 @@ pub fn tier_decay_factor(hours_elapsed: f64, tier: u8, ltp_decay_factor: f32) ->
     // Check if edge exceeded max age (should prune)
     // PIPE-4: Potentiated edges (ltp_decay_factor < 1.0) extend max age proportionally
     let effective_max_age = if ltp_decay_factor < 1.0 {
-        max_age_hours / ltp_decay_factor as f64
+        max_age_hours / (ltp_decay_factor as f64).max(0.01)
     } else {
         max_age_hours
     };

--- a/src/memory/feedback.rs
+++ b/src/memory/feedback.rs
@@ -385,9 +385,9 @@ impl ContextFingerprint {
         // Compress embedding to 16 components by taking evenly spaced samples
         let mut signature = [0.0f32; 16];
         if !embedding.is_empty() {
-            let step = embedding.len() / 16;
+            let len = embedding.len();
             for (i, sig) in signature.iter_mut().enumerate() {
-                let idx = (i * step).min(embedding.len() - 1);
+                let idx = (i * len / 16).min(len - 1);
                 *sig = embedding[idx];
             }
         }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -181,8 +181,9 @@ pub fn unwrap_sho(data: &[u8]) -> Option<(u8, &[u8])> {
         tracing::warn!(
             stored_crc = format_args!("{stored_crc:08x}"),
             computed_crc = format_args!("{computed_crc:08x}"),
-            "SHO envelope checksum mismatch"
+            "SHO envelope checksum mismatch — rejecting corrupted payload"
         );
+        return None;
     }
     Some((version, &data[4..payload_end]))
 }

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -20,7 +20,7 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
         return 0.0;
     }
 
-    dot / (norm_a * norm_b)
+    (dot / (norm_a * norm_b)).clamp(-1.0, 1.0)
 }
 
 /// Find top-k most similar vectors


### PR DESCRIPTION
## Summary
- **P0**: Box-Muller `ln(0)` NaN poisoning in Bayesian analysis — clamped LCG output away from zero
- **P0**: `sequential_analysis` division-by-zero when `planned_analyses=0` — early return guard
- **P1**: `beta_sample` 0/0 NaN — denominator check before division
- **P1**: `chi_squared_p_value` negative interpolation values — `.max(0.0)` clamp
- **P1**: SHO envelope CRC mismatch was warn-only, now rejects corrupted payloads
- **P1**: Cosine similarity float precision could exceed [-1, 1] — added `.clamp(-1.0, 1.0)`
- **P1**: `tier_decay_factor` division by zero when `ltp_decay_factor=0.0` — `.max(0.01)` guard
- **P1**: `ContextFingerprint` `step=0` for embeddings < 16 dims — all 16 signature slots got same value

## Files Changed
- `src/ab_testing.rs` — 4 numeric guards
- `src/serialization.rs` — CRC reject instead of warn
- `src/similarity.rs` — cosine clamp
- `src/decay.rs` — ltp division guard
- `src/memory/feedback.rs` — fingerprint step fix

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo clippy --lib` passes
- [ ] CI green on all platforms
- [ ] Existing tests still pass (no behavioral change for valid inputs)