### PR TITLE
feat: wire robotics retrieval modes + reward-based Hebbian learning

### DIFF
--- a/docs/robotics-quickstart.md
+++ b/docs/robotics-quickstart.md
@@ -1,0 +1,218 @@
+# Robotics Quickstart
+
+Shodh-memory gives robots persistent, queryable memory that survives power cycles. Store experiences with GPS coordinates, mission context, reward signals, and sensor data — then recall them by location, mission, or outcome.
+
+## Setup
+
+```bash
+docker run -d -p 3030:3030 -v shodh_data:/data varunankuS/shodh-memory:latest
+```
+
+The server is now running at `http://localhost:3030`.
+
+## Store a Robotics Memory
+
+```bash
+curl -X POST http://localhost:3030/api/remember -H "Content-Type: application/json" -d '{
+  "user_id": "robot_001",
+  "content": "Navigated to charging station via corridor B. Obstacle detected at waypoint 3, rerouted through corridor C.",
+  "type": "Task",
+  "importance": 0.7,
+  "tags": ["navigation", "obstacle-avoidance"],
+  "robot_id": "robot_001",
+  "mission_id": "patrol_night_shift_042",
+  "action_type": "navigate",
+  "reward": 0.8,
+  "outcome_type": "success",
+  "terrain_type": "indoor",
+  "geo_location": [37.7749, -122.4194, 2.5],
+  "heading": 127.3,
+  "local_position": [12.5, 3.2, 0.0],
+  "sensor_data": {
+    "battery": 23.5,
+    "temperature": 22.1,
+    "lidar_range": 4.7
+  }
+}'
+```
+
+### Fields Reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `robot_id` | string | Robot identifier (for multi-robot fleets) |
+| `mission_id` | string | Mission/task grouping (e.g., "patrol_night_042") |
+| `action_type` | string | Action performed (navigate, grasp, dock, inspect) |
+| `reward` | float | RL reward signal, -1.0 to 1.0 |
+| `outcome_type` | string | success, failure, partial, aborted, timeout |
+| `terrain_type` | string | indoor, outdoor, urban, rural, water, aerial |
+| `geo_location` | [lat, lon, alt] | WGS84 GPS coordinates |
+| `heading` | float | Heading in degrees, 0-360 |
+| `local_position` | [x, y, z] | Local frame position in meters |
+| `sensor_data` | object | Arbitrary sensor readings (battery, temp, etc.) |
+
+## Recall by Location (Spatial Mode)
+
+Find memories near a GPS coordinate. Uses geohash indexing for sub-meter precision.
+
+```bash
+curl -X POST http://localhost:3030/api/recall -H "Content-Type: application/json" -d '{
+  "user_id": "robot_001",
+  "query": "obstacle near corridor",
+  "mode": "spatial",
+  "geo_lat": 37.7749,
+  "geo_lon": -122.4194,
+  "geo_radius_meters": 50.0,
+  "limit": 10
+}'
+```
+
+Results are sorted by distance (closest first).
+
+## Recall by Mission
+
+Replay all memories from a specific mission in chronological order.
+
+```bash
+curl -X POST http://localhost:3030/api/recall -H "Content-Type: application/json" -d '{
+  "user_id": "robot_001",
+  "query": "what happened during patrol",
+  "mode": "mission",
+  "mission_id": "patrol_night_shift_042",
+  "limit": 50
+}'
+```
+
+## Recall by Outcome (Reinforcement Learning)
+
+Find memories with specific reward outcomes. Useful for learning from success/failure.
+
+```bash
+# What actions led to positive rewards?
+curl -X POST http://localhost:3030/api/recall -H "Content-Type: application/json" -d '{
+  "user_id": "robot_001",
+  "query": "successful navigation actions",
+  "mode": "action_outcome",
+  "reward_min": 0.5,
+  "reward_max": 1.0,
+  "limit": 20
+}'
+
+# What went wrong? (failures only)
+curl -X POST http://localhost:3030/api/recall -H "Content-Type: application/json" -d '{
+  "user_id": "robot_001",
+  "query": "failed actions",
+  "mode": "action_outcome",
+  "reward_min": -1.0,
+  "reward_max": -0.3,
+  "failures_only": true,
+  "limit": 20
+}'
+```
+
+Results are sorted by reward (highest first).
+
+## Combined Filters
+
+All filters compose. Query by location within a mission, or by action type with outcome filters:
+
+```bash
+curl -X POST http://localhost:3030/api/recall -H "Content-Type: application/json" -d '{
+  "user_id": "robot_001",
+  "query": "grasp attempts",
+  "mode": "action_outcome",
+  "action_type": "grasp",
+  "robot_id": "robot_001",
+  "terrain_type": "indoor",
+  "reward_min": 0.0,
+  "reward_max": 1.0,
+  "limit": 10
+}'
+```
+
+## Reward-Based Learning
+
+Shodh uses reward signals for Hebbian edge strengthening in the knowledge graph:
+
+- **Positive reward** (e.g., +0.8): Strengthens associations between entities in the memory. "Battery low" → "navigate to charger" becomes a stronger association.
+- **Negative reward** (e.g., -0.7): Weakens associations. "Take corridor A during rush hour" becomes less preferred.
+- **Neutral** (0.0): No modulation, standard edge strength.
+
+This happens automatically at store time — no extra API calls needed. Over time, the graph learns which action-context pairs produce good outcomes.
+
+## Multi-Robot Fleets
+
+Use `robot_id` to partition memories per robot, and `mission_id` to group shared missions:
+
+```bash
+# Store from robot 2
+curl -X POST http://localhost:3030/api/remember -H "Content-Type: application/json" -d '{
+  "user_id": "fleet_warehouse_01",
+  "content": "Aisle 7 blocked by fallen pallet at position (15.2, 7.1, 0.0)",
+  "robot_id": "robot_002",
+  "mission_id": "inventory_scan_043",
+  "action_type": "inspect",
+  "reward": -0.3,
+  "outcome_type": "partial",
+  "geo_location": [37.7750, -122.4195, 0.0],
+  "local_position": [15.2, 7.1, 0.0],
+  "sensor_data": {"battery": 67.2}
+}'
+
+# Robot 3 queries: "anything blocking the aisles?"
+curl -X POST http://localhost:3030/api/recall -H "Content-Type: application/json" -d '{
+  "user_id": "fleet_warehouse_01",
+  "query": "blocked aisles obstacles",
+  "mode": "spatial",
+  "geo_lat": 37.7750,
+  "geo_lon": -122.4195,
+  "geo_radius_meters": 200.0
+}'
+```
+
+## Python SDK
+
+```python
+from shodh_memory import ShodhMemory
+
+mem = ShodhMemory(storage_path="/data/robot_memory")
+
+# Store
+mem.remember(
+    user_id="robot_001",
+    content="Docked successfully at station B",
+    experience_type="Task",
+    robot_id="robot_001",
+    mission_id="patrol_042",
+    reward=0.9,
+    geo_location=[37.7749, -122.4194, 2.5],
+)
+
+# Recall by location
+results = mem.recall(
+    user_id="robot_001",
+    query="docking experiences",
+    mode="spatial",
+    geo_lat=37.7749,
+    geo_lon=-122.4194,
+    geo_radius_meters=10.0,
+)
+```
+
+## Zenoh Transport (ROS2 / DDS)
+
+For real-time robotics middleware, shodh-memory supports Zenoh pub/sub transport. See `src/zenoh_transport/` for the implementation. Zenoh enables:
+
+- Sub-millisecond memory store/recall over local network
+- No HTTP overhead — direct binary protocol
+- Compatible with ROS2 via zenoh-bridge-ros2dds
+
+## Architecture Notes
+
+- **Storage**: RocksDB with column families, persists across power cycles
+- **Spatial indexing**: Geohash precision 10 (~1.2m × 0.6m cells), 9-cell neighbor search
+- **Reward indexing**: Bucketed (-1.0 to 1.0 → 21 integer buckets) for O(1) range queries
+- **Mission indexing**: Prefix-scanned by mission_id for chronological replay
+- **Knowledge graph**: Entities from memories form a Hebbian graph with reward-modulated edge strengths
+- **Embeddings**: MiniLM-L6-v2 (384-dim) via ONNX Runtime, runs locally on CPU/GPU
+- **No cloud dependency**: All processing is local, no API keys, no data leaves the device

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -47,6 +47,20 @@ pub const HEBBIAN_DECAY_MISLEADING: f32 = 0.10;
 /// - Allows for context-dependent recovery
 pub const IMPORTANCE_FLOOR: f32 = 0.05;
 
