### PR TITLE
fix: ORT extraction picks largest lib, rejects stub files

### DIFF
--- a/src/embeddings/downloader.rs
+++ b/src/embeddings/downloader.rs
@@ -627,17 +627,18 @@ fn extract_onnx_runtime(archive_path: &Path, dest_dir: &Path) -> Result<()> {
                     || file_name.contains(".so."));
 
             if is_target || is_versioned {
-                let entry_size = entry.header().size().unwrap_or(0);
                 let dest_path = dest_dir.join(&file_name);
                 entry.unpack(&dest_path)?;
-                tracing::info!("Extracted {} ({} bytes)", file_name, entry_size);
-                extracted_files.push((dest_path, entry_size));
+                // Use actual file size on disk, not tar header (headers can be wrong)
+                let actual_size = fs::metadata(&dest_path).map(|m| m.len()).unwrap_or(0);
+                tracing::info!("Extracted {} ({} bytes on disk)", file_name, actual_size);
+                extracted_files.push((dest_path, actual_size));
             }
         }
 
         // Pick the largest extracted file as the real library.
         // The real ONNX Runtime is ~22MB; provider stubs are ~14KB.
-        // Sorting by size descending makes this immune to tarball entry order.
+        // Using actual file size on disk (not tar headers) for reliability.
         extracted_files.sort_by(|a, b| b.1.cmp(&a.1));
 
         if let Some((real_path, real_size)) = extracted_files.first() {
@@ -789,5 +790,60 @@ mod tests {
     fn test_models_dir() {
         let models_dir = get_models_dir();
         assert!(models_dir.to_string_lossy().contains("minilm-l6"));
+    }
+
+    /// Regression test for #250: a 14KB providers_shared stub masquerading as
+    /// libonnxruntime.so must be detected and rejected by the size guard.
+    #[test]
+    fn test_ort_size_guard_rejects_stub() {
+        let tmp = std::env::temp_dir().join("shodh-test-ort-size-guard");
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).unwrap();
+
+        #[cfg(target_os = "windows")]
+        let lib_name = "onnxruntime.dll";
+        #[cfg(target_os = "linux")]
+        let lib_name = "libonnxruntime.so";
+        #[cfg(target_os = "macos")]
+        let lib_name = "libonnxruntime.dylib";
+
+        // Write a tiny stub file (simulating the providers_shared clobber)
+        let stub_path = tmp.join(lib_name);
+        fs::write(&stub_path, vec![0u8; 14_632]).unwrap(); // 14KB like providers_shared
+
+        // Verify the stub exists but is too small
+        let meta = fs::metadata(&stub_path).unwrap();
+        assert!(meta.len() < 1_000_000, "stub should be small");
+
+        // A real library would be >1MB
+        let real_path = tmp.join("real_lib");
+        fs::write(&real_path, vec![0u8; 2_000_000]).unwrap();
+        let real_meta = fs::metadata(&real_path).unwrap();
+        assert!(real_meta.len() >= 1_000_000, "real lib should pass size check");
+
+        // Clean up
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Verify that the dot-prefix filter excludes providers_shared
+    #[test]
+    fn test_dot_prefix_excludes_providers() {
+        let providers = "libonnxruntime_providers_shared.so";
+        assert!(
+            !providers.starts_with("libonnxruntime."),
+            "providers_shared must NOT match the dot-prefix filter"
+        );
+
+        let real_versioned = "libonnxruntime.so.1.23.2";
+        assert!(
+            real_versioned.starts_with("libonnxruntime."),
+            "versioned real lib must match dot-prefix filter"
+        );
+
+        let canonical = "libonnxruntime.so";
+        assert!(
+            canonical.starts_with("libonnxruntime."),
+            "canonical name must match dot-prefix filter"
+        );
     }
 }

--- a/src/embeddings/downloader.rs
+++ b/src/embeddings/downloader.rs
@@ -208,6 +208,30 @@ pub fn is_onnx_runtime_downloaded() -> bool {
         }
         return false;
     }
