### PR TITLE
fix: neuroscience-aligned quality hardening for facts, entities, lineage, threading

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2553,6 +2553,21 @@ pub const LINEAGE_CONFIDENCE_BRANCHED_FROM: f32 = 0.9;
 /// Base confidence for RelatedTo relation (same-group fallback).
 pub const LINEAGE_CONFIDENCE_RELATED_TO: f32 = 0.5;
 
+/// Minimum confidence to persist an inferred lineage edge — the LTP induction
+/// threshold. In Bienenstock-Cooper-Munro (BCM) theory, synaptic stimulation
+/// below the modification threshold θ produces long-term depression (weakening),
+/// not long-term potentiation. Similarly, inferred edges below this threshold
+/// are noise that would drown out genuine causal structure if stored.
+///
+/// At 0.20, this retains edges where confidence = base × entity_overlap ×
+/// temporal_factor is non-trivial (e.g., RelatedTo at 0.5 base needs ≥40%
+/// effective overlap × temporal proximity), while pruning the 0.075-level
+/// noise that constitutes ~99% of weak RelatedTo edges.
+///
+/// Reference: Bienenstock, Cooper & Munro (1982) "Theory for the development of
+/// neuron selectivity: orientation specificity and binocular interaction"
+pub const LINEAGE_MIN_STORE_CONFIDENCE: f32 = 0.20;
+
 /// Scale factor for propagating lineage confidence into graph edge weights.
 ///
 /// When a causal lineage edge is inferred between two memories with confidence C,

--- a/src/handlers/consolidation.rs
+++ b/src/handlers/consolidation.rs
@@ -88,6 +88,41 @@ pub async fn consolidate_memories(
             }
         };
 
