### PR TITLE
fix(downloader): select macOS ONNX Runtime by target_arch

### DIFF
--- a/src/embeddings/downloader.rs
+++ b/src/embeddings/downloader.rs
@@ -76,8 +76,10 @@ impl ModelChecksums {
 const ONNX_RUNTIME_URL: &str = "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-win-x64-1.23.2.zip";
 #[cfg(target_os = "linux")]
 const ONNX_RUNTIME_URL: &str = "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-linux-x64-1.23.2.tgz";
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 const ONNX_RUNTIME_URL: &str = "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-osx-arm64-1.23.2.tgz";
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+const ONNX_RUNTIME_URL: &str = "https://github.com/microsoft/onnxruntime/releases/download/v1.23.2/onnxruntime-osx-x86_64-1.23.2.tgz";
 
 /// Get the cache directory for shodh-memory
 pub fn get_cache_dir() -> PathBuf {


### PR DESCRIPTION
## Summary
The macOS ONNX Runtime download URL in `src/embeddings/downloader.rs` was hardcoded to the **arm64** archive, so x86_64 macOS builds (e.g., the Homebrew formula running on an Intel Mac) downloaded an Apple Silicon dylib that `dlopen` then rejected with an incompatible-architecture error at startup:

```
Failed to load ONNX Runtime dylib: dlopen failed (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64'))
```

## Fix
Branch the `#[cfg]` by `target_arch` so:
- `aarch64` macOS → `onnxruntime-osx-arm64-1.23.2.tgz`
- `x86_64` macOS → `onnxruntime-osx-x86_64-1.23.2.tgz`

Per-arch archives (10–11 MB each) avoid the ~4× size overhead of the `universal2` build (~41 MB) that would otherwise be needed for a single URL.

## Test plan
- [x] `cargo check --lib` clean
- [x] Both URLs return HTTP 200 from GitHub's release assets CDN
- [x] Reproduced the original dlopen error on an Intel Mac with an unpatched build; after manually swapping in the x86_64 dylib, startup succeeds — this PR automates that swap for fresh installs