### PR TITLE
feat: session history, fact narratives, session digest

### DIFF
--- a/hooks/memory-hook.ts
+++ b/hooks/memory-hook.ts
@@ -1452,19 +1452,85 @@ async function handleStop(input: HookInput): Promise<void> {
     await extractConversationMemories(input.transcript_path);
   }
 
-  // Store rich summary as memory for next session's handleSessionStart
-  const summaryContent = `Session in ${projectDir} (${durationMin}min): ${s.memoriesStored} memories captured (${s.editsTracked} edits, ${s.errorsTracked} errors), ${s.memoriesSurfaced} memories surfaced, ${s.factsReturned} facts used. Ended: ${stopReason}.`;
+  // Fetch structured digest for rich session summary
+  const digestResp = (await callBrain("/api/sessions/digest", {
+    user_id: SHODH_USER_ID,
+  })) as {
+    digest?: {
+      session_id: string;
+      started_at: string;
+      duration_secs: number;
+      memories_created: number;
+      memories_surfaced: number;
+      memories_used: number;
+      memory_hit_rate: number;
+      todos_created: number;
+      todos_completed: number;
+      entities_extracted: string[];
+      entity_count: number;
+      tools_used: Record<string, number>;
+      topic_changes: number;
+      compressions: number;
+    };
+  } | null;
+
+  let summaryContent: string;
+  let summaryEntities: string[] = [];
+  let summaryMetadata: Record<string, string> = {};
+
+  if (digestResp?.digest) {
+    const d = digestResp.digest;
+    const dm = Math.round(d.duration_secs / 60);
+    const topTools = Object.entries(d.tools_used || {})
+      .sort(([, a], [, b]) => (b as number) - (a as number))
+      .slice(0, 5)
+      .map(([t, c]) => `${t}(${c})`)
+      .join(", ");
+
+    summaryContent = [
+      `Session in ${projectDir} (${dm}min):`,
+      `  Memories: ${d.memories_created} created, ${d.memories_surfaced} surfaced (${Math.round(d.memory_hit_rate * 100)}% hit rate)`,
+      `  Todos: ${d.todos_created} created, ${d.todos_completed} completed`,
+      d.entities_extracted.length > 0
+        ? `  Entities: ${d.entities_extracted.slice(0, 15).join(", ")}`
+        : null,
+      topTools ? `  Tools: ${topTools}` : null,
+      `  Topics changed: ${d.topic_changes} | Compressions: ${d.compressions}`,
+      `  Ended: ${stopReason}`,
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    summaryEntities = d.entities_extracted.slice(0, 20);
+    summaryMetadata = {
+      session_digest: "true",
+      session_id: String(d.session_id),
+      started_at: d.started_at,
+      duration_secs: String(d.duration_secs),
+      memories_created: String(d.memories_created),
+      entity_count: String(d.entity_count),
+    };
+  } else {
+    // Fallback: digest unavailable (server down, no active session)
+    summaryContent = `Session in ${projectDir} (${durationMin}min): ${s.memoriesStored} memories captured (${s.editsTracked} edits, ${s.errorsTracked} errors), ${s.memoriesSurfaced} memories surfaced, ${s.factsReturned} facts used. Ended: ${stopReason}.`;
+  }
+
+  // Merge entities into tags — RememberRequest only has `tags`, not `entities`.
+  // Deduplicate to avoid indexing the same entity twice.
+  const allTags = ["session-summary", "source:hook", ...summaryEntities];
+  const uniqueTags = [...new Set(allTags)];
 
   await callBrain("/api/remember", {
     user_id: SHODH_USER_ID,
     content: summaryContent,
     memory_type: "Context",
-    tags: ["session-summary", "source:hook"],
+    tags: uniqueTags,
     source_type: "system",
     importance: 0.4,
     episode_id: sessionId,
     preceding_memory_id: hookState.lastStoredMemoryId || undefined,
     credibility: 1.0,
+    metadata: summaryMetadata,
   });
 }
 

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -998,7 +998,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "token_status",
-        description: "Get current token usage status for this session. Returns tokens used, budget remaining, and percentage consumed. Use this to check context window health.",
+        description: "Get MCP pipeline token throughput for this session. Tracks tokens flowing through shodh memory tools only — NOT the AI context window. Use for internal diagnostics, not context window health.",
         inputSchema: {
           type: "object",
           properties: {},
@@ -2781,18 +2781,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const filledLength = Math.round(percentUsed / 100 * barLength);
         const bar = '█'.repeat(filledLength) + '░'.repeat(barLength - filledLength);
 
-        let response = `🐘 Token Status\n`;
+        let response = `🐘 MCP Pipeline Throughput\n`;
         response += `━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`;
         response += `${bar} ${percentUsed}%\n`;
         response += `━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`;
-        response += `Used: ${status.tokens.toLocaleString()} tokens\n`;
-        response += `Budget: ${status.budget.toLocaleString()} tokens\n`;
-        response += `Remaining: ${remaining.toLocaleString()} tokens\n`;
+        response += `Pipeline tokens: ${status.tokens.toLocaleString()}\n`;
+        response += `Budget: ${status.budget.toLocaleString()}\n`;
         response += `Session: ${sessionDuration} min\n`;
         response += `━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`;
-        response += status.alert
-          ? `⚠️ ALERT: ${percentUsed}% used - Consider new session`
-          : `✓ Context window healthy`;
+        response += `Note: Tracks memory tool I/O only, not AI context window.`;
 
         return {
           content: [{ type: "text", text: response }],
@@ -4008,7 +4005,7 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
 - **verify_index** - Check memory index health
 - **repair_index** - Fix orphaned memories
 - **streaming_status** - Check streaming connection
-- **token_status** - Check context window usage
+- **token_status** - MCP pipeline throughput (internal diagnostic)
 - **reset_token_session** - Reset token tracking
 
 ## Reminders

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -138,16 +138,17 @@ const MAX_LIMIT = 250;              // Max results per query
 const TOKEN_BUDGET = parseInt(process.env.SHODH_TOKEN_BUDGET || "100000", 10);
 const ALERT_THRESHOLD = parseFloat(process.env.SHODH_ALERT_THRESHOLD || "0.9");
 
-// Session token tracking
+// Content-aware token tracker (replaces naive len/4 with CJK/code/prose heuristic)
+const tokenTracker = new TokenTracker(TOKEN_BUDGET, ALERT_THRESHOLD);
+
+// Legacy aliases for compatibility with existing code that uses module globals
 let sessionTokens = 0;
 let sessionStartTime = Date.now();
 
-// Simple token estimation: ~4 chars per token (rough approximation)
 function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
+  return tokenTracker.estimateTokens(text);
 }
 
-// Get current token status
 function getTokenStatus(): { tokens: number; budget: number; percent: number; alert: string | null } {
   const percent = sessionTokens / TOKEN_BUDGET;
   return {
@@ -158,10 +159,18 @@ function getTokenStatus(): { tokens: number; budget: number; percent: number; al
   };
 }
 
+// =============================================================================
+// TOOL CALL TRACKING - For session digest
+// =============================================================================
+
+// Tracks tool invocation counts per session (reset on session reset)
+const toolCallCounts: Map<string, number> = new Map();
+
 // Reset session (call on new conversation or explicit clear)
 function resetTokenSession(): void {
   sessionTokens = 0;
   sessionStartTime = Date.now();
+  toolCallCounts.clear();
 }
 
 // Streaming ingestion settings
@@ -1003,6 +1012,51 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           properties: {},
         },
       },
