### PR TITLE
fix: remove garbage fact extraction + session start briefing

### DIFF
--- a/hooks/memory-hook.ts
+++ b/hooks/memory-hook.ts
@@ -914,60 +914,173 @@ async function handleSessionStart(input: HookInput): Promise<void> {
   const projectName = projectDir.split(/[/\\]/).pop() || "unknown";
   const claudeDir = `${projectDir}/.claude`;
 
-  // Ensure .claude directory exists before any writes
   try {
     require("fs").mkdirSync(claudeDir, { recursive: true });
   } catch {
     // Best effort
   }
 
-  // Visibility Moment 4: Memory count at session start
-  const statsResp = (await callBrainGet(
-    `/api/stats?user_id=${encodeURIComponent(SHODH_USER_ID)}`
-  )) as { total_memories?: number; graph_nodes?: number; graph_edges?: number } | null;
+  // ── Phase 1: Parallel data fetch ──────────────────────────────────────
+  // Four independent calls — stats, session history, todos, semantic context
 
-  if (statsResp && statsResp.total_memories != null) {
-    const edges = statsResp.graph_edges || 0;
-    console.error(`[shodh] Memory: ${statsResp.total_memories} memories | ${edges} graph edges`);
+  interface SessionEntry {
+    content: string;
+    entities: string[];
+    session_id?: string;
+    started_at?: string;
+    duration_secs?: number;
+    memories_created?: number;
+    created_at: string;
+  }
+  interface ProjectThread {
+    name: string;
+    sessions: number[];
+    shared_entities: string[];
+    session_count: number;
+  }
+  interface SessionHistoryResponse {
+    success: boolean;
+    sessions: SessionEntry[];
+    project_threads: ProjectThread[];
+    total: number;
   }
 
-  const context = `Starting session in project: ${projectName}`;
+  interface SummaryItem {
+    id: string;
+    content: string;
+    importance: number;
+    created_at: string;
+  }
+  interface ContextSummaryResponse {
+    total_memories: number;
+    decisions: SummaryItem[];
+    learnings: SummaryItem[];
+    context: SummaryItem[];
+    patterns: SummaryItem[];
+    errors: SummaryItem[];
+  }
 
-  // Parallel: semantic context + tag-based session restoration + active todos
-  const [memoryResult, tagResult, activeTodosResult] = await Promise.all([
-    surfaceProactiveContext(context, 5),
-    callBrain("/api/recall/tags", {
+  const [statsResp, historyResp, activeTodosResult, memoryResult, summaryResp] = await Promise.all([
+    callBrainGet(
+      `/api/stats?user_id=${encodeURIComponent(SHODH_USER_ID)}`
+    ) as Promise<{ total_memories?: number; graph_nodes?: number; graph_edges?: number; total_facts?: number } | null>,
+
+    callBrain("/api/sessions/history", {
       user_id: SHODH_USER_ID,
-      tags: ["session-summary", "source:hook"],
       limit: 5,
-    }) as Promise<{ memories?: Array<{ id: string; content?: string; experience?: { content?: string } }> } | null>,
+      group_by_project: true,
+    }) as Promise<SessionHistoryResponse | null>,
+
     callBrain("/api/todos/list", {
       user_id: SHODH_USER_ID,
       status: ["in_progress", "todo"],
-      limit: 5,
+      limit: 8,
     }) as Promise<{ todos?: Array<{ id: string; seq_num?: number; project_prefix?: string; content: string; status: string; priority: string }> } | null>,
+
+    surfaceProactiveContext(`Starting session in project: ${projectName}`, 5),
+
+    callBrain("/api/context_summary", {
+      user_id: SHODH_USER_ID,
+      max_items: 5,
+      include_decisions: true,
+      include_learnings: true,
+      include_context: false,
+    }) as Promise<ContextSummaryResponse | null>,
   ]);
 
-  // Extract tag-based session context (cap at 3 to avoid noise)
-  let tagContext = "";
-  if (tagResult?.memories?.length) {
-    tagContext = tagResult.memories
-      .slice(0, 3)
-      .map((m) => {
-        const content = m.content || m.experience?.content || "";
-        return `\u2022 [session] ${content.slice(0, 120)}${content.length > 120 ? "..." : ""}`;
-      })
-      .join("\n");
+  // ── Phase 2: Compute state ────────────────────────────────────────────
+
+  const totalMemories = statsResp?.total_memories || 0;
+  const graphEdges = statsResp?.graph_edges || 0;
+  const totalFacts = statsResp?.total_facts || 0;
+  const sessions = historyResp?.success ? historyResp.sessions : [];
+  const projectThreads = historyResp?.success ? historyResp.project_threads : [];
+  const todos = activeTodosResult?.todos || [];
+  const isFirstSession = totalMemories < 5 && sessions.length === 0;
+
+  // ── Phase 3: stderr status line (always visible to user) ──────────────
+
+  if (isFirstSession) {
+    console.error(`[shodh] First session — memory capture active`);
+  } else {
+    const statParts: string[] = [];
+    if (totalMemories > 0) statParts.push(`${totalMemories} memories`);
+    if (graphEdges > 0) statParts.push(`${graphEdges} edges`);
+    if (totalFacts > 0) statParts.push(`${totalFacts} facts`);
+    console.error(`[shodh] ${statParts.join(" | ")}`);
+
+    // Show recent sessions in stderr so user sees continuity
+    if (sessions.length > 0) {
+      const sessionLines = sessions.slice(0, 3).map((s, i) => {
+        const age = timeAgo(s.created_at);
+        const dur = s.duration_secs ? ` (${formatDuration(s.duration_secs)})` : "";
+        const preview = s.content.length > 80 ? s.content.slice(0, 77) + "..." : s.content;
+        return `  ${i + 1}. ${age}${dur}: ${preview}`;
+      });
+      console.error(`[shodh] Recent sessions:\n${sessionLines.join("\n")}`);
+    }
+
+    if (todos.length > 0) {
+      const inProgress = todos.filter(t => t.status === "in_progress").length;
+      const pending = todos.filter(t => t.status === "todo").length;
+      const parts: string[] = [];
+      if (inProgress > 0) parts.push(`${inProgress} in progress`);
+      if (pending > 0) parts.push(`${pending} pending`);
+      console.error(`[shodh] Active work: ${parts.join(", ")}`);
+    }
   }
 
-  const hasMemoryContext = memoryResult !== null;
-  const hasTagContext = tagContext.length > 0;
+  // ── Phase 4: Build additionalContext for Claude ───────────────────────
 
-  // Active work surfacing
-  let activeWorkContext = "";
-  if (activeTodosResult?.todos?.length) {
-    const todoLines: string[] = [];
-    for (const t of activeTodosResult.todos) {
+  if (isFirstSession) {
+    console.log(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext: `\n<shodh-memory>\nFirst session detected. Shodh will learn automatically — edits, errors, and commands are captured as memories. A session report will be shown when you end the session.\n</shodh-memory>`,
+      },
+    }));
+    return;
+  }
+
+  const contextParts: string[] = [];
+
+  // Session history — structured timeline
+  if (sessions.length > 0) {
+    const sessionBlock: string[] = ["Recent sessions:"];
+    for (const s of sessions) {
+      const age = timeAgo(s.created_at);
+      const dur = s.duration_secs ? ` (${formatDuration(s.duration_secs)})` : "";
+      const memCount = s.memories_created != null ? ` | ${s.memories_created} memories` : "";
+      sessionBlock.push(`• ${age}${dur}${memCount}`);
+      sessionBlock.push(`  ${s.content.slice(0, 200)}`);
+      if (s.entities.length > 0) {
+        const filtered = s.entities.filter(e =>
+          !["session-summary", "session-digest", "source:hook"].includes(e)
+        );
+        if (filtered.length > 0) {
+          sessionBlock.push(`  Topics: ${filtered.slice(0, 8).join(", ")}`);
+        }
+      }
+    }
+    contextParts.push(sessionBlock.join("\n"));
+  }
+
+  // Project threads — cross-session continuity
+  if (projectThreads.length > 0) {
+    const threadBlock: string[] = ["Active projects:"];
+    for (const t of projectThreads) {
+      threadBlock.push(`• ${t.name} — ${t.session_count} sessions`);
+      if (t.shared_entities.length > 0) {
+        threadBlock.push(`  Shared context: ${t.shared_entities.slice(0, 6).join(", ")}`);
+      }
+    }
+    contextParts.push(threadBlock.join("\n"));
+  }
+
+  // Active todos — what's in flight
+  if (todos.length > 0) {
+    const todoBlock: string[] = ["Active work:"];
+    for (const t of todos) {
       const shortId = t.project_prefix && t.seq_num != null
         ? `${t.project_prefix}-${t.seq_num}`
         : "?";
@@ -975,57 +1088,117 @@ async function handleSessionStart(input: HookInput): Promise<void> {
       const truncContent = t.content.length > 60
         ? t.content.slice(0, 57) + "..."
         : t.content;
-      todoLines.push(`  ${icon} ${shortId.padEnd(8)} ${truncContent}`);
+      todoBlock.push(`${icon} ${shortId.padEnd(8)} ${truncContent}`);
     }
-    console.error(`[shodh] Active work:\n${todoLines.join("\n")}`);
-    activeWorkContext = `\nActive todos:\n${todoLines.join("\n")}`;
+    contextParts.push(todoBlock.join("\n"));
   }
 
-  // Visibility Moment 3: First-session welcome
-  if (!hasMemoryContext && !hasTagContext) {
-    // No memories and no session summaries — likely first session
-    const isFirstSession = !statsResp || (statsResp.total_memories || 0) < 5;
-    if (isFirstSession) {
-      console.error(`[shodh] First session \u2014 memory capture active`);
-      console.log(
-        JSON.stringify({
-          hookSpecificOutput: {
-            hookEventName: "SessionStart",
-            additionalContext: `\n<shodh-memory>\nFirst session detected. Shodh will learn automatically \u2014 edits, errors, and commands are captured as memories. A session report will be shown when you end the session.${activeWorkContext}\n</shodh-memory>`,
-          },
-        })
-      );
-    } else if (activeWorkContext) {
-      // No memories but has active todos — still inject context
-      console.log(
-        JSON.stringify({
-          hookSpecificOutput: {
-            hookEventName: "SessionStart",
-            additionalContext: `\n<shodh-memory>${activeWorkContext}\n</shodh-memory>`,
-          },
-        })
-      );
+  // Consolidated knowledge — decisions, learnings, patterns from past sessions
+  if (summaryResp) {
+    const knowledgeBlock: string[] = [];
+
+    const decisions = summaryResp.decisions || [];
+    const learnings = summaryResp.learnings || [];
+    const patterns = summaryResp.patterns || [];
+    const errors = summaryResp.errors || [];
+
+    if (decisions.length > 0) {
+      knowledgeBlock.push("Key decisions:");
+      for (const d of decisions.slice(0, 3)) {
+        const age = timeAgo(d.created_at);
+        const preview = d.content.length > 120 ? d.content.slice(0, 117) + "..." : d.content;
+        knowledgeBlock.push(`  • [${age}] ${preview}`);
+      }
     }
+
+    if (learnings.length > 0) {
+      knowledgeBlock.push("Learnings:");
+      for (const l of learnings.slice(0, 3)) {
+        const age = timeAgo(l.created_at);
+        const preview = l.content.length > 120 ? l.content.slice(0, 117) + "..." : l.content;
+        knowledgeBlock.push(`  • [${age}] ${preview}`);
+      }
+    }
+
+    if (patterns.length > 0) {
+      knowledgeBlock.push("Patterns observed:");
+      for (const p of patterns.slice(0, 2)) {
+        const preview = p.content.length > 120 ? p.content.slice(0, 117) + "..." : p.content;
+        knowledgeBlock.push(`  • ${preview}`);
+      }
+    }
+
+    if (errors.length > 0) {
+      knowledgeBlock.push("Recent errors:");
+      for (const e of errors.slice(0, 2)) {
+        const age = timeAgo(e.created_at);
+        const preview = e.content.length > 120 ? e.content.slice(0, 117) + "..." : e.content;
+        knowledgeBlock.push(`  • [${age}] ${preview}`);
+      }
+    }
+
+    if (knowledgeBlock.length > 0) {
+      contextParts.push(knowledgeBlock.join("\n"));
+    }
+  }
+
+  // Semantic memories — relevant to this project
+  if (memoryResult) {
+    contextParts.push(memoryResult.text);
+  }
+
+  if (contextParts.length === 0) {
     return;
   }
 
-  // Build combined context
-  const parts: string[] = [];
-  if (memoryResult) parts.push(memoryResult.text);
-  if (hasTagContext) parts.push(tagContext);
-  if (activeWorkContext) parts.push(activeWorkContext);
-  const combinedContext = parts.join("\n\n");
-
+  const briefing = contextParts.join("\n\n");
   const surfacedCount = memoryResult?.meta.count || 0;
-  console.error(`[shodh] Session context loaded (${surfacedCount} memories surfaced)`);
+  console.error(`[shodh] Briefing loaded (${sessions.length} sessions, ${todos.length} todos, ${surfacedCount} memories)`);
 
-  // Write to project memory file
+  // Inject into Claude's context
+  console.log(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: `\n<shodh-memory>\n${briefing}\n</shodh-memory>`,
+    },
+  }));
+
+  // Persist to project memory file for reference
   const memoryFile = `${claudeDir}/memory-context.md`;
   try {
-    await Bun.write(memoryFile, `# Shodh Memory Context\n\n${combinedContext}\n`);
+    await Bun.write(memoryFile, `# Session Briefing\n\n${briefing}\n`);
   } catch {
     // Best effort
   }
+}
+
+/** Format seconds into human-readable duration */
+function formatDuration(secs: number): string {
+  if (secs < 60) return `${secs}s`;
+  if (secs < 3600) return `${Math.round(secs / 60)}m`;
+  const h = Math.floor(secs / 3600);
+  const m = Math.round((secs % 3600) / 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+/** Format ISO timestamp into relative age */
+function timeAgo(isoDate: string): string {
+  const now = Date.now();
+  const then = new Date(isoDate).getTime();
+  if (isNaN(then)) return "unknown";
+
+  const diffMs = now - then;
+  const diffMin = Math.floor(diffMs / 60_000);
+  const diffHr = Math.floor(diffMs / 3_600_000);
+  const diffDay = Math.floor(diffMs / 86_400_000);
+
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffDay === 1) return "yesterday";
+  if (diffDay < 7) return `${diffDay} days ago`;
+  if (diffDay < 30) return `${Math.floor(diffDay / 7)} weeks ago`;
+  return `${Math.floor(diffDay / 30)} months ago`;
 }
 
 async function handleUserPrompt(input: HookInput): Promise<void> {

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -1057,6 +1057,25 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
         },
       },
+      {
+        name: "purge_facts",
+        description: "Delete facts matching a content pattern. Use dry_run=true to preview before deleting. Useful for cleaning up garbage facts (e.g., 'relates to' template noise).",
+        inputSchema: {
+          type: "object",
+          properties: {
+            pattern: {
+              type: "string",
+              description: "Substring to match in fact content (case-insensitive, min 3 chars)",
+            },
+            dry_run: {
+              type: "boolean",
+              description: "If true, count matches without deleting (default: false)",
+              default: false,
+            },
+          },
+          required: ["pattern"],
+        },
+      },
       // Prospective Memory / Reminders (SHO-116)
       {
         name: "set_reminder",
@@ -3026,6 +3045,44 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         return {
           content: [{ type: "text", text: narResponse }],
+        };
+      }
+
+      case "purge_facts": {
+        const { pattern, dry_run = false } = args as {
+          pattern: string;
+          dry_run?: boolean;
+        };
+
+        if (!pattern || pattern.length < 3) {
+          return {
+            content: [{ type: "text", text: "Pattern must be at least 3 characters." }],
+          };
+        }
+
+        const purgeResult = await callBrain("/api/facts/purge", {
+          user_id: userId,
+          pattern,
+          dry_run,
+        }) as {
+          success?: boolean;
+          deleted?: number;
+          total_scanned?: number;
+          dry_run?: boolean;
+        } | null;
+
+        if (!purgeResult?.success) {
+          return {
+            content: [{ type: "text", text: "Failed to purge facts. Server may be unavailable." }],
+          };
+        }
+
+        const mode = purgeResult.dry_run ? "DRY RUN" : "PURGED";
+        return {
+          content: [{
+            type: "text",
+            text: `${mode}: ${purgeResult.deleted} of ${purgeResult.total_scanned} facts match "${pattern}"${purgeResult.dry_run ? "\nRe-run with dry_run=false to delete." : ""}`,
+          }],
         };
       }
 

--- a/src/handlers/facts.rs
+++ b/src/handlers/facts.rs
@@ -159,6 +159,80 @@ pub async fn get_facts_stats(
 }
 
 // =============================================================================
+// Fact Purge
+// =============================================================================
+
+/// Request for purging garbage facts
+#[derive(Debug, Deserialize)]
+pub struct FactPurgeRequest {
+    pub user_id: String,
+    /// Pattern to match against fact content (case-insensitive substring).
+    /// Facts containing this pattern will be deleted.
+    pub pattern: String,
+    /// If true, only count matches without deleting (default: false)
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+/// Response for fact purge
+#[derive(Debug, Serialize)]
+pub struct FactPurgeResponse {
+    pub success: bool,
+    pub deleted: usize,
+    pub total_scanned: usize,
+    pub dry_run: bool,
+}
+
+/// POST /api/facts/purge - Delete facts matching a content pattern
+#[tracing::instrument(skip(state), fields(user_id = %req.user_id, pattern = %req.pattern))]
+pub async fn purge_facts(
+    State(state): State<AppState>,
+    Json(req): Json<FactPurgeRequest>,
+) -> Result<Json<FactPurgeResponse>, AppError> {
+    validation::validate_user_id(&req.user_id).map_validation_err("user_id")?;
+
+    if req.pattern.len() < 3 {
+        return Err(AppError::InvalidInput {
+            field: "pattern".into(),
+            reason: "Must be at least 3 characters to prevent accidental mass deletion".into(),
+        });
+    }
+
+    let memory = state
+        .get_user_memory(&req.user_id)
+        .map_err(AppError::Internal)?;
+    let user_id = req.user_id.clone();
+    let pattern = req.pattern.to_lowercase();
+    let dry_run = req.dry_run;
+
+    let (deleted, total_scanned) = tokio::task::spawn_blocking(move || {
+        let ms = memory.read();
+        if dry_run {
+            // Count only — don't delete
+            let all_facts = ms.get_facts(&user_id, 10_000)?;
+            let total = all_facts.len();
+            let matched = all_facts
+                .iter()
+                .filter(|f| f.fact.to_lowercase().contains(&pattern))
+                .count();
+            Ok::<_, anyhow::Error>((matched, total))
+        } else {
+            ms.purge_facts(&user_id, |f| f.fact.to_lowercase().contains(&pattern))
+        }
+    })
+    .await
+    .map_err(|e| AppError::Internal(anyhow::anyhow!("Blocking task panicked: {e}")))?
+    .map_err(AppError::Internal)?;
+
+    Ok(Json(FactPurgeResponse {
+        success: true,
+        deleted,
+        total_scanned,
+        dry_run,
+    }))
+}
+
+// =============================================================================
 // Fact Narratives
 // =============================================================================
 

--- a/src/handlers/router.rs
+++ b/src/handlers/router.rs
@@ -181,6 +181,7 @@ pub fn build_protected_routes(state: AppState) -> Router {
         .route("/api/facts/by-entity", post(facts::facts_by_entity))
         .route("/api/facts/stats", post(facts::get_facts_stats))
         .route("/api/facts/narratives", post(facts::fact_narratives))
+        .route("/api/facts/purge", post(facts::purge_facts))
         // =================================================================
         // LINEAGE
         // =================================================================

--- a/src/memory/compression.rs
+++ b/src/memory/compression.rs
@@ -910,43 +910,20 @@ impl SemanticConsolidator {
             candidates.push((fact, importance * 0.6));
         }
 
+        // Filter operational noise before dedup/truncation
+        candidates.retain(|(text, _)| Self::is_knowledge_worthy(text));
+
         // Deduplicate overlapping extractions from the same memory
         candidates = self.dedup_within_memory(candidates);
 
         // Cap per-memory candidates
         candidates.truncate(CONSOLIDATION_MAX_CANDIDATES_PER_MEMORY);
 
-        // Entity pair relationships (sorted for determinism)
-        // Filter: min 3 chars, no stop words, remove substring-redundant entities
-        if memory.experience.entities.len() >= 2 {
-            let mut sorted_entities: Vec<String> = memory
-                .experience
-                .entities
-                .iter()
-                .map(|e| e.to_lowercase())
-                .filter(|e| e.len() >= 3 && !self.keyword_extractor.is_stop_word(e))
-                .collect();
-            sorted_entities.sort();
-            sorted_entities.dedup();
-
-            // Remove entities that are substrings of another entity in the set
-            // e.g. "chose" is redundant when "chose rust" exists
-            let before_dedup = sorted_entities.clone();
-            sorted_entities.retain(|entity| {
-                !before_dedup
-                    .iter()
-                    .any(|other| other != entity && other.contains(entity.as_str()))
-            });
-
-            let max_entities = sorted_entities.len().min(4);
-            for i in 0..max_entities {
-                for j in (i + 1)..max_entities {
-                    let relationship =
-                        format!("{} relates to {}", sorted_entities[i], sorted_entities[j]);
-                    candidates.push((relationship, importance * 0.8));
-                }
-            }
-        }
+        // NOTE: Entity pair relationships ("X relates to Y") were removed here.
+        // The knowledge graph already captures entity co-occurrence via O(n²) all-pairs
+        // RelationshipEdge creation (state.rs process_experience_into_graph) with Hebbian
+        // strengthening and edge tier promotion. The template-based pairs were redundant,
+        // lower-fidelity, and constituted ~86% of all extracted facts as noise.
 
         candidates
     }
@@ -1171,6 +1148,83 @@ impl SemanticConsolidator {
         }
 
         best.map(|(s, _)| s)
+    }
+
+    // ── Quality Gate ──────────────────────────────────────────────────────
+
+    /// Reject operational noise that shouldn't become semantic facts.
+    /// Facts should capture domain knowledge, decisions, and patterns —
+    /// not session lifecycle events, tool invocations, or status updates.
+    fn is_knowledge_worthy(text: &str) -> bool {
+        let lower = text.to_lowercase();
+        let len = text.trim().len();
+
+        // Too short to carry meaningful knowledge
+        if len < 25 {
+            return false;
+        }
+
+        // Session lifecycle noise
+        const SESSION_NOISE: &[&str] = &[
+            "session started",
+            "session ended",
+            "session summary",
+            "context compressed",
+            "context window",
+            "token budget",
+            "tokens used",
+            "proactive_context",
+            "auto_ingest",
+            "memory surfaced",
+            "memories surfaced",
+            "memory stored",
+            "memories stored",
+        ];
+        if SESSION_NOISE.iter().any(|s| lower.contains(s)) {
+            return false;
+        }
+
+        // Tool/MCP invocation logs
+        const TOOL_NOISE: &[&str] = &[
+            "tool call",
+            "tool_name",
+            "mcp tool",
+            "called remember",
+            "called recall",
+            "called forget",
+            "hook triggered",
+            "hook fired",
+        ];
+        if TOOL_NOISE.iter().any(|s| lower.contains(s)) {
+            return false;
+        }
+
+        // Todo/task status chatter
+        const TODO_NOISE: &[&str] = &[
+            "todo created",
+            "todo completed",
+            "todo updated",
+            "task created",
+            "task completed",
+            "task updated",
+            "marked as done",
+            "marked as complete",
+            "moved to backlog",
+            "moved to in_progress",
+        ];
+        if TODO_NOISE.iter().any(|s| lower.contains(s)) {
+            return false;
+        }
+
+        // Bare file paths as standalone "facts" (e.g. "src/memory/mod.rs")
+        // Heuristic: short text with path separators and few words is not knowledge
+        let path_chars = lower.chars().filter(|c| *c == '/' || *c == '\\').count();
+        let word_count = text.split_whitespace().count();
+        if path_chars >= 1 && word_count < 6 {
+            return false;
+        }
+
+        true
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────
@@ -1707,41 +1761,88 @@ mod tests {
     }
 
     #[test]
-    fn test_entity_relationships_sorted_deterministic() {
+    fn test_no_relates_to_patterns() {
         let consolidator = SemanticConsolidator::new();
 
-        let m1 = create_typed_memory(
-            "Testing entity ordering",
+        let memory = create_typed_memory(
+            "Testing entity extraction without template patterns",
             0.7,
             ExperienceType::Observation,
             vec!["JWT".to_string(), "Auth".to_string(), "Token".to_string()],
         );
 
-        let m2 = create_typed_memory(
-            "Testing entity ordering",
-            0.7,
-            ExperienceType::Observation,
-            vec!["Token".to_string(), "Auth".to_string(), "JWT".to_string()],
+        let candidates = consolidator.extract_fact_candidates(&memory);
+
+        // Entity pair "relates to" patterns were removed (redundant with knowledge graph)
+        let has_relates_to = candidates.iter().any(|(t, _)| t.contains("relates to"));
+        assert!(
+            !has_relates_to,
+            "Should not produce synthetic 'X relates to Y' patterns"
         );
+    }
 
-        let c1 = consolidator.extract_fact_candidates(&m1);
-        let c2 = consolidator.extract_fact_candidates(&m2);
+    #[test]
+    fn test_quality_gate_rejects_session_noise() {
+        assert!(!SemanticConsolidator::is_knowledge_worthy(
+            "Session started at 2:15 PM with token budget of 200k"
+        ));
+        assert!(!SemanticConsolidator::is_knowledge_worthy(
+            "Context compressed after reaching 80% of token budget"
+        ));
+        assert!(!SemanticConsolidator::is_knowledge_worthy(
+            "3 memories surfaced via proactive_context for the current query"
+        ));
+    }
 
-        // Entity relationships should be identical regardless of input order
-        let relations1: Vec<&str> = c1
-            .iter()
-            .filter(|(t, _)| t.contains("relates to"))
-            .map(|(t, _)| t.as_str())
-            .collect();
-        let relations2: Vec<&str> = c2
-            .iter()
-            .filter(|(t, _)| t.contains("relates to"))
-            .map(|(t, _)| t.as_str())
-            .collect();
+    #[test]
+    fn test_quality_gate_rejects_todo_noise() {
+        assert!(!SemanticConsolidator::is_knowledge_worthy(
+            "Todo created for implementing the new authentication module"
+        ));
+        assert!(!SemanticConsolidator::is_knowledge_worthy(
+            "Task completed after fixing the database connection pooling issue"
+        ));
+    }
 
-        assert_eq!(
-            relations1, relations2,
-            "Entity relationships should be deterministic regardless of input order"
-        );
+    #[test]
+    fn test_quality_gate_rejects_short_text() {
+        assert!(!SemanticConsolidator::is_knowledge_worthy("short"));
+        assert!(!SemanticConsolidator::is_knowledge_worthy(
+            "too short to be fact"
+        ));
+    }
+
+    #[test]
+    fn test_quality_gate_rejects_bare_file_paths() {
+        assert!(!SemanticConsolidator::is_knowledge_worthy(
+            "src/memory/compression.rs:919"
+        ));
+        assert!(!SemanticConsolidator::is_knowledge_worthy(
+            "hooks/memory-hook.ts file"
+        ));
+    }
+
+    #[test]
+    fn test_quality_gate_accepts_genuine_knowledge() {
+        assert!(SemanticConsolidator::is_knowledge_worthy(
+            "Rust provides memory safety without garbage collection through its ownership system"
+        ));
+        assert!(SemanticConsolidator::is_knowledge_worthy(
+            "The Vamana index automatically switches to SPANN when the dataset exceeds 100k vectors"
+        ));
+        assert!(SemanticConsolidator::is_knowledge_worthy(
+            "Hebbian learning uses additive boost and multiplicative decay for asymmetric strengthening"
+        ));
+        assert!(SemanticConsolidator::is_knowledge_worthy(
+            "RocksDB column families reduce file descriptor usage by consolidating multiple stores"
+        ));
+    }
+
+    #[test]
+    fn test_quality_gate_accepts_file_paths_with_prose() {
+        // File paths in context of explanation are fine
+        assert!(SemanticConsolidator::is_knowledge_worthy(
+            "The router configuration in src/handlers/router.rs defines all API endpoint routes for the server"
+        ));
     }
 }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -7040,6 +7040,24 @@ impl MemorySystem {
         self.fact_store.delete(user_id, fact_id)
     }
 
+    /// Purge facts matching a content predicate. Returns (deleted, total_scanned).
+    pub fn purge_facts<F>(&self, user_id: &str, predicate: F) -> Result<(usize, usize)>
+    where
+        F: Fn(&SemanticFact) -> bool,
+    {
+        let all_facts = self.fact_store.list(user_id, 10_000)?;
+        let total = all_facts.len();
+        let mut deleted = 0;
+        for fact in &all_facts {
+            if predicate(fact) {
+                if self.fact_store.delete(user_id, &fact.id)? {
+                    deleted += 1;
+                }
+            }
+        }
+        Ok((deleted, total))
+    }
+
     /// Get the fact store for direct access
     pub fn fact_store(&self) -> &Arc<facts::SemanticFactStore> {
         &self.fact_store


### PR DESCRIPTION
## Summary

- **Remove entity pair generator** from `compression.rs` — produced 86% of all facts as "X relates to Y" template noise, fully redundant with knowledge graph co-occurrence edges (Hebbian-strengthened RelationshipEdge in state.rs)
- **Add content quality gate** (`is_knowledge_worthy()`) — filters session lifecycle, tool/MCP logs, todo status chatter, bare file paths, and short text from fact extraction pipeline
- **Add `POST /api/facts/purge`** endpoint + `purge_facts` MCP tool — pattern-based fact deletion with dry_run support for cleaning existing garbage
- **Rewrite session start briefing** in hook — 5 parallel fetches (stats, session history, todos, context summary, semantic memories), structured output with relative timestamps, project thread detection, consolidated decisions/learnings/patterns/errors

## Test plan

- [x] 581/581 tests pass (`cargo test --lib`)
- [x] `cargo check` clean
- [x] `cargo fmt` clean
- [x] Bun transpiles hook without errors
- [x] 7 new tests: quality gate (session noise, todo noise, short text, bare paths, genuine knowledge, paths with prose) + no-relates-to assertion
- [ ] Manual: rebuild server, call `purge_facts` with `dry_run=true` on `"relates to"` pattern
- [ ] Manual: start new Claude Code session, verify enriched briefing in stderr + additionalContext