### PR TITLE
fix: persist vector index after repair/rebuild

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -4953,6 +4953,13 @@ impl MemorySystem {
             stats.vector_index_count = indexed_after;
         }
 
+        // Persist repaired index to disk so orphans don't reappear on restart
+        if repaired > 0 {
+            if let Err(e) = self.retriever.save() {
+                tracing::error!(error = %e, "Failed to persist vector index after repair");
+            }
+        }
+
         tracing::info!(
             total_storage = total_storage,
             indexed_before = indexed_before,
@@ -5025,6 +5032,11 @@ impl MemorySystem {
         {
             let mut stats = self.stats.write();
             stats.vector_index_count = indexed;
+        }
+
+        // Persist rebuilt index to disk so it survives restart
+        if let Err(e) = self.retriever.save() {
+            tracing::error!(error = %e, "Failed to persist vector index after rebuild");
         }
 
         tracing::info!(


### PR DESCRIPTION
## Summary

`repair_vector_index()` and `rebuild_index()` updated the in-memory Vamana index but never persisted it to disk. On restart, the stale `.vamana` file was loaded and orphaned memories reappeared — every single time.

**Fix:** Call `self.retriever.save()` after successful repair/rebuild operations.

## Test plan

- [x] `cargo check` passes
- [ ] CI green
- [ ] Run `repair_index` → restart server → `verify_index` shows 0 orphans