+      {
+        name: "session_digest",
+        description: "Get a consolidated digest of the current session: timestamps, token usage, memories created/recalled, tools used with counts, entities extracted, topic changes, and consolidation events. Use after context compression or at session milestones.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+        },
+      },
+      {
+        name: "session_history",
+        description: "Show what you worked on across recent sessions. Returns session summaries with entities, memory stats, and timestamps. Use group_by_project to detect cross-session project continuity via entity overlap.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            limit: {
+              type: "number",
+              description: "Number of sessions to show (default: 10, max: 100)",
+              default: 10,
+            },
+            group_by_project: {
+              type: "boolean",
+              description: "Detect and show project threads across sessions (default: false)",
+              default: false,
+            },
+          },
+        },
+      },
+      {
+        name: "fact_narratives",
+        description: "Get synthesized narratives from accumulated facts, clustered by topic with confidence levels and causal chains. Shows what the system has learned, organized into coherent themes.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            limit: {
+              type: "number",
+              description: "Maximum clusters to return (default: 20, max: 50)",
+              default: 20,
+            },
+            entity_filter: {
+              type: "string",
+              description: "Filter to facts related to a specific entity/topic",
+            },
+          },
+        },
+      },
       // Prospective Memory / Reminders (SHO-116)
       {
         name: "set_reminder",
@@ -1504,6 +1558,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   if (STREAM_ENABLED && (!streamSocket || streamSocket.readyState !== WebSocket.OPEN)) {
     connectStream().catch(() => {});
   }
+
+  // Track tool call counts for session digest
+  toolCallCounts.set(name, (toolCallCounts.get(name) || 0) + 1);
 
   // Auto-capture context from tool arguments (non-blocking)
   autoStreamContext(name, args as Record<string, unknown>);
@@ -2746,6 +2803,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const previousTokens = sessionTokens;
         resetTokenSession();
 
+        // Signal context compression to backend session tracker
+        callBrain("/api/sessions/context-compressed", {
+          user_id: userId,
+          tokens_before: previousTokens,
+          tokens_after: 0,
+        }).catch(() => {});
+
         let response = `🐘 Token Session Reset\n`;
         response += `━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`;
         response += `Previous: ${previousTokens.toLocaleString()} tokens\n`;
@@ -2756,6 +2820,215 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         return {
           content: [{ type: "text", text: response }],
+        };
+      }
+
+      case "session_digest": {
+        // Fetch backend session digest
+        const digestResult = await callBrain("/api/sessions/digest", {
+          user_id: userId,
+          token_budget: TOKEN_BUDGET,
+        });
+
+        const now = new Date();
+        const sessionStart = new Date(sessionStartTime);
+        const durationMins = Math.round((now.getTime() - sessionStartTime) / 60000);
+
+        let digestResponse = `📊 Session Digest\n`;
+        digestResponse += `━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`;
+        digestResponse += `📅 ${now.toLocaleDateString()} | ⏱ ${sessionStart.toLocaleTimeString()} → ${now.toLocaleTimeString()} (${durationMins}m)\n\n`;
+
+        // Token usage
+        const tokenStatus = getTokenStatus();
+        const pct = Math.round(tokenStatus.percent * 100);
+        const barLen = 20;
+        const filled = Math.round(pct / 100 * barLen);
+        const bar = "█".repeat(filled) + "░".repeat(barLen - filled);
+        digestResponse += `🔤 Tokens: ${tokenStatus.tokens.toLocaleString()} / ${tokenStatus.budget.toLocaleString()} (${pct}%)\n`;
+        digestResponse += `   [${bar}]\n\n`;
+
+        // Backend session data (memories, entities, etc.)
+        if (digestResult && typeof digestResult === "object" && "digest" in digestResult && digestResult.digest) {
+          const d = digestResult.digest as Record<string, unknown>;
+          digestResponse += `🧠 Memory: ${d.memories_created ?? 0} created, ${d.memories_surfaced ?? 0} surfaced, ${d.memories_used ?? 0} used`;
+          const hitRate = d.memory_hit_rate as number;
+          if (hitRate > 0) digestResponse += ` (${Math.round(hitRate * 100)}% hit rate)`;
+          digestResponse += `\n`;
+
+          if ((d.todos_created as number) > 0 || (d.todos_completed as number) > 0) {
+            digestResponse += `📋 Todos: ${d.todos_created ?? 0} created, ${d.todos_completed ?? 0} completed\n`;
+          }
+          if ((d.entity_count as number) > 0) {
+            const entities = d.entities_extracted as string[];
+            const preview = entities.slice(0, 8).join(", ");
+            const more = entities.length > 8 ? ` +${entities.length - 8} more` : "";
+            digestResponse += `🏷️ Entities: ${d.entity_count} extracted (${preview}${more})\n`;
+          }
+          if ((d.topic_changes as number) > 0) {
+            digestResponse += `🔀 Topic changes: ${d.topic_changes}\n`;
+          }
+          if ((d.compressions as number) > 0) {
+            digestResponse += `⟳ Context compressions: ${d.compressions}\n`;
+          }
+          if ((d.consolidation_events as number) > 0) {
+            digestResponse += `⚙️ Consolidation events: ${d.consolidation_events}\n`;
+          }
+        }
+
+        // MCP-side tool call counts
+        if (toolCallCounts.size > 0) {
+          digestResponse += `\n🔧 Tools Used:\n`;
+          const sorted = [...toolCallCounts.entries()].sort((a, b) => b[1] - a[1]);
+          for (const [tool, count] of sorted) {
+            digestResponse += `   ${tool}: ${count}\n`;
+          }
+        }
+
+        digestResponse += `━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`;
+
+        return {
+          content: [{ type: "text", text: digestResponse }],
+        };
+      }
+
+      case "session_history": {
+        const { limit: histLimit = 10, group_by_project = false } = args as {
+          limit?: number;
+          group_by_project?: boolean;
+        };
+
+        const histResult = await callBrain("/api/sessions/history", {
+          user_id: userId,
+          limit: histLimit,
+          group_by_project,
+        }) as {
+          success?: boolean;
+          sessions?: Array<{
+            session_id?: string;
+            content: string;
+            entities: string[];
+            started_at?: string;
+            duration_secs?: number;
+            memories_created?: number;
+            created_at: string;
+          }>;
+          project_threads?: Array<{
+            name: string;
+            sessions: number[];
+            shared_entities: string[];
+            session_count: number;
+          }>;
+          total?: number;
+        } | null;
+
+        if (!histResult?.success || !histResult?.sessions?.length) {
+          return {
+            content: [{ type: "text", text: "No session history found. Sessions are recorded when Claude Code exits." }],
+          };
+        }
+
+        let histResponse = `Session History (${histResult.total ?? histResult.sessions.length} sessions)\n`;
+        histResponse += `━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`;
+
+        for (let i = 0; i < histResult.sessions.length; i++) {
+          const s = histResult.sessions[i];
+          const created = new Date(s.created_at);
+          const dateStr = created.toLocaleDateString([], { month: "short", day: "numeric" });
+          const timeStr = created.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+          const durMin = s.duration_secs ? Math.round(s.duration_secs / 60) : null;
+          const durStr = durMin ? ` (${durMin}m)` : "";
+
+          histResponse += `\n${i + 1}. ${dateStr}, ${timeStr}${durStr}\n`;
+
+          if (s.entities.length > 0) {
+            const preview = s.entities.slice(0, 10).join(", ");
+            const more = s.entities.length > 10 ? ` +${s.entities.length - 10} more` : "";
+            histResponse += `   Entities: ${preview}${more}\n`;
+          }
+
+          if (s.memories_created != null) {
+            histResponse += `   Memories created: ${s.memories_created}\n`;
+          }
+
+          // Show content (first 200 chars if long)
+          const contentPreview = s.content.length > 200 ? s.content.slice(0, 200) + "..." : s.content;
+          histResponse += `   ${contentPreview}\n`;
+        }
+
+        // Project threads
+        if (histResult.project_threads && histResult.project_threads.length > 0) {
+          histResponse += `\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`;
+          histResponse += `Active Projects (cross-session continuity):\n`;
+          for (const thread of histResult.project_threads) {
+            histResponse += `  • ${thread.name} — ${thread.session_count} sessions\n`;
+            if (thread.shared_entities.length > 0) {
+              histResponse += `    Shared: ${thread.shared_entities.slice(0, 8).join(", ")}\n`;
+            }
+          }
+        }
+
+        return {
+          content: [{ type: "text", text: histResponse }],
+        };
+      }
+
+      case "fact_narratives": {
+        const { limit: narLimit = 20, entity_filter } = args as {
+          limit?: number;
+          entity_filter?: string;
+        };
+
+        const narResult = await callBrain("/api/facts/narratives", {
+          user_id: userId,
+          limit: narLimit,
+          entity_filter: entity_filter || null,
+        }) as {
+          success?: boolean;
+          clusters?: Array<{
+            topic: string;
+            entities: string[];
+            facts: Array<{ id: string; fact: string; confidence: number; support_count: number }>;
+            narrative: string;
+            avg_confidence: number;
+            total_support: number;
+            causal_chains: Array<{
+              from_fact: string;
+              to_fact: string;
+              relation: string;
+            }>;
+          }>;
+          total_facts?: number;
+          total_clusters?: number;
+        } | null;
+
+        if (!narResult?.success || !narResult?.clusters?.length) {
+          return {
+            content: [{ type: "text", text: "No fact narratives found. Facts are extracted during memory consolidation." }],
+          };
+        }
+
+        let narResponse = `Fact Narratives (${narResult.total_clusters ?? narResult.clusters.length} topics, ${narResult.total_facts ?? 0} facts)\n`;
+        narResponse += `━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`;
+
+        for (const cluster of narResult.clusters) {
+          narResponse += `\n${cluster.narrative || `Regarding ${cluster.topic}:`}\n`;
+          narResponse += `  Confidence: ${Math.round((cluster.avg_confidence ?? 0) * 100)}% avg | Support: ${cluster.total_support ?? 0} memories\n`;
+
+          if (cluster.causal_chains?.length > 0) {
+            narResponse += `  Causal chains:\n`;
+            for (const chain of cluster.causal_chains) {
+              const arrow = chain.relation === "superseded_by" ? " ✕→ "
+                : chain.relation === "resolved_by" ? " ✓→ "
+                : " → ";
+              const fromPreview = chain.from_fact.length > 60 ? chain.from_fact.slice(0, 60) + "..." : chain.from_fact;
+              const toPreview = chain.to_fact.length > 60 ? chain.to_fact.slice(0, 60) + "..." : chain.to_fact;
+              narResponse += `    ${fromPreview}${arrow}${toPreview}\n`;
+            }
+          }
+        }
+
+        return {
+          content: [{ type: "text", text: narResponse }],
         };
       }
 

--- a/mcp-server/token-tracking.ts
+++ b/mcp-server/token-tracking.ts
@@ -24,9 +24,57 @@ export class TokenTracker {
     this.sessionStartTime = clock();
   }
 