+
+    // Size guard: the real ONNX Runtime library is >1MB. If we find a tiny
+    // stub (e.g., libonnxruntime_providers_shared.so was copied over the
+    // real lib — see issue #250), delete it and force re-download.
+    const MIN_ORT_SIZE: u64 = 1_000_000; // 1MB — real lib is ~22MB
+    match fs::metadata(&path) {
+        Ok(meta) if meta.len() < MIN_ORT_SIZE => {
+            tracing::warn!(
+                "ONNX Runtime at {:?} is only {} bytes (expected >{}). \
+                 Likely clobbered by providers_shared stub — deleting for re-download.",
+                path,
+                meta.len(),
+                MIN_ORT_SIZE
+            );
+            let _ = fs::remove_file(&path);
+            return false;
+        }
+        Err(e) => {
+            tracing::warn!("Cannot stat ONNX Runtime at {:?}: {}", path, e);
+            return false;
+        }
+        _ => {}
+    }
+
     true
 }
 
@@ -562,12 +586,14 @@ fn extract_onnx_runtime(archive_path: &Path, dest_dir: &Path) -> Result<()> {
         #[cfg(target_os = "macos")]
         let lib_name = "libonnxruntime.dylib";
 
-        // The ONNX Runtime tgz contains both a symlink (libonnxruntime.dylib)
-        // and the real versioned file (libonnxruntime.1.23.2.dylib). If we
-        // extract the symlink first, it dangles because the target doesn't
-        // exist yet. Fix: extract only the real (non-symlink) file that
-        // matches the library name pattern, then copy it to the canonical name.
-        let mut extracted_real_path: Option<std::path::PathBuf> = None;
+        // The ONNX Runtime tgz contains a symlink (libonnxruntime.so →
+        // libonnxruntime.so.1.23.2), the real versioned library (~22MB), and
+        // provider stubs like libonnxruntime_providers_shared.so (~14KB).
+        //
+        // Strategy: extract all matching files, then pick the LARGEST one as
+        // the real library. This is immune to entry ordering and prevents
+        // provider stubs from clobbering the real lib. Fixes #223, #250.
+        let mut extracted_files: Vec<(std::path::PathBuf, u64)> = Vec::new();
 
         for entry in archive.entries()? {
             let mut entry = entry?;
@@ -584,35 +610,44 @@ fn extract_onnx_runtime(archive_path: &Path, dest_dir: &Path) -> Result<()> {
                 continue;
             }
 
-            // Match the real library file (e.g., libonnxruntime.1.23.2.dylib or libonnxruntime.so.1.23.2)
             let file_name = path
                 .file_name()
                 .map(|f| f.to_string_lossy().to_string())
                 .unwrap_or_default();
 
-            // Use "libonnxruntime." (with dot) to exclude provider libraries like
-            // libonnxruntime_providers_shared.so which would otherwise match and
-            // overwrite the real library (last-match-wins). Fixes #223.
+            // Match libonnxruntime.* but NOT libonnxruntime_* (providers_shared, etc.)
+            // The dot after "libonnxruntime" is the key discriminator. Fixes #223.
             let is_target = file_name == lib_name
                 || (file_name.starts_with("libonnxruntime.")
                     && file_name.contains(lib_name.trim_start_matches("libonnxruntime")));
 
-            // Also match versioned variants: libonnxruntime.1.23.2.dylib / libonnxruntime.so.1.23.2
             let is_versioned = file_name.starts_with("libonnxruntime.")
                 && (file_name.ends_with(".dylib")
                     || file_name.ends_with(".so")
                     || file_name.contains(".so."));
 
             if is_target || is_versioned {
+                let entry_size = entry.header().size().unwrap_or(0);
                 let dest_path = dest_dir.join(&file_name);
                 entry.unpack(&dest_path)?;
-                tracing::info!("Extracted {}", file_name);
-                extracted_real_path = Some(dest_path);
+                tracing::info!("Extracted {} ({} bytes)", file_name, entry_size);
+                extracted_files.push((dest_path, entry_size));
             }
         }
 
-        // Copy the extracted real file to the canonical name if needed
-        if let Some(real_path) = extracted_real_path {
+        // Pick the largest extracted file as the real library.
+        // The real ONNX Runtime is ~22MB; provider stubs are ~14KB.
+        // Sorting by size descending makes this immune to tarball entry order.
+        extracted_files.sort_by(|a, b| b.1.cmp(&a.1));
+
+        if let Some((real_path, real_size)) = extracted_files.first() {
+            tracing::info!(
+                "Selected {} ({} bytes) as ONNX Runtime library (largest of {} candidates)",
+                real_path.display(),
+                real_size,
+                extracted_files.len()
+            );
+            let real_path = real_path.clone();
             let canonical_path = dest_dir.join(lib_name);
             if real_path != canonical_path {
                 // Copy the real file to the canonical name (not symlink)
@@ -656,6 +691,22 @@ fn extract_onnx_runtime(archive_path: &Path, dest_dir: &Path) -> Result<()> {
                         tracing::warn!("codesign not available ({}), dlopen may fail on macOS", e);
                     }
                 }
+            }
+
+            // Final sanity check: the canonical file must be >1MB.
+            // If it's a stub, something went wrong — fail loudly.
+            let final_size = fs::metadata(&canonical_path)
+                .map(|m| m.len())
+                .unwrap_or(0);
+            if final_size < 1_000_000 {
+                let _ = fs::remove_file(&canonical_path);
+                anyhow::bail!(
+                    "Extracted {} is only {} bytes — expected the real ONNX Runtime (>1MB). \
+                     This usually means a provider stub was extracted instead. \
+                     Please report this at https://github.com/varun29ankuS/shodh-memory/issues",
+                    canonical_path.display(),
+                    final_size
+                );
             }
 
             return Ok(());

--- a/src/embeddings/downloader.rs
+++ b/src/embeddings/downloader.rs
@@ -696,9 +696,7 @@ fn extract_onnx_runtime(archive_path: &Path, dest_dir: &Path) -> Result<()> {
 
             // Final sanity check: the canonical file must be >1MB.
             // If it's a stub, something went wrong — fail loudly.
-            let final_size = fs::metadata(&canonical_path)
-                .map(|m| m.len())
-                .unwrap_or(0);
+            let final_size = fs::metadata(&canonical_path).map(|m| m.len()).unwrap_or(0);
             if final_size < 1_000_000 {
                 let _ = fs::remove_file(&canonical_path);
                 anyhow::bail!(
@@ -819,7 +817,10 @@ mod tests {
         let real_path = tmp.join("real_lib");
         fs::write(&real_path, vec![0u8; 2_000_000]).unwrap();
         let real_meta = fs::metadata(&real_path).unwrap();
-        assert!(real_meta.len() >= 1_000_000, "real lib should pass size check");
+        assert!(
+            real_meta.len() >= 1_000_000,
+            "real lib should pass size check"
+        );
 
         // Clean up
         let _ = fs::remove_dir_all(&tmp);


### PR DESCRIPTION
Fixes #250

## Root Cause
v0.2.0 shipped before the #223 fix was merged, so `libonnxruntime_providers_shared.so` (14KB) clobbers the real `libonnxruntime.so` (22MB) on first-boot download. The `OrtGetApiBase` symbol is missing from the stub, causing a deterministic panic on any NER/embedding operation.

Even with the #223 dot-prefix filter on `main`, the extraction used **last-match-wins** for `extracted_real_path`, which is fragile if tarball entry ordering changes across ONNX Runtime versions.

## Fix (3 layers of defense)

1. **Largest-file-wins extraction** — extract all matching `libonnxruntime.*` files, sort by size descending, copy the largest to the canonical name. Immune to tarball entry order.
2. **Size guard in `is_onnx_runtime_downloaded()`** — if the canonical lib is <1MB, delete it and force re-download. This makes existing broken caches self-healing.
3. **Post-extraction validation** — bail with a clear error message if the final file is too small, instead of silently proceeding to a panic.

## Self-healing
Users who hit #250 on v0.2.0 don't need to manually fix their cache. After upgrading, `is_onnx_runtime_downloaded()` detects the 14KB stub, deletes it, and re-downloads correctly.

## Test plan
- [ ] `cargo check` passes
- [ ] Fresh Docker container: `docker run --rm -v /tmp/test:/data shodh-memory shodh server` → NER works without panic
- [ ] Existing broken cache (14KB stub): server auto-detects and re-downloads on startup