### PR TITLE
fix: ORT extraction overwrites library with providers_shared (#223)

### DIFF
--- a/src/embeddings/downloader.rs
+++ b/src/embeddings/downloader.rs
@@ -588,12 +588,15 @@ fn extract_onnx_runtime(archive_path: &Path, dest_dir: &Path) -> Result<()> {
                 .map(|f| f.to_string_lossy().to_string())
                 .unwrap_or_default();
 
+            // Use "libonnxruntime." (with dot) to exclude provider libraries like
+            // libonnxruntime_providers_shared.so which would otherwise match and
+            // overwrite the real library (last-match-wins). Fixes #223.
             let is_target = file_name == lib_name
-                || (file_name.starts_with("libonnxruntime")
+                || (file_name.starts_with("libonnxruntime.")
                     && file_name.contains(lib_name.trim_start_matches("libonnxruntime")));
 
             // Also match versioned variants: libonnxruntime.1.23.2.dylib / libonnxruntime.so.1.23.2
-            let is_versioned = file_name.starts_with("libonnxruntime")
+            let is_versioned = file_name.starts_with("libonnxruntime.")
                 && (file_name.ends_with(".dylib")
                     || file_name.ends_with(".so")
                     || file_name.contains(".so."));


### PR DESCRIPTION
## Summary

Fixes #223 — `shodh-memory-server` v0.2.0 panics with `OrtGetApiBase missing from ONNX Runtime` on Linux.

**Root cause:** The archive extraction pattern `starts_with("libonnxruntime")` matches both:
- `libonnxruntime.so.1.23.2` (the real library)
- `libonnxruntime_providers_shared.so` (unrelated provider library)

Since `extracted_real_path` uses last-match-wins assignment, the providers library overwrites the correct one. When `ort` tries to load it, `OrtGetApiBase` is missing → panic.

**Fix:** `starts_with("libonnxruntime.")` — the dot excludes underscore-prefixed provider libraries while matching all versioned variants (`.so.1.23.2`, `.1.23.2.dylib`).

## Test plan

- [x] `cargo check` passes
- [ ] CI green on all platforms
- [ ] Linux: fresh install downloads ORT, extracts correct library, `/api/remember` works
- [ ] Verify `libonnxruntime_providers_shared.so` is NOT extracted as the canonical library