### PR TITLE
fix: vector index durability + error propagation

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -261,10 +261,7 @@ impl ShodhBackupEngine {
                     Ok(bytes) => {
                         total_secondary_bytes += bytes;
                         backed_up_stores.push("vector_index".to_string());
-                        tracing::debug!(
-                            size_kb = bytes / 1024,
-                            "Vector index copied to backup"
-                        );
+                        tracing::debug!(size_kb = bytes / 1024, "Vector index copied to backup");
                     }
                     Err(e) => {
                         // Non-fatal: index can be rebuilt from RocksDB on restore

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -161,16 +161,17 @@ impl ShodhBackupEngine {
         user_id: &str,
         secondary_stores: &[SecondaryStoreRef<'_>],
     ) -> Result<BackupMetadata> {
-        self.create_comprehensive_backup_with_graph(db, user_id, secondary_stores, None)
+        self.create_comprehensive_backup_with_graph(db, user_id, secondary_stores, None, None)
     }
 
-    /// Create a comprehensive backup including the knowledge graph DB.
+    /// Create a comprehensive backup including the knowledge graph DB and optional vector index.
     pub fn create_comprehensive_backup_with_graph(
         &self,
         db: &DB,
         user_id: &str,
         secondary_stores: &[SecondaryStoreRef<'_>],
         graph_db: Option<&DB>,
+        vector_index_file: Option<&Path>,
     ) -> Result<BackupMetadata> {
         // Step 1: Create main memories backup (existing logic)
         let mut metadata = self.create_backup(db, user_id)?;
@@ -244,6 +245,36 @@ impl ShodhBackupEngine {
         // Track graph in metadata if it was checkpointed
         if graph_db.is_some() {
             backed_up_stores.push("graph".to_string());
+        }
+
+        // Step 2b: Copy vector index file if present (flat binary outside RocksDB)
+        if let Some(vamana_path) = vector_index_file {
+            if vamana_path.exists() {
+                let vi_dir = secondary_dir.join("vector_index");
+                fs::create_dir_all(&vi_dir)?;
+                let dest = vi_dir.join(
+                    vamana_path
+                        .file_name()
+                        .unwrap_or(std::ffi::OsStr::new("vamana.idx")),
+                );
+                match fs::copy(vamana_path, &dest) {
+                    Ok(bytes) => {
+                        total_secondary_bytes += bytes;
+                        backed_up_stores.push("vector_index".to_string());
+                        tracing::debug!(
+                            size_kb = bytes / 1024,
+                            "Vector index copied to backup"
+                        );
+                    }
+                    Err(e) => {
+                        // Non-fatal: index can be rebuilt from RocksDB on restore
+                        tracing::warn!(
+                            error = %e,
+                            "Failed to copy vector index to backup (will rebuild on restore)"
+                        );
+                    }
+                }
+            }
         }
 
         // Step 3: Update metadata with secondary store info
@@ -347,12 +378,16 @@ impl ShodhBackupEngine {
     ///
     /// The `secondary_restore_paths` map store names to their target restore directories.
     /// Secondary stores are restored by copying the checkpoint directory to the target path.
+    /// `vector_index_restore_dir` is the directory to restore the vector index file into
+    /// (e.g., `<storage_path>/<user_id>/vector_index/`). If None, vector index is not restored
+    /// and will be rebuilt from RocksDB on next startup.
     pub fn restore_comprehensive_backup(
         &self,
         user_id: &str,
         backup_id: Option<u32>,
         restore_path: &Path,
         secondary_restore_paths: &[(&str, &Path)],
+        vector_index_restore_dir: Option<&Path>,
     ) -> Result<Vec<String>> {
         // Step 1: Restore main memories DB
         self.restore_backup(user_id, backup_id, restore_path)?;
@@ -451,6 +486,38 @@ impl ShodhBackupEngine {
                     target = ?target_path,
                     "Secondary store restored from checkpoint"
                 );
+            }
+        }
+
+        // Step 4: Restore vector index file if present in backup
+        if let Some(vi_restore_dir) = vector_index_restore_dir {
+            let vi_backup_dir = secondary_dir.join("vector_index");
+            if vi_backup_dir.exists() {
+                fs::create_dir_all(vi_restore_dir)?;
+                // Copy all files from vector_index backup dir to restore target
+                if let Ok(entries) = fs::read_dir(&vi_backup_dir) {
+                    for entry in entries.flatten() {
+                        let src = entry.path();
+                        if src.is_file() {
+                            let dest = vi_restore_dir.join(entry.file_name());
+                            match fs::copy(&src, &dest) {
+                                Ok(_) => {
+                                    restored_stores.push("vector_index".to_string());
+                                    tracing::info!(
+                                        file = ?entry.file_name(),
+                                        "Vector index restored from backup (instant startup)"
+                                    );
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        error = %e,
+                                        "Failed to restore vector index (will rebuild from RocksDB)"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/src/handlers/consolidation.rs
+++ b/src/handlers/consolidation.rs
@@ -44,6 +44,15 @@ pub async fn consolidate_memories(
         .get_user_memory(&req.user_id)
         .map_err(AppError::Internal)?;
 
+    // Prevent concurrent consolidation for the same user.
+    // Double consolidation causes double decay, duplicate facts, and lost edge boosts.
+    if !state.try_acquire_consolidation_lock(&req.user_id) {
+        return Err(AppError::InvalidInput {
+            field: "user_id".to_string(),
+            reason: "Consolidation already in progress for this user".to_string(),
+        });
+    }
+
     let user_id = req.user_id.clone();
     let min_support = req.min_support;
     let min_age_days = req.min_age_days;
@@ -51,7 +60,24 @@ pub async fn consolidate_memories(
 
     // Spawn the entire pipeline as a detached background task.
     // This survives HTTP timeout cancellation — the work always completes.
+    // The consolidation lock is released when the task completes (all exit paths).
+    let lock_user_id = user_id.clone();
     tokio::task::spawn(async move {
+        // RAII guard: releases consolidation lock on drop (normal exit, early return, or panic).
+        struct ConsolidationGuard {
+            state: std::sync::Arc<MultiUserMemoryManager>,
+            user_id: String,
+        }
+        impl Drop for ConsolidationGuard {
+            fn drop(&mut self) {
+                self.state.release_consolidation_lock(&self.user_id);
+            }
+        }
+        let _lock_guard = ConsolidationGuard {
+            state: state_clone.clone(),
+            user_id: lock_user_id,
+        };
+
         let op_start = std::time::Instant::now();
 
         let memory = match state_clone.get_user_memory(&user_id) {
@@ -375,12 +401,28 @@ pub async fn create_backup(
     let graph_guard = graph_lock.as_ref().map(|g| g.read());
     let graph_db_ref = graph_guard.as_ref().map(|g| g.get_db());
 
+    // Vector index file for backup (flat binary outside RocksDB)
+    let vamana_path = state
+        .base_path
+        .join(&req.user_id)
+        .join("vector_index")
+        .join("vamana.idx");
+    let vamana_ref = if vamana_path.exists() {
+        Some(vamana_path.as_path())
+    } else {
+        None
+    };
+
     let result = if store_refs.is_empty() && graph_db_ref.is_none() {
         state.backup_engine().create_backup(&db, &req.user_id)
     } else {
-        state
-            .backup_engine()
-            .create_comprehensive_backup_with_graph(&db, &req.user_id, &store_refs, graph_db_ref)
+        state.backup_engine().create_comprehensive_backup_with_graph(
+            &db,
+            &req.user_id,
+            &store_refs,
+            graph_db_ref,
+            vamana_ref,
+        )
     };
 
     match result {
@@ -514,6 +556,9 @@ pub async fn restore_backup(
     // todos, reminders, audit logs, etc. Only per-user stores are restored.
     let secondary_restore_paths: Vec<(&str, &std::path::Path)> = vec![];
 
+    // Vector index restore directory
+    let vi_restore_dir = state.base_path().join(&user_id).join("vector_index");
+
     // Execute restore
     let restored_stores = state
         .backup_engine()
@@ -522,6 +567,7 @@ pub async fn restore_backup(
             req.backup_id,
             &memory_db_path,
             &secondary_restore_paths,
+            Some(&vi_restore_dir),
         )
         .map_err(AppError::Internal)?;
 

--- a/src/handlers/consolidation.rs
+++ b/src/handlers/consolidation.rs
@@ -416,13 +416,15 @@ pub async fn create_backup(
     let result = if store_refs.is_empty() && graph_db_ref.is_none() {
         state.backup_engine().create_backup(&db, &req.user_id)
     } else {
-        state.backup_engine().create_comprehensive_backup_with_graph(
-            &db,
-            &req.user_id,
-            &store_refs,
-            graph_db_ref,
-            vamana_ref,
-        )
+        state
+            .backup_engine()
+            .create_comprehensive_backup_with_graph(
+                &db,
+                &req.user_id,
+                &store_refs,
+                graph_db_ref,
+                vamana_ref,
+            )
     };
 
     match result {

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -491,12 +491,15 @@ pub async fn recall(
                 ..Default::default()
             };
 
-            let memories = memory_guard.recall(&query).unwrap_or_default();
+            let memories = memory_guard
+                .recall(&query)
+                .map_err(|e| anyhow::anyhow!("Recall failed: {e}"))?;
 
-            (memories, reminders, prospective_signals)
+            Ok::<_, anyhow::Error>((memories, reminders, prospective_signals))
         })
         .await
-        .map_err(|e| AppError::Internal(anyhow::anyhow!("Blocking task panicked: {e}")))?;
+        .map_err(|e| AppError::Internal(anyhow::anyhow!("Blocking task panicked: {e}")))?
+        .map_err(AppError::Internal)?;
 
     let triggered_reminder_count = triggered_reminders.len();
     if triggered_reminder_count > 0 {
@@ -1894,7 +1897,9 @@ pub async fn proactive_context(
                 },
                 ..Default::default()
             };
-            let results = memory_guard.recall(&query).unwrap_or_default();
+            let results = memory_guard
+                .recall(&query)
+                .map_err(|e| anyhow::anyhow!("Recall failed: {e}"))?;
 
             let candidates: Vec<(SharedMemory, f32)> = results
                 .into_iter()
@@ -2197,7 +2202,7 @@ pub async fn proactive_context(
             }
 
             // Return top results with entity overlap annotation
-            enriched
+            let result = enriched
                 .into_iter()
                 .take(max_results)
                 .map(|(m, score, matched)| {
@@ -2226,10 +2231,12 @@ pub async fn proactive_context(
                         embedding: m.experience.embeddings.clone().unwrap_or_default(),
                     }
                 })
-                .collect()
+                .collect();
+            Ok::<_, anyhow::Error>(result)
         })
         .await
         .map_err(|e| AppError::Internal(anyhow::anyhow!("Blocking task panicked: {e}")))?
+        .map_err(AppError::Internal)?
     };
 
     let t_recall = op_start.elapsed();
@@ -2945,10 +2952,13 @@ pub async fn recall_tracked(
                 retrieval_mode,
                 ..Default::default()
             };
-            memory_guard.recall(&query).unwrap_or_default()
+            memory_guard
+                .recall(&query)
+                .map_err(|e| anyhow::anyhow!("Recall failed: {e}"))
         })
         .await
         .map_err(|e| AppError::Internal(anyhow::anyhow!("Blocking task panicked: {e}")))?
+        .map_err(AppError::Internal)?
     };
 
     // Extract memory IDs for tracking

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -690,6 +690,11 @@ pub struct MultiUserMemoryManager {
     /// remember/upsert handlers. On shutdown, we close + await all tracked tasks
     /// to prevent data loss from fire-and-forget graph writes.
     pub task_tracker: tokio_util::task::TaskTracker,
+
+    /// Per-user consolidation guards to prevent concurrent consolidation.
+    /// Without this, overlapping consolidation (manual + maintenance timer, or double API call)
+    /// causes double decay, duplicate fact extraction, and lost edge boosts.
+    consolidation_locks: DashMap<String, std::sync::atomic::AtomicBool>,
 }
 
 impl MultiUserMemoryManager {
@@ -1015,6 +1020,7 @@ impl MultiUserMemoryManager {
             shared_rocksdb_cache,
             habituation_tracker,
             task_tracker: tokio_util::task::TaskTracker::new(),
+            consolidation_locks: DashMap::new(),
         };
 
         info!("Running initial audit log rotation...");
@@ -1849,6 +1855,31 @@ impl MultiUserMemoryManager {
         Ok(graph_arc)
     }
 
+    /// Try to acquire the consolidation lock for a user.
+    /// Returns true if acquired (caller must release), false if already running.
+    pub fn try_acquire_consolidation_lock(&self, user_id: &str) -> bool {
+        let entry = self
+            .consolidation_locks
+            .entry(user_id.to_string())
+            .or_insert_with(|| std::sync::atomic::AtomicBool::new(false));
+        // compare_exchange: if currently false, set to true (acquired)
+        entry
+            .compare_exchange(
+                false,
+                true,
+                std::sync::atomic::Ordering::Acquire,
+                std::sync::atomic::Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+
+    /// Release the consolidation lock for a user.
+    pub fn release_consolidation_lock(&self, user_id: &str) {
+        if let Some(entry) = self.consolidation_locks.get(user_id) {
+            entry.store(false, std::sync::atomic::Ordering::Release);
+        }
+    }
+
     /// Get graph statistics for a user
     pub fn get_user_graph_stats(&self, user_id: &str) -> Result<GraphStats> {
         let graph = self.get_user_graph(user_id)?;
@@ -1893,6 +1924,15 @@ impl MultiUserMemoryManager {
         let mut total_facts_reinforced = 0;
 
         for user_id in user_ids {
+            // Skip users with active consolidation (manual API call in progress)
+            if !self.try_acquire_consolidation_lock(&user_id) {
+                tracing::debug!(
+                    user_id = %user_id,
+                    "Skipping maintenance — consolidation already in progress"
+                );
+                continue;
+            }
+
             let maintenance_result = if let Ok(memory_lock) = self.get_user_memory(&user_id) {
                 let memory = memory_lock.read();
                 match memory.run_maintenance(decay_factor, &user_id, is_heavy) {
@@ -2072,6 +2112,9 @@ impl MultiUserMemoryManager {
                     }
                 }
             }
+
+            // Release consolidation lock for this user
+            self.release_consolidation_lock(&user_id);
         }
 
         // Heavy cycle: compute Forman-Ricci curvature on graph edges
@@ -2197,6 +2240,12 @@ impl MultiUserMemoryManager {
                     self.audit_logs.len()
                 );
             }
+        }
+
+        // Periodic vector index save — crash between maintenance cycles loses at most 1 cycle
+        // worth of vectors. The atomic save in retrieval.rs (.tmp + rename) ensures no corruption.
+        if let Err(e) = self.save_all_vector_indices() {
+            tracing::warn!("Periodic vector index save failed: {}", e);
         }
 
         tracing::info!(
@@ -2409,11 +2458,22 @@ impl MultiUserMemoryManager {
                     let graph_lock = self.get_user_graph(name).ok();
                     let graph_guard = graph_lock.as_ref().map(|g| g.read());
                     let graph_db_ref = graph_guard.as_ref().map(|g| g.get_db());
+                    let vamana_path = self
+                        .base_path
+                        .join(name)
+                        .join("vector_index")
+                        .join("vamana.idx");
+                    let vamana_ref = if vamana_path.exists() {
+                        Some(vamana_path.as_path())
+                    } else {
+                        None
+                    };
                     match self.backup_engine.create_comprehensive_backup_with_graph(
                         &db,
                         name,
                         &store_refs,
                         graph_db_ref,
+                        vamana_ref,
                     ) {
                         Ok(metadata) => {
                             tracing::info!(

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1295,7 +1295,13 @@ impl StreamingMemoryExtractor {
                     max_results,
                     ..Default::default()
                 };
-                let results = memory_guard.recall(&query).unwrap_or_default();
+                let results = match memory_guard.recall(&query) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        tracing::error!("Stream recall failed: {e}");
+                        return Vec::new();
+                    }
+                };
 
                 // Use scores from unified 5-layer pipeline (PIPE-9: feedback now in pipeline)
                 // Recall already applies: RRF fusion + hebbian + recency + feedback

--- a/src/zenoh_transport/handlers.rs
+++ b/src/zenoh_transport/handlers.rs
@@ -692,11 +692,18 @@ pub async fn handle_recall(query: Query, manager: Arc<MultiUserMemoryManager>) {
             terrain_type,
             ..Default::default()
         };
-        guard.recall(&mq).unwrap_or_default()
+        guard
+            .recall(&mq)
+            .map_err(|e| anyhow::anyhow!("Recall failed: {e}"))
     })
     .await
     {
-        Ok(memories) => memories,
+        Ok(Ok(memories)) => memories,
+        Ok(Err(e)) => {
+            error!("Recall failed: {:?}", e);
+            reply_error(&query, &format!("Recall error: {e}")).await;
+            return;
+        }
         Err(e) => {
             error!("Recall task panicked: {:?}", e);
             reply_error(&query, "Internal error during recall").await;


### PR DESCRIPTION
## Summary
- **Periodic vector index save** — saves every maintenance cycle (hourly) instead of only on shutdown. Crash now loses at most 1 hour of vectors, not all since startup.
- **Backup includes vamana.idx** — backup/restore copies the vector index file for instant startup on restore (previously required slow rebuild from RocksDB).
- **Consolidation concurrency lock** — per-user AtomicBool + RAII guard prevents overlapping consolidation from causing double decay, duplicate facts, and lost edge boosts.
- **Recall error propagation** — replaced 5 instances of `recall().unwrap_or_default()` with proper error handling across handlers, streaming, and zenoh transport.

## Test plan
- [x] `cargo check` — clean compile
- [ ] `cargo test` — all existing tests pass
- [ ] Manual: verify vamana.idx mtime updates after maintenance cycle
- [ ] Manual: verify backup contains `vector_index/vamana.idx`
- [ ] Manual: trigger concurrent consolidation API calls — second should return 400