-  /** Rough token estimation: ~4 chars per token */
+  /**
+   * Content-aware token estimation.
+   *
+   * Three modes: CJK (1.5 tokens/char), code (bytes*10/32), prose (bytes/4).
+   * Classifies via single-pass sampling of first 512 chars.
+   */
   estimateTokens(text: string): number {
-    return Math.ceil(text.length / 4);
+    if (text.length === 0) return 0;
+
+    const sampleEnd = Math.min(text.length, 512);
+    let syntaxCount = 0;
+    let highCharCount = 0;
+
+    for (let i = 0; i < sampleEnd; i++) {
+      const code = text.charCodeAt(i);
+      if (code > 0x7F) {
+        highCharCount++;
+      } else if (
+        code === 0x7B || code === 0x7D || // { }
+        code === 0x5B || code === 0x5D || // [ ]
+        code === 0x28 || code === 0x29 || // ( )
+        code === 0x3B || code === 0x3D || // ; =
+        code === 0x3C || code === 0x3E || // < >
+        code === 0x7C || code === 0x26 || // | &
+        code === 0x23 || code === 0x40 || // # @
+        code === 0x21 || code === 0x7E || // ! ~
+        code === 0x5E || code === 0x5C || // ^ \
+        code === 0x22 || code === 0x27    // " '
+      ) {
+        syntaxCount++;
+      }
+    }
+
+    // CJK detection: high ratio of non-ASCII characters
+    if (highCharCount > 0) {
+      const charCount = [...text].length;
+      const byteLen = new TextEncoder().encode(text).length;
+      if (charCount > 0 && byteLen > charCount * 2.5) {
+        return Math.ceil(charCount * 1.5);
+      }
+    }
+
+    // Code detection: 8%+ syntax characters in sample
+    if (sampleEnd > 0 && (syntaxCount / sampleEnd) >= 0.08) {
+      const byteLen = new TextEncoder().encode(text).length;
+      return Math.ceil(byteLen * 10 / 32);
+    }
+
+    // Prose mode (default)
+    const byteLen = new TextEncoder().encode(text).length;
+    return Math.ceil(byteLen / 4);
   }
 
   /** Track tokens consumed by a text */

--- a/src/handlers/facts.rs
+++ b/src/handlers/facts.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use super::state::MultiUserMemoryManager;
 use crate::errors::{AppError, ValidationErrorExt};
-use crate::memory::{self, SemanticFact};
+use crate::memory::{self, FactCluster, SemanticFact};
 use crate::validation;
 use std::sync::Arc;
 
@@ -156,4 +156,63 @@ pub async fn get_facts_stats(
     .map_err(AppError::Internal)?;
 
     Ok(Json(stats))
+}
+
+// =============================================================================
+// Fact Narratives
+// =============================================================================
+
+fn default_narratives_limit() -> usize {
+    20
+}
+
+/// Request for fact narratives
+#[derive(Debug, Deserialize)]
+pub struct FactNarrativesRequest {
+    pub user_id: String,
+    #[serde(default = "default_narratives_limit")]
+    pub limit: usize,
+    #[serde(default)]
+    pub entity_filter: Option<String>,
+}
+
+/// Response for fact narratives
+#[derive(Debug, Serialize)]
+pub struct FactNarrativesResponse {
+    pub success: bool,
+    pub clusters: Vec<FactCluster>,
+    pub total_facts: usize,
+    pub total_clusters: usize,
+}
+
+/// POST /api/facts/narratives - Get fact narratives clustered by topic
+pub async fn fact_narratives(
+    State(state): State<AppState>,
+    Json(req): Json<FactNarrativesRequest>,
+) -> Result<Json<FactNarrativesResponse>, AppError> {
+    validation::validate_user_id(&req.user_id).map_validation_err("user_id")?;
+
+    let memory = state
+        .get_user_memory(&req.user_id)
+        .map_err(AppError::Internal)?;
+    let user_id = req.user_id.clone();
+    let limit = req.limit.min(50);
+    let entity_filter = req.entity_filter.clone();
+
+    let clusters = tokio::task::spawn_blocking(move || {
+        let ms = memory.read();
+        ms.build_fact_narratives(&user_id, limit, entity_filter.as_deref())
+    })
+    .await
+    .map_err(|e| AppError::Internal(anyhow::anyhow!("Blocking task panicked: {e}")))?
+    .map_err(AppError::Internal)?;
+
+    let total_facts: usize = clusters.iter().map(|c| c.facts.len()).sum();
+    let total_clusters = clusters.len();
+    Ok(Json(FactNarrativesResponse {
+        success: true,
+        clusters,
+        total_facts,
+        total_clusters,
+    }))
 }

--- a/src/handlers/remember.rs
+++ b/src/handlers/remember.rs
@@ -117,6 +117,10 @@ pub struct RememberRequest {
     /// When true, require robot_id and geo_location for strict robotics mode
     #[serde(default)]
     pub validate_robotics: Option<bool>,
+    /// Arbitrary key-value metadata (e.g., session_id, started_at, duration_secs).
+    /// Stored directly on the Experience and queryable via session_history.
+    #[serde(default)]
+    pub metadata: std::collections::HashMap<String, String>,
 }
 
 /// Remember response
