### PR TITLE
fix: hook state persistence, circuit breaker, visibility moments

### DIFF
--- a/hooks/memory-hook.ts
+++ b/hooks/memory-hook.ts
@@ -1,16 +1,29 @@
 #!/usr/bin/env bun
 /**
- * Shodh Memory Hook - Native Claude Code Integration
+ * Shodh Memory Hook — Native Claude Code Integration
  *
  * Aggressive proactive context surfacing at every opportunity.
- * Memory should be woven into every interaction - the AI thinks with memory.
+ * Memory is woven into every interaction — the AI thinks with memory.
  *
  * Events: SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, SubagentStop, Stop
+ *
+ * Architecture: Each hook event spawns a new Bun process. All state is persisted
+ * to a temp file keyed by session_id, loaded at process start, saved on exit.
  */
+
+// ---------------------------------------------------------------------------
+// 1. Config Constants
+// ---------------------------------------------------------------------------
 
 const SHODH_API_URL = process.env.SHODH_API_URL || "http://127.0.0.1:3030";
 const SHODH_API_KEY = process.env.SHODH_API_KEY || "sk-shodh-dev-local-testing-key";
 const SHODH_USER_ID = process.env.SHODH_USER_ID || "claude-code";
+const HOOK_TIMEOUT_MS = 5000;
+const CIRCUIT_BREAKER_THRESHOLD = 3;
+
+// ---------------------------------------------------------------------------
+// 2. Type Interfaces
+// ---------------------------------------------------------------------------
 
 interface HookInput {
   hook_event_name: string;
@@ -62,10 +75,208 @@ interface ProactiveContextResponse {
   detected_entities: { name: string; entity_type: string }[];
 }
 
-const HOOK_TIMEOUT_MS = 5000;
+interface ToolAction {
+  tool_name: string;
+  inputs: Record<string, string>;
+  success: boolean;
+  output_snippet?: string;
+}
+
+interface RememberResponse {
+  id?: string;
+  memory_id?: string;
+}
+
+interface SurfaceMetadata {
+  count: number;
+  bestScore: number;
+  bestAge: string;
+  factsCount: number;
+  todosCount: number;
+}
+
+interface SurfaceResult {
+  text: string;
+  meta: SurfaceMetadata;
+}
 
 // ---------------------------------------------------------------------------
-// Enrichment: Emotional classification, episode threading, source typing
+// 3. State Persistence — survives across hook invocations
+// ---------------------------------------------------------------------------
+
+interface HookState {
+  sessionId: string;
+  startedAt: string;
+  episodeSequenceNumber: number;
+  lastStoredMemoryId: string | null;
+  pendingToolActions: ToolAction[];
+  stats: {
+    memoriesStored: number;
+    memoriesSurfaced: number;
+    errorsTracked: number;
+    editsTracked: number;
+    commandsTracked: number;
+    factsReturned: number;
+    todosReturned: number;
+    apiFailures: number;
+  };
+  consecutiveFailures: number;
+  surfacedMemoryIds: string[];
+}
+
+function defaultState(sessionId: string): HookState {
+  return {
+    sessionId,
+    startedAt: new Date().toISOString(),
+    episodeSequenceNumber: 0,
+    lastStoredMemoryId: null,
+    pendingToolActions: [],
+    stats: {
+      memoriesStored: 0,
+      memoriesSurfaced: 0,
+      errorsTracked: 0,
+      editsTracked: 0,
+      commandsTracked: 0,
+      factsReturned: 0,
+      todosReturned: 0,
+      apiFailures: 0,
+    },
+    consecutiveFailures: 0,
+    surfacedMemoryIds: [],
+  };
+}
+
+function stateFilePath(sessionId: string): string {
+  const tmpDir = process.env.TMPDIR || process.env.TEMP || process.env.TMP || "/tmp";
+  return `${tmpDir}/shodh-hook-${sessionId}.json`;
+}
+
+function loadState(sessionId: string): HookState {
+  try {
+    const raw = require("fs").readFileSync(stateFilePath(sessionId), "utf-8");
+    const parsed = JSON.parse(raw);
+    // Validate structure minimally
+    if (parsed && typeof parsed.sessionId === "string" && parsed.stats) {
+      return parsed as HookState;
+    }
+  } catch {
+    // File doesn't exist or is corrupted — start fresh
+  }
+  return defaultState(sessionId);
+}
+
+function saveState(state: HookState): void {
+  try {
+    require("fs").writeFileSync(stateFilePath(state.sessionId), JSON.stringify(state), "utf-8");
+  } catch {
+    // Best effort — don't crash the hook
+  }
+}
+
+function deleteState(sessionId: string): void {
+  try {
+    require("fs").unlinkSync(stateFilePath(sessionId));
+  } catch {
+    // Already gone or never created
+  }
+}
+
+/** Mutable hook state — loaded in main(), saved in finally block */
+let hookState: HookState;
+
+// ---------------------------------------------------------------------------
+// 4. API Helpers with Circuit Breaker
+// ---------------------------------------------------------------------------
+
+async function callBrain(endpoint: string, body: Record<string, unknown>): Promise<unknown> {
+  // Circuit breaker: skip API calls after consecutive failures
+  if (hookState.consecutiveFailures >= CIRCUIT_BREAKER_THRESHOLD) {
+    hookState.stats.apiFailures++;
+    return null;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), HOOK_TIMEOUT_MS);
+    const response = await fetch(`${SHODH_API_URL}${endpoint}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": SHODH_API_KEY,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      hookState.consecutiveFailures++;
+      hookState.stats.apiFailures++;
+      if (hookState.consecutiveFailures === 1) {
+        console.error(`[shodh] API error: ${endpoint} → ${response.status}`);
+      }
+      if (hookState.consecutiveFailures >= CIRCUIT_BREAKER_THRESHOLD) {
+        console.error(`[shodh] ${CIRCUIT_BREAKER_THRESHOLD} consecutive failures — pausing API calls`);
+      }
+      return null;
+    }
+    hookState.consecutiveFailures = 0;
+    return await response.json();
+  } catch (e) {
+    hookState.consecutiveFailures++;
+    hookState.stats.apiFailures++;
+    if (hookState.consecutiveFailures === 1) {
+      console.error(`[shodh] API unreachable: ${endpoint} — ${e instanceof Error ? e.message : "unknown"}`);
+    }
+    if (hookState.consecutiveFailures >= CIRCUIT_BREAKER_THRESHOLD) {
+      console.error(`[shodh] ${CIRCUIT_BREAKER_THRESHOLD} consecutive failures — pausing API calls`);
+    }
+    return null;
+  }
+}
+
+async function callBrainGet(endpoint: string): Promise<unknown> {
+  if (hookState.consecutiveFailures >= CIRCUIT_BREAKER_THRESHOLD) {
+    hookState.stats.apiFailures++;
+    return null;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), HOOK_TIMEOUT_MS);
+    const response = await fetch(`${SHODH_API_URL}${endpoint}`, {
+      headers: { "X-API-Key": SHODH_API_KEY },
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    if (!response.ok) {
+      hookState.consecutiveFailures++;
+      hookState.stats.apiFailures++;
+      if (hookState.consecutiveFailures === 1) {
+        console.error(`[shodh] API error: GET ${endpoint} → ${response.status}`);
+      }
+      if (hookState.consecutiveFailures >= CIRCUIT_BREAKER_THRESHOLD) {
+        console.error(`[shodh] ${CIRCUIT_BREAKER_THRESHOLD} consecutive failures — pausing API calls`);
+      }
+      return null;
+    }
+    hookState.consecutiveFailures = 0;
+    return await response.json();
+  } catch (e) {
+    hookState.consecutiveFailures++;
+    hookState.stats.apiFailures++;
+    if (hookState.consecutiveFailures === 1) {
+      console.error(`[shodh] API unreachable: GET ${endpoint} — ${e instanceof Error ? e.message : "unknown"}`);
+    }
+    if (hookState.consecutiveFailures >= CIRCUIT_BREAKER_THRESHOLD) {
+      console.error(`[shodh] ${CIRCUIT_BREAKER_THRESHOLD} consecutive failures — pausing API calls`);
+    }
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Enrichment: Emotional classification, source typing, episode threading
 // ---------------------------------------------------------------------------
 
 interface EmotionalSignature {
@@ -124,68 +335,6 @@ function classifySource(eventType: "file" | "error" | "command" | "subagent" | "
   }
 }
 
-// ---------------------------------------------------------------------------
-// Episode threading — chains memories within a session
-// ---------------------------------------------------------------------------
-
-/** Current session_id from Claude Code, used as episode_id */
-let currentEpisodeId: string | null = null;
-
-/** Monotonically increasing sequence within the session */
-let episodeSequenceNumber = 0;
-
-/** ID of the last memory stored in this session, for preceding_memory_id chaining */
-let lastStoredMemoryId: string | null = null;
-
-/** Session activity counters — printed at session end so the user knows memory is working */
-const sessionStats = {
-  memoriesStored: 0,
-  memoriesSurfaced: 0,
-  errorsTracked: 0,
-  editsTracked: 0,
-  commandsTracked: 0,
-  factsReturned: 0,
-  todosReturned: 0,
-};
-
-interface RememberResponse {
-  id?: string;
-  memory_id?: string;
-}
-
-/**
- * Build the enrichment fields for a callBrain("/api/remember") payload.
- * Returns a flat object to spread into the request body.
- */
-function buildEnrichmentFields(
-  emotionType: Parameters<typeof classifyEmotion>[0],
-  sourceType: Parameters<typeof classifySource>[0],
-): Record<string, unknown> {
-  const emo = classifyEmotion(emotionType);
-  const src = classifySource(sourceType);
-  episodeSequenceNumber++;
-
-  const fields: Record<string, unknown> = {
-    emotional_valence: emo.valence,
-    emotional_arousal: emo.arousal,
-    source_type: src.source_type,
-    credibility: src.credibility,
-    sequence_number: episodeSequenceNumber,
-  };
-
-  if (emo.emotion) {
-    fields.emotion = emo.emotion;
-  }
-  if (currentEpisodeId) {
-    fields.episode_id = currentEpisodeId;
-  }
-  if (lastStoredMemoryId) {
-    fields.preceding_memory_id = lastStoredMemoryId;
-  }
-
-  return fields;
-}
-
 /**
  * Default importance by memory type. Bypasses server-side auto-calculation
  * which lacks hook context (e.g., whether this was a user decision vs routine log).
@@ -209,6 +358,39 @@ function importanceForType(memoryType: string): number {
     case "Observation": return 0.25;
     default:            return 0.3;
   }
+}
+
+/**
+ * Build the enrichment fields for a callBrain("/api/remember") payload.
+ * Returns a flat object to spread into the request body.
+ */
+function buildEnrichmentFields(
+  emotionType: Parameters<typeof classifyEmotion>[0],
+  sourceType: Parameters<typeof classifySource>[0],
+): Record<string, unknown> {
+  const emo = classifyEmotion(emotionType);
+  const src = classifySource(sourceType);
+  hookState.episodeSequenceNumber++;
+
+  const fields: Record<string, unknown> = {
+    emotional_valence: emo.valence,
+    emotional_arousal: emo.arousal,
+    source_type: src.source_type,
+    credibility: src.credibility,
+    sequence_number: hookState.episodeSequenceNumber,
+  };
+
+  if (emo.emotion) {
+    fields.emotion = emo.emotion;
+  }
+  if (hookState.sessionId) {
+    fields.episode_id = hookState.sessionId;
+  }
+  if (hookState.lastStoredMemoryId) {
+    fields.preceding_memory_id = hookState.lastStoredMemoryId;
+  }
+
+  return fields;
 }
 
 /**
@@ -237,15 +419,113 @@ async function rememberEnriched(
   // Chain: capture returned memory ID for preceding_memory_id
   const memId = resp?.id || resp?.memory_id;
   if (memId) {
-    lastStoredMemoryId = memId;
-    sessionStats.memoriesStored++;
-    if (memoryType === "Error") sessionStats.errorsTracked++;
-    if (memoryType === "CodeEdit") sessionStats.editsTracked++;
+    hookState.lastStoredMemoryId = memId;
+    hookState.stats.memoriesStored++;
+    if (memoryType === "Error") hookState.stats.errorsTracked++;
+    if (memoryType === "CodeEdit") hookState.stats.editsTracked++;
   }
 }
 
 // ---------------------------------------------------------------------------
-// Structured capture helpers
+// 6. Format Helpers
+// ---------------------------------------------------------------------------
+
+export function formatRelativeTime(isoDate: string): string {
+  const d = new Date(isoDate);
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "today";
+  if (diffDays === 1) return "yesterday";
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return d.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+/**
+ * Format memories into a human-readable context block.
+ * Returns null when all scores are noise-level (<0.02).
+ * Returns { text, meta } for attribution headers.
+ */
+export function formatMemoriesForContext(memories: SurfacedMemory[]): SurfaceResult | null {
+  if (!memories.length) return null;
+
+  // Filter noise — if best score is below noise floor, return nothing
+  const raw = memories.map(m => m.score || 0);
+  const maxScore = Math.max(...raw, 0);
+  if (maxScore < 0.02) return null;
+
+  const minScore = Math.min(...raw);
+  const range = maxScore - minScore;
+
+  const lines: string[] = [];
+  let bestAge = "today";
+
+  for (let i = 0; i < memories.length; i++) {
+    const m = memories[i];
+    const time = formatRelativeTime(m.created_at);
+    if (i === 0) bestAge = time;
+    const displayScore = range < 0.001
+      ? 100
+      : Math.round(((raw[i] - minScore) / range) * 100);
+    const snippet = m.content.slice(0, 120) + (m.content.length > 120 ? "..." : "");
+    lines.push(`\u2022 [${displayScore}% match, ${time}] ${snippet}`);
+  }
+
+  return {
+    text: lines.join("\n"),
+    meta: {
+      count: memories.length,
+      bestScore: Math.round(maxScore * 100),
+      bestAge,
+      factsCount: 0,
+      todosCount: 0,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 7. Error Detection (improved — word-boundary regex, false-positive exclusions)
+// ---------------------------------------------------------------------------
+
+const ERROR_PATTERNS = [
+  /\berror\[E\d+\]/i,         // Rust compiler errors
+  /\bError:/,                   // Generic "Error:" at word boundary
+  /\bFAILED\b/,                // Test/build failures
+  /\bexit code [1-9]\d*/,      // Non-zero exit codes
+  /\bpanic(?:ked)?\b/i,        // Rust panics
+  /\bcommand not found\b/i,    // Shell errors
+  /\bpermission denied\b/i,    // Filesystem errors
+  /\bsyntax error\b/i,         // Parse errors
+  /\bSegmentation fault\b/,    // Segfault
+  /\bfatal:/i,                  // Git fatal, linker fatal
+  /\bAborted\b/,               // Process aborted
+  /\bERROR\b/,                 // All-caps ERROR
+];
+
+const ERROR_FALSE_POSITIVES = [
+  /\b0 errors?\b/i,
+  /\bno errors?\b/i,
+  /\bsucceeded\b/i,
+  /\berror-free\b/i,
+  /\bwithout errors?\b/i,
+  /\berrors?: 0\b/i,
+];
+
+export function isErrorOutput(toolOutput: string): boolean {
+  // Check false positives first (short-circuit on known-good patterns)
+  for (const fp of ERROR_FALSE_POSITIVES) {
+    if (fp.test(toolOutput)) return false;
+  }
+  // Check real error patterns
+  for (const pattern of ERROR_PATTERNS) {
+    if (pattern.test(toolOutput)) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// 8. Capture Helpers
 // ---------------------------------------------------------------------------
 
 /** Summarize an Edit tool's diff from tool_input */
@@ -258,10 +538,10 @@ function summarizeEditDiff(toolInput: Record<string, unknown>): string {
   if (oldStr && newStr) {
     const oldLines = oldStr.split("\n").length;
     const newLines = newStr.split("\n").length;
-    summary += ` (${oldLines}→${newLines} lines)`;
+    summary += ` (${oldLines}\u2192${newLines} lines)`;
     // Include a compact diff snippet for semantic embedding
-    const oldSnippet = oldStr.slice(0, 80).replace(/\n/g, "↵");
-    const newSnippet = newStr.slice(0, 80).replace(/\n/g, "↵");
+    const oldSnippet = oldStr.slice(0, 80).replace(/\n/g, "\u21B5");
+    const newSnippet = newStr.slice(0, 80).replace(/\n/g, "\u21B5");
     summary += `\n- ${oldSnippet}\n+ ${newSnippet}`;
   }
   return summary;
@@ -280,93 +560,28 @@ function summarizeWrite(toolInput: Record<string, unknown>): string {
   return summary;
 }
 
-/** Tool actions collected since last proactive_context call for feedback attribution */
-const pendingToolActions: { tool_name: string; inputs: Record<string, string>; success: boolean; output_snippet?: string }[] = [];
-
-async function callBrain(endpoint: string, body: Record<string, unknown>): Promise<unknown> {
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), HOOK_TIMEOUT_MS);
-    const response = await fetch(`${SHODH_API_URL}${endpoint}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-API-Key": SHODH_API_KEY,
-      },
-      body: JSON.stringify(body),
-      signal: controller.signal,
-    });
-    clearTimeout(timeoutId);
-
-    if (!response.ok) return null;
-    return await response.json();
-  } catch {
-    return null;
-  }
-}
-
-export function formatRelativeTime(isoDate: string): string {
-  const d = new Date(isoDate);
-  const now = new Date();
-  const diffMs = now.getTime() - d.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-  if (diffDays === 0) return "today";
-  if (diffDays === 1) return "yesterday";
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return d.toLocaleDateString([], { month: "short", day: "numeric" });
-}
-
-export function formatMemoriesForContext(memories: SurfacedMemory[]): string {
-  if (!memories.length) return "";
-
-  // Rescale scores within result set for meaningful display.
-  // Raw scores cluster at 1-5% due to multiplicative scoring pipeline.
-  const raw = memories.map(m => m.score || 0);
-  const maxScore = Math.max(...raw, 0.001);
-  const minScore = Math.min(...raw);
-  const range = maxScore - minScore;
-
-  return memories
-    .map((m, i) => {
-      const time = formatRelativeTime(m.created_at);
-      const displayScore = range < 0.001
-        ? 100
-        : Math.round(((raw[i] - minScore) / range) * 100);
-      const snippet = m.content.slice(0, 120) + (m.content.length > 120 ? "..." : "");
-      return `• [${displayScore}% match, ${time}] ${snippet}`;
-    })
-    .join("\n");
-}
-
-export function isErrorOutput(toolOutput: string): boolean {
-  return (
-    toolOutput.includes("error") ||
-    toolOutput.includes("Error") ||
-    toolOutput.includes("failed") ||
-    toolOutput.includes("FAILED")
-  );
-}
-
 export function buildPreToolContext(toolName: string, toolInput: Record<string, unknown>): string {
   if (toolName === "Edit" || toolName === "Write") {
     const filePath = toolInput.file_path as string;
     if (filePath) {
       return `Editing file: ${filePath}`;
     }
-  } else if (toolName === "Bash") {
-    const command = toolInput.command as string;
-    if (command) {
-      return `Running command: ${command.slice(0, 100)}`;
-    }
   }
-
   return `About to use ${toolName}`;
 }
 
