### PR TITLE
fix: harden error propagation and eliminate panic paths

### DIFF
--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -1136,9 +1136,12 @@ impl MultiUserMemoryManager {
             let key_bytes = key.into_bytes();
 
             tokio::task::spawn_blocking(move || {
-                let audit = db.cf_handle(CF_AUDIT).expect("audit CF must exist");
-                if let Err(e) = db.put_cf(&audit, &key_bytes, &serialized) {
-                    tracing::error!("Failed to persist audit log: {}", e);
+                if let Some(audit) = db.cf_handle(CF_AUDIT) {
+                    if let Err(e) = db.put_cf(&audit, &key_bytes, &serialized) {
+                        tracing::error!("Failed to persist audit log: {}", e);
+                    }
+                } else {
+                    tracing::error!("audit CF missing from shared DB — audit event dropped");
                 }
             });
         }
@@ -1177,7 +1180,11 @@ impl MultiUserMemoryManager {
                     audit_max_entries,
                 };
                 if let Err(e) = manager.rotate_user_audit_logs(&user_id_clone) {
-                    tracing::debug!("Audit log rotation check for user {}: {}", user_id_clone, e);
+                    tracing::warn!(
+                        "Audit log rotation failed for user {}: {}",
+                        user_id_clone,
+                        e
+                    );
                 }
             });
         }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -2351,7 +2351,9 @@ impl MemorySystem {
                     + graph_w
                         * crate::constants::ACTIVATION_BONUS_SCALE
                         * activation.clamp(0.0, 1.0);
-                *fused.get_mut(id).unwrap() *= activation_factor;
+                if let Some(score) = fused.get_mut(id) {
+                    *score *= activation_factor;
+                }
             }
 
             // Hybrid (BM25+vector) results: pure RRF with density weight
@@ -2530,8 +2532,10 @@ impl MemorySystem {
                                         + (PROSPECTIVE_BOOST_PER_MATCH
                                             * (match_count as f32).sqrt())
                                         .min(PROSPECTIVE_BOOST_MAX);
-                                    *fused.get_mut(id).unwrap() *= boost_factor;
-                                    boosted_count += 1;
+                                    if let Some(score) = fused.get_mut(id) {
+                                        *score *= boost_factor;
+                                        boosted_count += 1;
+                                    }
                                 }
                             }
                         }

--- a/src/memory/query_parser.rs
+++ b/src/memory/query_parser.rs
@@ -30,6 +30,7 @@ use chrono::{DateTime, Datelike, NaiveDate, Utc};
 use rust_stemmers::{Algorithm, Stemmer};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use std::sync::LazyLock;
 
 // ============================================================================
 // SHALLOW PARSING / CHUNKING MODULE
