### PR TITLE
chore: remove dead code in decay.rs

### DIFF
--- a/src/decay.rs
+++ b/src/decay.rs
@@ -107,61 +107,6 @@ pub fn hybrid_decay_factor(days_elapsed: f64, potentiated: bool) -> f32 {
     }
 }
 
-/// Calculates the hybrid decay factor with custom parameters.
-///
-/// Use this for contexts that need different decay characteristics.
-///
-/// # Arguments
-///
-/// * `days_elapsed` - Time since last activation in days
-/// * `crossover_days` - Days before switching from exponential to power-law
-/// * `lambda` - Exponential decay rate for consolidation phase
-/// * `beta` - Power-law exponent for long-term phase
-///
-/// # Example
-///
-/// ```ignore
-/// // Faster decay for edge weights
-/// let factor = hybrid_decay_factor_custom(days_elapsed, 1.0, 1.0, 0.6);
-/// ```
-#[inline]
-pub fn hybrid_decay_factor_custom(
-    days_elapsed: f64,
-    crossover_days: f64,
-    lambda: f64,
-    beta: f64,
-) -> f32 {
-    if days_elapsed <= 0.0 {
-        return 1.0;
-    }
-
-    if days_elapsed < crossover_days {
-        // Consolidation phase: exponential decay
-        (-lambda * days_elapsed).exp() as f32
-    } else {
-        // Long-term phase: power-law decay
-        let value_at_crossover = (-lambda * crossover_days).exp();
-        let power_law_factor = (days_elapsed / crossover_days).powf(-beta);
-        (value_at_crossover * power_law_factor) as f32
-    }
-}
-
-/// Calculates retention percentage for debugging/visualization.
-///
-/// Returns a human-readable percentage string showing retention at various time points.
-#[allow(dead_code)]
-pub fn retention_curve_debug(potentiated: bool) -> String {
-    let days = [0.5, 1.0, 3.0, 7.0, 14.0, 30.0, 90.0, 365.0];
-    let mode = if potentiated { "potentiated" } else { "normal" };
-
-    let mut output = format!("Retention curve ({mode}):\n");
-    for d in days {
-        let factor = hybrid_decay_factor(d, potentiated);
-        output.push_str(&format!("  Day {:>5.1}: {:>6.2}%\n", d, factor * 100.0));
-    }
-    output
-}
-
 /// Tier-aware decay factor for edge consolidation (3-tier memory model)
 ///
 /// Each tier has different decay characteristics based on hippocampal-cortical research:
@@ -305,15 +250,6 @@ mod tests {
         assert!(year_retention > 0.01);
         // Potentiated: should be > 5%
         assert!(year_retention_potentiated > 0.05);
-    }
-
-    #[test]
-    fn test_custom_parameters() {
-        // Test custom function with aggressive decay
-        let aggressive = hybrid_decay_factor_custom(7.0, 1.0, 1.5, 0.7);
-        let normal = hybrid_decay_factor(7.0, false);
-
-        assert!(aggressive < normal);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Remove `hybrid_decay_factor_custom()` — only called from its own test, never used in production code
- Remove `retention_curve_debug()` — never called anywhere
- Remove orphaned `test_custom_parameters` test

64 lines deleted, 0 added. Pure cleanup.

## Test plan

- [x] `cargo check` — clean
- [x] All 24 remaining decay tests pass