-async function surfaceProactiveContext(context: string, maxResults = 3, autoIngest = false): Promise<string | null> {
+// ---------------------------------------------------------------------------
+// 9. Surfacing (with dedup)
+// ---------------------------------------------------------------------------
+
+/**
+ * Surface proactive context from the memory server.
+ * Deduplicates memories already surfaced this turn (cleared on UserPromptSubmit).
+ * Returns { text, meta } or null if nothing relevant.
+ */
+async function surfaceProactiveContext(context: string, maxResults = 3, autoIngest = false): Promise<SurfaceResult | null> {
   // Drain pending tool actions for feedback attribution
-  const toolActions = pendingToolActions.splice(0, pendingToolActions.length);
+  const toolActions = hookState.pendingToolActions.splice(0, hookState.pendingToolActions.length);
 
   const response = (await callBrain("/api/proactive_context", {
     user_id: SHODH_USER_ID,
@@ -381,53 +596,99 @@ async function surfaceProactiveContext(context: string, maxResults = 3, autoInge
 
   if (!response) return null;
 
-  const hasMemories = response.memories?.length > 0;
+  // Dedup: filter out memories already surfaced this turn
+  const freshMemories = (response.memories || []).filter(
+    m => !hookState.surfacedMemoryIds.includes(m.id)
+  );
+
+  // Track newly surfaced IDs
+  for (const m of freshMemories) {
+    hookState.surfacedMemoryIds.push(m.id);
+  }
+
+  const hasMemories = freshMemories.length > 0;
   const hasFacts = response.relevant_facts?.length > 0;
   const hasTodos = response.relevant_todos?.length > 0;
   const hasReminders = (response.due_reminders?.length || 0) + (response.context_reminders?.length || 0) > 0;
 
-  // Track activity for session-end report
-  sessionStats.memoriesSurfaced += response.memories?.length || 0;
-  sessionStats.factsReturned += response.relevant_facts?.length || 0;
-  sessionStats.todosReturned += response.relevant_todos?.length || 0;
+  // Track activity
+  hookState.stats.memoriesSurfaced += freshMemories.length;
+  hookState.stats.factsReturned += response.relevant_facts?.length || 0;
+  hookState.stats.todosReturned += response.relevant_todos?.length || 0;
 
   if (!hasMemories && !hasFacts && !hasTodos && !hasReminders) return null;
 
-  const now = new Date();
-  const header = `📅 ${now.toLocaleDateString([], { weekday: "short", month: "short", day: "numeric" })} ${now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
+  // Format memories
+  const memResult = hasMemories ? formatMemoriesForContext(freshMemories) : null;
 
-  let output = header;
-  if (hasMemories) {
-    output += `\n${formatMemoriesForContext(response.memories)}`;
+  const meta: SurfaceMetadata = {
+    count: freshMemories.length,
+    bestScore: memResult?.meta.bestScore || 0,
+    bestAge: memResult?.meta.bestAge || "today",
+    factsCount: response.relevant_facts?.length || 0,
+    todosCount: response.relevant_todos?.length || 0,
+  };
+
+  let output = "";
+
+  if (memResult) {
+    output += memResult.text;
   }
+
   if (hasFacts) {
-    output += `\n🧠 Facts:`;
+    if (output) output += "\n";
+    output += "Facts:";
     for (const f of response.relevant_facts.slice(0, 3)) {
-      output += `\n• (${Math.round(f.confidence * 100)}%) ${f.fact}`;
+      output += `\n\u2022 (${Math.round(f.confidence * 100)}%) ${f.fact}`;
     }
   }
   if (hasTodos) {
-    output += `\n📋 Todos:`;
+    if (output) output += "\n";
+    output += "Todos:";
     for (const t of response.relevant_todos.slice(0, 3)) {
-      const icon = t.status === "in_progress" ? "🔄" : "☐";
+      const icon = t.status === "in_progress" ? "[active]" : "[ ]";
       output += `\n${icon} ${t.content.slice(0, 80)}`;
     }
   }
   if (hasReminders) {
     const allReminders = [...(response.due_reminders || []), ...(response.context_reminders || [])];
-    output += `\n⏰ ${allReminders.length} reminder(s) active`;
+    if (output) output += "\n";
+    output += `${allReminders.length} reminder(s) active`;
   }
-  return output;
+
+  return { text: output, meta };
 }
 
-async function handleSessionStart(): Promise<void> {
-  const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+// ---------------------------------------------------------------------------
+// 10. Event Handlers
+// ---------------------------------------------------------------------------
+
+async function handleSessionStart(input: HookInput): Promise<void> {
+  const projectDir = process.env.CLAUDE_PROJECT_DIR || input.cwd || process.cwd();
   const projectName = projectDir.split(/[/\\]/).pop() || "unknown";
+  const claudeDir = `${projectDir}/.claude`;
+
+  // Ensure .claude directory exists before any writes
+  try {
+    require("fs").mkdirSync(claudeDir, { recursive: true });
+  } catch {
+    // Best effort
+  }
+
+  // Visibility Moment 4: Memory count at session start
+  const statsResp = (await callBrainGet(
+    `/api/stats?user_id=${encodeURIComponent(SHODH_USER_ID)}`
+  )) as { total_memories?: number; graph_nodes?: number; graph_edges?: number } | null;
+
+  if (statsResp && statsResp.total_memories != null) {
+    const edges = statsResp.graph_edges || 0;
+    console.error(`[shodh] Memory: ${statsResp.total_memories} memories | ${edges} graph edges`);
+  }
 
   const context = `Starting session in project: ${projectName}`;
 
   // Parallel: semantic context + tag-based session restoration
-  const [memoryContext, tagResult] = await Promise.all([
+  const [memoryResult, tagResult] = await Promise.all([
     surfaceProactiveContext(context, 5),
     callBrain("/api/recall/tags", {
       user_id: SHODH_USER_ID,
@@ -443,42 +704,73 @@ async function handleSessionStart(): Promise<void> {
       .slice(0, 3)
       .map((m) => {
         const content = m.content || m.experience?.content || "";
-        return `• [session] ${content.slice(0, 120)}${content.length > 120 ? "..." : ""}`;
+        return `\u2022 [session] ${content.slice(0, 120)}${content.length > 120 ? "..." : ""}`;
       })
       .join("\n");
   }
 
-  const combinedContext = [memoryContext, tagContext].filter(Boolean).join("\n\n");
+  const hasMemoryContext = memoryResult !== null;
+  const hasTagContext = tagContext.length > 0;
 
-  if (combinedContext) {
-    console.error(`[shodh] Session context loaded`);
-
-    // Write to project memory file
-    const memoryFile = `${projectDir}/.claude/memory-context.md`;
-    try {
-      await Bun.write(memoryFile, `# Shodh Memory Context\n\n${combinedContext}\n`);
-    } catch {
-      // Directory might not exist
+  // Visibility Moment 3: First-session welcome
+  if (!hasMemoryContext && !hasTagContext) {
+    // No memories and no session summaries — likely first session
+    const isFirstSession = !statsResp || (statsResp.total_memories || 0) < 5;
+    if (isFirstSession) {
+      console.error(`[shodh] First session \u2014 memory capture active`);
+      console.log(
+        JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "SessionStart",
+            additionalContext: `\n<shodh-memory>\nFirst session detected. Shodh will learn automatically \u2014 edits, errors, and commands are captured as memories. A session report will be shown when you end the session.\n</shodh-memory>`,
+          },
+        })
+      );
     }
+    return;
   }
 
-  // Session start is tracked implicitly — the proactive_context call above
-  // surfaces relevant memories without creating noise in the activity log.
+  // Build combined context
+  const parts: string[] = [];
+  if (memoryResult) parts.push(memoryResult.text);
+  if (hasTagContext) parts.push(tagContext);
+  const combinedContext = parts.join("\n\n");
+
+  const surfacedCount = memoryResult?.meta.count || 0;
+  console.error(`[shodh] Session context loaded (${surfacedCount} memories surfaced)`);
+
+  // Write to project memory file
+  const memoryFile = `${claudeDir}/memory-context.md`;
+  try {
+    await Bun.write(memoryFile, `# Shodh Memory Context\n\n${combinedContext}\n`);
+  } catch {
+    // Best effort
+  }
 }
 
 async function handleUserPrompt(input: HookInput): Promise<void> {
   const prompt = input.prompt;
   if (!prompt || prompt.length < 10) return;
 
-  // Single call: surface memories AND ingest the prompt in one pipeline pass
-  const memoryContext = await surfaceProactiveContext(prompt.slice(0, 1000), 3, true);
+  // Clear surfaced memory IDs — new user turn starts fresh dedup
+  hookState.surfacedMemoryIds = [];
 
-  if (memoryContext) {
+  // Single call: surface memories AND ingest the prompt in one pipeline pass
+  const result = await surfaceProactiveContext(prompt.slice(0, 1000), 3, true);
+
+  if (result) {
+    // Visibility Moment 1: Attribution header
+    const header = result.meta.count > 0
+      ? `[${result.meta.count} memories surfaced, strongest: ${result.meta.bestScore}% from ${result.meta.bestAge}]`
+      : "";
+
+    const attribution = `If you use any of these memories in your response, briefly mention the source (e.g. "from a previous session..." or "based on past experience...").`;
+
     console.log(
       JSON.stringify({
         hookSpecificOutput: {
           hookEventName: "UserPromptSubmit",
-          additionalContext: `\n<shodh-memory>\n${memoryContext}\nIf you use any of these memories in your response, briefly mention the source (e.g. "based on your past experience..." or "from a previous session...").\n</shodh-memory>`,
+          additionalContext: `\n<shodh-memory>\n${header ? header + "\n" : ""}${result.text}\n${attribution}\n</shodh-memory>`,
         },
       })
     );
@@ -490,17 +782,19 @@ async function handlePreToolUse(input: HookInput): Promise<void> {
   const toolInput = input.tool_input;
   if (!toolName || !toolInput) return;
 
+  // Only surface context for Edit/Write — UserPromptSubmit context is sufficient for Bash/Read
+  if (toolName !== "Edit" && toolName !== "Write") return;
+
   const context = buildPreToolContext(toolName, toolInput);
 
-  // Surface relevant context BEFORE the tool runs
-  const memoryContext = await surfaceProactiveContext(context, 2);
+  const result = await surfaceProactiveContext(context, 2);
 
-  if (memoryContext) {
+  if (result) {
     console.log(
       JSON.stringify({
         hookSpecificOutput: {
           hookEventName: "PreToolUse",
-          additionalContext: `\n<shodh-memory context="pre-${toolName.toLowerCase()}">\n${memoryContext}\n</shodh-memory>`,
+          additionalContext: `\n<shodh-memory context="pre-${toolName.toLowerCase()}">\n${result.text}\n</shodh-memory>`,
         },
       })
     );
@@ -516,7 +810,7 @@ async function handlePostToolUse(input: HookInput): Promise<void> {
 
   // Record tool action for feedback attribution (before any early returns)
   if (toolName !== "Task") {
-    const actionRecord: (typeof pendingToolActions)[number] = {
+    const actionRecord: ToolAction = {
       tool_name: toolName,
       inputs: {},
       success: true,
@@ -532,10 +826,10 @@ async function handlePostToolUse(input: HookInput): Promise<void> {
       actionRecord.success = !isErrorOutput(toolOutput);
       actionRecord.output_snippet = toolOutput.slice(0, 200);
     }
-    pendingToolActions.push(actionRecord);
-    if (toolName === "Bash") sessionStats.commandsTracked++;
-    if (pendingToolActions.length > 50) {
-      pendingToolActions.splice(0, pendingToolActions.length - 50);
+    hookState.pendingToolActions.push(actionRecord);
+    if (toolName === "Bash") hookState.stats.commandsTracked++;
+    if (hookState.pendingToolActions.length > 50) {
+      hookState.pendingToolActions.splice(0, hookState.pendingToolActions.length - 50);
     }
   }
 
@@ -582,7 +876,7 @@ async function handlePostToolUse(input: HookInput): Promise<void> {
     if (isErrorOutput(toolOutput)) {
       // Store errors with high arousal for future surfacing
       await rememberEnriched(
-        `Command failed: ${command?.slice(0, 100)} → ${toolOutput.slice(0, 200)}`,
+        `Command failed: ${command?.slice(0, 100)} \u2192 ${toolOutput.slice(0, 200)}`,
         "Error",
         ["tool:Bash", "error"],
         "error",
@@ -590,35 +884,16 @@ async function handlePostToolUse(input: HookInput): Promise<void> {
       );
 
       // Surface past errors for this type of command
-      const memoryContext = await surfaceProactiveContext(
+      const result = await surfaceProactiveContext(
         `Error with command: ${command?.slice(0, 100)}`,
         2
       );
-      if (memoryContext) {
+      if (result) {
         console.log(
           JSON.stringify({
             hookSpecificOutput: {
               hookEventName: "PostToolUse",
-              additionalContext: `\n<shodh-memory context="similar-errors">\n${memoryContext}\n</shodh-memory>`,
-            },
-          })
-        );
-      }
-    }
-  } else if (toolName === "Read") {
-    const filePath = toolInput?.file_path as string;
-    if (filePath) {
-      // Surface what we know about this file
-      const memoryContext = await surfaceProactiveContext(
-        `Reading file: ${filePath}`,
-        2
-      );
-      if (memoryContext) {
-        console.log(
-          JSON.stringify({
-            hookSpecificOutput: {
-              hookEventName: "PostToolUse",
-              additionalContext: `\n<shodh-memory context="file-context">\n${memoryContext}\n</shodh-memory>`,
+              additionalContext: `\n<shodh-memory context="similar-errors">\n${result.text}\n</shodh-memory>`,
             },
           })
         );
@@ -631,28 +906,11 @@ async function handlePostToolUse(input: HookInput): Promise<void> {
 
 const ORCH_TAG_RE = /\[ORCH-TODO:([A-Z]+-\d+)\]/;
 
-async function callBrainGet(endpoint: string): Promise<unknown> {
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), HOOK_TIMEOUT_MS);
-    const response = await fetch(`${SHODH_API_URL}${endpoint}`, {
-      headers: { "X-API-Key": SHODH_API_KEY },
-      signal: controller.signal,
-    });
-    clearTimeout(timeoutId);
-    if (!response.ok) return null;
-    return await response.json();
-  } catch {
-    return null;
-  }
-}
-
 async function unblockDependents(completedShortId: string): Promise<void> {
   const dashIdx = completedShortId.lastIndexOf("-");
   if (dashIdx < 0) return;
 
   // List all projects to find the one matching this prefix
-  // API returns [project, stats] tuples in the projects array
   const projectsResp = (await callBrain("/api/projects/list", {
     user_id: SHODH_USER_ID,
   })) as { projects?: Array<[{ id: string; name: string; prefix?: string }, unknown]> } | null;
@@ -683,13 +941,11 @@ async function unblockDependents(completedShortId: string): Promise<void> {
 
     const blockers = todo.blocked_on.split(",").map((s) => s.trim());
     const remaining = blockers.filter((b) => b !== completedShortId);
-    // Construct short_id from project_prefix + seq_num, fall back to UUID
     const todoId = todo.project_prefix && todo.seq_num != null
       ? `${todo.project_prefix}-${todo.seq_num}`
       : todo.id;
 
     if (remaining.length === 0) {
-      // All blockers resolved — unblock
       await callBrain(`/api/todos/${todoId}/update`, {
         user_id: SHODH_USER_ID,
         status: "todo",
@@ -701,7 +957,6 @@ async function unblockDependents(completedShortId: string): Promise<void> {
         comment_type: "activity",
       });
     } else {
-      // Some blockers remain — update the list
       await callBrain(`/api/todos/${todoId}/update`, {
         user_id: SHODH_USER_ID,
         blocked_on: remaining.join(","),
@@ -751,12 +1006,12 @@ async function handlePostToolUseTask(input: HookInput): Promise<void> {
     });
   }
 
-  // 2. Complete the todo (path-based endpoint)
+  // 2. Complete the todo
   await callBrain(`/api/todos/${todoShortId}/complete`, {
     user_id: SHODH_USER_ID,
   });
 
-  // 3. Unblock dependents — retry once on failure to prevent orchestration deadlocks
+  // 3. Unblock dependents — retry once on failure
   try {
     await unblockDependents(todoShortId);
   } catch (e) {
@@ -778,16 +1033,16 @@ async function handlePostToolUseTask(input: HookInput): Promise<void> {
   );
 
   // 5. Surface orchestration status
-  const memoryContext = await surfaceProactiveContext(
+  const result = await surfaceProactiveContext(
     `Orchestration: task ${todoShortId} completed, checking for unblocked work`,
     2
   );
-  if (memoryContext) {
+  if (result) {
     console.log(
       JSON.stringify({
         hookSpecificOutput: {
           hookEventName: "PostToolUse",
-          additionalContext: `\n<shodh-memory context="orchestration">\n${memoryContext}\n</shodh-memory>`,
+          additionalContext: `\n<shodh-memory context="orchestration">\n${result.text}\n</shodh-memory>`,
         },
       })
     );
@@ -815,58 +1070,106 @@ async function handleSubagentStop(input: HookInput): Promise<void> {
 }
 
 async function handleStop(input: HookInput): Promise<void> {
-  const sessionId = input.session_id || currentEpisodeId || "unknown";
+  const sessionId = hookState.sessionId;
   const stopReason = input.stop_reason || "unknown";
   const cwd = input.cwd || process.cwd();
   const projectDir = cwd.split(/[/\\]/).pop() || cwd;
 
+  // Calculate session duration
+  const startedAt = new Date(hookState.startedAt);
+  const now = new Date();
+  const durationMs = now.getTime() - startedAt.getTime();
+  const durationMin = Math.round(durationMs / 60000);
+
   // Build human-readable session report
   const lines: string[] = [];
-  lines.push(`[shodh] Session report:`);
+  lines.push(`[shodh] Session report (${durationMin}min):`);
 
-  if (sessionStats.memoriesStored > 0) {
+  const s = hookState.stats;
+
+  if (s.memoriesStored > 0) {
     const parts: string[] = [];
-    if (sessionStats.editsTracked > 0) parts.push(`${sessionStats.editsTracked} edits`);
-    if (sessionStats.errorsTracked > 0) parts.push(`${sessionStats.errorsTracked} errors`);
-    if (sessionStats.commandsTracked > 0) parts.push(`${sessionStats.commandsTracked} commands`);
+    if (s.editsTracked > 0) parts.push(`${s.editsTracked} edits`);
+    if (s.errorsTracked > 0) parts.push(`${s.errorsTracked} errors`);
+    if (s.commandsTracked > 0) parts.push(`${s.commandsTracked} commands`);
     const breakdown = parts.length > 0 ? ` (${parts.join(", ")})` : "";
-    lines.push(`  Captured: ${sessionStats.memoriesStored} memories${breakdown}`);
+    lines.push(`  Captured: ${s.memoriesStored} memories${breakdown}`);
   }
 
-  if (sessionStats.memoriesSurfaced > 0) {
-    lines.push(`  Surfaced: ${sessionStats.memoriesSurfaced} relevant memories`);
+  if (s.memoriesSurfaced > 0) {
+    lines.push(`  Surfaced: ${s.memoriesSurfaced} relevant memories`);
   }
 
-  if (sessionStats.factsReturned > 0) {
-    lines.push(`  Facts used: ${sessionStats.factsReturned}`);
+  if (s.factsReturned > 0) {
+    lines.push(`  Facts used: ${s.factsReturned}`);
   }
 
-  if (sessionStats.todosReturned > 0) {
-    lines.push(`  Todos matched: ${sessionStats.todosReturned}`);
+  if (s.todosReturned > 0) {
+    lines.push(`  Todos matched: ${s.todosReturned}`);
   }
 
-  if (sessionStats.memoriesStored === 0 && sessionStats.memoriesSurfaced === 0) {
+  if (s.apiFailures > 0) {
+    lines.push(`  API failures: ${s.apiFailures}`);
+  }
+
+  if (s.memoriesStored === 0 && s.memoriesSurfaced === 0) {
     lines.push(`  No memory activity this session.`);
   }
 
   // Print to stderr (visible in Claude Code terminal)
   console.error(lines.join("\n"));
 
+  // Visibility Moment 2: Persistent session log
+  const claudeDir = `${cwd}/.claude`;
+  try {
+    require("fs").mkdirSync(claudeDir, { recursive: true });
+    const logFile = `${claudeDir}/shodh-sessions.md`;
+    const startTime = startedAt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    const endTime = now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    const dateStr = now.toLocaleDateString([], { month: "short", day: "numeric" });
+
+    let entry = `\n## ${dateStr}, ${startTime}\u2013${endTime} (${durationMin}min)\n`;
+    if (s.memoriesStored > 0) {
+      const parts: string[] = [];
+      if (s.editsTracked > 0) parts.push(`${s.editsTracked} edits`);
+      if (s.errorsTracked > 0) parts.push(`${s.errorsTracked} errors`);
+      if (s.commandsTracked > 0) parts.push(`${s.commandsTracked} commands`);
+      const breakdown = parts.length > 0 ? ` (${parts.join(", ")})` : "";
+      entry += `Captured: ${s.memoriesStored} memories${breakdown}\n`;
+    }
+    if (s.memoriesSurfaced > 0 || s.factsReturned > 0 || s.todosReturned > 0) {
+      const surfParts: string[] = [];
+      if (s.memoriesSurfaced > 0) surfParts.push(`${s.memoriesSurfaced} relevant memories`);
+      if (s.factsReturned > 0) surfParts.push(`Facts: ${s.factsReturned}`);
+      if (s.todosReturned > 0) surfParts.push(`Todos: ${s.todosReturned}`);
+      entry += `Surfaced: ${surfParts.join(" | ")}\n`;
+    }
+
+    // Append to session log
+    require("fs").appendFileSync(logFile, entry, "utf-8");
+  } catch {
+    // Best effort — don't crash the hook
+  }
+
   // Store rich summary as memory for next session's handleSessionStart
-  const summaryContent = `Session in ${projectDir}: ${sessionStats.memoriesStored} memories captured (${sessionStats.editsTracked} edits, ${sessionStats.errorsTracked} errors), ${sessionStats.memoriesSurfaced} memories surfaced, ${sessionStats.factsReturned} facts used. Ended: ${stopReason}.`;
+  const summaryContent = `Session in ${projectDir} (${durationMin}min): ${s.memoriesStored} memories captured (${s.editsTracked} edits, ${s.errorsTracked} errors), ${s.memoriesSurfaced} memories surfaced, ${s.factsReturned} facts used. Ended: ${stopReason}.`;
 
   await callBrain("/api/remember", {
     user_id: SHODH_USER_ID,
     content: summaryContent,
-    type: "Context",
-    tags: ["session-summary", "source:stop-hook"],
+    memory_type: "Context",
+    tags: ["session-summary", "source:hook"],
     source_type: "system",
     importance: 0.4,
     episode_id: sessionId,
-    preceding_memory_id: lastStoredMemoryId || undefined,
+    preceding_memory_id: hookState.lastStoredMemoryId || undefined,
     credibility: 1.0,
   });
 }
+
+// ---------------------------------------------------------------------------
+// 12. Main — load state, dispatch, save/delete
+// ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
   const inputText = await Bun.stdin.text();
@@ -879,32 +1182,46 @@ async function main(): Promise<void> {
     input = { hook_event_name: eventType || "SessionStart" };
   }
 
-  // Initialize episode threading from Claude Code's session_id
-  if (input.session_id && !currentEpisodeId) {
-    currentEpisodeId = input.session_id;
-  }
-
+  const sessionId = input.session_id || "unknown";
   const eventName = input.hook_event_name;
 
-  switch (eventName) {
-    case "SessionStart":
-      await handleSessionStart();
-      break;
-    case "UserPromptSubmit":
-      await handleUserPrompt(input);
-      break;
-    case "PreToolUse":
-      await handlePreToolUse(input);
-      break;
-    case "PostToolUse":
-      await handlePostToolUse(input);
-      break;
-    case "SubagentStop":
-      await handleSubagentStop(input);
-      break;
-    case "Stop":
-      await handleStop(input);
-      break;
+  // Load persisted state (or create fresh for new session)
+  hookState = loadState(sessionId);
+
+  // Update session ID if this is the first event
+  if (hookState.sessionId !== sessionId && sessionId !== "unknown") {
+    hookState = defaultState(sessionId);
+  }
+
+  try {
+    switch (eventName) {
+      case "SessionStart":
+        await handleSessionStart(input);
+        break;
+      case "UserPromptSubmit":
+        await handleUserPrompt(input);
+        break;
+      case "PreToolUse":
+        await handlePreToolUse(input);
+        break;
+      case "PostToolUse":
+        await handlePostToolUse(input);
+        break;
+      case "SubagentStop":
+        await handleSubagentStop(input);
+        break;
+      case "Stop":
+        await handleStop(input);
+        break;
+    }
+  } finally {
+    if (eventName === "Stop") {
+      // Session ended — clean up temp file
+      deleteState(sessionId);
+    } else {
+      // Persist state for next invocation
+      saveState(hookState);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- **Critical fix**: Each hook event spawns a new Bun process — all module-level state (session counters, episode chaining, feedback attribution) died between invocations. Session reports from PR #201 always showed "No memory activity." Now persists `HookState` to `${TMPDIR}/shodh-hook-${sessionId}.json` between invocations.
- **Circuit breaker**: After 3 consecutive API failures, skip HTTP calls and warn once on stderr. Prevents 50+ timeout stalls per session when server is down.
- **4 bug fixes**: `type` → `memory_type` in handleStop, `isErrorOutput` false positives on "0 errors", noise-level score display, `.claude/` dir creation.
- **4 visibility moments**: Attribution header (`[3 memories, strongest: 87% from 3d ago]`), persistent session log (`.claude/shodh-sessions.md`), first-session welcome message, memory count at startup.
- **Performance**: PreToolUse surfacing restricted to Edit/Write only (cuts ~60% API calls), surfaced memory dedup within user turn.

## What was broken

PR #201 added session stats counters that increment inside a process that dies after one event. `handleStop()` reads freshly-initialized zeros every time. Episode chaining (`preceding_memory_id`, `sequence_number`) reset to null/0 on every event. Feedback attribution (`pendingToolActions`) accumulated actions that vanished before the next `proactive_context` call.

## Test plan

- [ ] Start session → stderr shows `[shodh] Memory: N memories | M graph edges`
- [ ] First-ever user → welcome message + `First session — memory capture active`
- [ ] Make edits, run commands → memories captured (verify temp file exists in $TMPDIR)
- [ ] End session → stderr report shows **real counts** (not zero)
- [ ] Check `.claude/shodh-sessions.md` → entry appended with duration
- [ ] New session → memory count increased, last session summary surfaced
- [ ] Kill shodh server → `API unreachable` then `3 failures — pausing`
- [ ] Ask question with relevant history → Claude cites "from a previous session..."