### PR TITLE
fix: robotics validation hardening (P1/P2/P3)

### DIFF
--- a/src/handlers/remember.rs
+++ b/src/handlers/remember.rs
@@ -114,6 +114,9 @@ pub struct RememberRequest {
     /// Severity level: info, warning, error, critical
     #[serde(default)]
     pub severity: Option<String>,
+    /// When true, require robot_id and geo_location for strict robotics mode
+    #[serde(default)]
+    pub validate_robotics: Option<bool>,
 }
 
 /// Remember response
@@ -468,6 +471,47 @@ pub async fn remember(
     // Validate robotics fields
     if let Some(ref geo) = req.geo_location {
         validation::validate_geo_location(geo).map_validation_err("geo_location")?;
+    }
+    if let Some(reward) = req.reward {
+        validation::validate_reward(reward).map_validation_err("reward")?;
+    }
+    if let Some(heading) = req.heading {
+        validation::validate_heading(heading).map_validation_err("heading")?;
+    }
+    if let Some(ref sensor_data) = req.sensor_data {
+        validation::validate_sensor_data(sensor_data).map_validation_err("sensor_data")?;
+    }
+
+    // Warn on unknown outcome_type/severity (log, don't reject)
+    let mut warnings = Vec::new();
+    if let Some(ref outcome_type) = req.outcome_type {
+        if let Some(warn) = validation::warn_outcome_type(outcome_type) {
+            warnings.push(warn);
+        }
+    }
+    if let Some(ref severity) = req.severity {
+        if let Some(warn) = validation::warn_severity(severity) {
+            warnings.push(warn);
+        }
+    }
+    for warn in &warnings {
+        tracing::warn!("remember validation warning: {}", warn);
+    }
+
+    // Strict robotics mode: require robot_id and geo_location
+    if req.validate_robotics.unwrap_or(false) {
+        if req.robot_id.is_none() {
+            return Err(AppError::InvalidInput {
+                field: "robot_id".into(),
+                reason: "validate_robotics=true requires robot_id".into(),
+            });
+        }
+        if req.geo_location.is_none() {
+            return Err(AppError::InvalidInput {
+                field: "geo_location".into(),
+                reason: "validate_robotics=true requires geo_location".into(),
+            });
+        }
     }
 
     let experience = Experience {

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -2189,15 +2189,15 @@ impl Query {
             }
         }
 
-        // Failures only filter
+        // Failures only filter — check both outcome_type strings AND is_failure boolean
         if self.failures_only {
-            let is_failure = memory
+            let outcome_is_failure = memory
                 .experience
                 .outcome_type
                 .as_ref()
                 .map(|o| o == "failure" || o == "failed" || o == "error")
                 .unwrap_or(false);
-            if !is_failure {
+            if !outcome_is_failure && !memory.experience.is_failure {
                 return false;
             }
         }

--- a/src/python.rs
+++ b/src/python.rs
@@ -77,12 +77,15 @@ pub struct PyGeoLocation {
 impl PyGeoLocation {
     #[new]
     #[pyo3(signature = (latitude=0.0, longitude=0.0, altitude=0.0))]
-    fn new(latitude: f64, longitude: f64, altitude: f64) -> Self {
-        PyGeoLocation {
+    fn new(latitude: f64, longitude: f64, altitude: f64) -> PyResult<Self> {
+        use crate::validation::validate_geo_location;
+        validate_geo_location(&[latitude, longitude, altitude])
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        Ok(PyGeoLocation {
             latitude,
             longitude,
             altitude,
-        }
+        })
     }
 
     fn to_list(&self) -> Vec<f64> {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -336,6 +336,88 @@ pub fn validate_geo_filter(lat: f64, lon: f64, radius_meters: f64) -> Result<()>
     Ok(())
 }
 
+/// Maximum number of keys in sensor_data
+pub const MAX_SENSOR_DATA_KEYS: usize = 1000;
+
+/// Known outcome_type values for robotics experiences
+const KNOWN_OUTCOME_TYPES: &[&str] = &[
+    "success", "failure", "failed", "error", "partial", "aborted", "timeout",
+];
+
+/// Known severity levels for robotics experiences
+const KNOWN_SEVERITIES: &[&str] = &["info", "warning", "error", "critical"];
+
+/// Validate reward signal is finite and within [-1.0, 1.0]
+pub fn validate_reward(reward: f32) -> Result<()> {
+    if !reward.is_finite() {
+        return Err(anyhow!("reward must be a finite number, got: {reward}"));
+    }
+    if !(-1.0..=1.0).contains(&reward) {
+        return Err(anyhow!(
+            "reward must be between -1.0 and 1.0, got: {reward}"
+        ));
+    }
+    Ok(())
+}
+
+/// Validate heading is finite and within [0.0, 360.0]
+pub fn validate_heading(heading: f32) -> Result<()> {
+    if !heading.is_finite() {
+        return Err(anyhow!("heading must be a finite number, got: {heading}"));
+    }
+    if !(0.0..=360.0).contains(&heading) {
+        return Err(anyhow!(
+            "heading must be between 0.0 and 360.0 degrees, got: {heading}"
+        ));
+    }
+    Ok(())
+}
+
+/// Warn on unknown outcome_type values (returns warning message, does not reject)
+pub fn warn_outcome_type(outcome_type: &str) -> Option<String> {
+    if !KNOWN_OUTCOME_TYPES.contains(&outcome_type) {
+        Some(format!(
+            "unknown outcome_type '{}', known values: {:?}",
+            outcome_type, KNOWN_OUTCOME_TYPES
+        ))
+    } else {
+        None
+    }
+}
+
+/// Warn on unknown severity values (returns warning message, does not reject)
+pub fn warn_severity(severity: &str) -> Option<String> {
+    if !KNOWN_SEVERITIES.contains(&severity) {
+        Some(format!(
+            "unknown severity '{}', known values: {:?}",
+            severity, KNOWN_SEVERITIES
+        ))
+    } else {
+        None
+    }
+}
+
+/// Validate sensor_data: max key count, all values must be finite
+pub fn validate_sensor_data(sensor_data: &std::collections::HashMap<String, f64>) -> Result<()> {
+    if sensor_data.len() > MAX_SENSOR_DATA_KEYS {
+        return Err(anyhow!(
+            "sensor_data has too many keys: {} (max: {})",
+            sensor_data.len(),
+            MAX_SENSOR_DATA_KEYS
+        ));
+    }
+    for (key, value) in sensor_data {
+        if !value.is_finite() {
+            return Err(anyhow!(
+                "sensor_data value for key '{}' is not finite: {}",
+                key,
+                value
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Validate a reminder timestamp is not unreasonably far in the past or future
 pub fn validate_reminder_timestamp(at: &chrono::DateTime<chrono::Utc>) -> Result<()> {
     let now = chrono::Utc::now();
@@ -590,6 +672,74 @@ mod tests {
         assert!(validate_geo_filter(0.0, 0.0, 0.0).is_err());
         assert!(validate_geo_filter(0.0, 0.0, -1.0).is_err());
         assert!(validate_geo_filter(0.0, 0.0, 50_000_000.0).is_err()); // > Earth circumference
+    }
+
+    #[test]
+    fn test_validate_reward() {
+        assert!(validate_reward(0.0).is_ok());
+        assert!(validate_reward(-1.0).is_ok());
+        assert!(validate_reward(1.0).is_ok());
+        assert!(validate_reward(0.5).is_ok());
+        assert!(validate_reward(-0.5).is_ok());
+        assert!(validate_reward(-1.1).is_err());
+        assert!(validate_reward(1.1).is_err());
+        assert!(validate_reward(f32::NAN).is_err());
+        assert!(validate_reward(f32::INFINITY).is_err());
+        assert!(validate_reward(f32::NEG_INFINITY).is_err());
+    }
+
+    #[test]
+    fn test_validate_heading() {
+        assert!(validate_heading(0.0).is_ok());
+        assert!(validate_heading(180.0).is_ok());
+        assert!(validate_heading(360.0).is_ok());
+        assert!(validate_heading(-1.0).is_err());
+        assert!(validate_heading(361.0).is_err());
+        assert!(validate_heading(f32::NAN).is_err());
+        assert!(validate_heading(f32::INFINITY).is_err());
+    }
+
+    #[test]
+    fn test_warn_outcome_type() {
+        assert!(warn_outcome_type("success").is_none());
+        assert!(warn_outcome_type("failure").is_none());
+        assert!(warn_outcome_type("timeout").is_none());
+        assert!(warn_outcome_type("unknown_value").is_some());
+        assert!(warn_outcome_type("").is_some());
+    }
+
+    #[test]
+    fn test_warn_severity() {
+        assert!(warn_severity("info").is_none());
+        assert!(warn_severity("critical").is_none());
+        assert!(warn_severity("unknown").is_some());
+    }
+
+    #[test]
+    fn test_validate_sensor_data() {
+        use std::collections::HashMap;
+
+        // Valid
+        let mut data = HashMap::new();
+        data.insert("battery".to_string(), 72.5);
+        data.insert("temperature".to_string(), 23.1);
+        assert!(validate_sensor_data(&data).is_ok());
+
+        // Empty is valid
+        assert!(validate_sensor_data(&HashMap::new()).is_ok());
+
+        // Non-finite value
+        let mut bad = HashMap::new();
+        bad.insert("broken".to_string(), f64::NAN);
+        assert!(validate_sensor_data(&bad).is_err());
+
+        let mut inf = HashMap::new();
+        inf.insert("overflow".to_string(), f64::INFINITY);
+        assert!(validate_sensor_data(&inf).is_err());
+
+        // Too many keys
+        let too_many: HashMap<String, f64> = (0..1001).map(|i| (format!("k{i}"), 0.0)).collect();
+        assert!(validate_sensor_data(&too_many).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Robotics audit findings — validation hardening (PR 1 of 3).

- **P1-1:** `failures_only` filter now checks `is_failure` boolean alongside `outcome_type` string matching
- **P1-2:** `validate_reward()` (finite, [-1.0, 1.0]) and `validate_heading()` (finite, [0.0, 360.0])
- **P2-5:** `PyGeoLocation::new()` validates lat/lon/alt ranges, returns `PyResult<Self>`
- **P3-1:** Warn on unknown `outcome_type` and `severity` values (non-blocking)
- **P3-4:** `validate_sensor_data()` — max 1000 keys, all values finite
- **P3-6:** `validate_robotics` strict mode requires `robot_id` and `geo_location`

## Test plan

- [x] `cargo check --features python` passes
- [x] `cargo clippy` passes
- [ ] CI green on all platforms
- [ ] POST `/api/remember` with reward=NaN, heading=400, sensor_data with 1001 keys → all 400
- [ ] POST with is_failure=true, outcome_type=null → found by failures_only query