+/// Reward-based edge strength modulation factor for robotics feedback.
+///
+/// When a memory carries an explicit reward signal (from robot action outcomes),
+/// initial graph edge strength is scaled by (1.0 + reward × this factor).
+/// - reward=+1.0 → edges 40% stronger (successful action → reinforce associations)
+/// - reward=0.0  → no change (neutral outcome)
+/// - reward=-1.0 → edges 40% weaker (failed action → weaken associations)
+///
+/// Justification:
+/// - Bridges explicit RL reward signals to Hebbian graph learning
+/// - 0.4 keeps modulation within ±40% of baseline, preventing runaway strengthening
+/// - Applied at store time (immediate effect) rather than deferred consolidation
+pub const REWARD_EDGE_MODULATION: f32 = 0.4;
+
 // =============================================================================
 // NEUROSCIENCE-INSPIRED DYNAMICS
 // =============================================================================

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -3049,6 +3049,27 @@ impl MultiUserMemoryManager {
         // Edge quality gate: skip edges between two confirmed stop-word hubs
         // or when either endpoint is a saturated hub (degree > 300).
         let truncated_context: String = experience.content.chars().take(150).collect();
+
+        // Reward-modulated edge strength: robotics memories with explicit reward
+        // signals get stronger/weaker initial edges via Hebbian-RL bridge.
+        let base_strength = EdgeTier::L1Working.initial_weight();
+        let edge_strength = if let Some(reward) = experience.reward {
+            let modulated =
+                base_strength * (1.0 + reward * crate::constants::REWARD_EDGE_MODULATION);
+            let clamped = modulated.clamp(0.05, 1.0);
+            if (reward).abs() > f32::EPSILON {
+                tracing::info!(
+                    reward = reward,
+                    base = base_strength,
+                    modulated = clamped,
+                    "Reward-modulated edge strength for robotics memory"
+                );
+            }
+            clamped
+        } else {
+            base_strength
+        };
+
         for i in 0..entity_uuids.len() {
             for j in (i + 1)..entity_uuids.len() {
                 // Edge quality gate using graph reputation
@@ -3088,7 +3109,7 @@ impl MultiUserMemoryManager {
                     from_entity: entity_uuids[i].1,
                     to_entity: entity_uuids[j].1,
                     relation_type: RelationType::RelatedTo,
-                    strength: EdgeTier::L1Working.initial_weight(),
+                    strength: edge_strength,
                     created_at: now,
                     valid_at: now,
                     invalidated_at: None,

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1439,6 +1439,28 @@ impl MemorySystem {
         let recall_start = std::time::Instant::now();
 
         // ===========================================================================
+        // ROBOTICS MODE DELEGATION
+        // ===========================================================================
+        // Spatial, Mission, and ActionOutcome modes use index-based retrieval
+        // (geohash, mission_id, reward buckets) rather than semantic search.
+        // Delegate directly to the retrieval engine which has full implementations.
+        match query.retrieval_mode {
+            RetrievalMode::Spatial | RetrievalMode::Mission | RetrievalMode::ActionOutcome => {
+                tracing::info!(
+                    mode = ?query.retrieval_mode,
+                    query = query_text,
+                    "Delegating to index-based retrieval engine for robotics mode"
+                );
+                let results = self.retriever.search(query, query.max_results)?;
+                if let Ok(count) = self.long_term_memory.increment_retrieval_count() {
+                    tracing::debug!("Retrieval count: {count}");
+                }
+                return Ok(results);
+            }
+            _ => {}
+        }
+
+        // ===========================================================================
         // TEMPORAL ANALYSIS (unified intent + date parsing)
         // ===========================================================================
         // Replaces independent calls to extract_temporal_refs() and detect_temporal_intent().
@@ -3727,6 +3749,14 @@ impl MemorySystem {
         }
 
         factors.push(("quality", quality_score.min(0.1)));
+
+        // Factor 8: Reward signal (0.0 - 0.15)
+        // Robotics memories with strong reward signals (positive or negative)
+        // are more important — both successes and failures carry learning value.
+        if let Some(reward) = experience.reward {
+            let reward_score = reward.abs() * 0.15;
+            factors.push(("reward", reward_score));
+        }
 
         // Aggregate all factors
         let importance: f32 = factors.iter().map(|(_, score)| score).sum();

--- a/tests/query_filter_tests.rs
+++ b/tests/query_filter_tests.rs
@@ -878,3 +878,125 @@ fn test_query_builder_with_tags() {
     );
     assert_eq!(query.retrieval_mode, RetrievalMode::Hybrid);
 }
+
+// ============================================================================
+// ROBOTICS RETRIEVAL MODE ROUTING TESTS
+// ============================================================================
+
+#[test]
+fn test_spatial_query_requires_geo_filter() {
+    let query = Query {
+        retrieval_mode: RetrievalMode::Spatial,
+        geo_filter: Some(GeoFilter {
+            lat: 37.7749,
+            lon: -122.4194,
+            radius_meters: 100.0,
+        }),
+        ..Default::default()
+    };
+    assert!(matches!(query.retrieval_mode, RetrievalMode::Spatial));
+    assert!(query.geo_filter.is_some());
+}
+
+#[test]
+fn test_mission_query_requires_mission_id() {
+    let query = Query {
+        retrieval_mode: RetrievalMode::Mission,
+        mission_id: Some("mission_alpha".to_string()),
+        ..Default::default()
+    };
+    assert!(matches!(query.retrieval_mode, RetrievalMode::Mission));
+    assert_eq!(query.mission_id, Some("mission_alpha".to_string()));
+}
+
+#[test]
+fn test_action_outcome_query_with_reward_range() {
+    let query = Query {
+        retrieval_mode: RetrievalMode::ActionOutcome,
+        reward_range: Some((0.5, 1.0)),
+        ..Default::default()
+    };
+    assert!(matches!(query.retrieval_mode, RetrievalMode::ActionOutcome));
+    assert_eq!(query.reward_range, Some((0.5, 1.0)));
+}
+
+#[test]
+fn test_reward_edge_modulation_constant() {
+    use shodh_memory::constants::REWARD_EDGE_MODULATION;
+
+    // Verify the constant is in a sane range
+    assert!(REWARD_EDGE_MODULATION > 0.0);
+    assert!(REWARD_EDGE_MODULATION <= 1.0);
+
+    // Verify modulation math: base_strength * (1.0 + reward * modulation)
+    let base = 0.5_f32;
+
+    // Positive reward should increase strength
+    let positive = base * (1.0 + 1.0 * REWARD_EDGE_MODULATION);
+    assert!(positive > base, "Positive reward should increase edge strength");
+
+    // Negative reward should decrease strength
+    let negative = base * (1.0 + (-1.0) * REWARD_EDGE_MODULATION);
+    assert!(negative < base, "Negative reward should decrease edge strength");
+    assert!(negative > 0.0, "Negative reward should not zero out edges");
+
+    // Zero reward should leave strength unchanged
+    let neutral = base * (1.0 + 0.0 * REWARD_EDGE_MODULATION);
+    assert!((neutral - base).abs() < f32::EPSILON, "Zero reward should not change edges");
+}
+
+#[test]
+fn test_robotics_memory_with_reward_matches_filter() {
+    let memory = create_robotics_memory(
+        "Robot navigated to target successfully",
+        Some("robot_001"),
+        Some("mission_1"),
+        Some([37.7749, -122.4194, 10.0]),
+        Some("navigate"),
+        Some(0.8),
+        None,
+    );
+
+    // Reward filter: should match memories with reward >= 0.5
+    let query = Query {
+        reward_range: Some((0.5, 1.0)),
+        ..Default::default()
+    };
+    assert!(
+        query.matches(&memory),
+        "Memory with reward=0.8 should match reward_range=(0.5, 1.0)"
+    );
+
+    // Reward filter: should NOT match memories outside range
+    let query_negative = Query {
+        reward_range: Some((-1.0, -0.5)),
+        ..Default::default()
+    };
+    assert!(
+        !query_negative.matches(&memory),
+        "Memory with reward=0.8 should not match negative reward range"
+    );
+}
+
+#[test]
+fn test_geo_filter_haversine_distance() {
+    let filter = GeoFilter {
+        lat: 37.7749,
+        lon: -122.4194,
+        radius_meters: 1000.0,
+    };
+
+    // Point ~400m away (within radius)
+    let dist_close = filter.haversine_distance(37.7785, -122.4194);
+    assert!(
+        dist_close < 1000.0,
+        "Point 400m away should be within 1000m radius"
+    );
+
+    // Same point (zero distance)
+    let dist_same = filter.haversine_distance(37.7749, -122.4194);
+    assert!(
+        dist_same < 1.0,
+        "Same point should have near-zero distance"
+    );
+}

--- a/tests/query_filter_tests.rs
+++ b/tests/query_filter_tests.rs
@@ -933,16 +933,25 @@ fn test_reward_edge_modulation_constant() {
 
     // Positive reward should increase strength
     let positive = base * (1.0 + 1.0 * REWARD_EDGE_MODULATION);
-    assert!(positive > base, "Positive reward should increase edge strength");
+    assert!(
+        positive > base,
+        "Positive reward should increase edge strength"
+    );
 
     // Negative reward should decrease strength
     let negative = base * (1.0 + (-1.0) * REWARD_EDGE_MODULATION);
-    assert!(negative < base, "Negative reward should decrease edge strength");
+    assert!(
+        negative < base,
+        "Negative reward should decrease edge strength"
+    );
     assert!(negative > 0.0, "Negative reward should not zero out edges");
 
     // Zero reward should leave strength unchanged
     let neutral = base * (1.0 + 0.0 * REWARD_EDGE_MODULATION);
-    assert!((neutral - base).abs() < f32::EPSILON, "Zero reward should not change edges");
+    assert!(
+        (neutral - base).abs() < f32::EPSILON,
+        "Zero reward should not change edges"
+    );
 }
 
 #[test]
@@ -995,8 +1004,5 @@ fn test_geo_filter_haversine_distance() {
 
     // Same point (zero distance)
     let dist_same = filter.haversine_distance(37.7749, -122.4194);
-    assert!(
-        dist_same < 1.0,
-        "Same point should have near-zero distance"
-    );
+    assert!(dist_same < 1.0, "Same point should have near-zero distance");
 }


### PR DESCRIPTION
## Summary

- **Robotics mode routing fix**: `semantic_retrieve()` now delegates Spatial/Mission/ActionOutcome modes to the retrieval engine instead of running the semantic pipeline. Previously, these modes were dead code when called from MCP (which always sets `query_text`).
- **Reward → Hebbian bridge**: Memories with explicit reward signals (-1.0 to 1.0) now modulate initial graph edge strength via `REWARD_EDGE_MODULATION` (±40%). Positive rewards strengthen entity associations; negative rewards weaken them.
- **Reward importance factor**: `calculate_importance()` now includes a Factor 8 for reward signals — memories with strong rewards (positive or negative) get higher importance since both successes and failures carry learning value.
- **6 integration tests**: Spatial query, mission query, action-outcome query, reward edge modulation constant validation, reward filter matching, geo haversine distance.
- **Robotics quickstart guide**: Full API reference with curl examples for store, spatial recall, mission replay, action-outcome queries, multi-robot fleets, and Python SDK.

## Files Changed

| File | Change |
|------|--------|
| `src/memory/mod.rs` | Early return in `semantic_retrieve()` for robotics modes; reward importance factor |
| `src/handlers/state.rs` | Reward-modulated edge strength in `process_experience_into_graph()` |
| `src/constants.rs` | `REWARD_EDGE_MODULATION` constant (0.4) |
| `tests/query_filter_tests.rs` | 6 new robotics tests |
| `docs/robotics-quickstart.md` | New quickstart guide |

## Test plan

- [x] `cargo check` passes
- [x] 6 new tests pass (`cargo test --test query_filter_tests -- test_spatial test_mission test_action test_reward test_geo`)
- [x] No new clippy warnings in changed files
- [ ] CI green