### PR TITLE
fix: deep error hardening — lineage types, error codes, silent failures

### DIFF
--- a/src/handlers/consolidation.rs
+++ b/src/handlers/consolidation.rs
@@ -397,7 +397,17 @@ pub async fn create_backup(
         .collect();
 
     // Get graph DB reference for backup (per-user graph at {user_id}/graph/)
-    let graph_lock = state.get_user_graph(&req.user_id).ok();
+    let graph_lock = match state.get_user_graph(&req.user_id) {
+        Ok(g) => Some(g),
+        Err(e) => {
+            tracing::warn!(
+                user_id = %req.user_id,
+                error = %e,
+                "Graph DB unavailable during backup — backup will exclude knowledge graph"
+            );
+            None
+        }
+    };
     let graph_guard = graph_lock.as_ref().map(|g| g.read());
     let graph_db_ref = graph_guard.as_ref().map(|g| g.get_db());
 

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -1908,7 +1908,13 @@ pub async fn proactive_context(
     let memory_type_filter: Vec<ExperienceType> = req
         .memory_types
         .iter()
-        .map(|s| super::remember::parse_experience_type(Some(s)))
+        .filter_map(|s| match super::remember::parse_experience_type(Some(s)) {
+            Ok(t) => Some(t),
+            Err(e) => {
+                tracing::warn!("Ignoring invalid memory_type filter '{}': {}", s, e);
+                None
+            }
+        })
         .collect();
     let memories: Vec<ProactiveSurfacedMemory> = {
         let memory = memory_system.clone();

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -382,14 +382,39 @@ pub async fn recall(
     let mode = req.mode.clone();
     let retrieval_mode_for_recall = parse_retrieval_mode(&mode);
 
+    // Pre-flight validation for robotics retrieval modes.
+    // Catch missing required parameters here (400) instead of deep in the retrieval
+    // engine where errors get wrapped as INTERNAL_ERROR (500).
+    match retrieval_mode_for_recall {
+        RetrievalMode::Spatial if geo_filter.is_none() => {
+            return Err(AppError::InvalidInput {
+                field: "geo_filter".to_string(),
+                reason: "spatial mode requires geo_lat, geo_lon, and geo_radius_meters".to_string(),
+            });
+        }
+        RetrievalMode::Mission if req.mission_id.is_none() => {
+            return Err(AppError::InvalidInput {
+                field: "mission_id".to_string(),
+                reason: "mission mode requires mission_id parameter".to_string(),
+            });
+        }
+        _ => {}
+    }
+
     // SESSION-SCOPED RETRIEVAL: resolve session_id → time_range before spawn_blocking.
     // When session_id is provided, look up the session's time window and set
     // retrieval_mode to Temporal so temporal_search() uses the date range.
-    let session_time_range = req.session_id.as_ref().and_then(|sid| {
+    let session_time_range = if let Some(sid) = req.session_id.as_ref() {
         use crate::memory::sessions::SessionId;
-        let session_id = SessionId(uuid::Uuid::parse_str(sid).ok()?);
+        let parsed_uuid = uuid::Uuid::parse_str(sid).map_err(|_| AppError::InvalidInput {
+            field: "session_id".to_string(),
+            reason: format!("invalid UUID format: '{}'", sid),
+        })?;
+        let session_id = SessionId(parsed_uuid);
         state.session_store().get_session_time_range(&session_id)
-    });
+    } else {
+        None
+    };
     let session_id_for_recall = req.session_id.clone();
 
     // If session_id resolved to a time range, force Temporal mode
@@ -816,7 +841,10 @@ pub async fn recall(
                 facts
             })
             .await
-            .unwrap_or_default()
+            .unwrap_or_else(|e| {
+                tracing::warn!("Fact fetch task panicked: {e} — facts excluded from recall");
+                Vec::new()
+            })
         };
 
         // Deduplicate by fact ID and take top 5 by confidence
@@ -884,7 +912,12 @@ pub async fn recall(
                 edges
             })
             .await
-            .unwrap_or_default()
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    "Lineage edge fetch task panicked: {e} — lineage excluded from recall"
+                );
+                Vec::new()
+            })
         } else {
             Vec::new()
         }

