### PR TITLE
fix: resolve all 128 clippy warnings with manual audit

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -602,6 +602,7 @@ pub const FACT_DECAY_HALF_LIFE_PER_SUPPORT_DAYS: f64 = 30.0;
 /// - MiniLM-L6-v2 cosine > 0.80 indicates near-paraphrase for short factual statements
 /// - Below 0.80 risks merging topically related but semantically distinct facts
 /// - Combined with entity + polarity gates for high precision
+///
 /// Reference: Reimers & Gurevych 2019 (Sentence-BERT)
 pub const FACT_DEDUP_COSINE_THRESHOLD: f32 = 0.80;
 

--- a/src/embeddings/minilm.rs
+++ b/src/embeddings/minilm.rs
@@ -368,7 +368,7 @@ impl MiniLMEmbedder {
                 |downloaded, total| {
                     if total > 0 {
                         let percent = (downloaded as f64 / total as f64 * 100.0) as u32;
-                        if percent % 10 == 0 {
+                        if percent.is_multiple_of(10) {
                             tracing::info!(
                                 "Downloading models: {}% ({}/{})",
                                 percent,

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -1223,6 +1223,7 @@ pub struct GraphMemory {
     /// Maps entity UUID → embedding vector. Loaded on startup, updated on add.
     /// Used when string-based dedup (exact/case/stemmed) fails — catches synonyms
     /// like "authentication" ↔ "auth" via cosine similarity.
+    #[allow(clippy::type_complexity)]
     entity_embedding_cache: Arc<parking_lot::RwLock<Vec<(Uuid, Vec<f32>)>>>,
 
     /// Edges found below prune threshold during lazy-decay reads.
@@ -1453,7 +1454,7 @@ impl GraphMemory {
                                 batch.put_cf(cf, &key, &value);
                                 count += 1;
                                 // Flush in chunks to limit memory usage
-                                if count % 10_000 == 0 {
+                                if count.is_multiple_of(10_000) {
                                     db.write(std::mem::take(&mut batch))?;
                                     batch = WriteBatch::default();
                                 }
@@ -1706,10 +1707,10 @@ impl GraphMemory {
                 let mut best_match: Option<(Uuid, f32)> = None;
                 for (uuid, existing_emb) in cache.iter() {
                     let sim = crate::similarity::cosine_similarity(new_emb, existing_emb);
-                    if sim >= ENTITY_CONCEPT_MERGE_THRESHOLD {
-                        if best_match.map_or(true, |(_, best_sim)| sim > best_sim) {
-                            best_match = Some((*uuid, sim));
-                        }
+                    if sim >= ENTITY_CONCEPT_MERGE_THRESHOLD
+                        && best_match.is_none_or(|(_, best_sim)| sim > best_sim)
+                    {
+                        best_match = Some((*uuid, sim));
                     }
                 }
                 if let Some((matched_uuid, sim)) = best_match {
@@ -3704,7 +3705,7 @@ impl GraphMemory {
                     let _ = edge.strengthen();
                     match crate::serialization::encode(&edge) {
                         Ok(encoded) => {
-                            batch.put_cf(self.relationships_cf(), &keys[i], encoded);
+                            batch.put_cf(self.relationships_cf(), keys[i], encoded);
                             strengthened += 1;
                         }
                         Err(e) => {
@@ -4982,7 +4983,7 @@ impl GraphMemory {
                     }
 
                     if let Ok(encoded) = crate::serialization::encode(&entity) {
-                        batch.put_cf(self.entities_cf(), &keys[i], encoded);
+                        batch.put_cf(self.entities_cf(), keys[i], encoded);
                         adjusted += 1;
                     }
                 }

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -1644,13 +1644,14 @@ pub async fn proactive_context(
                         for edges in [
                             lineage.get_edges_from(&user_id, memory_id),
                             lineage.get_edges_to(&user_id, memory_id),
-                        ] {
-                            if let Ok(edges) = edges {
-                                for mut edge in edges {
-                                    if reinforced_edge_ids.insert(edge.id.clone()) {
-                                        edge.reinforce();
-                                        let _ = lineage.store_edge(&user_id, &edge);
-                                    }
+                        ]
+                        .into_iter()
+                        .flatten()
+                        {
+                            for mut edge in edges {
+                                if reinforced_edge_ids.insert(edge.id.clone()) {
+                                    edge.reinforce();
+                                    let _ = lineage.store_edge(&user_id, &edge);
                                 }
                             }
                         }
@@ -1661,16 +1662,17 @@ pub async fn proactive_context(
                         for edges in [
                             lineage.get_edges_from(&user_id, memory_id),
                             lineage.get_edges_to(&user_id, memory_id),
-                        ] {
-                            if let Ok(edges) = edges {
-                                for mut edge in edges {
-                                    if reinforced_edge_ids.insert(edge.id.clone()) {
-                                        let should_prune = edge.weaken();
-                                        if should_prune {
-                                            let _ = lineage.delete_edge(&user_id, &edge.id);
-                                        } else {
-                                            let _ = lineage.store_edge(&user_id, &edge);
-                                        }
+                        ]
+                        .into_iter()
+                        .flatten()
+                        {
+                            for mut edge in edges {
+                                if reinforced_edge_ids.insert(edge.id.clone()) {
+                                    let should_prune = edge.weaken();
+                                    if should_prune {
+                                        let _ = lineage.delete_edge(&user_id, &edge.id);
+                                    } else {
+                                        let _ = lineage.store_edge(&user_id, &edge);
                                     }
                                 }
                             }

--- a/src/handlers/remember.rs
+++ b/src/handlers/remember.rs
@@ -303,6 +303,7 @@ pub fn parse_source_type(s: Option<&String>) -> SourceType {
 }
 
 /// Build RichContext from request fields
+#[allow(clippy::too_many_arguments)]
 pub fn build_rich_context(
     emotional_valence: Option<f32>,
     emotional_arousal: Option<f32>,

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -548,7 +548,7 @@ impl MultiUserMemoryManagerRotationHelper {
                 batch.delete_cf(audit, &key);
                 removed_count += 1;
 
-                if removed_count % BATCH_FLUSH_SIZE == 0 {
+                if removed_count.is_multiple_of(BATCH_FLUSH_SIZE) {
                     self.shared_db
                         .write(std::mem::take(&mut batch))
                         .map_err(|e| anyhow::anyhow!("Failed to write rotation batch: {e}"))?;
@@ -560,7 +560,7 @@ impl MultiUserMemoryManagerRotationHelper {
         }
 
         // Flush remaining
-        if removed_count % BATCH_FLUSH_SIZE != 0 {
+        if !removed_count.is_multiple_of(BATCH_FLUSH_SIZE) {
             self.shared_db
                 .write(batch)
                 .map_err(|e| anyhow::anyhow!("Failed to write rotation batch: {e}"))?;
@@ -729,7 +729,7 @@ impl MultiUserMemoryManager {
             match download_ner_models(Some(std::sync::Arc::new(|downloaded, total| {
                 if total > 0 {
                     let percent = (downloaded as f64 / total as f64 * 100.0) as u32;
-                    if percent % 20 == 0 {
+                    if percent.is_multiple_of(20) {
                         tracing::info!("NER model download: {}%", percent);
                     }
                 }
@@ -1082,7 +1082,7 @@ impl MultiUserMemoryManager {
             batch.put_cf(audit_cf, &key, &value);
             count += 1;
 
-            if count % BATCH_SIZE == 0 {
+            if count.is_multiple_of(BATCH_SIZE) {
                 shared_db
                     .write(std::mem::take(&mut batch))
                     .map_err(|e| anyhow::anyhow!("audit migration batch write error: {e}"))?;
@@ -1090,7 +1090,7 @@ impl MultiUserMemoryManager {
             }
         }
 
-        if count % BATCH_SIZE != 0 {
+        if !count.is_multiple_of(BATCH_SIZE) {
             shared_db
                 .write(batch)
                 .map_err(|e| anyhow::anyhow!("audit migration final batch error: {e}"))?;
@@ -1164,7 +1164,7 @@ impl MultiUserMemoryManager {
             .audit_log_counter
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        if count % self.server_config.audit_rotation_check_interval == 0 && count > 0 {
+        if count.is_multiple_of(self.server_config.audit_rotation_check_interval) && count > 0 {
             let shared_db = self.shared_db.clone();
             let audit_logs = self.audit_logs.clone();
             let user_id_clone = user_id.to_string();
@@ -1903,7 +1903,7 @@ impl MultiUserMemoryManager {
         // Heavy cycle every 6th iteration (6 hours at 3600s intervals).
         // Heavy cycles run replay, entity-entity strengthening, fact extraction (full memory scan),
         // and flush databases (triggers compaction). Light cycles only touch in-memory data.
-        let is_heavy = cycle % 6 == 0;
+        let is_heavy = cycle.is_multiple_of(6);
 
         if is_heavy {
             tracing::info!(

--- a/src/memory/compression.rs
+++ b/src/memory/compression.rs
@@ -571,7 +571,7 @@ pub struct SemanticFact {
 }
 
 /// Types of semantic facts
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub enum FactType {
     /// User preference: "prefers concise code"
     Preference,
@@ -584,13 +584,8 @@ pub enum FactType {
     /// Definition: "MemoryId is a UUID wrapper"
     Definition,
     /// Pattern: "errors often occur after deployment"
+    #[default]
     Pattern,
-}
-
-impl Default for FactType {
-    fn default() -> Self {
-        Self::Pattern
-    }
 }
 
 /// A cluster of related facts grouped by shared entities, with a template-generated
@@ -1024,8 +1019,7 @@ impl SemanticConsolidator {
                 let subject = &content[subject_start..pos];
 
                 if subject.len() >= 2 {
-                    let def_end = content[pos + marker.len()..]
-                        .find(|c| c == '.' || c == '!' || c == '?' || c == ',');
+                    let def_end = content[pos + marker.len()..].find(['.', '!', '?', ',']);
                     let def_end = def_end
                         .map(|i| pos + marker.len() + i)
                         .unwrap_or(content.len().min(pos + marker.len() + 100));
@@ -1142,7 +1136,7 @@ impl SemanticConsolidator {
 
             let score = content_words as f32 + entity_bonus;
 
-            if best.as_ref().map_or(true, |(_, s)| score > *s) {
+            if best.as_ref().is_none_or(|(_, s)| score > *s) {
                 best = Some((trimmed.to_string(), score));
             }
         }
@@ -1231,10 +1225,10 @@ impl SemanticConsolidator {
 
     /// Extract the sentence containing a character position
     fn extract_sentence(content: &str, pos: usize) -> Option<String> {
-        let start = content[..pos].rfind(|c| c == '.' || c == '!' || c == '?');
+        let start = content[..pos].rfind(['.', '!', '?']);
         let start = start.map(|i| i + 1).unwrap_or(0);
 
-        let end = content[pos..].find(|c| c == '.' || c == '!' || c == '?');
+        let end = content[pos..].find(['.', '!', '?']);
         let end = end.map(|i| pos + i).unwrap_or(content.len());
 
         let sentence = content[start..end].trim();

--- a/src/memory/facts.rs
+++ b/src/memory/facts.rs
@@ -422,14 +422,14 @@ impl SemanticFactStore {
                         }
 
                         // Passed all gates — rank by cosine
-                        if best_match.as_ref().map_or(true, |(s, _)| cosine > *s) {
+                        if best_match.as_ref().is_none_or(|(s, _)| cosine > *s) {
                             best_match = Some((cosine, fact));
                         }
                     }
                     _ => {
                         // No stored embedding — fall back to Jaccard-only for this candidate
                         if jaccard >= FACT_DEDUP_JACCARD_FALLBACK
-                            && best_match.as_ref().map_or(true, |(s, _)| jaccard > *s)
+                            && best_match.as_ref().is_none_or(|(s, _)| jaccard > *s)
                         {
                             best_match = Some((jaccard, fact));
                         }

--- a/src/memory/feedback.rs
+++ b/src/memory/feedback.rs
@@ -1487,6 +1487,7 @@ pub struct PreviousContext {
 }
 
 /// Persistent store for feedback momentum with in-memory cache
+#[derive(Default)]
 pub struct FeedbackStore {
     /// In-memory cache: memory_id -> FeedbackMomentum
     pub momentum: HashMap<MemoryId, FeedbackMomentum>,
@@ -1523,19 +1524,6 @@ impl std::fmt::Debug for FeedbackStore {
     }
 }
 
-impl Default for FeedbackStore {
-    fn default() -> Self {
-        Self {
-            momentum: HashMap::new(),
-            pending: HashMap::new(),
-            windows: HashMap::new(),
-            previous_context: HashMap::new(),
-            db: None,
-            dirty: HashSet::new(),
-        }
-    }
-}
-
 impl FeedbackStore {
     /// Create in-memory only store (no persistence)
     pub fn new() -> Self {
@@ -1561,33 +1549,29 @@ impl FeedbackStore {
         // Load all momentum entries from the feedback CF
         let mut momentum = HashMap::new();
         let iter = db.prefix_iterator_cf(cf, b"momentum:");
-        for item in iter {
-            if let Ok((key, value)) = item {
-                if let Ok(key_str) = std::str::from_utf8(&key) {
-                    if !key_str.starts_with("momentum:") {
-                        break;
-                    }
-                    if let Ok(m) = serde_json::from_slice::<FeedbackMomentum>(&value) {
-                        momentum.insert(m.memory_id.clone(), m);
-                    }
+        for (key, value) in iter.flatten() {
+            if let Ok(key_str) = std::str::from_utf8(&key) {
+                if !key_str.starts_with("momentum:") {
+                    break;
+                }
+                if let Ok(m) = serde_json::from_slice::<FeedbackMomentum>(&value) {
+                    momentum.insert(m.memory_id.clone(), m);
                 }
             }
         }
 
         let mut pending = HashMap::new();
         let iter = db.prefix_iterator_cf(cf, b"pending:");
-        for item in iter {
-            if let Ok((key, value)) = item {
-                if let Ok(key_str) = std::str::from_utf8(&key) {
-                    if !key_str.starts_with("pending:") {
-                        break;
-                    }
-                    if let Ok(p) = serde_json::from_slice::<PendingFeedback>(&value) {
-                        if !p.is_expired() {
-                            pending.insert(p.user_id.clone(), p);
-                        } else {
-                            let _ = db.delete_cf(cf, key_str.as_bytes());
-                        }
+        for (key, value) in iter.flatten() {
+            if let Ok(key_str) = std::str::from_utf8(&key) {
+                if !key_str.starts_with("pending:") {
+                    break;
+                }
+                if let Ok(p) = serde_json::from_slice::<PendingFeedback>(&value) {
+                    if !p.is_expired() {
+                        pending.insert(p.user_id.clone(), p);
+                    } else {
+                        let _ = db.delete_cf(cf, key_str.as_bytes());
                     }
                 }
             }
@@ -1595,16 +1579,14 @@ impl FeedbackStore {
 
         let mut previous_context = HashMap::new();
         let iter = db.prefix_iterator_cf(cf, b"prev_ctx:");
-        for item in iter {
-            if let Ok((key, value)) = item {
-                if let Ok(key_str) = std::str::from_utf8(&key) {
-                    if !key_str.starts_with("prev_ctx:") {
-                        break;
-                    }
-                    if let Ok(ctx) = serde_json::from_slice::<PreviousContext>(&value) {
-                        let user_id = key_str.strip_prefix("prev_ctx:").unwrap_or("");
-                        previous_context.insert(user_id.to_string(), ctx);
-                    }
+        for (key, value) in iter.flatten() {
+            if let Ok(key_str) = std::str::from_utf8(&key) {
+                if !key_str.starts_with("prev_ctx:") {
+                    break;
+                }
+                if let Ok(ctx) = serde_json::from_slice::<PreviousContext>(&value) {
+                    let user_id = key_str.strip_prefix("prev_ctx:").unwrap_or("");
+                    previous_context.insert(user_id.to_string(), ctx);
                 }
             }
         }
@@ -1612,18 +1594,16 @@ impl FeedbackStore {
         // Load feedback windows (discard stale ones older than 2 hours)
         let mut windows = HashMap::new();
         let iter = db.prefix_iterator_cf(cf, b"window:");
-        for item in iter {
-            if let Ok((key, value)) = item {
-                if let Ok(key_str) = std::str::from_utf8(&key) {
-                    if !key_str.starts_with("window:") {
-                        break;
-                    }
-                    if let Ok(w) = serde_json::from_slice::<FeedbackWindow>(&value) {
-                        if !w.is_expired() {
-                            windows.insert(w.user_id.clone(), w);
-                        } else {
-                            let _ = db.delete_cf(cf, key_str.as_bytes());
-                        }
+        for (key, value) in iter.flatten() {
+            if let Ok(key_str) = std::str::from_utf8(&key) {
+                if !key_str.starts_with("window:") {
+                    break;
+                }
+                if let Ok(w) = serde_json::from_slice::<FeedbackWindow>(&value) {
+                    if !w.is_expired() {
+                        windows.insert(w.user_id.clone(), w);
+                    } else {
+                        let _ = db.delete_cf(cf, key_str.as_bytes());
                     }
                 }
             }
@@ -1665,12 +1645,13 @@ impl FeedbackStore {
                 let mut batch = WriteBatch::default();
                 let mut count = 0usize;
                 for item in old_db.iterator(IteratorMode::Start) {
-                    if let Ok((key, value)) = item {
-                        batch.put_cf(cf, &key, &value);
-                        count += 1;
-                        if count % 10_000 == 0 {
-                            db.write(std::mem::take(&mut batch))?;
-                        }
+                    let (key, value) = item.map_err(|e| {
+                        anyhow::anyhow!("RocksDB iterator error during feedback migration: {e}")
+                    })?;
+                    batch.put_cf(cf, &key, &value);
+                    count += 1;
+                    if count.is_multiple_of(10_000) {
+                        db.write(std::mem::take(&mut batch))?;
                     }
                 }
                 if !batch.is_empty() {
@@ -1718,15 +1699,13 @@ impl FeedbackStore {
         // Load all momentum entries from the feedback CF
         let mut momentum = HashMap::new();
         let iter = db.prefix_iterator_cf(cf, b"momentum:");
-        for item in iter {
-            if let Ok((key, value)) = item {
-                if let Ok(key_str) = std::str::from_utf8(&key) {
-                    if !key_str.starts_with("momentum:") {
-                        break;
-                    }
-                    if let Ok(m) = serde_json::from_slice::<FeedbackMomentum>(&value) {
-                        momentum.insert(m.memory_id.clone(), m);
-                    }
+        for (key, value) in iter.flatten() {
+            if let Ok(key_str) = std::str::from_utf8(&key) {
+                if !key_str.starts_with("momentum:") {
+                    break;
+                }
+                if let Ok(m) = serde_json::from_slice::<FeedbackMomentum>(&value) {
+                    momentum.insert(m.memory_id.clone(), m);
                 }
             }
         }
@@ -1734,19 +1713,16 @@ impl FeedbackStore {
         // Also load pending feedback entries (filter expired ones)
         let mut pending = HashMap::new();
         let iter = db.prefix_iterator_cf(cf, b"pending:");
-        for item in iter {
-            if let Ok((key, value)) = item {
-                if let Ok(key_str) = std::str::from_utf8(&key) {
-                    if !key_str.starts_with("pending:") {
-                        break;
-                    }
-                    if let Ok(p) = serde_json::from_slice::<PendingFeedback>(&value) {
-                        if !p.is_expired() {
-                            pending.insert(p.user_id.clone(), p);
-                        } else {
-                            // Clean up expired pending feedback from disk
-                            let _ = db.delete_cf(cf, key_str.as_bytes());
-                        }
+        for (key, value) in iter.flatten() {
+            if let Ok(key_str) = std::str::from_utf8(&key) {
+                if !key_str.starts_with("pending:") {
+                    break;
+                }
+                if let Ok(p) = serde_json::from_slice::<PendingFeedback>(&value) {
+                    if !p.is_expired() {
+                        pending.insert(p.user_id.clone(), p);
+                    } else {
+                        let _ = db.delete_cf(cf, key_str.as_bytes());
                     }
                 }
             }
@@ -1755,16 +1731,14 @@ impl FeedbackStore {
         // Load previous context entries
         let mut previous_context = HashMap::new();
         let iter = db.prefix_iterator_cf(cf, b"prev_ctx:");
-        for item in iter {
-            if let Ok((key, value)) = item {
-                if let Ok(key_str) = std::str::from_utf8(&key) {
-                    if !key_str.starts_with("prev_ctx:") {
-                        break;
-                    }
-                    if let Ok(ctx) = serde_json::from_slice::<PreviousContext>(&value) {
-                        let user_id = key_str.strip_prefix("prev_ctx:").unwrap_or("");
-                        previous_context.insert(user_id.to_string(), ctx);
-                    }
+        for (key, value) in iter.flatten() {
+            if let Ok(key_str) = std::str::from_utf8(&key) {
+                if !key_str.starts_with("prev_ctx:") {
+                    break;
+                }
+                if let Ok(ctx) = serde_json::from_slice::<PreviousContext>(&value) {
+                    let user_id = key_str.strip_prefix("prev_ctx:").unwrap_or("");
+                    previous_context.insert(user_id.to_string(), ctx);
                 }
             }
         }

--- a/src/memory/files.rs
+++ b/src/memory/files.rs
@@ -94,12 +94,13 @@ impl FileMemoryStore {
                     let mut batch = WriteBatch::default();
                     let mut count = 0usize;
                     for item in old_db.iterator(rocksdb::IteratorMode::Start) {
-                        if let Ok((key, value)) = item {
-                            batch.put_cf(cf, &key, &value);
-                            count += 1;
-                            if count % 10_000 == 0 {
-                                db.write(std::mem::take(&mut batch))?;
-                            }
+                        let (key, value) = item.map_err(|e| {
+                            anyhow::anyhow!("RocksDB iterator error during files migration: {e}")
+                        })?;
+                        batch.put_cf(cf, &key, &value);
+                        count += 1;
+                        if count.is_multiple_of(10_000) {
+                            db.write(std::mem::take(&mut batch))?;
                         }
                     }
                     if !batch.is_empty() {
@@ -889,19 +890,19 @@ impl FileMemoryStore {
 
         if line.starts_with("fn ") {
             let rest = line.strip_prefix("fn ")?;
-            let name = rest.split(|c| c == '(' || c == '<').next()?;
+            let name = rest.split(['(', '<']).next()?;
             Some(name.trim().to_string())
         } else if line.starts_with("struct ") {
             let rest = line.strip_prefix("struct ")?;
-            let name = rest.split(|c| c == '{' || c == '<' || c == '(').next()?;
+            let name = rest.split(['{', '<', '(']).next()?;
             Some(name.trim().to_string())
         } else if line.starts_with("enum ") {
             let rest = line.strip_prefix("enum ")?;
-            let name = rest.split(|c| c == '{' || c == '<').next()?;
+            let name = rest.split(['{', '<']).next()?;
             Some(name.trim().to_string())
         } else if line.starts_with("trait ") {
             let rest = line.strip_prefix("trait ")?;
-            let name = rest.split(|c| c == '{' || c == '<' || c == ':').next()?;
+            let name = rest.split(['{', '<', ':']).next()?;
             Some(name.trim().to_string())
         } else if line.starts_with("impl ") {
             let rest = line.strip_prefix("impl ")?;
@@ -926,15 +927,15 @@ impl FileMemoryStore {
             Some(name.trim().to_string())
         } else if line.starts_with("class ") {
             let rest = line.strip_prefix("class ")?;
-            let name = rest.split(|c| c == '{' || c == ' ').next()?;
+            let name = rest.split(['{', ' ']).next()?;
             Some(name.trim().to_string())
         } else if line.starts_with("interface ") {
             let rest = line.strip_prefix("interface ")?;
-            let name = rest.split(|c| c == '{' || c == ' ' || c == '<').next()?;
+            let name = rest.split(['{', ' ', '<']).next()?;
             Some(name.trim().to_string())
         } else if line.starts_with("const ") {
             let rest = line.strip_prefix("const ")?;
-            let name = rest.split(|c| c == '=' || c == ':').next()?;
+            let name = rest.split(['=', ':']).next()?;
             Some(name.trim().to_string())
         } else {
             None
@@ -952,7 +953,7 @@ impl FileMemoryStore {
             Some(name.trim().to_string())
         } else if line.starts_with("class ") {
             let rest = line.strip_prefix("class ")?;
-            let name = rest.split(|c| c == '(' || c == ':').next()?;
+            let name = rest.split(['(', ':']).next()?;
             Some(name.trim().to_string())
         } else {
             None

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -1061,8 +1061,8 @@ fn calculate_lateral_inhibition(scored: &[ActivatedMemory]) -> Vec<f32> {
 
         let mut total_penalty = 0.0f32;
 
-        for j in 0..i {
-            let emb_j = match &scored[j].memory.experience.embeddings {
+        for prev in &scored[..i] {
+            let emb_j = match &prev.memory.experience.embeddings {
                 Some(e) => e,
                 None => continue,
             };
@@ -1070,7 +1070,7 @@ fn calculate_lateral_inhibition(scored: &[ActivatedMemory]) -> Vec<f32> {
             let sim = cosine_similarity(emb_i, emb_j);
             if sim > GRAPH_LATERAL_INHIBITION_THRESHOLD {
                 // Higher-ranked memory suppresses this one proportional to similarity
-                total_penalty += scored[j].final_score * GRAPH_LATERAL_INHIBITION_STRENGTH * sim;
+                total_penalty += prev.final_score * GRAPH_LATERAL_INHIBITION_STRENGTH * sim;
             }
         }
 

--- a/src/memory/learning_history.rs
+++ b/src/memory/learning_history.rs
@@ -612,8 +612,10 @@ impl LearningHistoryStore {
         // Get all events (could be optimized with counters)
         let all_events = self.events_since(user_id, now - Duration::days(365))?;
 
-        let mut stats = LearningStats::default();
-        stats.total_events = all_events.len();
+        let mut stats = LearningStats {
+            total_events: all_events.len(),
+            ..Default::default()
+        };
 
         let mut memory_event_counts: HashMap<String, usize> = HashMap::new();
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1112,7 +1112,7 @@ impl MemorySystem {
                 .experience
                 .entities
                 .iter()
-                .zip(entity_embeddings.into_iter())
+                .zip(entity_embeddings)
                 .map(|(entity_name, embedding)| {
                     let (label, salience) = resolve_entity_label(entity_name, &ner_lookup);
                     crate::graph_memory::EntityNode {
@@ -1921,6 +1921,7 @@ impl MemorySystem {
             query.retrieval_mode,
             RetrievalMode::Hybrid | RetrievalMode::Associative | RetrievalMode::Causal
         );
+        #[allow(clippy::type_complexity)]
         let (
             graph_results,
             graph_density,
@@ -2066,7 +2067,7 @@ impl MemorySystem {
                                             let mid = MemoryId(ep.uuid);
                                             if episode_candidates
                                                 .as_ref()
-                                                .map_or(true, |c| c.contains(&mid))
+                                                .is_none_or(|c| c.contains(&mid))
                                             {
                                                 ids.push((
                                                     mid,
@@ -2125,9 +2126,7 @@ impl MemorySystem {
                                 eps.truncate(50);
                                 for ep in eps {
                                     let mid = MemoryId(ep.uuid);
-                                    if episode_candidates
-                                        .as_ref()
-                                        .map_or(true, |c| c.contains(&mid))
+                                    if episode_candidates.as_ref().is_none_or(|c| c.contains(&mid))
                                     {
                                         ids.push((
                                             mid,
@@ -3237,7 +3236,7 @@ impl MemorySystem {
                 }
 
                 // Clean up interference records
-                self.cleanup_interference_for_ids(&[memory_id.clone()]);
+                self.cleanup_interference_for_ids(std::slice::from_ref(&memory_id));
 
                 // Update stats - decrement each tier count that had this memory
                 if deleted_from_any {
@@ -4703,27 +4702,23 @@ impl MemorySystem {
                 "facts_embedding:",
             ] {
                 let iter = db.prefix_iterator(prefix.as_bytes());
-                for item in iter {
-                    if let Ok((key, _)) = item {
-                        if !key.starts_with(prefix.as_bytes()) {
-                            break;
-                        }
-                        batch.delete(&key);
-                        if *prefix == "facts:" {
-                            facts_deleted += 1;
-                        }
+                for (key, _) in iter.flatten() {
+                    if !key.starts_with(prefix.as_bytes()) {
+                        break;
+                    }
+                    batch.delete(&key);
+                    if *prefix == "facts:" {
+                        facts_deleted += 1;
                     }
                 }
             }
             // Clear temporal facts
             let iter = db.prefix_iterator(b"temporal_facts:");
-            for item in iter {
-                if let Ok((key, _)) = item {
-                    if !key.starts_with(b"temporal_facts:") {
-                        break;
-                    }
-                    batch.delete(&key);
+            for (key, _) in iter.flatten() {
+                if !key.starts_with(b"temporal_facts:") {
+                    break;
                 }
+                batch.delete(&key);
             }
             if facts_deleted > 0 || !batch.is_empty() {
                 if let Err(e) = db.write(batch) {
@@ -5039,10 +5034,8 @@ impl MemorySystem {
 
         let mut orphaned_ids = Vec::new();
         for memory in &all_memories {
-            if !indexed_ids.contains(&memory.id) {
-                if orphaned_ids.len() < 100 {
-                    orphaned_ids.push(memory.id.clone());
-                }
+            if !indexed_ids.contains(&memory.id) && orphaned_ids.len() < 100 {
+                orphaned_ids.push(memory.id.clone());
             }
         }
 
@@ -5264,7 +5257,7 @@ impl MemorySystem {
 
         let mut stats = ReinforcementStats {
             memories_processed: memory_ids.len(),
-            outcome: outcome.clone(),
+            outcome,
             ..Default::default()
         };
 
@@ -5872,7 +5865,7 @@ impl MemorySystem {
                     .experience
                     .entities
                     .iter()
-                    .zip(entity_embeddings.into_iter())
+                    .zip(entity_embeddings)
                     .map(|(entity_name, embedding)| {
                         let (label, salience) = resolve_entity_label(entity_name, &ner_lookup);
                         crate::graph_memory::EntityNode {
@@ -6682,7 +6675,7 @@ impl MemorySystem {
         }
 
         // Sort by timestamp
-        all_events.sort_by(|a, b| a.timestamp().cmp(&b.timestamp()));
+        all_events.sort_by_key(|a| a.timestamp());
 
         // Generate report from combined events
         let report =
@@ -7094,10 +7087,8 @@ impl MemorySystem {
         let total = all_facts.len();
         let mut deleted = 0;
         for fact in &all_facts {
-            if predicate(fact) {
-                if self.fact_store.delete(user_id, &fact.id)? {
-                    deleted += 1;
-                }
+            if predicate(fact) && self.fact_store.delete(user_id, &fact.id)? {
+                deleted += 1;
             }
         }
         Ok((deleted, total))
@@ -7320,9 +7311,10 @@ impl MemorySystem {
     }
 }
 
-/// Automatic persistence on drop - ensures vector index and ID mappings survive restarts
-///
-/// This is CRITICAL for local memory: when the system shuts down (gracefully or via drop),
+// Automatic persistence on drop - ensures vector index and ID mappings survive restarts
+//
+// This is CRITICAL for local memory: when the system shuts down (gracefully or via drop),
+
 // =============================================================================
 // Fact Narrative Helpers (private, used by MemorySystem::build_fact_narratives)
 // =============================================================================

--- a/src/memory/prospective.rs
+++ b/src/memory/prospective.rs
@@ -159,12 +159,15 @@ impl ProspectiveStore {
                     let mut batch = WriteBatch::default();
                     let mut count = 0usize;
                     for item in old_db.iterator(rocksdb::IteratorMode::Start) {
-                        if let Ok((key, value)) = item {
-                            batch.put_cf(cf, &key, &value);
-                            count += 1;
-                            if count % 10_000 == 0 {
-                                db.write(std::mem::take(&mut batch))?;
-                            }
+                        let (key, value) = item.map_err(|e| {
+                            anyhow::anyhow!(
+                                "RocksDB iterator error during prospective migration: {e}"
+                            )
+                        })?;
+                        batch.put_cf(cf, &key, &value);
+                        count += 1;
+                        if count.is_multiple_of(10_000) {
+                            db.write(std::mem::take(&mut batch))?;
                         }
                     }
                     if !batch.is_empty() {
@@ -662,7 +665,7 @@ impl ProspectiveStore {
                 let task_emb = task
                     .embedding
                     .as_deref()
-                    .map(|e| std::borrow::Cow::Borrowed(e))
+                    .map(std::borrow::Cow::Borrowed)
                     .or_else(|| embed_fn(&task.content).map(std::borrow::Cow::Owned));
 
                 if let Some(task_embedding) = task_emb {

--- a/src/memory/query_parser.rs
+++ b/src/memory/query_parser.rs
@@ -244,7 +244,7 @@ pub fn extract_temporal_refs(text: &str) -> TemporalExtraction {
     // Helper to validate date is in reasonable range (1900-2100)
     let is_valid_date = |date: &NaiveDate| -> bool {
         let year = date.year();
-        year >= 1900 && year <= 2100
+        (1900..=2100).contains(&year)
     };
 
     // Try dateparser on the full text (returns Result, never panics)
@@ -1044,7 +1044,7 @@ pub fn detect_attribute_query(query: &str) -> Option<AttributeQuery> {
                 if let Some(pos) = after_is.find(status) {
                     let entity = after_is[..pos].trim().to_string();
                     if !entity.is_empty()
-                        && entity.chars().next().map_or(false, |c| c.is_alphabetic())
+                        && entity.chars().next().is_some_and(|c| c.is_alphabetic())
                     {
                         return Some(AttributeQuery {
                             entity: capitalize_first(&entity),
@@ -1156,10 +1156,7 @@ fn extract_entity_after_verb(query: &str) -> Option<String> {
 
 /// Normalize an attribute name (e.g., "relationship status" → "relationship_status")
 fn normalize_attribute(attr: &str) -> String {
-    attr.trim()
-        .to_lowercase()
-        .replace(' ', "_")
-        .replace('-', "_")
+    attr.trim().to_lowercase().replace([' ', '-'], "_")
 }
 
 /// Get synonyms for common attributes
@@ -2117,7 +2114,7 @@ pub struct Relation {
 /// - Needle: Looking for specific facts → favor BM25/Vector (high precision)
 /// - Exploratory: Seeking related concepts → favor Graph (high recall)
 /// - Hybrid: Balanced query → use all retrieval methods equally
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum QueryIntent {
     /// Needle query: Seeking specific information
     /// Examples: "What is John's email?", "When did we deploy v2.0?"
@@ -2132,13 +2129,8 @@ pub enum QueryIntent {
     /// Hybrid query: Balanced between specific and exploratory
     /// Examples: "How does authentication work?", "What are the deployment options?"
     /// Strategy: Balanced weights for all retrieval methods
+    #[default]
     Hybrid,
-}
-
-impl Default for QueryIntent {
-    fn default() -> Self {
-        QueryIntent::Hybrid
-    }
 }
 
 /// Complete linguistic analysis of a query

--- a/src/memory/replay.rs
+++ b/src/memory/replay.rs
@@ -97,6 +97,7 @@ impl ReplayManager {
     /// - Important (above REPLAY_IMPORTANCE_THRESHOLD)
     /// - Connected (at least REPLAY_MIN_CONNECTIONS)
     /// - Optionally: high emotional arousal for priority
+    #[allow(clippy::type_complexity)]
     pub fn identify_replay_candidates(
         &self,
         memories: &[(String, f32, f32, DateTime<Utc>, Vec<String>, String)], // (id, importance, arousal, created_at, connections, content_preview)
@@ -160,6 +161,7 @@ impl ReplayManager {
     /// Execute replay for a batch of candidates
     ///
     /// Returns strength boosts to apply to memories and edges
+    #[allow(clippy::type_complexity)]
     pub fn execute_replay(
         &mut self,
         candidates: &[ReplayCandidate],

--- a/src/memory/retrieval.rs
+++ b/src/memory/retrieval.rs
@@ -1523,7 +1523,7 @@ pub struct IndexHealth {
 ///
 /// When memories are retrieved and used to complete a task, this feedback
 /// tells the system whether they were helpful, enabling adaptive learning.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum RetrievalOutcome {
     /// Memory helped complete the task successfully
     /// Triggers: +importance boost, +association strength, +access count
@@ -1533,6 +1533,7 @@ pub enum RetrievalOutcome {
     Misleading,
     /// Memory was retrieved but not actionably useful
     /// Triggers: +access count only (neutral)
+    #[default]
     Neutral,
 }
 
@@ -1730,12 +1731,6 @@ pub struct ReinforcementStats {
     /// Average prediction error multiplier applied to learning signals (VTA/Dopamine).
     /// 0.5 = expected outcomes (slow learning), 2.0 = max surprise (fast learning).
     pub prediction_error_multiplier: f32,
-}
-
-impl Default for RetrievalOutcome {
-    fn default() -> Self {
-        Self::Neutral
-    }
 }
 
 // NOTE: MemoryGraph has been consolidated into GraphMemory (src/graph_memory.rs)
@@ -1962,11 +1957,7 @@ impl AnticipatoryPrefetch {
         let now = chrono::Utc::now();
 
         // Find similar time window
-        let start_hour = if hour >= PREFETCH_TEMPORAL_WINDOW_HOURS as u32 {
-            hour - PREFETCH_TEMPORAL_WINDOW_HOURS as u32
-        } else {
-            0
-        };
+        let start_hour = hour.saturating_sub(PREFETCH_TEMPORAL_WINDOW_HOURS as u32);
         let end_hour = (hour + PREFETCH_TEMPORAL_WINDOW_HOURS as u32).min(23);
 
         // Calculate time range for today at similar hours
@@ -2032,7 +2023,7 @@ impl AnticipatoryPrefetch {
         // Temporal relevance (same hour of day)
         if let Some(hour) = context.hour_of_day {
             let memory_hour = memory.created_at.hour();
-            if (memory_hour as i32 - hour as i32).abs() <= PREFETCH_TEMPORAL_WINDOW_HOURS as i32 {
+            if (memory_hour as i32 - hour as i32).abs() <= PREFETCH_TEMPORAL_WINDOW_HOURS {
                 score += 0.1;
             }
         }

--- a/src/memory/storage.rs
+++ b/src/memory/storage.rs
@@ -804,15 +804,13 @@ fn deserialize_with_fallback(data: &[u8]) -> Result<(Memory, bool)> {
     // Try current format first (bincode 2.x with current Memory/Experience)
     // This is the hot path — avoid any allocations before this check.
     match bincode::serde::decode_from_slice::<Memory, _>(data, crate::bincode_safe_config()) {
-        Ok((memory, _)) => {
-            return Ok((memory, false));
-        } // Current format, no migration needed
+        Ok((memory, _)) => Ok((memory, false)), // Current format, no migration needed
         Err(e) => {
             // Current format failed — enter fallback chain.
             // Bincode 1.x paths use with_limit() to cap allocations.
             // MessagePack paths use try_msgpack_deserialize() which scans for
             // oversized length prefixes before calling rmp_serde::from_slice.
-            return deserialize_legacy_fallback(data, e, record_branch);
+            deserialize_legacy_fallback(data, e, record_branch)
         }
     }
 }
@@ -999,13 +997,10 @@ fn deserialize_legacy_fallback(
     }
 
     // Try bincode 1.x format (used in versions prior to bincode 2.0 migration)
-    match bincode1_safe.deserialize::<LegacyMemoryV1>(data) {
-        Ok(legacy) => {
-            tracing::debug!("Migrated memory from bincode 1.x format");
-            record_branch("bincode1_legacy_v1_repeat");
-            return Ok((legacy.into_memory(), true));
-        }
-        Err(_) => {} // Already tried above
+    if let Ok(legacy) = bincode1_safe.deserialize::<LegacyMemoryV1>(data) {
+        tracing::debug!("Migrated memory from bincode 1.x format");
+        record_branch("bincode1_legacy_v1_repeat");
+        return Ok((legacy.into_memory(), true));
     }
 
     // Try legacy v2 format with bincode 1.x (cognitive extensions era)
@@ -1084,16 +1079,16 @@ pub(crate) fn crc32_simple(data: &[u8]) -> u32 {
 /// Column family name for secondary indices (tags, types, timestamps, etc.)
 const CF_INDEX: &str = "memory_index";
 
-/// Storage engine for long-term memory persistence
-///
-/// Uses a single RocksDB instance with 2 column families:
-/// - default: main memory data (also shared by LearningHistoryStore, TemporalFactStore, etc. via key prefixes)
-/// - `memory_index`: secondary indices for tag/type/timestamp queries
 /// Maximum number of failed writes to buffer for retry.
 /// Small enough to bound memory usage (~100 memories × ~2KB ≈ 200KB)
 /// but large enough to absorb transient RocksDB contention bursts.
 const WRITE_RETRY_BUFFER_CAPACITY: usize = 100;
 
+/// Storage engine for long-term memory persistence
+///
+/// Uses a single RocksDB instance with 2 column families:
+/// - default: main memory data (also shared by LearningHistoryStore, TemporalFactStore, etc. via key prefixes)
+/// - `memory_index`: secondary indices for tag/type/timestamp queries
 pub struct MemoryStorage {
     db: Arc<DB>,
     /// Base storage path for all memory data
@@ -1286,13 +1281,14 @@ impl MemoryStorage {
                     let mut batch = WriteBatch::default();
                     let mut count = 0usize;
                     for item in old_db.iterator(IteratorMode::Start) {
-                        if let Ok((key, value)) = item {
-                            batch.put(&key, &value);
-                            count += 1;
-                            if count % 10_000 == 0 {
-                                db.write(std::mem::take(&mut batch))?;
-                                tracing::info!("  memories: migrated {count} entries...");
-                            }
+                        let (key, value) = item.map_err(|e| {
+                            anyhow::anyhow!("RocksDB iterator error during memory migration: {e}")
+                        })?;
+                        batch.put(&key, &value);
+                        count += 1;
+                        if count.is_multiple_of(10_000) {
+                            db.write(std::mem::take(&mut batch))?;
+                            tracing::info!("  memories: migrated {count} entries...");
                         }
                     }
                     if !batch.is_empty() {
@@ -1328,13 +1324,14 @@ impl MemoryStorage {
                     let mut batch = WriteBatch::default();
                     let mut count = 0usize;
                     for item in old_db.iterator(IteratorMode::Start) {
-                        if let Ok((key, value)) = item {
-                            batch.put_cf(&index_cf, &key, &value);
-                            count += 1;
-                            if count % 10_000 == 0 {
-                                db.write(std::mem::take(&mut batch))?;
-                                tracing::info!("  index: migrated {count} entries...");
-                            }
+                        let (key, value) = item.map_err(|e| {
+                            anyhow::anyhow!("RocksDB iterator error during index migration: {e}")
+                        })?;
+                        batch.put_cf(&index_cf, &key, &value);
+                        count += 1;
+                        if count.is_multiple_of(10_000) {
+                            db.write(std::mem::take(&mut batch))?;
+                            tracing::info!("  index: migrated {count} entries...");
                         }
                     }
                     if !batch.is_empty() {
@@ -2211,8 +2208,8 @@ impl MemoryStorage {
                         (parts[0].parse::<u32>(), uuid::Uuid::parse_str(parts[1]))
                     {
                         // Apply sequence filters
-                        let passes_min = min_sequence.map_or(true, |min| seq >= min);
-                        let passes_max = max_sequence.map_or(true, |max| seq <= max);
+                        let passes_min = min_sequence.is_none_or(|min| seq >= min);
+                        let passes_max = max_sequence.is_none_or(|max| seq <= max);
 
                         if passes_min && passes_max {
                             results.push((seq, MemoryId(uuid)));
@@ -2431,15 +2428,13 @@ impl MemoryStorage {
 
         // Iterate all memories and check for parent_id = None
         let iter = self.db.iterator(IteratorMode::Start);
-        for item in iter {
-            if let Ok((key, value)) = item {
-                if key.len() != 16 {
-                    continue;
-                }
-                if let Ok((memory, _)) = deserialize_memory(&value) {
-                    if memory.parent_id.is_none() {
-                        roots.push(memory.id);
-                    }
+        for (key, value) in iter.flatten() {
+            if key.len() != 16 {
+                continue;
+            }
+            if let Ok((memory, _)) = deserialize_memory(&value) {
+                if memory.parent_id.is_none() {
+                    roots.push(memory.id);
                 }
             }
         }
@@ -2524,12 +2519,10 @@ impl MemoryStorage {
         let mut read_opts = rocksdb::ReadOptions::default();
         read_opts.fill_cache(false);
         let iter = self.db.iterator_opt(IteratorMode::Start, read_opts);
-        for item in iter {
-            if let Ok((key, _)) = item {
-                if key.len() == 16 {
-                    let uuid_bytes: [u8; 16] = key[..16].try_into().unwrap();
-                    ids.push(MemoryId(uuid::Uuid::from_bytes(uuid_bytes)));
-                }
+        for (key, _) in iter.flatten() {
+            if key.len() == 16 {
+                let uuid_bytes: [u8; 16] = key[..16].try_into().unwrap();
+                ids.push(MemoryId(uuid::Uuid::from_bytes(uuid_bytes)));
             }
         }
         Ok(ids)
@@ -2546,16 +2539,14 @@ impl MemoryStorage {
         let mut read_opts = rocksdb::ReadOptions::default();
         read_opts.fill_cache(false);
         let iter = self.db.iterator_opt(IteratorMode::Start, read_opts);
-        for item in iter {
-            if let Ok((key, value)) = item {
-                // Only process valid 16-byte UUID keys (consistent with get_stats)
-                if key.len() != 16 {
-                    continue;
-                }
-                if let Ok((memory, _)) = deserialize_memory(&value) {
-                    if !memory.is_forgotten() {
-                        memories.push(memory);
-                    }
+        for (key, value) in iter.flatten() {
+            // Only process valid 16-byte UUID keys (consistent with get_stats)
+            if key.len() != 16 {
+                continue;
+            }
+            if let Ok((memory, _)) = deserialize_memory(&value) {
+                if !memory.is_forgotten() {
+                    memories.push(memory);
                 }
             }
         }
@@ -2568,16 +2559,13 @@ impl MemoryStorage {
 
         // Iterate through all memories
         let iter = self.db.iterator(IteratorMode::Start);
-        for item in iter {
-            if let Ok((key, value)) = item {
-                // Only process valid 16-byte UUID keys
-                if key.len() != 16 {
-                    continue;
-                }
-                if let Ok((memory, _)) = deserialize_memory(&value) {
-                    if !memory.compressed && !memory.is_forgotten() && memory.created_at < cutoff {
-                        memories.push(memory);
-                    }
+        for (key, value) in iter.flatten() {
+            if key.len() != 16 {
+                continue;
+            }
+            if let Ok((memory, _)) = deserialize_memory(&value) {
+                if !memory.compressed && !memory.is_forgotten() && memory.created_at < cutoff {
+                    memories.push(memory);
                 }
             }
         }
@@ -2594,29 +2582,27 @@ impl MemoryStorage {
         let now = Utc::now().to_rfc3339();
 
         let iter = self.db.iterator(IteratorMode::Start);
-        for item in iter {
-            if let Ok((key, value)) = item {
-                if key.len() != 16 {
+        for (key, value) in iter.flatten() {
+            if key.len() != 16 {
+                continue;
+            }
+            if let Ok((mut memory, _)) = deserialize_memory(&value) {
+                if memory.is_forgotten() {
                     continue;
                 }
-                if let Ok((mut memory, _)) = deserialize_memory(&value) {
-                    if memory.is_forgotten() {
-                        continue;
-                    }
-                    if memory.created_at < cutoff {
-                        flagged_ids.push(memory.id.clone());
-                        memory
-                            .experience
-                            .metadata
-                            .insert("forgotten".to_string(), "true".to_string());
-                        memory
-                            .experience
-                            .metadata
-                            .insert("forgotten_at".to_string(), now.clone());
+                if memory.created_at < cutoff {
+                    flagged_ids.push(memory.id.clone());
+                    memory
+                        .experience
+                        .metadata
+                        .insert("forgotten".to_string(), "true".to_string());
+                    memory
+                        .experience
+                        .metadata
+                        .insert("forgotten_at".to_string(), now.clone());
 
-                        let updated_value = crate::serialization::encode_sho(&memory)?;
-                        batch.put(&key, updated_value);
-                    }
+                    let updated_value = crate::serialization::encode_sho(&memory)?;
+                    batch.put(&key, updated_value);
                 }
             }
         }
@@ -2639,29 +2625,27 @@ impl MemoryStorage {
         let now = Utc::now().to_rfc3339();
 
         let iter = self.db.iterator(IteratorMode::Start);
-        for item in iter {
-            if let Ok((key, value)) = item {
-                if key.len() != 16 {
+        for (key, value) in iter.flatten() {
+            if key.len() != 16 {
+                continue;
+            }
+            if let Ok((mut memory, _)) = deserialize_memory(&value) {
+                if memory.is_forgotten() {
                     continue;
                 }
-                if let Ok((mut memory, _)) = deserialize_memory(&value) {
-                    if memory.is_forgotten() {
-                        continue;
-                    }
-                    if memory.importance() < threshold {
-                        flagged_ids.push(memory.id.clone());
-                        memory
-                            .experience
-                            .metadata
-                            .insert("forgotten".to_string(), "true".to_string());
-                        memory
-                            .experience
-                            .metadata
-                            .insert("forgotten_at".to_string(), now.clone());
+                if memory.importance() < threshold {
+                    flagged_ids.push(memory.id.clone());
+                    memory
+                        .experience
+                        .metadata
+                        .insert("forgotten".to_string(), "true".to_string());
+                    memory
+                        .experience
+                        .metadata
+                        .insert("forgotten_at".to_string(), now.clone());
 
-                        let updated_value = crate::serialization::encode_sho(&memory)?;
-                        batch.put(&key, updated_value);
-                    }
+                    let updated_value = crate::serialization::encode_sho(&memory)?;
+                    batch.put(&key, updated_value);
                 }
             }
         }
@@ -2681,17 +2665,14 @@ impl MemoryStorage {
         let mut to_delete: Vec<MemoryId> = Vec::new();
 
         let iter = self.db.iterator(IteratorMode::Start);
-        for item in iter {
-            if let Ok((key, value)) = item {
-                // Only process valid 16-byte UUID keys
-                if key.len() != 16 {
-                    continue;
-                }
-                if let Ok((memory, _)) = deserialize_memory(&value) {
-                    if regex.is_match(&memory.experience.content) {
-                        to_delete.push(memory.id);
-                        count += 1;
-                    }
+        for (key, value) in iter.flatten() {
+            if key.len() != 16 {
+                continue;
+            }
+            if let Ok((memory, _)) = deserialize_memory(&value) {
+                if regex.is_match(&memory.experience.content) {
+                    to_delete.push(memory.id);
+                    count += 1;
                 }
             }
         }
@@ -2851,31 +2832,27 @@ impl MemoryStorage {
         ];
 
         let iter = self.db.iterator(IteratorMode::Start);
-        for item in iter {
-            if let Ok((key, value)) = item {
-                // Skip known non-memory prefixed entries
-                if skip_prefixes.iter().any(|p| key.starts_with(p)) {
-                    continue;
-                }
+        for (key, value) in iter.flatten() {
+            // Skip known non-memory prefixed entries
+            if skip_prefixes.iter().any(|p| key.starts_with(p)) {
+                continue;
+            }
 
-                // Valid memory keys should be exactly 16 bytes (UUID bytes)
-                let is_valid_memory_key = key.len() == 16;
+            // Valid memory keys should be exactly 16 bytes (UUID bytes)
+            let is_valid_memory_key = key.len() == 16;
 
-                if !is_valid_memory_key {
-                    // Key is not a valid UUID - this is a corrupted or misplaced entry
-                    tracing::debug!(
-                        "Marking for deletion: invalid key length {} (expected 16)",
-                        key.len()
-                    );
-                    to_delete.push(key.to_vec());
-                } else if deserialize_memory(&value).is_err() {
-                    // Key is valid but value fails all format fallbacks - truly corrupted
-                    tracing::debug!(
-                        "Marking for deletion: valid key but corrupted value ({} bytes)",
-                        value.len()
-                    );
-                    to_delete.push(key.to_vec());
-                }
+            if !is_valid_memory_key {
+                tracing::debug!(
+                    "Marking for deletion: invalid key length {} (expected 16)",
+                    key.len()
+                );
+                to_delete.push(key.to_vec());
+            } else if deserialize_memory(&value).is_err() {
+                tracing::debug!(
+                    "Marking for deletion: valid key but corrupted value ({} bytes)",
+                    value.len()
+                );
+                to_delete.push(key.to_vec());
             }
         }
 
@@ -2916,35 +2893,32 @@ impl MemoryStorage {
         let iter = self.db.iterator(IteratorMode::Start);
         let mut to_migrate = Vec::new();
 
-        for item in iter {
-            if let Ok((key, value)) = item {
-                // Skip stats entries
-                if key.starts_with(stats_prefix) {
-                    continue;
+        for (key, value) in iter.flatten() {
+            // Skip stats entries
+            if key.starts_with(stats_prefix) {
+                continue;
+            }
+
+            // Skip non-UUID keys
+            if key.len() != 16 {
+                continue;
+            }
+
+            // Try current format first (quick check) — postcard or bincode
+            let is_current = deserialize_memory(&value).is_ok();
+
+            if is_current {
+                already_current += 1;
+                continue;
+            }
+
+            // Not current format - try with fallback
+            match deserialize_memory(&value) {
+                Ok((memory, _)) => {
+                    to_migrate.push((key.to_vec(), memory));
                 }
-
-                // Skip non-UUID keys
-                if key.len() != 16 {
-                    continue;
-                }
-
-                // Try current format first (quick check) — postcard or bincode
-                let is_current = deserialize_memory(&value).is_ok();
-
-                if is_current {
-                    already_current += 1;
-                    continue;
-                }
-
-                // Not current format - try with fallback
-                match deserialize_memory(&value) {
-                    Ok((memory, _)) => {
-                        // Successfully deserialized legacy format - queue for migration
-                        to_migrate.push((key.to_vec(), memory));
-                    }
-                    Err(_) => {
-                        failed += 1;
-                    }
+                Err(_) => {
+                    failed += 1;
                 }
             }
         }
@@ -3467,13 +3441,11 @@ impl MemoryStorage {
             .iterator(IteratorMode::From(prefix, rocksdb::Direction::Forward));
 
         let mut count = 0;
-        for item in iter {
-            if let Ok((key, _)) = item {
-                if key.starts_with(prefix) {
-                    count += 1;
-                } else {
-                    break;
-                }
+        for (key, _) in iter.flatten() {
+            if key.starts_with(prefix) {
+                count += 1;
+            } else {
+                break;
             }
         }
         count
@@ -3487,25 +3459,19 @@ impl MemoryStorage {
         let mut orphans = Vec::new();
 
         let iter = self.db.iterator(IteratorMode::Start);
-        for item in iter {
-            if let Ok((key, value)) = item {
-                // Skip non-memory keys
-                if key.len() != 16 {
-                    continue;
-                }
+        for (key, value) in iter.flatten() {
+            if key.len() != 16 {
+                continue;
+            }
 
-                // Try to deserialize as memory
-                if let Ok((memory, _)) = deserialize_memory(&value) {
-                    // Check if vector mapping exists and has text vectors
-                    let has_mapping = match self.get_vector_mapping(&memory.id) {
-                        Ok(Some(entry)) => entry.text_vectors().is_some_and(|v| !v.is_empty()),
-                        _ => false,
-                    };
+            if let Ok((memory, _)) = deserialize_memory(&value) {
+                let has_mapping = match self.get_vector_mapping(&memory.id) {
+                    Ok(Some(entry)) => entry.text_vectors().is_some_and(|v| !v.is_empty()),
+                    _ => false,
+                };
 
-                    // Memory has embeddings but no mapping - needs reindex
-                    if !has_mapping && memory.experience.embeddings.is_some() {
-                        orphans.push(memory.id);
-                    }
+                if !has_mapping && memory.experience.embeddings.is_some() {
+                    orphans.push(memory.id);
                 }
             }
         }
@@ -3654,7 +3620,7 @@ impl MemoryStorage {
         self.db
             .put_opt(
                 b"interference_meta:total",
-                &(count as u64).to_le_bytes(),
+                (count as u64).to_le_bytes(),
                 &write_opts,
             )
             .context("Failed to persist interference event count")?;
@@ -3682,9 +3648,9 @@ impl MemoryStorage {
         let key = format!("_watermark:fact_extraction:{user_id}");
         let mut write_opts = WriteOptions::default();
         write_opts.set_sync(self.write_mode == WriteMode::Sync);
-        if let Err(e) =
-            self.db
-                .put_opt(key.as_bytes(), &timestamp_millis.to_le_bytes(), &write_opts)
+        if let Err(e) = self
+            .db
+            .put_opt(key.as_bytes(), timestamp_millis.to_le_bytes(), &write_opts)
         {
             tracing::warn!("Failed to persist fact extraction watermark: {e}");
         }

--- a/src/memory/temporal_facts.rs
+++ b/src/memory/temporal_facts.rs
@@ -216,7 +216,7 @@ impl TemporalFactStore {
                 // Check if any event stem matches
                 let has_event_match = f.event_stems.iter().any(|s| event_stems.contains(s));
                 // Check event type if specified
-                let type_matches = event_type.map_or(true, |t| f.event_type == t);
+                let type_matches = event_type.is_none_or(|t| f.event_type == t);
                 has_event_match && type_matches
             })
             .collect();
@@ -309,7 +309,7 @@ pub fn extract_temporal_facts(
 
     // Split into sentences
     let sentences: Vec<&str> = content
-        .split(|c| c == '.' || c == '!' || c == '?')
+        .split(['.', '!', '?'])
         .filter(|s| !s.trim().is_empty())
         .collect();
 
@@ -542,7 +542,7 @@ fn extract_event_and_time(sentence: &str, patterns: &[&str]) -> (String, String)
     let _matched_pattern = patterns
         .iter()
         .find(|p| sentence_lower.contains(*p))
-        .map(|s| *s)
+        .copied()
         .unwrap_or("");
 
     // Extract time expression

--- a/src/memory/todo_formatter.rs
+++ b/src/memory/todo_formatter.rs
@@ -72,7 +72,7 @@ pub fn format_todo_line(todo: &Todo, project_name: Option<&str>, show_meta: bool
 /// Format due date relative to now
 pub fn format_due_date(due: &DateTime<Utc>) -> String {
     let now = Utc::now();
-    let diff_secs = (due.timestamp() - now.timestamp()) as i64;
+    let diff_secs = due.timestamp() - now.timestamp();
     let diff_hours = diff_secs / 3600;
     let diff_days = diff_secs / 86400;
 
@@ -299,17 +299,17 @@ pub fn format_todo_created(todo: &Todo, project_name: Option<&str>) -> String {
 pub fn format_todo_completed(todo: &Todo, next: Option<&Todo>) -> String {
     let duration = todo
         .completed_at
-        .and_then(|completed| {
+        .map(|completed| {
             let created = todo.created_at;
             let diff = completed - created;
             let hours = diff.num_hours();
             let mins = diff.num_minutes() % 60;
             if hours > 0 {
-                Some(format!("{}h {}m", hours, mins))
+                format!("{}h {}m", hours, mins)
             } else if mins > 0 {
-                Some(format!("{}m", mins))
+                format!("{}m", mins)
             } else {
-                Some("< 1m".to_string())
+                "< 1m".to_string()
             }
         })
         .unwrap_or_default();

--- a/src/memory/todos.rs
+++ b/src/memory/todos.rs
@@ -165,7 +165,7 @@ impl TodoStore {
                     for (key, value) in old_db.iterator(rocksdb::IteratorMode::Start).flatten() {
                         batch.put_cf(cf, &key, &value);
                         count += 1;
-                        if count % 10_000 == 0 {
+                        if count.is_multiple_of(10_000) {
                             db.write(std::mem::take(&mut batch))?;
                         }
                     }
@@ -813,7 +813,7 @@ impl TodoStore {
 
         // Get all todos with the same status
         let mut same_status_todos: Vec<Todo> = self
-            .list_todos_for_user(user_id, Some(&[todo.status.clone()]))?
+            .list_todos_for_user(user_id, Some(std::slice::from_ref(&todo.status)))?
             .into_iter()
             .collect();
 
@@ -1208,6 +1208,7 @@ impl TodoStore {
     }
 
     /// Update a project's properties
+    #[allow(clippy::too_many_arguments)]
     pub fn update_project(
         &self,
         user_id: &str,

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -547,17 +547,6 @@ pub enum RelationshipType {
     Opposite,  // Antonym/opposite
 }
 
-/// Raw experience data to be stored (ENHANCED with smart defaults)
-///
-/// Only `content` is required. All other fields have intelligent defaults:
-/// - experience_type: Defaults to Observation
-/// - context: Optional (null by default)
-/// - entities: Empty vector (auto-extracted if empty)
-/// - metadata: Empty HashMap
-/// - embeddings: Optional (auto-generated)
-/// - related_memories: Empty vector
-/// - causal_chain: Empty vector
-/// - outcomes: Empty vector
 /// Structured NER entity record preserving type classification and confidence.
 /// Used to carry NER results from handler through to graph insertion
 /// without losing type information (Person, Organization, Location, Misc).
@@ -575,6 +564,17 @@ pub struct NerEntityRecord {
     pub end_char: Option<usize>,
 }
 
+/// Raw experience data to be stored (ENHANCED with smart defaults)
+///
+/// Only `content` is required. All other fields have intelligent defaults:
+/// - experience_type: Defaults to Observation
+/// - context: Optional (null by default)
+/// - entities: Empty vector (auto-extracted if empty)
+/// - metadata: Empty HashMap
+/// - embeddings: Optional (auto-generated)
+/// - related_memories: Empty vector
+/// - causal_chain: Empty vector
+/// - outcomes: Empty vector
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Experience {
     /// Type of experience (defaults to Observation)
@@ -879,9 +879,10 @@ pub struct EntityRef {
 }
 
 /// Memory tier in the cognitive hierarchy
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum MemoryTier {
     /// Active, immediate context (Cowan's focus of attention)
+    #[default]
     Working,
     /// Current task/session context
     Session,
@@ -889,12 +890,6 @@ pub enum MemoryTier {
     LongTerm,
     /// Compressed archival storage
     Archive,
-}
-
-impl Default for MemoryTier {
-    fn default() -> Self {
-        MemoryTier::Working
-    }
 }
 
 /// Type of change made to a memory
@@ -1078,6 +1073,7 @@ impl Memory {
     }
 
     /// Create a new memory linked to an external system (enables upsert)
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_external_id(
         id: MemoryId,
         experience: Experience,
@@ -2203,10 +2199,8 @@ impl Query {
         }
 
         // Anomalies only filter
-        if self.anomalies_only {
-            if !memory.experience.is_anomaly {
-                return false;
-            }
+        if self.anomalies_only && !memory.experience.is_anomaly {
+            return false;
         }
 
         // Severity filter
@@ -2963,8 +2957,10 @@ impl ProspectiveTrigger {
 /// Status of a prospective task
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum ProspectiveTaskStatus {
     /// Waiting for trigger condition
+    #[default]
     Pending,
     /// Trigger condition met, shown to user
     Triggered,
@@ -2972,12 +2968,6 @@ pub enum ProspectiveTaskStatus {
     Dismissed,
     /// Task expired without being triggered (optional cleanup)
     Expired,
-}
-
-impl Default for ProspectiveTaskStatus {
-    fn default() -> Self {
-        Self::Pending
-    }
 }
 
 /// A prospective memory task (reminder/intention)
@@ -3903,9 +3893,10 @@ impl Default for FileType {
 }
 
 /// How we learned about this file
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub enum LearnedFrom {
     /// User triggered batch indexing
+    #[default]
     ManualIndex,
     /// AI read the file content
     ReadAccess,
@@ -3913,12 +3904,6 @@ pub enum LearnedFrom {
     EditAccess,
     /// File was mentioned in conversation
     Mentioned,
-}
-
-impl Default for LearnedFrom {
-    fn default() -> Self {
-        LearnedFrom::ManualIndex
-    }
 }
 
 /// Learned knowledge about a file in a codebase
@@ -4003,6 +3988,7 @@ pub struct FileMemory {
 
 impl FileMemory {
     /// Create a new FileMemory from a file path
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         project_id: ProjectId,
         user_id: String,
@@ -4044,12 +4030,15 @@ impl FileMemory {
         self.updated_at = Utc::now();
         // Upgrade the learned_from if more meaningful
         // EditAccess > ReadAccess > Mentioned > ManualIndex
-        let should_upgrade = match (&self.learned_from, &learned_from) {
-            (LearnedFrom::ManualIndex, _) => true,
-            (LearnedFrom::Mentioned, LearnedFrom::ReadAccess | LearnedFrom::EditAccess) => true,
-            (LearnedFrom::ReadAccess, LearnedFrom::EditAccess) => true,
-            _ => false,
-        };
+        let should_upgrade = matches!(
+            (&self.learned_from, &learned_from),
+            (LearnedFrom::ManualIndex, _)
+                | (
+                    LearnedFrom::Mentioned,
+                    LearnedFrom::ReadAccess | LearnedFrom::EditAccess
+                )
+                | (LearnedFrom::ReadAccess, LearnedFrom::EditAccess)
+        );
         if should_upgrade {
             self.learned_from = learned_from;
         }

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -340,7 +340,7 @@ fn migrate_memory_db(storage_dir: &Path, dry_run: bool) -> Result<MemoryDbCounts
         let (key, value) = item?;
 
         total_processed += 1;
-        if total_processed % 1000 == 0 {
+        if total_processed.is_multiple_of(1000) {
             eprintln!("  ... processed {total_processed} records");
         }
 

--- a/src/relevance.rs
+++ b/src/relevance.rs
@@ -525,6 +525,7 @@ impl LearnedWeights {
     /// - `momentum_ema`: Feedback momentum EMA (-1.0 to 1.0, 0.0 = neutral)
     /// - `access_count`: Number of times this memory has been retrieved
     /// - `graph_strength`: Hebbian edge strength from knowledge graph (0.0 to 1.0)
+    #[allow(clippy::too_many_arguments)]
     pub fn fuse_scores_full(
         &self,
         semantic_score: f32,

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -109,19 +109,15 @@ pub fn content_hash(content: &str) -> u64 {
 /// Stream processing modes - determines extraction behavior
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum StreamMode {
     /// Agent-user dialogue - extract semantic concepts, entities, decisions
+    #[default]
     Conversation,
     /// IoT/robotics sensor data - aggregate readings, detect anomalies
     Sensor,
     /// Discrete system events - logs, errors, state changes
     Event,
-}
-
-impl Default for StreamMode {
-    fn default() -> Self {
-        StreamMode::Conversation
-    }
 }
 
 /// Configuration for automatic memory extraction from streams

--- a/src/vector_db/distance_inline.rs
+++ b/src/vector_db/distance_inline.rs
@@ -379,8 +379,8 @@ unsafe fn l2_norm_squared_avx2_inline(a: &[f32]) -> f32 {
         + sum_array[6]
         + sum_array[7];
 
-    for j in simd_len..len {
-        result += a[j] * a[j];
+    for val in &a[simd_len..] {
+        result += val * val;
     }
 
     result
@@ -423,8 +423,8 @@ fn l2_norm_squared_scalar_inline(a: &[f32]) -> f32 {
         i += 4;
     }
 
-    for j in unroll_len..len {
-        sum += a[j] * a[j];
+    for val in &a[unroll_len..] {
+        sum += val * val;
     }
 
     sum

--- a/src/vector_db/mod.rs
+++ b/src/vector_db/mod.rs
@@ -103,6 +103,7 @@ pub enum VectorIndexBackend {
 impl VectorIndexBackend {
     /// Create backend with auto-selection based on expected vector count
     pub fn auto(config: BackendConfig, expected_vectors: usize) -> Result<Self> {
+        #[allow(clippy::unnecessary_lazy_evaluations)] // Intentionally lazy: default depends on expected_vectors
         let backend_type = config.force_backend.unwrap_or_else(|| {
             if expected_vectors >= SPANN_AUTO_THRESHOLD {
                 BackendType::Spann

--- a/src/vector_db/mod.rs
+++ b/src/vector_db/mod.rs
@@ -103,7 +103,8 @@ pub enum VectorIndexBackend {
 impl VectorIndexBackend {
     /// Create backend with auto-selection based on expected vector count
     pub fn auto(config: BackendConfig, expected_vectors: usize) -> Result<Self> {
-        #[allow(clippy::unnecessary_lazy_evaluations)] // Intentionally lazy: default depends on expected_vectors
+        #[allow(clippy::unnecessary_lazy_evaluations)]
+        // Intentionally lazy: default depends on expected_vectors
         let backend_type = config.force_backend.unwrap_or_else(|| {
             if expected_vectors >= SPANN_AUTO_THRESHOLD {
                 BackendType::Spann

--- a/src/vector_db/pq.rs
+++ b/src/vector_db/pq.rs
@@ -41,7 +41,7 @@ impl PQConfig {
         let num_subvectors = dimension / subvec_dim;
 
         assert!(
-            dimension % subvec_dim == 0,
+            dimension.is_multiple_of(subvec_dim),
             "Dimension {} must be divisible by subvec_dim {}",
             dimension,
             subvec_dim
@@ -204,8 +204,8 @@ impl ProductQuantizer {
             // Average and handle empty clusters
             for c in 0..k {
                 if counts[c] > 0 {
-                    for j in 0..dim {
-                        new_centroids[c][j] /= counts[c] as f32;
+                    for elem in new_centroids[c].iter_mut().take(dim) {
+                        *elem /= counts[c] as f32;
                     }
                     centroids[c] = new_centroids[c].clone();
                 }

--- a/src/vector_db/spann.rs
+++ b/src/vector_db/spann.rs
@@ -217,6 +217,7 @@ impl SpannHeader {
         }
     }
 
+    #[allow(clippy::wrong_self_convention)] // &self avoids copying 128-byte header struct
     fn to_bytes(&self) -> [u8; HEADER_SIZE] {
         let mut bytes = [0u8; HEADER_SIZE];
         let mut offset = 0;
@@ -500,8 +501,8 @@ impl SpannIndex {
 
             for c in 0..k {
                 if counts[c] > 0 {
-                    for j in 0..dim {
-                        new_centroids[c][j] /= counts[c] as f32;
+                    for elem in new_centroids[c].iter_mut().take(dim) {
+                        *elem /= counts[c] as f32;
                     }
                     centroids[c] = new_centroids[c].clone();
                 }

--- a/src/vector_db/vamana.rs
+++ b/src/vector_db/vamana.rs
@@ -343,7 +343,7 @@ impl VamanaIndex {
             }
 
             // SAFETY CHECK: Verify size is properly aligned for f32 (4-byte alignment)
-            if file_size % std::mem::align_of::<f32>() != 0 {
+            if !file_size.is_multiple_of(std::mem::align_of::<f32>()) {
                 anyhow::bail!(
                     "File size {} is not aligned to f32 alignment ({})",
                     file_size,
@@ -978,7 +978,7 @@ impl VamanaIndex {
         let inserts = self
             .incremental_inserts
             .load(std::sync::atomic::Ordering::Relaxed);
-        inserts >= REPAIR_THRESHOLD && inserts < REBUILD_THRESHOLD
+        (REPAIR_THRESHOLD..REBUILD_THRESHOLD).contains(&inserts)
     }
 
     /// Perform incremental repair on recently inserted nodes

--- a/src/vector_db/vamana_persist.rs
+++ b/src/vector_db/vamana_persist.rs
@@ -94,6 +94,7 @@ impl VamanaHeader {
         }
     }
 
+    #[allow(clippy::wrong_self_convention)] // &self avoids copying 56-byte header struct
     fn to_bytes(&self) -> [u8; HEADER_SIZE] {
         let mut bytes = [0u8; HEADER_SIZE];
         bytes[0..4].copy_from_slice(&self.magic);


### PR DESCRIPTION
## Summary
- Audited and resolved all 128 clippy warnings across 31 files (net -88 lines)
- Migration code (6 sites): RocksDB iterator errors now propagate instead of being silently swallowed
- Scan/query code (21 sites): flattened iterator patterns preserving identical error-skip semantics
- Caught and reverted 1 incorrect auto-fix (`unwrap_or_else` → `unwrap_or` on backend auto-selection)
- Suppressed 11 warnings with justification (`too_many_arguments`, `type_complexity`, `wrong_self_convention`)

## Test plan
- [x] `cargo clippy --lib` — 0 warnings (was 128)
- [x] `cargo test --lib` — 589 pass, 0 fail
- [x] Manual diff audit of all 31 files for semantic correctness
- [ ] CI green