+        // Step 0: Synaptic pruning — purge duplicate and noise facts before extraction.
+        // Analogous to sleep consolidation (Tononi & Cirelli 2014): revisit existing
+        // engrams, merge redundant traces, and prune noise that predates quality filters.
+        // This runs as both a one-time cleanup (for pre-filter garbage) and ongoing
+        // garbage collection (for duplicates created by race conditions).
+        {
+            let memory = memory.clone();
+            let uid = user_id.clone();
+            match tokio::task::spawn_blocking(move || {
+                let memory_guard = memory.read();
+                let purged_dupes = memory_guard.purge_duplicate_facts(&uid);
+                let purged_noise = memory_guard.purge_noise_facts(&uid);
+                (purged_dupes, purged_noise)
+            })
+            .await
+            {
+                Ok((Ok(dupes), Ok(noise))) => {
+                    if dupes > 0 || noise > 0 {
+                        tracing::info!(
+                            user_id = %user_id,
+                            duplicate_facts_purged = dupes,
+                            noise_facts_purged = noise,
+                            "Synaptic pruning complete"
+                        );
+                    }
+                }
+                Ok((Err(e), _)) | Ok((_, Err(e))) => {
+                    tracing::warn!(user_id = %user_id, "Fact pruning partial failure: {e}");
+                }
+                Err(e) => {
+                    tracing::warn!(user_id = %user_id, "Fact pruning panicked: {e}");
+                }
+            }
+        }
+
         // Step 1: Fact extraction
         let result = {
             let memory = memory.clone();

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -467,11 +467,43 @@ pub async fn session_history(
 fn compute_project_threads(entries: &[SessionHistoryEntry]) -> Vec<ProjectThread> {
     use std::collections::HashSet;
 
-    const MIN_OVERLAP: usize = 3;
+    // Jaccard threshold for entity overlap — analogous to the thalamic reticular
+    // nucleus gating irrelevant stimuli before cortical processing. Raw count
+    // overlap (e.g., 3/30 entities = 10%) causes sessions with many entities to
+    // trivially match. Jaccard normalizes by set union, requiring genuine semantic
+    // overlap to cluster sessions together.
+    const JACCARD_THRESHOLD: f32 = 0.15;
 
-    // System tags appear in every entry and would inflate overlap counts,
-    // causing unrelated sessions to cluster together.
-    const SYSTEM_TAGS: &[&str] = &["session-summary", "session-digest", "source:hook"];
+    // Noise entities filtered before clustering — the attentional gate.
+    // These appear in every session (system boilerplate, auto-extraction artifacts,
+    // generic terms) and would inflate overlap counts if not filtered, causing
+    // every session to cluster together. Analogous to how the PFC suppresses
+    // habitual/background stimuli (e.g., the hum of a fridge) to focus on signal.
+    const NOISE_ENTITIES: &[&str] = &[
+        // System tags
+        "session-summary",
+        "session-digest",
+        "source:hook",
+        // Auto-extraction artifacts
+        "auto-extract",
+        "source:transcript",
+        // Session summary boilerplate entities
+        "completed entities",
+        "topics changed",
+        "hit rate",
+        "created",
+        "memories",
+        "todos",
+        "compressions",
+        "context",
+        "proactive",
+        "ended",
+        "tools",
+        // Generic terms appearing in most sessions
+        "file",
+        "source",
+        "cargo.toml",
+    ];
 
     if entries.len() < 2 {
         return vec![];
@@ -480,14 +512,14 @@ fn compute_project_threads(entries: &[SessionHistoryEntry]) -> Vec<ProjectThread
     let n = entries.len();
     let mut parent: Vec<usize> = (0..n).collect();
 
-    // Build entity sets once, filtering out system tags
+    // Build entity sets once, filtering out noise entities (attentional gate)
     let entity_sets: Vec<HashSet<&str>> = entries
         .iter()
         .map(|e| {
             e.entities
                 .iter()
                 .map(|s| s.as_str())
-                .filter(|s| !SYSTEM_TAGS.contains(s))
+                .filter(|s| !NOISE_ENTITIES.contains(s))
                 .collect()
         })
         .collect();
@@ -495,7 +527,13 @@ fn compute_project_threads(entries: &[SessionHistoryEntry]) -> Vec<ProjectThread
     for i in 0..n {
         for j in (i + 1)..n {
             let overlap = entity_sets[i].intersection(&entity_sets[j]).count();
-            if overlap >= MIN_OVERLAP {
+            let union = entity_sets[i].union(&entity_sets[j]).count();
+            let jaccard = if union > 0 {
+                overlap as f32 / union as f32
+            } else {
+                0.0
+            };
+            if jaccard >= JACCARD_THRESHOLD {
                 let ri = uf_find_root(&parent, i);
                 let rj = uf_find_root(&parent, j);
                 if ri != rj {
@@ -519,7 +557,7 @@ fn compute_project_threads(entries: &[SessionHistoryEntry]) -> Vec<ProjectThread
             let mut entity_counts: HashMap<&str, usize> = HashMap::new();
             for &i in &indices {
                 for e in &entries[i].entities {
-                    if !SYSTEM_TAGS.contains(&e.as_str()) {
+                    if !NOISE_ENTITIES.contains(&e.as_str()) {
                         *entity_counts.entry(e.as_str()).or_default() += 1;
                     }
                 }
@@ -532,8 +570,12 @@ fn compute_project_threads(entries: &[SessionHistoryEntry]) -> Vec<ProjectThread
                 .collect();
             shared.sort();
 
+            // Thread naming: pick the most-frequent entity that is semantically
+            // meaningful (>= 4 chars, not noise). Short fragments like "sho",
+            // "dh", "mem" are typically entity extraction artifacts, not topics.
             let name = entity_counts
                 .iter()
+                .filter(|(&e, _)| e.len() >= 4 && !NOISE_ENTITIES.contains(&e))
                 .max_by_key(|(_, c)| *c)
                 .map(|(&e, _)| e.to_string())
                 .unwrap_or_else(|| "Unknown".to_string());

--- a/src/memory/compression.rs
+++ b/src/memory/compression.rs
@@ -1149,7 +1149,7 @@ impl SemanticConsolidator {
     /// Reject operational noise that shouldn't become semantic facts.
     /// Facts should capture domain knowledge, decisions, and patterns —
     /// not session lifecycle events, tool invocations, or status updates.
-    fn is_knowledge_worthy(text: &str) -> bool {
+    pub(crate) fn is_knowledge_worthy(text: &str) -> bool {
         let lower = text.to_lowercase();
         let len = text.trim().len();
 
@@ -1158,11 +1158,15 @@ impl SemanticConsolidator {
             return false;
         }
 
-        // Session lifecycle noise
+        // Session lifecycle noise — analogous to hippocampal filtering during
+        // consolidation: routine maintenance signals are pruned before entering
+        // long-term cortical storage (Dudai 2004, systems consolidation).
         const SESSION_NOISE: &[&str] = &[
             "session started",
             "session ended",
+            "session ended:",
             "session summary",
+            "session in ",
             "context compressed",
             "context window",
             "token budget",
@@ -1173,6 +1177,10 @@ impl SemanticConsolidator {
             "memories surfaced",
             "memory stored",
             "memories stored",
+            "hit rate",
+            "topics changed",
+            "entities extracted",
+            "compressions ran",
         ];
         if SESSION_NOISE.iter().any(|s| lower.contains(s)) {
             return false;
@@ -1193,11 +1201,13 @@ impl SemanticConsolidator {
             return false;
         }
 
-        // Todo/task status chatter
+        // Todo/task status chatter — task state transitions are operational
+        // metadata, not semantic knowledge worth encoding into long-term memory.
         const TODO_NOISE: &[&str] = &[
             "todo created",
             "todo completed",
             "todo updated",
+            "todo updated (status",
             "task created",
             "task completed",
             "task updated",
@@ -1205,6 +1215,11 @@ impl SemanticConsolidator {
             "marked as complete",
             "moved to backlog",
             "moved to in_progress",
+            "status → done",
+            "status → inprogress",
+            "status → in_progress",
+            "status → cancelled",
+            "status → blocked",
         ];
         if TODO_NOISE.iter().any(|s| lower.contains(s)) {
             return false;

--- a/src/memory/facts.rs
+++ b/src/memory/facts.rs
@@ -516,6 +516,88 @@ impl SemanticFactStore {
 
         Ok(users.into_iter().collect())
     }
+
+    /// Purge duplicate facts — analogous to synaptic consolidation where
+    /// redundant traces merge into a single strong engram (Tononi & Cirelli 2014,
+    /// synaptic homeostasis hypothesis: sleep prunes redundant synapses while
+    /// strengthening unique traces).
+    ///
+    /// Groups facts by normalized text, keeps highest-support version,
+    /// merges source_memories from duplicates into the survivor.
+    pub fn purge_duplicates(&self, user_id: &str) -> Result<usize> {
+        let all_facts = self.list(user_id, 10_000)?;
+        if all_facts.is_empty() {
+            return Ok(0);
+        }
+
+        // Group by normalized text: lowercase, trimmed, collapsed whitespace
+        let mut groups: std::collections::HashMap<String, Vec<SemanticFact>> =
+            std::collections::HashMap::new();
+        for fact in all_facts {
+            let normalized: String = fact
+                .fact
+                .to_lowercase()
+                .split_whitespace()
+                .collect::<Vec<&str>>()
+                .join(" ");
+            groups.entry(normalized).or_default().push(fact);
+        }
+
+        let mut purged = 0;
+        for (_key, mut group) in groups {
+            if group.len() < 2 {
+                continue;
+            }
+
+            // Keep the fact with highest support_count (strongest trace)
+            group.sort_by(|a, b| b.support_count.cmp(&a.support_count));
+            let mut survivor = group.remove(0);
+
+            // Merge source_memories from duplicates into survivor
+            let mut all_sources: std::collections::HashSet<crate::memory::types::MemoryId> =
+                survivor.source_memories.iter().cloned().collect();
+            for dup in &group {
+                for src in &dup.source_memories {
+                    all_sources.insert(src.clone());
+                }
+                survivor.support_count += dup.support_count;
+            }
+            survivor.source_memories = all_sources.into_iter().collect();
+            survivor.last_reinforced = chrono::Utc::now();
+            self.update(user_id, &survivor)?;
+
+            // Delete duplicates
+            for dup in &group {
+                self.delete(user_id, &dup.id)?;
+                purged += 1;
+            }
+        }
+
+        Ok(purged)
+    }
+
+    /// Purge noise facts that predate the quality filter — analogous to
+    /// retroactive interference cleanup: the brain's consolidation process
+    /// revisits existing traces and prunes those that no longer pass the
+    /// hippocampal quality gate (Frankland & Bontempi 2005).
+    ///
+    /// Runs each stored fact through `is_knowledge_worthy()` and deletes
+    /// facts that fail (noise that was stored before the filter existed).
+    pub fn purge_noise_facts(&self, user_id: &str) -> Result<usize> {
+        use super::compression::SemanticConsolidator;
+
+        let all_facts = self.list(user_id, 10_000)?;
+        let mut purged = 0;
+
+        for fact in &all_facts {
+            if !SemanticConsolidator::is_knowledge_worthy(&fact.fact) {
+                self.delete(user_id, &fact.id)?;
+                purged += 1;
+            }
+        }
+
+        Ok(purged)
+    }
 }
 
 /// Detect negation polarity of a fact statement.

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -6815,26 +6815,79 @@ impl MemorySystem {
         // Run consolidation
         let result = consolidator.consolidate(&memories);
 
-        // Store extracted facts
-        if !result.new_facts.is_empty() {
-            let stored = self.fact_store.store_batch(user_id, &result.new_facts)?;
+        // Pattern separation gate (dentate gyrus analogy): before storing new
+        // facts, check if each one matches an existing engram. If so, reinforce
+        // the existing trace (pattern completion) instead of creating a duplicate.
+        // This prevents within-batch duplicates that bypass the find_similar() gate
+        // because both members are stored in the same consolidation cycle.
+        let mut deduplicated_facts: Vec<SemanticFact> = Vec::new();
+        let mut merged_count: usize = 0;
+
+        // Pre-encode all new facts to enable hybrid dedup with cosine gate
+        let new_texts: Vec<&str> = result.new_facts.iter().map(|f| f.fact.as_str()).collect();
+        let new_embeddings: Vec<Option<Vec<f32>>> = match self.embedder.encode_batch(&new_texts) {
+            Ok(embs) => embs.into_iter().map(Some).collect(),
+            Err(_) => vec![None; result.new_facts.len()],
+        };
+
+        for (fact, embedding) in result.new_facts.iter().zip(new_embeddings.iter()) {
+            let emb_ref = embedding.as_deref();
+            match self
+                .fact_store
+                .find_similar(user_id, &fact.fact, &fact.related_entities, emb_ref)
+            {
+                Ok(Some(mut existing)) => {
+                    // Pattern completion: reinforce existing trace
+                    existing.support_count += fact.support_count;
+                    let mut all_sources: std::collections::HashSet<MemoryId> =
+                        existing.source_memories.iter().cloned().collect();
+                    for src in &fact.source_memories {
+                        all_sources.insert(src.clone());
+                    }
+                    existing.source_memories = all_sources.into_iter().collect();
+                    existing.last_reinforced = chrono::Utc::now();
+                    let _ = self.fact_store.update(user_id, &existing);
+                    merged_count += 1;
+                }
+                _ => {
+                    deduplicated_facts.push(fact.clone());
+                }
+            }
+        }
+
+        if merged_count > 0 {
+            tracing::info!(
+                user_id = %user_id,
+                merged = merged_count,
+                "Pattern separation: merged new facts into existing engrams"
+            );
+        }
+
+        // Store genuinely new facts (passed pattern separation gate)
+        if !deduplicated_facts.is_empty() {
+            let stored = self
+                .fact_store
+                .store_batch(user_id, &deduplicated_facts)?;
             tracing::info!(
                 user_id = %user_id,
                 facts_extracted = result.facts_extracted,
                 facts_stored = stored,
+                facts_merged = merged_count,
                 "Semantic distillation complete"
             );
 
-            // Batch-encode and store embeddings for distilled facts
-            let texts: Vec<&str> = result.new_facts.iter().map(|f| f.fact.as_str()).collect();
-            if let Ok(batch_embs) = self.embedder.encode_batch(&texts) {
-                for (fact, emb) in result.new_facts.iter().zip(batch_embs.iter()) {
-                    let _ = self.fact_store.store_embedding(user_id, &fact.id, emb);
+            // Store embeddings for the genuinely new facts
+            for fact in &deduplicated_facts {
+                // Find the matching embedding from the pre-encoded batch
+                if let Some(pos) = result.new_facts.iter().position(|f| f.id == fact.id) {
+                    if let Some(Some(emb)) = new_embeddings.get(pos) {
+                        let _ = self.fact_store.store_embedding(user_id, &fact.id, emb);
+                    }
                 }
             }
 
-            // Record consolidation event for each fact (persists significant events)
-            for fact in &result.new_facts {
+            // Record consolidation event for each stored fact
+            for fact in &deduplicated_facts {
                 self.record_consolidation_event_for_user(
                     user_id,
                     ConsolidationEvent::FactExtracted {
@@ -6859,6 +6912,16 @@ impl MemorySystem {
         }
 
         Ok(result)
+    }
+
+    /// Purge duplicate facts for a user (delegates to SemanticFactStore).
+    pub fn purge_duplicate_facts(&self, user_id: &str) -> Result<usize> {
+        self.fact_store.purge_duplicates(user_id)
+    }
+
+    /// Purge noise facts for a user (delegates to SemanticFactStore).
+    pub fn purge_noise_facts(&self, user_id: &str) -> Result<usize> {
+        self.fact_store.purge_noise_facts(user_id)
     }
 
     /// Get semantic facts for a user
@@ -7125,6 +7188,12 @@ impl MemorySystem {
             if let Some((relation, confidence)) =
                 self.lineage_graph.infer_relation(candidate, new_memory)
             {
+                // BCM LTP threshold: sub-threshold stimulation produces LTD, not LTP.
+                // Weak inferences below the confidence floor are noise that would
+                // drown out genuine causal structure if persisted.
+                if confidence < crate::constants::LINEAGE_MIN_STORE_CONFIDENCE {
+                    continue;
+                }
                 if !self
                     .lineage_graph
                     .edge_exists(user_id, &candidate.id, &new_memory.id)?
@@ -7148,6 +7217,10 @@ impl MemorySystem {
             if let Some((relation, confidence)) =
                 self.lineage_graph.infer_relation(new_memory, candidate)
             {
+                // BCM LTP threshold (forward pass)
+                if confidence < crate::constants::LINEAGE_MIN_STORE_CONFIDENCE {
+                    continue;
+                }
                 if !self
                     .lineage_graph
                     .edge_exists(user_id, &new_memory.id, &candidate.id)?
@@ -7390,31 +7463,80 @@ fn build_single_cluster(all_facts: &[SemanticFact], indices: &[usize]) -> FactCl
 
 /// Detect causal relationships between temporally ordered facts sharing entities.
 ///
-/// Uses keyword heuristics on the later fact to infer relationship type:
-/// - "replaced", "instead", "no longer" → superseded_by
-/// - "fixed", "resolved" → resolved_by
-/// - Other evolution keywords → led_to
+/// Analogous to hippocampal trace conditioning — the hippocampus bridges temporal
+/// gaps to form associations between events that share contextual features (entities).
+/// The keyword vocabulary defines the temporal receptive field: broader vocabulary
+/// detects more of the causal structure that actually exists in the fact timeline.
+///
+/// Relationship types:
+/// - superseded_by: fact B replaced/obsoleted fact A
+/// - resolved_by: fact B fixed/patched an issue described in fact A
+/// - informed_by: fact B was based on or learned from fact A
+/// - led_to: fact A generally caused or prompted fact B
 fn detect_causal_chains(sorted_facts: &[SemanticFact]) -> Vec<CausalFactLink> {
-    const EVOLUTION_KEYWORDS: &[&str] = &[
-        "migrated",
+    // Supersession signals: the later fact explicitly obsoletes the earlier one
+    const SUPERSEDED_KEYWORDS: &[&str] = &[
         "replaced",
+        "instead",
+        "no longer",
+        "removed",
+        "upgraded",
+        "converted",
+        "refactored",
+        "deprecated",
+    ];
+
+    // Resolution signals: the later fact fixed a problem in the earlier one
+    const RESOLVED_KEYWORDS: &[&str] = &[
         "fixed",
+        "resolved",
+        "patched",
+        "corrected",
+        "addressed",
+        "eliminated",
+    ];
+
+    // Informed-by signals: the later fact was derived from the earlier one
+    const INFORMED_KEYWORDS: &[&str] = &[
+        "based on",
+        "learned from",
+        "following",
+        "after discovering",
+        "informed by",
+        "derived from",
+    ];
+
+    // General evolution signals: any causal linkage between temporally ordered facts
+    const GENERAL_EVOLUTION: &[&str] = &[
+        "migrated",
         "updated",
         "changed",
         "now uses",
         "switched",
-        "deprecated",
-        "removed",
         "added",
-        "resolved",
-        "instead",
-        "no longer",
+        "resulted in",
+        "prompted",
+        "triggered",
+        "spawned",
+        "caused",
+        "introduced",
+        "implemented",
+        "enabled",
     ];
 
     let mut chains = Vec::new();
 
     // Pre-compute lowercase facts to avoid repeated allocations in O(n²) loop.
     let lowered: Vec<String> = sorted_facts.iter().map(|f| f.fact.to_lowercase()).collect();
+
+    // All keyword lists combined for the initial has-any-evolution check
+    let all_keywords: Vec<&str> = SUPERSEDED_KEYWORDS
+        .iter()
+        .chain(RESOLVED_KEYWORDS.iter())
+        .chain(INFORMED_KEYWORDS.iter())
+        .chain(GENERAL_EVOLUTION.iter())
+        .copied()
+        .collect();
 
     for i in 0..sorted_facts.len() {
         for j in (i + 1)..sorted_facts.len() {
@@ -7431,21 +7553,22 @@ fn detect_causal_chains(sorted_facts: &[SemanticFact]) -> Vec<CausalFactLink> {
             }
 
             let b_lower = &lowered[j];
-            let has_evolution = EVOLUTION_KEYWORDS.iter().any(|kw| b_lower.contains(kw));
+            let has_evolution = all_keywords.iter().any(|kw| b_lower.contains(kw));
             if !has_evolution {
                 continue;
             }
 
-            let relation = if b_lower.contains("replaced")
-                || b_lower.contains("instead")
-                || b_lower.contains("no longer")
-            {
-                "superseded_by"
-            } else if b_lower.contains("fixed") || b_lower.contains("resolved") {
-                "resolved_by"
-            } else {
-                "led_to"
-            };
+            // Classify by most specific match (superseded > resolved > informed > led_to)
+            let relation =
+                if SUPERSEDED_KEYWORDS.iter().any(|kw| b_lower.contains(kw)) {
+                    "superseded_by"
+                } else if RESOLVED_KEYWORDS.iter().any(|kw| b_lower.contains(kw)) {
+                    "resolved_by"
+                } else if INFORMED_KEYWORDS.iter().any(|kw| b_lower.contains(kw)) {
+                    "informed_by"
+                } else {
+                    "led_to"
+                };
 
             chains.push(CausalFactLink {
                 from_fact_id: a.id.clone(),

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -6865,9 +6865,7 @@ impl MemorySystem {
 
         // Store genuinely new facts (passed pattern separation gate)
         if !deduplicated_facts.is_empty() {
-            let stored = self
-                .fact_store
-                .store_batch(user_id, &deduplicated_facts)?;
+            let stored = self.fact_store.store_batch(user_id, &deduplicated_facts)?;
             tracing::info!(
                 user_id = %user_id,
                 facts_extracted = result.facts_extracted,
@@ -7559,16 +7557,15 @@ fn detect_causal_chains(sorted_facts: &[SemanticFact]) -> Vec<CausalFactLink> {
             }
 
             // Classify by most specific match (superseded > resolved > informed > led_to)
-            let relation =
-                if SUPERSEDED_KEYWORDS.iter().any(|kw| b_lower.contains(kw)) {
-                    "superseded_by"
-                } else if RESOLVED_KEYWORDS.iter().any(|kw| b_lower.contains(kw)) {
-                    "resolved_by"
-                } else if INFORMED_KEYWORDS.iter().any(|kw| b_lower.contains(kw)) {
-                    "informed_by"
-                } else {
-                    "led_to"
-                };
+            let relation = if SUPERSEDED_KEYWORDS.iter().any(|kw| b_lower.contains(kw)) {
+                "superseded_by"
+            } else if RESOLVED_KEYWORDS.iter().any(|kw| b_lower.contains(kw)) {
+                "resolved_by"
+            } else if INFORMED_KEYWORDS.iter().any(|kw| b_lower.contains(kw)) {
+                "informed_by"
+            } else {
+                "led_to"
+            };
 
             chains.push(CausalFactLink {
                 from_fact_id: a.id.clone(),


### PR DESCRIPTION
## Summary

Fixes 5 systemic quality failures in the memory pipeline, each mapped to a cognitive neuroscience principle:

- **Synaptic pruning** (Dudai 2004): Expanded noise filter (11 new patterns) + retroactive `purge_duplicates()` / `purge_noise_facts()` methods to clean pre-filter garbage during consolidation
- **Pattern separation** (dentate gyrus): Pre-store dedup via `find_similar()` — duplicates reinforce existing engrams instead of creating redundant traces
- **Attentional gating** (thalamic/PFC): 22-item NOISE_ENTITIES replaces 3-item SYSTEM_TAGS in session threading; Jaccard threshold (≥0.15) replaces raw overlap count (≥3); thread naming requires entities ≥4 chars
- **LTP induction threshold** (BCM theory): `LINEAGE_MIN_STORE_CONFIDENCE = 0.20` — sub-threshold inferred edges (99.1% weak RelatedTo) no longer persisted
- **Temporal association** (trace conditioning): Causal chain detection expanded from 13 to 30+ keywords across 4 categorized lists; new `informed_by` relation type

## Root causes addressed

| Problem | Root cause | Fix |
|---------|-----------|-----|
| Duplicate facts ("Always prefer async writes" ×2) | Within-batch duplicates bypass find_similar() | Pre-store dedup gate |
| Noise facts ("Session ended: user_stop" with 406 sources) | Incomplete noise filter + no retroactive cleanup | Expanded filter + purge methods |
| Thread named "created" | 3-item system tag filter, raw overlap count | 22-item noise list, Jaccard threshold, name length gate |
| 99.1% RelatedTo edges | No confidence floor before storage | BCM-inspired 0.20 threshold |
| 1/20 clusters with causal chains | Narrow keyword vocabulary | 4 categorized lists, 30+ keywords |

## Files changed (6)

- `src/memory/compression.rs` — Noise filter expansion, `is_knowledge_worthy` visibility
- `src/memory/facts.rs` — `purge_duplicates()`, `purge_noise_facts()` 
- `src/memory/mod.rs` — Pre-store dedup, lineage confidence floor, causal chain expansion, delegate methods
- `src/handlers/consolidation.rs` — Step 0 pruning before extraction
- `src/handlers/sessions.rs` — NOISE_ENTITIES, Jaccard clustering, thread naming
- `src/constants.rs` — `LINEAGE_MIN_STORE_CONFIDENCE`

## Test plan

- [x] `cargo check` — clean
- [x] `cargo clippy --lib` — zero warnings  
- [x] `cargo test --lib` — 589 passed, 0 failed
- [ ] CI green
- [ ] Live: consolidation → verify purge logs show duplicates/noise removed
- [ ] Live: `/api/facts/narratives` → no "Session ended" facts, more causal chains
- [ ] Live: `/api/sessions/history?group_by_project=true` → meaningful thread names