@@ -454,16 +455,10 @@ fn split_temporal_phrases(text: &str) -> Vec<String> {
 
 /// Extract explicit date patterns that date_time_parser might miss
 fn extract_explicit_dates(text: &str) -> Vec<(NaiveDate, String, usize)> {
-    use regex::Regex;
-
     let mut results = Vec::new();
 
     // Pattern: "Month Day, Year" (e.g., "May 7, 2023")
-    let month_day_year =
-        Regex::new(r"(?i)(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),?\s+(\d{4})")
-            .unwrap();
-
-    for cap in month_day_year.captures_iter(text) {
+    for cap in MONTH_DAY_YEAR_RE.captures_iter(text) {
         let month_str = &cap[1];
         let day: u32 = cap[2].parse().unwrap_or(1);
         let year: i32 = cap[3].parse().unwrap_or(2000);
@@ -476,8 +471,7 @@ fn extract_explicit_dates(text: &str) -> Vec<(NaiveDate, String, usize)> {
     }
 
     // Pattern: "YYYY-MM-DD"
-    let iso_date = Regex::new(r"(\d{4})-(\d{2})-(\d{2})").unwrap();
-    for cap in iso_date.captures_iter(text) {
+    for cap in ISO_DATE_RE.captures_iter(text) {
         let year: i32 = cap[1].parse().unwrap_or(2000);
         let month: u32 = cap[2].parse().unwrap_or(1);
         let day: u32 = cap[3].parse().unwrap_or(1);
@@ -489,8 +483,7 @@ fn extract_explicit_dates(text: &str) -> Vec<(NaiveDate, String, usize)> {
     }
 
     // Pattern: "MM/DD/YYYY" or "DD/MM/YYYY" (assume US format MM/DD)
-    let slash_date = Regex::new(r"(\d{1,2})/(\d{1,2})/(\d{4})").unwrap();
-    for cap in slash_date.captures_iter(text) {
+    for cap in SLASH_DATE_RE.captures_iter(text) {
         let month: u32 = cap[1].parse().unwrap_or(1);
         let day: u32 = cap[2].parse().unwrap_or(1);
         let year: i32 = cap[3].parse().unwrap_or(2000);
@@ -504,6 +497,30 @@ fn extract_explicit_dates(text: &str) -> Vec<(NaiveDate, String, usize)> {
     results
 }
 
+// Pre-compiled regex patterns for temporal extraction (avoid per-call allocation)
+static MONTH_DAY_YEAR_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r"(?i)(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),?\s+(\d{4})",
+    )
+    .unwrap()
+});
+static ISO_DATE_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(\d{4})-(\d{2})-(\d{2})").unwrap());
+static SLASH_DATE_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(\d{1,2})/(\d{1,2})/(\d{4})").unwrap());
+static AGO_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(?i)(\d+)\s+(day|week|month|year)s?\s+ago").unwrap());
+static LAST_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(?i)last\s+(week|month|year)").unwrap());
+static THIS_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(?i)this\s+(week|month|year)").unwrap());
+static MONTH_YEAR_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r"(?i)(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{4})",
+    )
+    .unwrap()
+});
+
 /// Extract relative temporal keywords from text.
 ///
 /// Handles patterns that dateparser misses when embedded in longer text:
@@ -513,8 +530,6 @@ fn extract_relative_dates(
     text: &str,
     now: &DateTime<Utc>,
 ) -> Vec<(NaiveDate, String, usize, TemporalRefType)> {
-    use regex::Regex;
-
     let text_lower = text.to_lowercase();
     let today = now.date_naive();
     let mut results = Vec::new();
@@ -536,8 +551,7 @@ fn extract_relative_dates(
     }
 
     // "N days/weeks/months ago"
-    let ago_re = Regex::new(r"(?i)(\d+)\s+(day|week|month|year)s?\s+ago").unwrap();
-    for cap in ago_re.captures_iter(text) {
+    for cap in AGO_RE.captures_iter(text) {
         let n: i64 = cap[1].parse().unwrap_or(1);
         let unit = cap[2].to_lowercase();
         let date = match unit.as_str() {
@@ -555,8 +569,7 @@ fn extract_relative_dates(
     }
 
     // "last week/month/year"
-    let last_re = Regex::new(r"(?i)last\s+(week|month|year)").unwrap();
-    for cap in last_re.captures_iter(text) {
+    for cap in LAST_RE.captures_iter(text) {
         let unit = cap[1].to_lowercase();
         let date = match unit.as_str() {
             "week" => today - chrono::Duration::weeks(1),
@@ -573,8 +586,7 @@ fn extract_relative_dates(
     }
 
     // "this week/month/year"
-    let this_re = Regex::new(r"(?i)this\s+(week|month|year)").unwrap();
-    for cap in this_re.captures_iter(text) {
+    for cap in THIS_RE.captures_iter(text) {
         let pos = cap.get(0).map(|m| m.start()).unwrap_or(0);
         if results.iter().any(|r| r.0 == today) {
             continue;
@@ -590,16 +602,10 @@ fn extract_relative_dates(
 /// Handles: "March 2026", "in May 2023", "last March"
 /// Returns the first day of the month as the date.
 fn extract_month_year_dates(text: &str) -> Vec<(NaiveDate, String, usize)> {
-    use regex::Regex;
-
     let mut results = Vec::new();
 
     // "Month Year" (e.g., "March 2026", "in September 2025")
-    let month_year_re = Regex::new(
-        r"(?i)(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{4})"
-    ).unwrap();
-
-    for cap in month_year_re.captures_iter(text) {
+    for cap in MONTH_YEAR_RE.captures_iter(text) {
         let month = month_to_num(&cap[1]);
         let year: i32 = cap[2].parse().unwrap_or(2000);
         if let Some(date) = NaiveDate::from_ymd_opt(year, month, 1) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -392,9 +392,12 @@ fn start_maintenance_scheduler(manager: AppState, interval_secs: u64) {
 
             // Run maintenance in blocking thread pool
             let manager_clone = Arc::clone(&manager);
-            tokio::task::spawn_blocking(move || {
+            let handle = tokio::task::spawn_blocking(move || {
                 manager_clone.run_maintenance_all_users();
             });
+            if let Err(e) = handle.await {
+                tracing::error!("Maintenance task panicked: {}", e);
+            }
         }
     });
 
@@ -416,11 +419,17 @@ fn start_backup_scheduler(manager: AppState, interval_secs: u64, max_backups: us
 
             info!("Starting scheduled backup run...");
             let manager_clone = Arc::clone(&manager);
-            let backed_up = tokio::task::spawn_blocking(move || {
+            let backed_up = match tokio::task::spawn_blocking(move || {
                 manager_clone.run_backup_all_users(max_backups)
             })
             .await
-            .unwrap_or(0);
+            {
+                Ok(n) => n,
+                Err(e) => {
+                    tracing::error!("Backup scheduler task panicked: {}", e);
+                    0
+                }
+            };
 
             if backed_up > 0 {
                 info!("Scheduled backup completed: {} users backed up", backed_up);

--- a/src/vector_db/vamana.rs
+++ b/src/vector_db/vamana.rs
@@ -1586,12 +1586,16 @@ impl VamanaIndex {
             );
             *self.vectors.write() = VectorStorage::Memory(data.vectors);
         } else {
-            match &mut *self.vectors.write() {
-                VectorStorage::Memory(vecs) => {
-                    *vecs = data.vectors;
-                }
-                VectorStorage::Mmap { .. } => unreachable!(),
+            let is_mmap_variant = matches!(&*self.vectors.read(), VectorStorage::Mmap { .. });
+            if is_mmap_variant {
+                warn!(
+                    "Unexpected mmap storage with use_mmap=false during apply_persisted_data; \
+                     converting {} vectors to in-memory storage",
+                    data.num_vectors
+                );
             }
+            // Both branches set to Memory storage — safe assignment without match borrow
+            *self.vectors.write() = VectorStorage::Memory(data.vectors);
         }
 
         // Restore soft-deleted IDs


### PR DESCRIPTION
## Summary
- Eliminates 6 HIGH-severity panic paths identified by systematic audit of all `unwrap()`, `expect()`, `unreachable!()`, and silent `spawn_blocking` patterns across the Rust codebase
- Converts 7 per-call `Regex::new().unwrap()` to `LazyLock` statics in query_parser for both safety and performance

## Changes

### Panic path elimination
- **vamana.rs**: Replace `unreachable!()` in `apply_persisted_data` with graceful mmap→memory conversion + warning
- **mod.rs**: Replace 2 `HashMap::get_mut().unwrap()` in retrieval pipeline (layers 2 and 4.7) with safe `if let` guards
- **server.rs**: Add `.await` + error logging for maintenance `spawn_blocking` (was fire-and-forget, panics silently swallowed)
- **server.rs**: Replace `unwrap_or(0)` with explicit `match` + error log for backup scheduler
- **state.rs**: Replace `expect("audit CF must exist")` inside fire-and-forget `spawn_blocking` with `if let Some(cf)` + error log
- **state.rs**: Upgrade audit rotation error from `debug!` to `warn!` (silent rotation failures → unbounded audit log growth)

### Regex allocation optimization
- 7 `Regex::new(...).unwrap()` calls in `query_parser.rs` migrated to `LazyLock<Regex>` statics
- Eliminates per-call heap allocation for date pattern matching (called on every temporal query)

## Test plan
- [x] `cargo check` — compiles clean
- [x] `cargo test --lib -- query_parser` — all 24 tests pass
- [x] `cargo fmt` — clean
- [ ] CI green