@@ -522,6 +526,7 @@ pub async fn remember(
         context,
         ner_entities,
         importance_override: req.importance.map(|v| v.clamp(0.0, 1.0)),
+        metadata: req.metadata,
         robot_id: req.robot_id.clone(),
         mission_id: req.mission_id.clone(),
         geo_location: req.geo_location,

--- a/src/handlers/router.rs
+++ b/src/handlers/router.rs
@@ -180,6 +180,7 @@ pub fn build_protected_routes(state: AppState) -> Router {
         .route("/api/facts/search", post(facts::search_facts))
         .route("/api/facts/by-entity", post(facts::facts_by_entity))
         .route("/api/facts/stats", post(facts::get_facts_stats))
+        .route("/api/facts/narratives", post(facts::fact_narratives))
         // =================================================================
         // LINEAGE
         // =================================================================
@@ -348,6 +349,9 @@ pub fn build_protected_routes(state: AppState) -> Router {
         .route("/api/sessions", post(sessions::list_sessions))
         .route("/api/sessions/stats", get(sessions::get_session_stats))
         .route("/api/sessions/end", post(sessions::end_session))
+        .route("/api/sessions/digest", post(sessions::get_session_digest))
+        .route("/api/sessions/context-compressed", post(sessions::context_compressed))
+        .route("/api/sessions/history", post(sessions::session_history))
         .route("/api/sessions/{session_id}", get(sessions::get_session))
         // =================================================================
         // A/B TESTING

--- a/src/handlers/router.rs
+++ b/src/handlers/router.rs
@@ -350,7 +350,10 @@ pub fn build_protected_routes(state: AppState) -> Router {
         .route("/api/sessions/stats", get(sessions::get_session_stats))
         .route("/api/sessions/end", post(sessions::end_session))
         .route("/api/sessions/digest", post(sessions::get_session_digest))
-        .route("/api/sessions/context-compressed", post(sessions::context_compressed))
+        .route(
+            "/api/sessions/context-compressed",
+            post(sessions::context_compressed),
+        )
         .route("/api/sessions/history", post(sessions::session_history))
         .route("/api/sessions/{session_id}", get(sessions::get_session))
         // =================================================================

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -10,8 +10,12 @@ use serde::{Deserialize, Serialize};
 
 use super::state::MultiUserMemoryManager;
 use crate::errors::{AppError, ValidationErrorExt};
-use crate::memory::{Session, SessionId, SessionStatus, SessionStoreStats, SessionSummary};
+use crate::memory::{
+    Experience, ExperienceType, Session, SessionDigest, SessionEvent, SessionId, SessionStatus,
+    SessionStoreStats, SessionSummary,
+};
 use crate::validation;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 type AppState = Arc<MultiUserMemoryManager>;
@@ -151,4 +155,427 @@ pub async fn get_session_stats(
         success: true,
         stats,
     }))
+}
+
+// =============================================================================
+// Session Digest
+// =============================================================================
+
+fn default_token_budget() -> usize {
+    100_000
+}
+
+/// Request for session digest
+#[derive(Debug, Deserialize)]
+pub struct DigestRequest {
+    pub user_id: String,
+    #[serde(default = "default_token_budget")]
+    pub token_budget: usize,
+}
+
+/// Response for session digest
+#[derive(Debug, Serialize)]
+pub struct DigestResponse {
+    pub success: bool,
+    pub digest: Option<SessionDigest>,
+}
+
+/// POST /api/sessions/digest - Get digest of active session
+pub async fn get_session_digest(
+    State(state): State<AppState>,
+    Json(req): Json<DigestRequest>,
+) -> Result<Json<DigestResponse>, AppError> {
+    validation::validate_user_id(&req.user_id).map_validation_err("user_id")?;
+
+    let digest = build_active_digest_with_budget(&state, &req.user_id, req.token_budget);
+
+    Ok(Json(DigestResponse {
+        success: digest.is_some(),
+        digest,
+    }))
+}
+
+/// Request for context compression signal
+#[derive(Debug, Deserialize)]
+pub struct ContextCompressedRequest {
+    pub user_id: String,
+    #[serde(default)]
+    pub tokens_before: usize,
+    #[serde(default)]
+    pub tokens_after: usize,
+}
+
+/// Response for context compression signal
+#[derive(Debug, Serialize)]
+pub struct ContextCompressedResponse {
+    pub success: bool,
+}
+
+/// POST /api/sessions/context-compressed - Record a context compression event
+/// Also persists a session digest snapshot as a Context memory for future recall.
+pub async fn context_compressed(
+    State(state): State<AppState>,
+    Json(req): Json<ContextCompressedRequest>,
+) -> Result<Json<ContextCompressedResponse>, AppError> {
+    validation::validate_user_id(&req.user_id).map_validation_err("user_id")?;
+
+    let now = chrono::Utc::now();
+
+    state.session_store.add_event_to_user(
+        &req.user_id,
+        SessionEvent::ContextCompressed {
+            timestamp: now,
+            tokens_before: req.tokens_before,
+            tokens_after: req.tokens_after,
+        },
+    );
+
+    // Persist a digest snapshot as a Context memory so it survives restarts
+    // and can be recalled in future sessions ("what was I working on?")
+    if let Some(digest) = build_active_digest(&state, &req.user_id) {
+        let reduction_pct = if req.tokens_before > 0 {
+            ((req.tokens_before.saturating_sub(req.tokens_after)) * 100) / req.tokens_before
+        } else {
+            0
+        };
+
+        let entities_str = if digest.entities_extracted.is_empty() {
+            "none".to_string()
+        } else {
+            digest.entities_extracted.join(", ")
+        };
+
+        let duration_mins = digest.duration_secs / 60;
+        let content = format!(
+            "Session digest at context compression ({now}):\n\
+             Duration: {duration_mins}m | Tokens: {before}→{after} ({reduction_pct}% reduced)\n\
+             Memories: {created} created, {surfaced} surfaced, {used} used (hit rate {hit_rate:.0}%)\n\
+             Todos: {todos_created} created, {todos_completed} completed\n\
+             Entities: {entities_str}\n\
+             Topic changes: {topics} | Compressions: {compressions}",
+            before = req.tokens_before,
+            after = req.tokens_after,
+            created = digest.memories_created,
+            surfaced = digest.memories_surfaced,
+            used = digest.memories_used,
+            hit_rate = digest.memory_hit_rate * 100.0,
+            todos_created = digest.todos_created,
+            todos_completed = digest.todos_completed,
+            topics = digest.topic_changes,
+            compressions = digest.compressions,
+        );
+
+        let mut metadata = HashMap::new();
+        metadata.insert("session_digest".to_string(), "true".to_string());
+        metadata.insert(
+            "session_id".to_string(),
+            digest.session_id.0.to_string(),
+        );
+        metadata.insert(
+            "started_at".to_string(),
+            digest.started_at.to_rfc3339(),
+        );
+        metadata.insert(
+            "duration_secs".to_string(),
+            digest.duration_secs.to_string(),
+        );
+        metadata.insert(
+            "memories_created".to_string(),
+            digest.memories_created.to_string(),
+        );
+        metadata.insert(
+            "tokens_before".to_string(),
+            req.tokens_before.to_string(),
+        );
+        metadata.insert(
+            "tokens_after".to_string(),
+            req.tokens_after.to_string(),
+        );
+
+        // Include "session-summary" tag so these show up in session_history queries,
+        // alongside "session-digest" to distinguish compression-time snapshots from
+        // session-end summaries.
+        let mut entities = digest.entities_extracted;
+        entities.push("session-summary".to_string());
+        entities.push("session-digest".to_string());
+
+        let experience = Experience {
+            experience_type: ExperienceType::Context,
+            content,
+            entities,
+            metadata,
+            ..Default::default()
+        };
+
+        // Best-effort persistence — don't fail the compression signal if memory write fails
+        if let Ok(user_memory) = state.get_user_memory(&req.user_id) {
+            let ms = user_memory.read();
+            let _ = ms.remember(experience, Some(now));
+        }
+    }
+
+    Ok(Json(ContextCompressedResponse { success: true }))
+}
+
+/// Build a digest for the active session, enriched with audit log tool counts.
+fn build_active_digest(state: &AppState, user_id: &str) -> Option<SessionDigest> {
+    build_active_digest_with_budget(state, user_id, 0)
+}
+
+fn build_active_digest_with_budget(
+    state: &AppState,
+    user_id: &str,
+    token_budget: usize,
+) -> Option<SessionDigest> {
+    let sessions = state.session_store.get_user_sessions(user_id, 1);
+    let active_summary = sessions
+        .into_iter()
+        .find(|s| matches!(s.status, SessionStatus::Active))?;
+
+    let session = state.session_store.get_session(&active_summary.id)?;
+    let mut digest = session.digest(token_budget);
+
+    // Enrich with audit log tool counts (cap at 1000 entries to bound scan cost)
+    let audit_entries = state.get_audit_logs(user_id, 1000);
+    if !audit_entries.is_empty() {
+        let mut tool_counts: HashMap<String, usize> = HashMap::new();
+        for entry in &audit_entries {
+            if entry.timestamp >= session.started_at {
+                *tool_counts.entry(entry.event_type.clone()).or_insert(0) += 1;
+            }
+        }
+        digest.tools_used = tool_counts;
+    }
+
+    Some(digest)
+}
+
+// =============================================================================
+// Session History
+// =============================================================================
+
+fn default_history_limit() -> usize {
+    10
+}
+
+/// Request for session history
+#[derive(Debug, Deserialize)]
+pub struct SessionHistoryRequest {
+    pub user_id: String,
+    #[serde(default = "default_history_limit")]
+    pub limit: usize,
+    #[serde(default)]
+    pub group_by_project: bool,
+}
+
+/// A single session entry in the history
+#[derive(Debug, Serialize)]
+pub struct SessionHistoryEntry {
+    pub session_id: Option<String>,
+    pub content: String,
+    pub entities: Vec<String>,
+    pub started_at: Option<String>,
+    pub duration_secs: Option<i64>,
+    pub memories_created: Option<usize>,
+    pub created_at: String,
+}
+
+/// A detected project thread spanning multiple sessions
+#[derive(Debug, Serialize)]
+pub struct ProjectThread {
+    pub name: String,
+    pub sessions: Vec<usize>,
+    pub shared_entities: Vec<String>,
+    pub session_count: usize,
+}
+
+/// Response for session history
+#[derive(Debug, Serialize)]
+pub struct SessionHistoryResponse {
+    pub success: bool,
+    pub sessions: Vec<SessionHistoryEntry>,
+    pub project_threads: Vec<ProjectThread>,
+    pub total: usize,
+}
+
+/// POST /api/sessions/history - Get persisted session history with project continuity
+pub async fn session_history(
+    State(state): State<AppState>,
+    Json(req): Json<SessionHistoryRequest>,
+) -> Result<Json<SessionHistoryResponse>, AppError> {
+    validation::validate_user_id(&req.user_id).map_validation_err("user_id")?;
+
+    let memory = state
+        .get_user_memory(&req.user_id)
+        .map_err(AppError::Internal)?;
+    let limit = req.limit.min(100);
+    let group = req.group_by_project;
+
+    let result = tokio::task::spawn_blocking(move || {
+        let ms = memory.read();
+        let tags = vec!["session-summary".to_string()];
+
+        // Fetch ALL matching memories (recall_by_tags truncates on random HashSet order,
+        // so we over-fetch with a high cap and sort/truncate ourselves).
+        let memories = ms.recall_by_tags(&tags, 500)?;
+
+        let mut entries: Vec<SessionHistoryEntry> = memories
+            .iter()
+            .map(|m| {
+                let meta = &m.experience.metadata;
+                SessionHistoryEntry {
+                    session_id: meta.get("session_id").cloned(),
+                    content: m.experience.content.clone(),
+                    entities: m.experience.entities.clone(),
+                    started_at: meta.get("started_at").cloned(),
+                    duration_secs: meta
+                        .get("duration_secs")
+                        .and_then(|s| s.parse().ok()),
+                    memories_created: meta
+                        .get("memories_created")
+                        .and_then(|s| s.parse().ok()),
+                    created_at: m.created_at.to_rfc3339(),
+                }
+            })
+            .collect();
+
+        // Sort newest-first, then deduplicate by session_id.
+        // A single session can produce both a compression digest ("session-digest" tag)
+        // and a hook stop summary ("source:hook" tag). Keep only the newest entry per
+        // session (hook stop comes after compression, so it's more complete).
+        entries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+        let mut seen_sessions: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        entries.retain(|e| {
+            match &e.session_id {
+                Some(sid) => seen_sessions.insert(sid.clone()),
+                // Entries without session_id (legacy) are always kept
+                None => true,
+            }
+        });
+
+        entries.truncate(limit);
+
+        let threads = if group {
+            compute_project_threads(&entries)
+        } else {
+            vec![]
+        };
+
+        let total = entries.len();
+        Ok::<_, anyhow::Error>(SessionHistoryResponse {
+            success: true,
+            sessions: entries,
+            project_threads: threads,
+            total,
+        })
+    })
+    .await
+    .map_err(|e| AppError::Internal(anyhow::anyhow!("Blocking task panicked: {e}")))??;
+
+    Ok(Json(result))
+}
+
+/// Detect project threads by clustering sessions with overlapping entities.
+///
+/// Uses union-find: sessions sharing >= 3 entities merge into the same cluster.
+/// Clusters with 2+ sessions become ProjectThread.
+fn compute_project_threads(entries: &[SessionHistoryEntry]) -> Vec<ProjectThread> {
+    use std::collections::HashSet;
+
+    const MIN_OVERLAP: usize = 3;
+
+    // System tags appear in every entry and would inflate overlap counts,
+    // causing unrelated sessions to cluster together.
+    const SYSTEM_TAGS: &[&str] = &[
+        "session-summary",
+        "session-digest",
+        "source:hook",
+    ];
+
+    if entries.len() < 2 {
+        return vec![];
+    }
+
+    let n = entries.len();
+    let mut parent: Vec<usize> = (0..n).collect();
+
+    // Build entity sets once, filtering out system tags
+    let entity_sets: Vec<HashSet<&str>> = entries
+        .iter()
+        .map(|e| {
+            e.entities
+                .iter()
+                .map(|s| s.as_str())
+                .filter(|s| !SYSTEM_TAGS.contains(s))
+                .collect()
+        })
+        .collect();
+
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let overlap = entity_sets[i].intersection(&entity_sets[j]).count();
+            if overlap >= MIN_OVERLAP {
+                let ri = uf_find_root(&parent, i);
+                let rj = uf_find_root(&parent, j);
+                if ri != rj {
+                    parent[rj] = ri;
+                }
+            }
+        }
+    }
+
+    // Group by root
+    let mut groups: HashMap<usize, Vec<usize>> = HashMap::new();
+    for i in 0..n {
+        groups
+            .entry(uf_find_root(&parent, i))
+            .or_default()
+            .push(i);
+    }
+
+    // Build threads from groups with 2+ sessions
+    groups
+        .into_values()
+        .filter(|indices| indices.len() >= 2)
+        .map(|indices| {
+            let mut entity_counts: HashMap<&str, usize> = HashMap::new();
+            for &i in &indices {
+                for e in &entries[i].entities {
+                    if !SYSTEM_TAGS.contains(&e.as_str()) {
+                        *entity_counts.entry(e.as_str()).or_default() += 1;
+                    }
+                }
+            }
+            // Shared = entities appearing in 2+ sessions of this thread
+            let mut shared: Vec<String> = entity_counts
+                .iter()
+                .filter(|(_, &c)| c >= 2)
+                .map(|(&e, _)| e.to_string())
+                .collect();
+            shared.sort();
+
+            let name = entity_counts
+                .iter()
+                .max_by_key(|(_, c)| *c)
+                .map(|(&e, _)| e.to_string())
+                .unwrap_or_else(|| "Unknown".to_string());
+
+            let session_count = indices.len();
+            ProjectThread {
+                name,
+                sessions: indices,
+                shared_entities: shared,
+                session_count,
+            }
+        })
+        .collect()
+}
+
+fn uf_find_root(parent: &[usize], mut i: usize) -> usize {
+    while parent[i] != i {
+        i = parent[i];
+    }
+    i
 }

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -267,14 +267,8 @@ pub async fn context_compressed(
 
         let mut metadata = HashMap::new();
         metadata.insert("session_digest".to_string(), "true".to_string());
-        metadata.insert(
-            "session_id".to_string(),
-            digest.session_id.0.to_string(),
-        );
-        metadata.insert(
-            "started_at".to_string(),
-            digest.started_at.to_rfc3339(),
-        );
+        metadata.insert("session_id".to_string(), digest.session_id.0.to_string());
+        metadata.insert("started_at".to_string(), digest.started_at.to_rfc3339());
         metadata.insert(
             "duration_secs".to_string(),
             digest.duration_secs.to_string(),
@@ -283,14 +277,8 @@ pub async fn context_compressed(
             "memories_created".to_string(),
             digest.memories_created.to_string(),
         );
-        metadata.insert(
-            "tokens_before".to_string(),
-            req.tokens_before.to_string(),
-        );
-        metadata.insert(
-            "tokens_after".to_string(),
-            req.tokens_after.to_string(),
-        );
+        metadata.insert("tokens_before".to_string(), req.tokens_before.to_string());
+        metadata.insert("tokens_after".to_string(), req.tokens_after.to_string());
 
         // Include "session-summary" tag so these show up in session_history queries,
         // alongside "session-digest" to distinguish compression-time snapshots from
@@ -428,12 +416,8 @@ pub async fn session_history(
                     content: m.experience.content.clone(),
                     entities: m.experience.entities.clone(),
                     started_at: meta.get("started_at").cloned(),
-                    duration_secs: meta
-                        .get("duration_secs")
-                        .and_then(|s| s.parse().ok()),
-                    memories_created: meta
-                        .get("memories_created")
-                        .and_then(|s| s.parse().ok()),
+                    duration_secs: meta.get("duration_secs").and_then(|s| s.parse().ok()),
+                    memories_created: meta.get("memories_created").and_then(|s| s.parse().ok()),
                     created_at: m.created_at.to_rfc3339(),
                 }
             })