--- a/src/handlers/remember.rs
+++ b/src/handlers/remember.rs
@@ -249,26 +249,42 @@ pub struct UpsertResponse {
 // HELPER FUNCTIONS
 // =============================================================================
 
-/// Parse memory type from string
-pub fn parse_experience_type(s: Option<&String>) -> ExperienceType {
-    s.and_then(|s| match s.to_lowercase().as_str() {
-        "observation" => Some(ExperienceType::Observation),
-        "decision" => Some(ExperienceType::Decision),
-        "learning" => Some(ExperienceType::Learning),
-        "error" => Some(ExperienceType::Error),
-        "discovery" => Some(ExperienceType::Discovery),
-        "pattern" => Some(ExperienceType::Pattern),
-        "context" => Some(ExperienceType::Context),
-        "task" => Some(ExperienceType::Task),
-        "codeedit" | "code_edit" => Some(ExperienceType::CodeEdit),
-        "fileaccess" | "file_access" => Some(ExperienceType::FileAccess),
-        "search" => Some(ExperienceType::Search),
-        "command" => Some(ExperienceType::Command),
-        "conversation" => Some(ExperienceType::Conversation),
-        "intention" => Some(ExperienceType::Intention),
-        _ => None,
-    })
-    .unwrap_or(ExperienceType::Observation)
+/// Parse memory type from string.
+///
+/// Returns `Ok(Observation)` when no type is provided (default).
+/// Returns `Err` when an explicit type string doesn't match any known type,
+/// preventing silent data corruption from typos.
+pub fn parse_experience_type(
+    s: Option<&String>,
+) -> Result<ExperienceType, crate::errors::AppError> {
+    match s {
+        None => Ok(ExperienceType::Observation),
+        Some(s) => match s.to_lowercase().as_str() {
+            "observation" => Ok(ExperienceType::Observation),
+            "decision" => Ok(ExperienceType::Decision),
+            "learning" => Ok(ExperienceType::Learning),
+            "error" => Ok(ExperienceType::Error),
+            "discovery" => Ok(ExperienceType::Discovery),
+            "pattern" => Ok(ExperienceType::Pattern),
+            "context" => Ok(ExperienceType::Context),
+            "task" => Ok(ExperienceType::Task),
+            "codeedit" | "code_edit" => Ok(ExperienceType::CodeEdit),
+            "fileaccess" | "file_access" => Ok(ExperienceType::FileAccess),
+            "search" => Ok(ExperienceType::Search),
+            "command" => Ok(ExperienceType::Command),
+            "conversation" => Ok(ExperienceType::Conversation),
+            "intention" => Ok(ExperienceType::Intention),
+            unknown => Err(crate::errors::AppError::InvalidInput {
+                field: "type".to_string(),
+                reason: format!(
+                    "Unknown memory type '{}'. Valid types: Observation, Decision, Learning, Error, \
+                     Discovery, Pattern, Context, Task, CodeEdit, FileAccess, Search, Command, \
+                     Conversation, Intention",
+                    unknown
+                ),
+            }),
+        },
+    }
 }
 
 /// Parse source type from string
@@ -372,7 +388,7 @@ pub async fn remember(
     validation::validate_user_id(&req.user_id).map_validation_err("user_id")?;
     validation::validate_content(&req.content, false).map_validation_err("content")?;
 
-    let experience_type = parse_experience_type(req.memory_type.as_ref());
+    let experience_type = parse_experience_type(req.memory_type.as_ref())?;
 
     // PERF: Run NER and YAKE extraction in parallel using spawn_blocking
     // Both are CPU-bound and independent - parallelization reduces latency by ~40%
@@ -817,7 +833,7 @@ pub async fn batch_remember(
     )> = Vec::with_capacity(valid_items.len());
 
     for (index, item) in valid_items {
-        let experience_type = parse_experience_type(item.memory_type.as_ref());
+        let experience_type = parse_experience_type(item.memory_type.as_ref())?;
 
         let (merged_entities, ner_records) = if extract_entities {
             // NER for named entities (Person, Org, Location, Misc)
@@ -984,7 +1000,7 @@ pub async fn upsert_memory(
         });
     }
 
-    let experience_type = parse_experience_type(req.memory_type.as_ref());
+    let experience_type = parse_experience_type(req.memory_type.as_ref())?;
 
     let change_type = match req.change_type.to_lowercase().as_str() {
         "created" => ChangeType::Created,

--- a/src/handlers/search.rs
+++ b/src/handlers/search.rs
@@ -147,6 +147,22 @@ pub async fn multimodal_search(
         }
     };
 
+    // Pre-flight validation for robotics modes
+    if matches!(retrieval_mode, memory::RetrievalMode::Spatial) {
+        return Err(AppError::InvalidInput {
+            field: "mode".to_string(),
+            reason: "spatial mode requires geo parameters — use /api/search/robotics instead"
+                .to_string(),
+        });
+    }
+    if matches!(retrieval_mode, memory::RetrievalMode::Mission) {
+        return Err(AppError::InvalidInput {
+            field: "mode".to_string(),
+            reason: "mission mode requires mission_id — use /api/search/robotics instead"
+                .to_string(),
+        });
+    }
+
     let query = MemoryQuery {
         query_text: Some(req.query_text.clone()),
         max_results: req.limit.unwrap_or(10),

--- a/src/handlers/todos.rs
+++ b/src/handlers/todos.rs
@@ -424,14 +424,20 @@ pub struct ListProjectsRequest {
 // =============================================================================
 
 /// Parse recurrence string to Recurrence enum
-fn parse_recurrence(s: &str) -> Option<Recurrence> {
+fn parse_recurrence(s: &str) -> Result<Recurrence, AppError> {
     match s.to_lowercase().as_str() {
-        "daily" => Some(Recurrence::Daily),
-        "weekly" => Some(Recurrence::Weekly {
+        "daily" => Ok(Recurrence::Daily),
+        "weekly" => Ok(Recurrence::Weekly {
             days: vec![1, 2, 3, 4, 5],
         }),
-        "monthly" => Some(Recurrence::Monthly { day: 1 }),
-        _ => None,
+        "monthly" => Ok(Recurrence::Monthly { day: 1 }),
+        unknown => Err(AppError::InvalidInput {
+            field: "recurrence".to_string(),
+            reason: format!(
+                "Unknown recurrence '{}'. Valid values: daily, weekly, monthly",
+                unknown
+            ),
+        }),
     }
 }
 
@@ -555,13 +561,22 @@ pub async fn list_reminders(
 ) -> Result<Json<ListRemindersResponse>, AppError> {
     validation::validate_user_id(&req.user_id).map_validation_err("user_id")?;
 
-    let status_filter = req.status.as_ref().and_then(|s| match s.as_str() {
-        "pending" => Some(ProspectiveTaskStatus::Pending),
-        "triggered" => Some(ProspectiveTaskStatus::Triggered),
-        "dismissed" => Some(ProspectiveTaskStatus::Dismissed),
-        "expired" => Some(ProspectiveTaskStatus::Expired),
-        _ => None,
-    });
+    let status_filter = match req.status.as_deref() {
+        Some("pending") => Some(ProspectiveTaskStatus::Pending),
+        Some("triggered") => Some(ProspectiveTaskStatus::Triggered),
+        Some("dismissed") => Some(ProspectiveTaskStatus::Dismissed),
+        Some("expired") => Some(ProspectiveTaskStatus::Expired),
+        Some("all") | None => None,
+        Some(unknown) => {
+            return Err(AppError::InvalidInput {
+                field: "status".to_string(),
+                reason: format!(
+                    "Unknown reminder status '{}'. Valid values: pending, triggered, dismissed, expired, all",
+                    unknown
+                ),
+            });
+        }
+    };
 
     let tasks = state
         .prospective_store
@@ -896,11 +911,27 @@ pub async fn create_todo(
     let mut todo = Todo::new(req.user_id.clone(), req.content.clone());
 
     if let Some(ref status_str) = req.status {
-        todo.status = TodoStatus::from_str_loose(status_str).unwrap_or_default();
+        todo.status = TodoStatus::from_str_loose(status_str).ok_or_else(|| {
+            AppError::InvalidInput {
+                field: "status".to_string(),
+                reason: format!(
+                    "Unknown todo status '{}'. Valid values: backlog, todo, in_progress, blocked, done, cancelled",
+                    status_str
+                ),
+            }
+        })?;
     }
 
     if let Some(ref priority_str) = req.priority {
-        todo.priority = TodoPriority::from_str_loose(priority_str).unwrap_or_default();
+        todo.priority = TodoPriority::from_str_loose(priority_str).ok_or_else(|| {
+            AppError::InvalidInput {
+                field: "priority".to_string(),
+                reason: format!(
+                    "Unknown priority '{}'. Valid values: urgent, high, medium, low, none",
+                    priority_str
+                ),
+            }
+        })?;
     }
 
     let mut project_name = None;
@@ -948,7 +979,7 @@ pub async fn create_todo(
     todo.external_id = req.external_id;
 
     if let Some(ref recurrence_str) = req.recurrence {
-        todo.recurrence = parse_recurrence(recurrence_str);
+        todo.recurrence = Some(parse_recurrence(recurrence_str)?);
     }
 
     // Compute embedding for semantic search
@@ -1133,12 +1164,21 @@ pub async fn list_todos(
         validation::validate_limit(limit, "limit").map_validation_err("limit")?;
     }
 
-    let status_filter: Option<Vec<TodoStatus>> = req.status.as_ref().map(|statuses| {
-        statuses
-            .iter()
-            .filter_map(|s| TodoStatus::from_str_loose(s))
-            .collect()
-    });
+    let status_filter: Option<Vec<TodoStatus>> = if let Some(ref statuses) = req.status {
+        let mut parsed = Vec::with_capacity(statuses.len());
+        for s in statuses {
+            parsed.push(TodoStatus::from_str_loose(s).ok_or_else(|| AppError::InvalidInput {
+                field: "status".to_string(),
+                reason: format!(
+                    "Unknown todo status '{}'. Valid values: backlog, todo, in_progress, blocked, done, cancelled",
+                    s
+                ),
+            })?);
+        }
+        Some(parsed)
+    } else {
+        None
+    };
 
     let mut todos = if let Some(ref query) = req.query {
         if query.trim().is_empty() {
@@ -1263,17 +1303,32 @@ pub async fn list_todos(
                         .unwrap_or(false)
                 });
             }
-            _ => {}
+            "all" => {} // No filtering
+            unknown => {
+                return Err(AppError::InvalidInput {
+                    field: "due".to_string(),
+                    reason: format!(
+                        "Unknown due filter '{}'. Valid values: today, overdue, this_week, all",
+                        unknown
+                    ),
+                });
+            }
         }
     }
 
     // Filter by priority
     if let Some(ref priority_str) = req.priority {
-        if let Some(target_priority) =
-            crate::memory::types::TodoPriority::from_str_loose(priority_str)
-        {
-            todos.retain(|t| t.priority == target_priority);
-        }
+        let target_priority =
+            crate::memory::types::TodoPriority::from_str_loose(priority_str).ok_or_else(|| {
+                AppError::InvalidInput {
+                    field: "priority".to_string(),
+                    reason: format!(
+                        "Unknown priority '{}'. Valid values: urgent, high, medium, low, none",
+                        priority_str
+                    ),
+                }
+            })?;
+        todos.retain(|t| t.priority == target_priority);
     }
 
     // Apply pagination
@@ -1387,14 +1442,26 @@ pub async fn update_todo(
         todo.content = content.clone();
     }
     if let Some(ref status_str) = req.status {
-        if let Some(status) = TodoStatus::from_str_loose(status_str) {
-            todo.status = status;
-        }
+        todo.status = TodoStatus::from_str_loose(status_str).ok_or_else(|| {
+            AppError::InvalidInput {
+                field: "status".to_string(),
+                reason: format!(
+                    "Unknown todo status '{}'. Valid values: backlog, todo, in_progress, blocked, done, cancelled",
+                    status_str
+                ),
+            }
+        })?;
     }
     if let Some(ref priority_str) = req.priority {
-        if let Some(priority) = TodoPriority::from_str_loose(priority_str) {
-            todo.priority = priority;
-        }
+        todo.priority = TodoPriority::from_str_loose(priority_str).ok_or_else(|| {
+            AppError::InvalidInput {
+                field: "priority".to_string(),
+                reason: format!(
+                    "Unknown priority '{}'. Valid values: urgent, high, medium, low, none",
+                    priority_str
+                ),
+            }
+        })?;
     }
     if let Some(ref contexts) = req.contexts {
         todo.contexts = contexts.clone();
@@ -1960,16 +2027,27 @@ pub async fn add_todo_comment(
         .map_err(AppError::Internal)?
         .ok_or_else(|| AppError::TodoNotFound(todo_id.clone()))?;
 
-    let comment_type = req
-        .comment_type
-        .as_ref()
-        .and_then(|ct| match ct.to_lowercase().as_str() {
-            "comment" => Some(TodoCommentType::Comment),
-            "progress" => Some(TodoCommentType::Progress),
-            "resolution" => Some(TodoCommentType::Resolution),
-            "activity" => Some(TodoCommentType::Activity),
-            _ => None,
-        });
+    let comment_type = match req.comment_type.as_deref() {
+        Some(ct) => {
+            let parsed = match ct.to_lowercase().as_str() {
+                "comment" => TodoCommentType::Comment,
+                "progress" => TodoCommentType::Progress,
+                "resolution" => TodoCommentType::Resolution,
+                "activity" => TodoCommentType::Activity,
+                unknown => {
+                    return Err(AppError::InvalidInput {
+                        field: "comment_type".to_string(),
+                        reason: format!(
+                            "Unknown comment type '{}'. Valid values: comment, progress, resolution, activity",
+                            unknown
+                        ),
+                    });
+                }
+            };
+            Some(parsed)
+        }
+        None => None,
+    };
 
     let author = req.author.unwrap_or_else(|| req.user_id.clone());
 

--- a/src/handlers/todos.rs
+++ b/src/handlers/todos.rs
@@ -972,14 +972,30 @@ pub async fn create_todo(
         {
             todo.embedding = Some(embedding.clone());
 
-            if let Ok(vector_id) =
-                state
-                    .todo_store
-                    .index_todo_embedding(&req.user_id, &todo.id, &embedding)
+            match state
+                .todo_store
+                .index_todo_embedding(&req.user_id, &todo.id, &embedding)
             {
-                let _ = state
-                    .todo_store
-                    .store_vector_id_mapping(&req.user_id, vector_id, &todo.id);
+                Ok(vector_id) => {
+                    if let Err(e) =
+                        state
+                            .todo_store
+                            .store_vector_id_mapping(&req.user_id, vector_id, &todo.id)
+                    {
+                        tracing::warn!(
+                            todo_id = %todo.id,
+                            error = %e,
+                            "Failed to store vector ID mapping — todo will not be findable via semantic search"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        todo_id = %todo.id,
+                        error = %e,
+                        "Failed to index todo embedding — todo will not be findable via semantic search"
+                    );
+                }
             }
         }
     }

--- a/src/handlers/todos.rs
+++ b/src/handlers/todos.rs
@@ -923,15 +923,14 @@ pub async fn create_todo(
     }
 
     if let Some(ref priority_str) = req.priority {
-        todo.priority = TodoPriority::from_str_loose(priority_str).ok_or_else(|| {
-            AppError::InvalidInput {
+        todo.priority =
+            TodoPriority::from_str_loose(priority_str).ok_or_else(|| AppError::InvalidInput {
                 field: "priority".to_string(),
                 reason: format!(
                     "Unknown priority '{}'. Valid values: urgent, high, medium, low, none",
                     priority_str
                 ),
-            }
-        })?;
+            })?;
     }
 
     let mut project_name = None;
@@ -1318,15 +1317,13 @@ pub async fn list_todos(
 
     // Filter by priority
     if let Some(ref priority_str) = req.priority {
-        let target_priority =
-            crate::memory::types::TodoPriority::from_str_loose(priority_str).ok_or_else(|| {
-                AppError::InvalidInput {
-                    field: "priority".to_string(),
-                    reason: format!(
-                        "Unknown priority '{}'. Valid values: urgent, high, medium, low, none",
-                        priority_str
-                    ),
-                }
+        let target_priority = crate::memory::types::TodoPriority::from_str_loose(priority_str)
+            .ok_or_else(|| AppError::InvalidInput {
+                field: "priority".to_string(),
+                reason: format!(
+                    "Unknown priority '{}'. Valid values: urgent, high, medium, low, none",
+                    priority_str
+                ),
             })?;
         todos.retain(|t| t.priority == target_priority);
     }
@@ -1453,15 +1450,14 @@ pub async fn update_todo(
         })?;
     }
     if let Some(ref priority_str) = req.priority {
-        todo.priority = TodoPriority::from_str_loose(priority_str).ok_or_else(|| {
-            AppError::InvalidInput {
+        todo.priority =
+            TodoPriority::from_str_loose(priority_str).ok_or_else(|| AppError::InvalidInput {
                 field: "priority".to_string(),
                 reason: format!(
                     "Unknown priority '{}'. Valid values: urgent, high, medium, low, none",
                     priority_str
                 ),
-            }
-        })?;
+            })?;
     }
     if let Some(ref contexts) = req.contexts {
         todo.contexts = contexts.clone();

--- a/src/memory/lineage.rs
+++ b/src/memory/lineage.rs
@@ -894,6 +894,239 @@ impl LineageGraph {
                     * 0.75, // weakest same-type pair — observations are less directed than conversations
             )),
 
+            // ===================================================================
+            // Hook-generated types: CodeEdit, FileAccess, Search, Command
+            // These are the most common types from Claude Code hooks and were
+            // previously falling through to RelatedTo (breaking causal chains).
+            // ===================================================================
+
+            // CodeEdit acts like Task (implementation work)
+            (Error, CodeEdit) | (Task, CodeEdit) => Some((
+                CausalRelation::ResolvedBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::ResolvedBy)
+                    .unwrap_or(&0.85)
+                    * 0.85,
+            )),
+            (CodeEdit, Error) | (Command, Error) => Some((
+                CausalRelation::Caused,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::Caused)
+                    .unwrap_or(&0.8)
+                    * 0.80,
+            )),
+            (CodeEdit, Learning) | (Command, Learning) => Some((
+                CausalRelation::ResolvedBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::ResolvedBy)
+                    .unwrap_or(&0.85)
+                    * 0.80,
+            )),
+            (Decision, CodeEdit) | (Learning, CodeEdit) | (Discovery, CodeEdit) => Some((
+                CausalRelation::InformedBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::InformedBy)
+                    .unwrap_or(&0.7)
+                    * 0.85,
+            )),
+            (Observation, CodeEdit) | (Conversation, CodeEdit) => Some((
+                CausalRelation::TriggeredBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::TriggeredBy)
+                    .unwrap_or(&0.75)
+                    * 0.80,
+            )),
+            (CodeEdit, CodeEdit) => Some((
+                CausalRelation::InformedBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::InformedBy)
+                    .unwrap_or(&0.7)
+                    * 0.75, // sequential edits — weakest same-type
+            )),
+            (CodeEdit, Decision) => Some((
+                CausalRelation::InformedBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::InformedBy)
+                    .unwrap_or(&0.7)
+                    * 0.80,
+            )),
+            (CodeEdit, Task) => Some((
+                CausalRelation::TriggeredBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::TriggeredBy)
+                    .unwrap_or(&0.75)
+                    * 0.80,
+            )),
+            (CodeEdit, Discovery) => Some((
+                CausalRelation::TriggeredBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::TriggeredBy)
+                    .unwrap_or(&0.75)
+                    * 0.75,
+            )),
+
+            // FileAccess and Search act like Observation (research/exploration)
+            (FileAccess, Decision) | (Search, Decision) => Some((
+                CausalRelation::InformedBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::InformedBy)
+                    .unwrap_or(&0.7)
+                    * 0.80,
+            )),
+            (FileAccess, CodeEdit) | (Search, CodeEdit) => Some((
+                CausalRelation::InformedBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::InformedBy)
+                    .unwrap_or(&0.7)
+                    * 0.80,
+            )),
+            (FileAccess, Task) | (Search, Task) => Some((
+                CausalRelation::TriggeredBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::TriggeredBy)
+                    .unwrap_or(&0.75)
+                    * 0.80,
+            )),
+            (FileAccess, Learning) | (Search, Learning) => Some((
+                CausalRelation::TriggeredBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::TriggeredBy)
+                    .unwrap_or(&0.75)
+                    * 0.80,
+            )),
+            (FileAccess, Discovery) | (Search, Discovery) => Some((
+                CausalRelation::TriggeredBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::TriggeredBy)
+                    .unwrap_or(&0.75)
+                    * 0.80,
+            )),
+            (FileAccess, Error) | (Search, Error) => Some((
+                CausalRelation::Caused,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::Caused)
+                    .unwrap_or(&0.8)
+                    * 0.70, // reading/searching rarely causes errors
+            )),
+            (FileAccess, FileAccess)
+            | (Search, Search)
+            | (FileAccess, Search)
+            | (Search, FileAccess) => Some((
+                CausalRelation::InformedBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::InformedBy)
+                    .unwrap_or(&0.7)
+                    * 0.70, // sequential research
+            )),
+
+            // Command acts like Task (system action)
+            (Error, Command) | (Task, Command) => Some((
+                CausalRelation::ResolvedBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::ResolvedBy)
+                    .unwrap_or(&0.85)
+                    * 0.80,
+            )),
+            (Decision, Command) | (Learning, Command) => Some((
+                CausalRelation::InformedBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::InformedBy)
+                    .unwrap_or(&0.7)
+                    * 0.80,
+            )),
+            (Observation, Command) | (Conversation, Command) => Some((
+                CausalRelation::TriggeredBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::TriggeredBy)
+                    .unwrap_or(&0.75)
+                    * 0.80,
+            )),
+            (Command, Command) => Some((
+                CausalRelation::InformedBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::InformedBy)
+                    .unwrap_or(&0.7)
+                    * 0.70,
+            )),
+            (Command, Decision) | (Command, Task) | (Command, CodeEdit) => Some((
+                CausalRelation::TriggeredBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::TriggeredBy)
+                    .unwrap_or(&0.75)
+                    * 0.75,
+            )),
+            (Command, Discovery) => Some((
+                CausalRelation::TriggeredBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::TriggeredBy)
+                    .unwrap_or(&0.75)
+                    * 0.75,
+            )),
+
+            // Cross-type hooks: FileAccess/Search → Command and vice versa
+            (FileAccess, Command) | (Search, Command) => Some((
+                CausalRelation::InformedBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::InformedBy)
+                    .unwrap_or(&0.7)
+                    * 0.75,
+            )),
+            (Command, FileAccess) | (Command, Search) => Some((
+                CausalRelation::TriggeredBy,
+                *self
+                    .config
+                    .relation_confidence
+                    .get(&CausalRelation::TriggeredBy)
+                    .unwrap_or(&0.75)
+                    * 0.70,
+            )),
+
             // Default: RelatedTo if same type or generic relation
             _ => {
                 // Only suggest RelatedTo for semantically related types


### PR DESCRIPTION
## Summary
- Adds 30+ causal relation match arms for hook-generated memory types (`CodeEdit`, `FileAccess`, `Search`, `Command`) that were all falling through to `RelatedTo` — the root cause of "19 RelatedTo edges" spam
- Fixes 500→400 error code mismatches for spatial/mission mode validation and invalid session_id UUIDs
- Adds observability for silent failures in backup, todo indexing, and recall enrichment

## Root cause: lineage RelatedTo spam
The `infer_by_types()` match table had explicit arms for the 7 original memory types (Observation, Decision, Learning, etc.) but the 4 hook-generated types (`CodeEdit`, `FileAccess`, `Search`, `Command`) — which are the **most common** types in production — all fell through to the `_ => RelatedTo` wildcard. This means every lineage inference between hook memories produced a generic `RelatedTo` edge instead of proper causal types like `ResolvedBy`, `InformedBy`, `TriggeredBy`, etc.

## Error code fixes
- **recall.rs**: Spatial mode without `geo_filter` and mission mode without `mission_id` now return `400 INVALID_INPUT` (was `500 INTERNAL_ERROR`)
- **recall.rs**: Invalid `session_id` UUID now returns `400 INVALID_INPUT` (was silently dropping temporal filter, returning wrong results with `200 OK`)
- **search.rs**: `multimodal_search` rejects spatial/mission modes (requires `/api/search/robotics`)

## Silent failure observability
- **consolidation.rs**: Graph DB init failure during backup now logged at `warn!` (was `.ok()` producing incomplete backups with `success: true`)
- **todos.rs**: Todo semantic indexing failures now logged at `warn!` (was silently making todos invisible to query)
- **recall.rs**: Fact-fetch and lineage-edge `spawn_blocking` panics now logged at `warn!` (was `unwrap_or_default()` with zero observability)

## Test plan
- [x] `cargo check` — compiles clean
- [x] `cargo test --lib` — 589 passed, 0 failed
- [x] `cargo fmt` — clean
- [x] Live MCP testing: remember, recall (semantic/associative/temporal/spatial/action_outcome), proactive_context, todos, verify_index all working
- [x] Validation guardrails confirmed working: importance, valence, reward range, empty query, tag limits all return proper 400 errors
- [ ] CI green