### PR TITLE
fix: harden MCP robotics tool validation

### DIFF
--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -700,7 +700,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             mode: {
               type: "string",
               enum: ["semantic", "associative", "temporal", "hybrid", "spatial", "mission", "action_outcome"],
-              description: "Retrieval mode: 'semantic' for pure vector similarity, 'associative' for graph-based traversal (follows learned connections), 'temporal' for time-based retrieval, 'hybrid' for density-dependent combination (default), 'spatial' for geo-location based, 'mission' for mission context, 'action_outcome' for reward-based learning",
+              description: "Retrieval mode: 'semantic' for pure vector similarity, 'associative' for graph-based traversal (follows learned connections), 'temporal' for time-based retrieval, 'hybrid' for density-dependent combination (default), 'spatial' for geo-location based (REQUIRES geo_lat, geo_lon, geo_radius_meters), 'mission' for mission context (REQUIRES mission_id), 'action_outcome' for reward-based learning (uses reward_min/reward_max, defaults to positive rewards)",
               default: "hybrid",
             },
             session_id: {
@@ -1667,6 +1667,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (content.length > MAX_CONTENT_LENGTH) {
           return { content: [{ type: "text", text: `Error: 'content' exceeds maximum length of ${MAX_CONTENT_LENGTH} characters` }], isError: true };
         }
+        // Validate robotics fields
+        if (geo_location && geo_location.length !== 3) {
+          return { content: [{ type: "text", text: "Error: 'geo_location' must be exactly [latitude, longitude, altitude]" }], isError: true };
+        }
+        if (local_position && local_position.length !== 3) {
+          return { content: [{ type: "text", text: "Error: 'local_position' must be exactly [x, y, z]" }], isError: true };
+        }
+        if (reward !== undefined && (reward < -1.0 || reward > 1.0)) {
+          return { content: [{ type: "text", text: `Error: 'reward' must be between -1.0 and 1.0, got: ${reward}` }], isError: true };
+        }
+        if (heading !== undefined && (heading < 0 || heading > 360)) {
+          return { content: [{ type: "text", text: `Error: 'heading' must be between 0 and 360 degrees, got: ${heading}` }], isError: true };
+        }
 
         const result = await apiCall<{ id: string }>("/api/remember", "POST", {
           user_id: USER_ID,
@@ -1742,6 +1755,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           return { content: [{ type: "text", text: `Error: 'mode' must be one of: ${validModes.join(", ")}` }], isError: true };
         }
         const limit = Math.max(1, Math.min(Math.floor(rawLimit), MAX_LIMIT));
+
+        // Mode-specific required parameter validation
+        if (mode === "spatial" && (geo_lat === undefined || geo_lon === undefined || geo_radius_meters === undefined)) {
+          return { content: [{ type: "text", text: "Error: 'spatial' mode requires geo_lat, geo_lon, and geo_radius_meters" }], isError: true };
+        }
+        if (mode === "mission" && !mission_id) {
+          return { content: [{ type: "text", text: "Error: 'mission' mode requires mission_id" }], isError: true };
+        }
+        if (reward_min !== undefined && reward_max !== undefined && reward_min > reward_max) {
+          return { content: [{ type: "text", text: `Error: reward_min (${reward_min}) must be <= reward_max (${reward_max})` }], isError: true };
+        }
 
         interface RetrievalStats {
           mode: string;

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -334,6 +334,27 @@ pub async fn recall(
     validation::validate_max_results(req.limit).map_validation_err("limit")?;
     validation::validate_query_text(&req.query).map_validation_err("query")?;
 
+    // Validate robotics string fields
+    if let Some(ref robot_id) = req.robot_id {
+        validation::validate_short_string(robot_id, "robot_id").map_validation_err("robot_id")?;
+    }
+    if let Some(ref mission_id) = req.mission_id {
+        validation::validate_short_string(mission_id, "mission_id")
+            .map_validation_err("mission_id")?;
+    }
+    if let Some(ref action_type) = req.action_type {
+        validation::validate_short_string(action_type, "action_type")
+            .map_validation_err("action_type")?;
+    }
+    if let Some(ref outcome_type) = req.outcome_type {
+        validation::validate_short_string(outcome_type, "outcome_type")
+            .map_validation_err("outcome_type")?;
+    }
+    if let Some(ref terrain_type) = req.terrain_type {
+        validation::validate_short_string(terrain_type, "terrain_type")
+            .map_validation_err("terrain_type")?;
+    }
+
     // Validate reward range
     if let (Some(min), Some(max)) = (req.reward_min, req.reward_max) {
         validation::validate_range(min as f64, max as f64, "reward_range")

--- a/src/handlers/remember.rs
+++ b/src/handlers/remember.rs
@@ -533,6 +533,13 @@ pub async fn remember(
         ];
         validation::validate_local_position(&pos_f64).map_validation_err("local_position")?;
     }
+    if let Some(ref robot_id) = req.robot_id {
+        validation::validate_short_string(robot_id, "robot_id").map_validation_err("robot_id")?;
+    }
+    if let Some(ref mission_id) = req.mission_id {
+        validation::validate_short_string(mission_id, "mission_id")
+            .map_validation_err("mission_id")?;
+    }
     if let Some(ref action_type) = req.action_type {
         validation::validate_short_string(action_type, "action_type")
             .map_validation_err("action_type")?;


### PR DESCRIPTION
## Summary
- Add `robot_id` and `mission_id` length validation (max 256 chars) in both remember and recall handlers
- Add `action_type`, `outcome_type`, `terrain_type` length validation in recall handler
- MCP layer: early validation for mode-specific required params — spatial mode rejects without geo params, mission mode rejects without mission_id, reward_min must be <= reward_max
- MCP remember: validate geo_location/local_position array length (must be exactly 3), reward range [-1,1], heading range [0,360] — errors instead of silently dropping malformed fields

## Test plan
- [x] `cargo check` — compiles
- [x] `cargo clippy --lib` — 0 warnings
- [x] `cargo test --lib` — 589 pass
- [ ] CI green on all platforms