@@ -445,8 +429,7 @@ pub async fn session_history(
         // session (hook stop comes after compression, so it's more complete).
         entries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
 
-        let mut seen_sessions: std::collections::HashSet<String> =
-            std::collections::HashSet::new();
+        let mut seen_sessions: std::collections::HashSet<String> = std::collections::HashSet::new();
         entries.retain(|e| {
             match &e.session_id {
                 Some(sid) => seen_sessions.insert(sid.clone()),
@@ -488,11 +471,7 @@ fn compute_project_threads(entries: &[SessionHistoryEntry]) -> Vec<ProjectThread
 
     // System tags appear in every entry and would inflate overlap counts,
     // causing unrelated sessions to cluster together.
-    const SYSTEM_TAGS: &[&str] = &[
-        "session-summary",
-        "session-digest",
-        "source:hook",
-    ];
+    const SYSTEM_TAGS: &[&str] = &["session-summary", "session-digest", "source:hook"];
 
     if entries.len() < 2 {
         return vec![];
@@ -529,10 +508,7 @@ fn compute_project_threads(entries: &[SessionHistoryEntry]) -> Vec<ProjectThread
     // Group by root
     let mut groups: HashMap<usize, Vec<usize>> = HashMap::new();
     for i in 0..n {
-        groups
-            .entry(uf_find_root(&parent, i))
-            .or_default()
-            .push(i);
+        groups.entry(uf_find_root(&parent, i)).or_default().push(i);
     }
 
     // Build threads from groups with 2+ sessions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod serialization;
 pub mod server;
 pub mod similarity;
 pub mod streaming;
+pub mod token_estimation;
 pub mod tracing_setup;
 pub mod validation;
 pub mod vector_db;

--- a/src/memory/compression.rs
+++ b/src/memory/compression.rs
@@ -593,6 +593,43 @@ impl Default for FactType {
     }
 }
 
+/// A cluster of related facts grouped by shared entities, with a template-generated
+/// narrative and heuristic causal chain detection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FactCluster {
+    /// Most common entity in the cluster (used as topic heading)
+    pub topic: String,
+    /// All entities appearing in the cluster's facts
+    pub entities: Vec<String>,
+    /// Facts in this cluster, sorted by created_at
+    pub facts: Vec<SemanticFact>,
+    /// Template-generated narrative summary (no LLM required)
+    pub narrative: String,
+    /// Average confidence across facts in the cluster
+    pub avg_confidence: f32,
+    /// Sum of support_count across all facts
+    pub total_support: usize,
+    /// Detected causal relationships between facts in this cluster
+    pub causal_chains: Vec<CausalFactLink>,
+}
+
+/// A heuristic-detected causal relationship between two facts.
+///
+/// Detected via keyword analysis on temporally ordered facts sharing entities.
+/// Relations: "led_to" (default), "superseded_by" (replaced/deprecated),
+/// "resolved_by" (fixed/resolved).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CausalFactLink {
+    pub from_fact_id: String,
+    pub to_fact_id: String,
+    /// The source fact statement
+    pub from_fact: String,
+    /// The target fact statement
+    pub to_fact: String,
+    /// Relationship type: "led_to", "superseded_by", "resolved_by"
+    pub relation: String,
+}
+
 /// Result of consolidation operation
 #[derive(Debug, Clone, Default)]
 pub struct ConsolidationResult {

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -61,7 +61,7 @@ pub use crate::memory::types::*;
 use crate::embeddings::Embedder;
 use crate::memory::compression::CompressionPipeline;
 pub use crate::memory::compression::{
-    ConsolidationResult, FactType, SemanticConsolidator, SemanticFact,
+    CausalFactLink, ConsolidationResult, FactCluster, FactType, SemanticConsolidator, SemanticFact,
 };
 pub use crate::memory::facts::{FactQueryResponse, FactStats, SemanticFactStore};
 pub use crate::memory::feedback::{
@@ -104,8 +104,8 @@ pub use crate::memory::segmentation::{
     AtomicMemory, DeduplicationEngine, DeduplicationResult, InputSource, SegmentationEngine,
 };
 pub use crate::memory::sessions::{
-    Session, SessionEvent, SessionId, SessionStats, SessionStatus, SessionStore, SessionStoreStats,
-    SessionSummary, TemporalContext, TimeOfDay,
+    Session, SessionDigest, SessionEvent, SessionId, SessionStats, SessionStatus, SessionStore,
+    SessionStoreStats, SessionSummary, TemporalContext, TimeOfDay,
 };
 pub use crate::memory::temporal_facts::{EventType, ResolvedTime, TemporalFact, TemporalFactStore};
 pub use crate::memory::todos::{ProjectStats, TodoStore, UserTodoStats};
@@ -6922,6 +6922,67 @@ impl MemorySystem {
         Ok(results)
     }
 
+    /// Build fact narratives by clustering facts on shared entities.
+    ///
+    /// Groups related facts into topic clusters using single-linkage clustering
+    /// on entity overlap. Each cluster gets a template-generated narrative and
+    /// heuristic-based causal chain detection (keyword analysis on temporally
+    /// ordered facts).
+    pub fn build_fact_narratives(
+        &self,
+        user_id: &str,
+        limit: usize,
+        entity_filter: Option<&str>,
+    ) -> Result<Vec<FactCluster>> {
+        let facts = if let Some(entity) = entity_filter {
+            self.fact_store.find_by_entity(user_id, entity, 200)?
+        } else {
+            self.fact_store.list(user_id, 500)?
+        };
+
+        if facts.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Union-find clustering: merge facts sharing >= 1 entity
+        let n = facts.len();
+        let mut parent: Vec<usize> = (0..n).collect();
+
+        for i in 0..n {
+            let entities_i: std::collections::HashSet<&str> =
+                facts[i].related_entities.iter().map(|s| s.as_str()).collect();
+            for j in (i + 1)..n {
+                let shared = facts[j]
+                    .related_entities
+                    .iter()
+                    .any(|e| entities_i.contains(e.as_str()));
+                if shared {
+                    let ri = uf_find(&parent, i);
+                    let rj = uf_find(&parent, j);
+                    if ri != rj {
+                        parent[rj] = ri;
+                    }
+                }
+            }
+        }
+
+        // Group indices by cluster root
+        let mut groups: std::collections::HashMap<usize, Vec<usize>> =
+            std::collections::HashMap::new();
+        for i in 0..n {
+            groups.entry(uf_find(&parent, i)).or_default().push(i);
+        }
+
+        let mut clusters: Vec<FactCluster> = groups
+            .into_values()
+            .map(|indices| build_single_cluster(&facts, &indices))
+            .collect();
+
+        clusters.sort_by(|a, b| b.total_support.cmp(&a.total_support));
+        clusters.truncate(limit);
+        Ok(clusters)
+    }
+
     /// Reinforce a fact with new supporting evidence
     ///
     /// Called when a new memory supports an existing fact.
@@ -7196,6 +7257,157 @@ impl MemorySystem {
 /// Automatic persistence on drop - ensures vector index and ID mappings survive restarts
 ///
 /// This is CRITICAL for local memory: when the system shuts down (gracefully or via drop),
+// =============================================================================
+// Fact Narrative Helpers (private, used by MemorySystem::build_fact_narratives)
+// =============================================================================
+
+/// Union-find: find root (no path compression — immutable slice, N≤500).
+fn uf_find(parent: &[usize], mut i: usize) -> usize {
+    while parent[i] != i {
+        i = parent[i];
+    }
+    i
+}
+
+/// Build a single FactCluster from a set of fact indices.
+fn build_single_cluster(all_facts: &[SemanticFact], indices: &[usize]) -> FactCluster {
+    use std::collections::HashMap;
+
+    let mut entity_counts: HashMap<&str, usize> = HashMap::new();
+    let mut cluster_facts: Vec<SemanticFact> = Vec::with_capacity(indices.len());
+
+    for &i in indices {
+        let f = &all_facts[i];
+        cluster_facts.push(f.clone());
+        for e in &f.related_entities {
+            *entity_counts.entry(e.as_str()).or_default() += 1;
+        }
+    }
+
+    // Sort by created_at for temporal ordering within narrative
+    cluster_facts.sort_by_key(|f| f.created_at);
+
+    let topic = entity_counts
+        .iter()
+        .max_by_key(|(_, c)| *c)
+        .map(|(n, _)| (*n).to_string())
+        .unwrap_or_else(|| "General".to_string());
+
+    let mut entities: Vec<String> = entity_counts.keys().map(|e| (*e).to_string()).collect();
+    entities.sort();
+
+    // Template-based narrative: no LLM needed
+    let narrative = if cluster_facts.len() == 1 {
+        format!("Regarding {}: {}", topic, cluster_facts[0].fact)
+    } else {
+        let mut lines = vec![format!(
+            "Regarding {} ({} facts):",
+            topic,
+            cluster_facts.len()
+        )];
+        for (i, f) in cluster_facts.iter().enumerate() {
+            let label = if f.confidence >= 0.8 {
+                "established"
+            } else if f.confidence >= 0.5 {
+                "probable"
+            } else {
+                "tentative"
+            };
+            lines.push(format!("  {}. [{}] {}", i + 1, label, f.fact));
+        }
+        lines.join("\n")
+    };
+
+    let causal_chains = detect_causal_chains(&cluster_facts);
+
+    let avg_confidence = if cluster_facts.is_empty() {
+        0.0
+    } else {
+        cluster_facts.iter().map(|f| f.confidence).sum::<f32>() / cluster_facts.len() as f32
+    };
+    let total_support: usize = cluster_facts.iter().map(|f| f.support_count).sum();
+
+    FactCluster {
+        topic,
+        entities,
+        facts: cluster_facts,
+        narrative,
+        avg_confidence,
+        total_support,
+        causal_chains,
+    }
+}
+
+/// Detect causal relationships between temporally ordered facts sharing entities.
+///
+/// Uses keyword heuristics on the later fact to infer relationship type:
+/// - "replaced", "instead", "no longer" → superseded_by
+/// - "fixed", "resolved" → resolved_by
+/// - Other evolution keywords → led_to
+fn detect_causal_chains(sorted_facts: &[SemanticFact]) -> Vec<CausalFactLink> {
+    const EVOLUTION_KEYWORDS: &[&str] = &[
+        "migrated",
+        "replaced",
+        "fixed",
+        "updated",
+        "changed",
+        "now uses",
+        "switched",
+        "deprecated",
+        "removed",
+        "added",
+        "resolved",
+        "instead",
+        "no longer",
+    ];
+
+    let mut chains = Vec::new();
+
+    // Pre-compute lowercase facts to avoid repeated allocations in O(n²) loop.
+    let lowered: Vec<String> = sorted_facts.iter().map(|f| f.fact.to_lowercase()).collect();
+
+    for i in 0..sorted_facts.len() {
+        for j in (i + 1)..sorted_facts.len() {
+            let a = &sorted_facts[i];
+            let b = &sorted_facts[j];
+
+            // Must share at least one entity
+            let shared = a
+                .related_entities
+                .iter()
+                .any(|e| b.related_entities.contains(e));
+            if !shared {
+                continue;
+            }
+
+            let b_lower = &lowered[j];
+            let has_evolution = EVOLUTION_KEYWORDS.iter().any(|kw| b_lower.contains(kw));
+            if !has_evolution {
+                continue;
+            }
+
+            let relation =
+                if b_lower.contains("replaced") || b_lower.contains("instead") || b_lower.contains("no longer") {
+                    "superseded_by"
+                } else if b_lower.contains("fixed") || b_lower.contains("resolved") {
+                    "resolved_by"
+                } else {
+                    "led_to"
+                };
+
+            chains.push(CausalFactLink {
+                from_fact_id: a.id.clone(),
+                to_fact_id: b.id.clone(),
+                from_fact: a.fact.clone(),
+                to_fact: b.fact.clone(),
+                relation: relation.to_string(),
+            });
+        }
+    }
+
+    chains
+}
+
 /// all in-memory state (vector index, ID mappings) must be persisted to disk.
 impl Drop for MemorySystem {
     fn drop(&mut self) {

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -6949,8 +6949,11 @@ impl MemorySystem {
         let mut parent: Vec<usize> = (0..n).collect();
 
         for i in 0..n {
-            let entities_i: std::collections::HashSet<&str> =
-                facts[i].related_entities.iter().map(|s| s.as_str()).collect();
+            let entities_i: std::collections::HashSet<&str> = facts[i]
+                .related_entities
+                .iter()
+                .map(|s| s.as_str())
+                .collect();
             for j in (i + 1)..n {
                 let shared = facts[j]
                     .related_entities
@@ -7386,14 +7389,16 @@ fn detect_causal_chains(sorted_facts: &[SemanticFact]) -> Vec<CausalFactLink> {
                 continue;
             }
 
-            let relation =
-                if b_lower.contains("replaced") || b_lower.contains("instead") || b_lower.contains("no longer") {
-                    "superseded_by"
-                } else if b_lower.contains("fixed") || b_lower.contains("resolved") {
-                    "resolved_by"
-                } else {
-                    "led_to"
-                };
+            let relation = if b_lower.contains("replaced")
+                || b_lower.contains("instead")
+                || b_lower.contains("no longer")
+            {
+                "superseded_by"
+            } else if b_lower.contains("fixed") || b_lower.contains("resolved") {
+                "resolved_by"
+            } else {
+                "led_to"
+            };
 
             chains.push(CausalFactLink {
                 from_fact_id: a.id.clone(),

--- a/src/memory/sessions.rs
+++ b/src/memory/sessions.rs
@@ -525,9 +525,7 @@ impl Session {
 
         for event in &self.timeline {
             match event {
-                SessionEvent::MemoryCreated {
-                    entities: ents, ..
-                } => {
+                SessionEvent::MemoryCreated { entities: ents, .. } => {
                     entities.extend(ents.iter().cloned());
                 }
                 SessionEvent::ContextCompressed { .. } => {
@@ -730,9 +728,7 @@ impl SessionStore {
 
             // Move to completed
             let mut completed = self.completed.write();
-            let user_sessions = completed
-                .entry(session.user_id.clone())
-                .or_default();
+            let user_sessions = completed.entry(session.user_id.clone()).or_default();
             user_sessions.push(session.clone());
 
             // Trim to max

--- a/src/memory/sessions.rs
+++ b/src/memory/sessions.rs
@@ -274,6 +274,13 @@ pub enum SessionEvent {
         tokens_estimated: usize,
     },
 
+    /// Context window was compressed (triggered by client)
+    ContextCompressed {
+        timestamp: DateTime<Utc>,
+        tokens_before: usize,
+        tokens_after: usize,
+    },
+
     /// Session ended
     SessionEnd {
         timestamp: DateTime<Utc>,
@@ -292,6 +299,7 @@ impl SessionEvent {
             Self::TodoCompleted { timestamp, .. } => *timestamp,
             Self::TopicChange { timestamp, .. } => *timestamp,
             Self::QueryProcessed { timestamp, .. } => *timestamp,
+            Self::ContextCompressed { timestamp, .. } => *timestamp,
             Self::SessionEnd { timestamp, .. } => *timestamp,
         }
     }
@@ -306,6 +314,7 @@ impl SessionEvent {
             Self::TodoCompleted { .. } => "todo_completed",
             Self::TopicChange { .. } => "topic_change",
             Self::QueryProcessed { .. } => "query_processed",
+            Self::ContextCompressed { .. } => "context_compressed",
             Self::SessionEnd { .. } => "session_end",
         }
     }
@@ -452,6 +461,9 @@ impl Session {
                 self.stats.queries_count += 1;
                 self.stats.tokens_estimated += tokens_estimated;
             }
+            SessionEvent::ContextCompressed { .. } => {
+                // No stat update — compressions counted from timeline in digest()
+            }
             _ => {}
         }
 
@@ -501,6 +513,105 @@ impl Session {
             stats: self.stats.clone(),
         }
     }
+
+    /// Generate a session digest by aggregating timeline events and stats.
+    ///
+    /// `tools_used` and `consolidation_events` are left at defaults (0/empty) —
+    /// the API handler enriches them from audit logs and learning history.
+    pub fn digest(&self, token_budget: usize) -> SessionDigest {
+        let now = Utc::now();
+        let mut entities: Vec<String> = Vec::new();
+        let mut compressions: usize = 0;
+
+        for event in &self.timeline {
+            match event {
+                SessionEvent::MemoryCreated {
+                    entities: ents, ..
+                } => {
+                    entities.extend(ents.iter().cloned());
+                }
+                SessionEvent::ContextCompressed { .. } => {
+                    compressions += 1;
+                }
+                _ => {}
+            }
+        }
+
+        entities.sort();
+        entities.dedup();
+        let entity_count = entities.len();
+
+        let token_percent = if token_budget > 0 {
+            self.stats.tokens_estimated as f32 / token_budget as f32
+        } else {
+            0.0
+        };
+
+        SessionDigest {
+            session_id: self.id.clone(),
+            started_at: self.started_at,
+            digest_at: now,
+            duration_secs: (now - self.started_at).num_seconds(),
+            tokens_estimated: self.stats.tokens_estimated,
+            token_budget,
+            token_percent,
+            memories_created: self.stats.memories_created,
+            memories_surfaced: self.stats.memories_surfaced,
+            memories_used: self.stats.memories_used,
+            memory_hit_rate: self.stats.memory_hit_rate,
+            todos_created: self.stats.todos_created,
+            todos_completed: self.stats.todos_completed,
+            entities_extracted: entities,
+            entity_count,
+            tools_used: HashMap::new(),
+            topic_changes: self.stats.topic_changes,
+            compressions,
+            consolidation_events: 0,
+        }
+    }
+}
+
+/// Aggregated session digest — computed on the fly from session timeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionDigest {
+    /// Session ID
+    pub session_id: SessionId,
+    /// When session started
+    pub started_at: DateTime<Utc>,
+    /// When this digest was generated
+    pub digest_at: DateTime<Utc>,
+    /// Session duration in seconds
+    pub duration_secs: i64,
+    /// Estimated tokens used (from proactive_context calls)
+    pub tokens_estimated: usize,
+    /// Token budget (client-configured)
+    pub token_budget: usize,
+    /// Token usage as fraction (0.0 - 1.0+)
+    pub token_percent: f32,
+    /// Memories created this session
+    pub memories_created: usize,
+    /// Memories surfaced (recalled) this session
+    pub memories_surfaced: usize,
+    /// Memories actually used in responses
+    pub memories_used: usize,
+    /// Memory hit rate (used / surfaced)
+    pub memory_hit_rate: f32,
+    /// Todos created
+    pub todos_created: usize,
+    /// Todos completed
+    pub todos_completed: usize,
+    /// Unique entities extracted from created memories
+    pub entities_extracted: Vec<String>,
+    /// Count of unique entities
+    pub entity_count: usize,
+    /// Tool usage counts (filled by handler from audit logs)
+    pub tools_used: HashMap<String, usize>,
+    /// Topic changes detected
+    pub topic_changes: usize,
+    /// Number of context compressions
+    pub compressions: usize,
+    /// Consolidation events during this session window
+    pub consolidation_events: usize,
 }
 
 /// Lightweight session summary (without full timeline)
@@ -621,7 +732,7 @@ impl SessionStore {
             let mut completed = self.completed.write();
             let user_sessions = completed
                 .entry(session.user_id.clone())
-                .or_insert_with(Vec::new);
+                .or_default();
             user_sessions.push(session.clone());
 
             // Trim to max

--- a/src/token_estimation.rs
+++ b/src/token_estimation.rs
@@ -1,0 +1,218 @@
+//! Content-aware token estimation.
+//!
+//! Replaces the naive `len / 4` heuristic with a three-mode classifier
+//! that detects CJK, code, and prose — yielding ~80% accuracy across
+//! content types without any tokenizer dependency.
+//!
+//! Zero dependencies, no_std compatible (uses only core byte/char ops).
+//!
+//! # Modes
+//! - **CJK**: bytes/chars > 2.5 → ~1.5 tokens per character
+//! - **Code**: 8%+ syntax punctuation in sample → bytes * 10 / 32
+//! - **Prose** (default): bytes / 4
+//!
+//! # Rationale
+//! - cl100k_base averages ~1.5 tokens/CJK character (3-byte UTF-8 → 1-2 BPE merges)
+//! - Code has more single-char tokens (`{`, `}`, `;`, `=`) → ~3.2 bytes/token vs prose ~4
+//! - 512-byte sample window avoids O(n) on multi-MB inputs while remaining reliable
+
+/// Maximum bytes to sample for content classification.
+const SAMPLE_WINDOW: usize = 512;
+
+/// Syntax characters that indicate code content.
+/// Threshold: if >= 8% of sample bytes are syntax chars, classify as code.
+const CODE_SYNTAX_THRESHOLD_PERCENT: usize = 8;
+
+/// Estimate the number of tokens in a text string.
+///
+/// Uses a single-pass heuristic that classifies content into CJK, code, or prose,
+/// then applies a mode-specific ratio. No allocations, no dependencies.
+///
+/// # Arguments
+/// * `text` - The text to estimate tokens for
+///
+/// # Returns
+/// Estimated token count (always >= 1 for non-empty input)
+pub fn estimate_tokens(text: &str) -> usize {
+    if text.is_empty() {
+        return 0;
+    }
+
+    let bytes = text.as_bytes();
+    let byte_len = bytes.len();
+    let sample_end = byte_len.min(SAMPLE_WINDOW);
+    let sample = &bytes[..sample_end];
+
+    // Single-pass classification over sample window
+    let mut syntax_count: usize = 0;
+    let mut high_byte_count: usize = 0;
+
+    for &b in sample {
+        match b {
+            // Syntax punctuation common in source code
+            b'{' | b'}' | b'[' | b']' | b'(' | b')' | b';' | b'=' | b'<' | b'>' | b'|'
+            | b'&' | b'#' | b'@' | b'!' | b'~' | b'^' | b'\\' | b'"' | b'\'' => {
+                syntax_count += 1;
+            }
+            // UTF-8 multi-byte sequence starters (0xC0..=0xFF)
+            // CJK codepoints are 3-byte (0xE0..0xEF start), so high_byte_count
+            // correlates with multi-byte character density.
+            0xC0..=0xFF => {
+                high_byte_count += 1;
+            }
+            _ => {}
+        }
+    }
+
+    // CJK detection: high byte-to-character ratio means multi-byte dominant.
+    // Pure CJK text has ~3 bytes/char (ratio 3.0). Threshold at 2.5 catches
+    // CJK-heavy mixed text while avoiding false positives on accented Latin.
+    if high_byte_count > 0 {
+        let char_count = text.chars().count();
+        if char_count > 0 && byte_len > char_count * 2 + char_count / 2 {
+            // CJK mode: ~1.5 tokens per character (GPT/Claude empirical average)
+            return (char_count * 3).div_ceil(2); // ceiling of chars * 1.5
+        }
+    }
+
+    // Code detection: 8%+ syntax characters in sample.
+    // English prose has ~2-3% punctuation. Source code in Rust/Python/JS: 10-15%.
+    if sample_end > 0 && syntax_count * 100 >= sample_end * CODE_SYNTAX_THRESHOLD_PERCENT {
+        // Code mode: ~3.2 bytes per token → multiply by 10/32 for integer math
+        return byte_len * 10 / 32;
+    }
+
+    // Prose mode (default): ~4 bytes per token, ceiling division
+    byte_len.div_ceil(4)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_string_returns_zero() {
+        assert_eq!(estimate_tokens(""), 0);
+    }
+
+    #[test]
+    fn single_word() {
+        // "hello" = 5 bytes → prose mode → ceil(5/4) = 2
+        assert_eq!(estimate_tokens("hello"), 2);
+    }
+
+    #[test]
+    fn english_prose() {
+        let text = "The quick brown fox jumps over the lazy dog. \
+                     This is a typical English sentence with normal punctuation.";
+        let tokens = estimate_tokens(text);
+        let expected_approx = text.len() / 4;
+        // Should be in prose mode, within ±2 of len/4
+        assert!(
+            tokens.abs_diff(expected_approx) <= 2,
+            "prose: got {tokens}, expected ~{expected_approx}"
+        );
+    }
+
+    #[test]
+    fn rust_code_detects_higher_token_density() {
+        let code = r#"
+fn main() {
+    let mut v: Vec<String> = Vec::new();
+    for i in 0..100 {
+        v.push(format!("{}: {}", i, i * 2));
+    }
+    println!("{:?}", &v[0..5]);
+}
+"#;
+        let prose_estimate = code.len() / 4;
+        let code_estimate = estimate_tokens(code);
+        // Code mode should produce a DIFFERENT estimate than naive len/4
+        // code mode: len * 10 / 32 ≈ len * 0.3125 which is < len/4 = len * 0.25
+        // Wait: 10/32 = 0.3125 > 0.25, so code estimate should be HIGHER
+        assert!(
+            code_estimate > prose_estimate,
+            "code mode ({code_estimate}) should be higher than prose ({prose_estimate})"
+        );
+    }
+
+    #[test]
+    fn cjk_text_detects_multibyte() {
+        let cjk = "你好世界这是一个测试用来验证中文内容的分词估算是否准确";
+        let tokens = estimate_tokens(cjk);
+        let char_count = cjk.chars().count();
+        // Should be in CJK mode: ~1.5 tokens per character
+        let expected = (char_count * 3 + 1) / 2;
+        assert_eq!(
+            tokens, expected,
+            "CJK: got {tokens}, expected {expected} (chars={char_count})"
+        );
+    }
+
+    #[test]
+    fn mixed_cjk_english_stays_prose_if_mostly_ascii() {
+        // Mostly ASCII with a few CJK chars → should NOT trigger CJK mode
+        let text = "This is an English sentence with a few Chinese characters 你好 in it.";
+        let tokens = estimate_tokens(text);
+        let prose_approx = text.len() / 4;
+        // byte/char ratio should be close to 1.x, not > 2.5
+        assert!(
+            tokens.abs_diff(prose_approx) <= 3,
+            "mixed: got {tokens}, expected ~{prose_approx} (prose mode)"
+        );
+    }
+
+    #[test]
+    fn python_code() {
+        let code = r#"
+def calculate(items: list[dict]) -> float:
+    total = sum(item["price"] * item["qty"] for item in items)
+    tax = total * 0.08
+    return round(total + tax, 2)
+
+if __name__ == "__main__":
+    result = calculate([{"price": 9.99, "qty": 3}])
+    print(f"Total: ${result:.2f}")
+"#;
+        let tokens = estimate_tokens(code);
+        let prose_estimate = code.len() / 4;
+        assert!(
+            tokens > prose_estimate,
+            "python code ({tokens}) should be > prose estimate ({prose_estimate})"
+        );
+    }
+
+    #[test]
+    fn json_data() {
+        let json = r#"{"users": [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}], "total": 2}"#;
+        let tokens = estimate_tokens(json);
+        // JSON has lots of syntax chars → code mode
+        let code_estimate = json.len() * 10 / 32;
+        assert_eq!(tokens, code_estimate, "JSON should trigger code mode");
+    }
+
+    #[test]
+    fn large_text_only_samples_512_bytes() {
+        // Create a large prose text — estimation should be based on sampling first 512 bytes
+        // but applied to full length
+        let text = "The quick brown fox jumps over the lazy dog. ".repeat(200);
+        let tokens = estimate_tokens(&text);
+        let prose_approx = text.len() / 4;
+        assert!(
+            tokens.abs_diff(prose_approx) <= 2,
+            "large prose: got {tokens}, expected ~{prose_approx}"
+        );
+    }
+
+    #[test]
+    fn whitespace_only() {
+        let text = "   \n\t  \n  ";
+        let tokens = estimate_tokens(text);
+        assert!(tokens > 0, "whitespace-only should return > 0");
+    }
+
+    #[test]
+    fn single_char() {
+        assert_eq!(estimate_tokens("a"), 1);
+    }
+}

--- a/src/token_estimation.rs
+++ b/src/token_estimation.rs
@@ -50,8 +50,8 @@ pub fn estimate_tokens(text: &str) -> usize {
     for &b in sample {
         match b {
             // Syntax punctuation common in source code
-            b'{' | b'}' | b'[' | b']' | b'(' | b')' | b';' | b'=' | b'<' | b'>' | b'|'
-            | b'&' | b'#' | b'@' | b'!' | b'~' | b'^' | b'\\' | b'"' | b'\'' => {
+            b'{' | b'}' | b'[' | b']' | b'(' | b')' | b';' | b'=' | b'<' | b'>' | b'|' | b'&'
+            | b'#' | b'@' | b'!' | b'~' | b'^' | b'\\' | b'"' | b'\'' => {
                 syntax_count += 1;
             }
             // UTF-8 multi-byte sequence starters (0xC0..=0xFF)
@@ -184,7 +184,8 @@ if __name__ == "__main__":
 
     #[test]
     fn json_data() {
-        let json = r#"{"users": [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}], "total": 2}"#;
+        let json =
+            r#"{"users": [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}], "total": 2}"#;
         let tokens = estimate_tokens(json);
         // JSON has lots of syntax chars → code mode
         let code_estimate = json.len() * 10 / 32;

--- a/tui/src/types.rs
+++ b/tui/src/types.rs
@@ -875,6 +875,7 @@ impl MemoryEvent {
             "TODO_DELETE" => Color::Red,
             "FEEDBACK_PROCESSED" => Color::Rgb(200, 180, 255), // Pastel purple
             "PROACTIVE_CONTEXT" => Color::Rgb(180, 220, 255),  // Light blue
+            "CONTEXT_COMPRESSED" => Color::Rgb(255, 200, 140), // Warm orange
             _ => Color::White,
         }
     }
@@ -897,6 +898,7 @@ impl MemoryEvent {
             "TODO_DELETE" => "☒",
             "FEEDBACK_PROCESSED" => "⟲",
             "PROACTIVE_CONTEXT" => "◉",
+            "CONTEXT_COMPRESSED" => "⟳",
             _ => "•",
         }
     }


### PR DESCRIPTION
## Summary

- **Session history** — `POST /api/sessions/history` retrieves persisted session summaries from RocksDB with project continuity detection (union-find clustering on entity overlap ≥3). Deduplicates by session_id, filters system tags from clustering, sorts newest-first.
- **Fact narratives** — `POST /api/facts/narratives` clusters facts by shared entities, generates template-based narratives with confidence labels (established/probable/tentative), detects causal chains via keyword heuristics (no LLM).
- **Session digest** — `POST /api/sessions/digest` returns structured session metrics. `POST /api/sessions/context-compressed` persists digest snapshots as Context memories with full metadata.
- **Token estimation** — Content-aware heuristic (code/prose/mixed detection) replacing naive length/4.
- **Metadata pipeline** — Added `metadata` HashMap to `RememberRequest` so hooks can transmit session_id, started_at, duration_secs. Enriched `handleStop()` with digest data (fallback to thin summary when server unavailable).
- **MCP tools** — `session_history`, `fact_narratives`, `session_digest` with defensive error handling.
- **TUI** — `CONTEXT_COMPRESSED` event icon.

## 12 bugs found & fixed during deep verification

| # | Bug | Severity |
|---|-----|----------|
| 1 | Hook `entities` silently dropped (no API field) | High |
| 2 | Hook `metadata` silently dropped (no API field) | Critical |
| 3 | Compression digests invisible to `session_history` (missing tag) | High |
| 4 | `session_history` returns random order (HashSet iteration) | High |
| 5 | Truncate-before-sort returns wrong subset | Critical |
| 6 | No session deduplication (compression + hook = 2 entries) | High |
| 7 | System tags inflate clustering overlap | High |
| 8 | `.to_lowercase()` in O(n²) causal chain inner loop | Medium |
| 9 | MCP tools ignore backend `success` field | Medium |
| 10 | MCP `fact_narratives` unsafe null field access | Medium |
| 11 | Compression metadata missing started_at/duration/memories | Medium |
| 12 | Misleading `uf_find` doc (claimed path halving) | Low |

## Files changed (13 files, +1478 -15)

| File | Change |
|------|--------|
| `src/handlers/sessions.rs` | Session history handler, project thread clustering, enriched context_compressed |
| `src/memory/mod.rs` | `build_fact_narratives()`, causal chain detection, exports |
| `src/memory/compression.rs` | `FactCluster`, `CausalFactLink` types |
| `src/memory/sessions.rs` | `SessionDigest`, token tracking in `Session` |
| `src/token_estimation.rs` | Content-aware token estimation (new file) |
| `src/handlers/facts.rs` | `fact_narratives` handler |
| `src/handlers/remember.rs` | Added `metadata` field to `RememberRequest` |
| `src/handlers/router.rs` | 4 new routes |
| `src/lib.rs` | `token_estimation` module export |
| `mcp-server/index.ts` | 3 MCP tools (session_history, fact_narratives, session_digest) |
| `mcp-server/token-tracking.ts` | Token tracking utilities |
| `hooks/memory-hook.ts` | Enriched `handleStop()` with digest data + metadata |
| `tui/src/types.rs` | `CONTEXT_COMPRESSED` event display |

## Test plan

- [x] `cargo check` — clean
- [x] `cargo clippy --lib` — no new warnings (128 pre-existing baseline)
- [x] `cargo test --lib` — 575 passed, 0 failed
- [ ] Manual: call `session_history` MCP tool → verify sessions sorted newest-first, no duplicates
- [ ] Manual: call `fact_narratives` MCP tool → verify clustered facts with confidence labels
- [ ] Manual: end a session → verify enriched summary stored with entities and metadata
- [ ] Manual: verify `session_history` with `group_by_project: true` clusters by real entities, not system tags