### PR TITLE
feat: pretty first-run experience + setup-hooks CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -351,4 +351,4 @@ Contributors will be:
 - Mentioned in release notes
 - Given credit in documentation
 
-Thank you for contributing to Shodh-Memory! 🧠
+Thank you for contributing to Shodh-Memory! 🐘

--- a/README.md
+++ b/README.md
@@ -50,22 +50,27 @@ Every other memory system delegates intelligence to LLM API calls — that's why
 
 ```bash
 # Download from GitHub Releases (or brew tap varun29ankuS/shodh-memory && brew install shodh-memory)
-shodh init       # First-time setup — creates config, generates API key, downloads AI model
-shodh server     # Start the memory server on :3030
-shodh tui        # Launch the TUI dashboard
-shodh status     # Check server health
-shodh doctor     # Diagnose issues
+shodh init          # First-time setup — creates config, generates API key, downloads AI model
+shodh server        # Start the memory server on :3030
+shodh setup-hooks   # Print instructions to set up Claude Code hooks
+shodh tui           # Launch the TUI dashboard
+shodh status        # Check server health
+shodh doctor        # Diagnose issues
 ```
 
 One binary, all functionality. No Docker, no API keys, no external dependencies.
 
-### Claude Code (one command)
+### Claude Code
 
 ```bash
+# 1. Add the MCP server (auto-downloads the backend binary)
 claude mcp add shodh-memory -- npx -y @shodh/memory-mcp
+
+# 2. Enable automatic memory capture (optional but recommended)
+npx @shodh/memory-mcp setup-hooks
 ```
 
-That's it. The MCP server auto-downloads the backend binary and starts it. No Docker, no API keys, no configuration. Claude now has persistent memory across sessions.
+Step 1 gives Claude persistent memory tools. Step 2 installs [Claude Code hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) that automatically capture context from every session — memories surface without you having to ask.
 
 <details>
 <summary>Or with Docker (for production / shared servers)</summary>

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -2759,7 +2759,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
           if (uniqueReminders.length > 0) {
             reminderBlock = `\n\n`;
-            reminderBlock += `🐘━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━🧠\n`;
+            reminderBlock += `🐘━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━🐘\n`;
             reminderBlock += `┃  SHODH MEMORY                    REMINDERS (${String(uniqueReminders.length).padStart(2)})  ┃\n`;
             reminderBlock += `┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫\n`;
 
@@ -2807,7 +2807,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const facts = (result.relevant_facts || [])
             .filter((f: ProactiveFact) => f.confidence >= 0.4);
           if (facts.length > 0) {
-            factsBlock = "\n\n🧠 Known Facts:\n";
+            factsBlock = "\n\n🐘 Known Facts:\n";
             for (const f of facts) {
               const conf = (f.confidence * 100).toFixed(0);
               const entities = f.related_entities.length > 0 ? ` [${f.related_entities.slice(0, 3).join(', ')}]` : '';
@@ -2978,7 +2978,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         // Backend session data (memories, entities, etc.)
         if (digestResult && typeof digestResult === "object" && "digest" in digestResult && digestResult.digest) {
           const d = digestResult.digest as Record<string, unknown>;
-          digestResponse += `🧠 Memory: ${d.memories_created ?? 0} created, ${d.memories_surfaced ?? 0} surfaced, ${d.memories_used ?? 0} used`;
+          digestResponse += `🐘 Memory: ${d.memories_created ?? 0} created, ${d.memories_surfaced ?? 0} surfaced, ${d.memories_used ?? 0} used`;
           const hitRate = d.memory_hit_rate as number;
           if (hitRate > 0) digestResponse += ` (${Math.round(hitRate * 100)}% hit rate)`;
           digestResponse += `\n`;
@@ -3283,7 +3283,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         // Memory changes
         if (stats.memories_strengthened > 0 || stats.memories_decayed > 0 || stats.memories_at_risk > 0) {
-          response += `🧠 MEMORY DYNAMICS\n`;
+          response += `🐘 MEMORY DYNAMICS\n`;
           if (stats.memories_strengthened > 0) response += `   ↑ ${stats.memories_strengthened} strengthened\n`;
           if (stats.memories_decayed > 0) response += `   ↓ ${stats.memories_decayed} decayed\n`;
           if (stats.memories_at_risk > 0) response += `   ⚠️ ${stats.memories_at_risk} at risk\n`;

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "shodh-memory-mcp": "dist/index.js"
+    "shodh-memory-mcp": "dist/index.js",
+    "shodh-setup-hooks": "scripts/setup-hooks.cjs"
   },
   "scripts": {
     "start": "bun run index.ts",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -16,11 +16,12 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "postinstall": "node scripts/postinstall.cjs",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build && node -e \"require('fs').mkdirSync('hooks',{recursive:true});require('fs').copyFileSync('../hooks/memory-hook.ts','hooks/memory-hook.ts')\""
   },
   "files": [
     "dist",
     "scripts",
+    "hooks",
     "README.md"
   ],
   "dependencies": {

--- a/mcp-server/scripts/postinstall.cjs
+++ b/mcp-server/scripts/postinstall.cjs
@@ -59,10 +59,12 @@ function drawProgress(downloaded, total, startTime) {
 }
 
 function printHeader() {
+  // Box inner width = 42. Full line before trailing ║ = 2(indent) + 1(║) + 42 = 45.
+  // 🐘 surrogate pair is 2 JS chars and 2 visual columns — no special handling needed.
   process.stderr.write('\n');
   process.stderr.write('  \u2554\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2557\n');
-  process.stderr.write(`  \u2551   \uD83D\uDC18 shodh-memory v${VERSION}`.padEnd(50) + '\u2551\n');
-  process.stderr.write('  \u2551   Cognitive Memory for AI Agents'.padEnd(50) + '\u2551\n');
+  process.stderr.write(`  \u2551   \uD83D\uDC18 shodh-memory v${VERSION}`.padEnd(45) + '\u2551\n');
+  process.stderr.write('  \u2551   Cognitive Memory for AI Agents         \u2551\n');
   process.stderr.write('  \u255A\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u255D\n');
   process.stderr.write('\n');
 }

--- a/mcp-server/scripts/postinstall.cjs
+++ b/mcp-server/scripts/postinstall.cjs
@@ -3,7 +3,7 @@
  * Postinstall script for @shodh/memory-mcp
  *
  * Downloads the appropriate shodh-memory-server binary for the current platform
- * from GitHub releases.
+ * from GitHub releases with a visual progress bar.
  */
 
 const fs = require('fs');
@@ -15,7 +15,74 @@ const VERSION = require('../package.json').version;
 const REPO = 'varun29ankuS/shodh-memory';
 const BIN_DIR = path.join(__dirname, '..', 'bin');
 
-// Platform detection
+// ─── Visual helpers ──────────────────────────────────────────────────────────
+
+const BAR_WIDTH = 30;
+const FILLED = '\u2588'; // █
+const EMPTY = '\u2591';  // ░
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatTime(seconds) {
+  if (seconds < 1) return '<1s';
+  if (seconds < 60) return `${Math.ceil(seconds)}s`;
+  const m = Math.floor(seconds / 60);
+  const s = Math.ceil(seconds % 60);
+  return `${m}m ${s}s`;
+}
+
+function drawProgress(downloaded, total, startTime) {
+  if (total === 0) {
+    process.stderr.write(`\r  Downloading... ${formatBytes(downloaded)}`);
+    return;
+  }
+
+  const pct = Math.min(downloaded / total, 1);
+  const filled = Math.round(pct * BAR_WIDTH);
+  const bar = FILLED.repeat(filled) + EMPTY.repeat(BAR_WIDTH - filled);
+  const pctStr = `${Math.round(pct * 100)}%`.padStart(4);
+
+  const elapsed = (Date.now() - startTime) / 1000;
+  let eta = '';
+  if (pct > 0.01 && pct < 1) {
+    const remaining = (elapsed / pct) * (1 - pct);
+    eta = ` | ${formatTime(remaining)} remaining`;
+  }
+
+  process.stderr.write(
+    `\r  ${bar}  ${pctStr} | ${formatBytes(downloaded)} / ${formatBytes(total)}${eta}   `
+  );
+}
+
+function printHeader() {
+  process.stderr.write('\n');
+  process.stderr.write('  \u2554\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2557\n');
+  process.stderr.write(`  \u2551   \uD83D\uDC18 shodh-memory v${VERSION}`.padEnd(50) + '\u2551\n');
+  process.stderr.write('  \u2551   Cognitive Memory for AI Agents'.padEnd(50) + '\u2551\n');
+  process.stderr.write('  \u255A\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u255D\n');
+  process.stderr.write('\n');
+}
+
+function printSuccess(binaryPath) {
+  process.stderr.write('\n');
+  process.stderr.write(`  \u2713 Binary installed at ${binaryPath}\n`);
+  process.stderr.write('\n');
+  process.stderr.write('  Next step \u2014 enable automatic memory:\n');
+  process.stderr.write('    npx shodh-setup-hooks\n');
+  process.stderr.write('\n');
+}
+
+function printAlreadyInstalled() {
+  process.stderr.write(`  \u2713 Server binary already installed\n`);
+  process.stderr.write('\n');
+}
+
+// ─── Platform detection ──────────────────────────────────────────────────────
+
 function getPlatformInfo() {
   const platform = process.platform;
   const arch = process.arch;
@@ -35,27 +102,41 @@ function getPlatformInfo() {
   }
 }
 
-// Download file with redirect following
+// ─── Download with progress ──────────────────────────────────────────────────
+
 function download(url, dest) {
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(dest);
+    const startTime = Date.now();
 
     const request = (url) => {
       https.get(url, (response) => {
         if (response.statusCode === 302 || response.statusCode === 301) {
-          // Follow redirect
           request(response.headers.location);
           return;
         }
 
         if (response.statusCode !== 200) {
-          reject(new Error(`Failed to download: ${response.statusCode}`));
+          reject(new Error(`HTTP ${response.statusCode}`));
           return;
         }
+
+        const totalSize = parseInt(response.headers['content-length'] || '0', 10);
+        let downloaded = 0;
+
+        response.on('data', (chunk) => {
+          downloaded += chunk.length;
+          drawProgress(downloaded, totalSize, startTime);
+        });
 
         response.pipe(file);
         file.on('finish', () => {
           file.close();
+          // Clear the progress line and show completion
+          if (totalSize > 0) {
+            drawProgress(totalSize, totalSize, startTime);
+          }
+          process.stderr.write(' \u2713\n');
           resolve();
         });
       }).on('error', (err) => {
@@ -68,26 +149,32 @@ function download(url, dest) {
   });
 }
 
-// Extract archive
+// ─── Extract archive ─────────────────────────────────────────────────────────
+
 function extract(archive, dest, platformInfo) {
   if (platformInfo.ext === '.tar.gz') {
-    execFileSync('tar', ['-xzf', archive, '-C', dest], { stdio: 'inherit' });
+    execFileSync('tar', ['-xzf', archive, '-C', dest], { stdio: 'pipe' });
   } else if (platformInfo.ext === '.zip') {
-    // Use PowerShell on Windows
-    execFileSync('powershell', ['-Command', `Expand-Archive -Path '${archive}' -DestinationPath '${dest}' -Force`], { stdio: 'inherit' });
+    execFileSync('powershell', [
+      '-Command',
+      `Expand-Archive -Path '${archive}' -DestinationPath '${dest}' -Force`,
+    ], { stdio: 'pipe' });
   }
 }
+
+// ─── Main ────────────────────────────────────────────────────────────────────
 
 async function main() {
   const platformInfo = getPlatformInfo();
 
+  printHeader();
+
   if (!platformInfo) {
-    console.log('[shodh-memory] Unsupported platform:', process.platform, process.arch);
-    console.log('[shodh-memory] You will need to run the server manually.');
+    process.stderr.write(`  \u2717 Unsupported platform: ${process.platform} ${process.arch}\n`);
+    process.stderr.write('  You will need to run the server manually.\n');
+    process.stderr.write(`  Download from: https://github.com/${REPO}/releases\n\n`);
     return;
   }
-
-  console.log('[shodh-memory] Installing server binary for', process.platform, process.arch);
 
   // Create bin directory
   if (!fs.existsSync(BIN_DIR)) {
@@ -98,23 +185,23 @@ async function main() {
 
   // Check if already installed
   if (fs.existsSync(binaryPath)) {
-    console.log('[shodh-memory] Binary already installed at', binaryPath);
+    printAlreadyInstalled();
     return;
   }
 
-  // Download URL
+  // Download
   const downloadUrl = `https://github.com/${REPO}/releases/download/v${VERSION}/${platformInfo.name}${platformInfo.ext}`;
   const archivePath = path.join(BIN_DIR, `${platformInfo.name}${platformInfo.ext}`);
 
-  console.log('[shodh-memory] Downloading from', downloadUrl);
+  process.stderr.write(`  Downloading server binary for ${process.platform} ${process.arch}...\n`);
 
   try {
     await download(downloadUrl, archivePath);
-    console.log('[shodh-memory] Downloaded archive');
 
     // Extract
+    process.stderr.write('  Extracting...');
     extract(archivePath, BIN_DIR, platformInfo);
-    console.log('[shodh-memory] Extracted binary');
+    process.stderr.write(' \u2713\n');
 
     // Clean up archive
     fs.unlinkSync(archivePath);
@@ -124,10 +211,11 @@ async function main() {
       fs.chmodSync(binaryPath, 0o755);
     }
 
-    console.log('[shodh-memory] Server binary installed at', binaryPath);
+    printSuccess(binaryPath);
   } catch (err) {
-    console.error('[shodh-memory] Failed to install binary:', err.message);
-    console.log('[shodh-memory] You can manually download from:', `https://github.com/${REPO}/releases`);
+    process.stderr.write('\n');
+    process.stderr.write(`  \u2717 Failed to install binary: ${err.message}\n`);
+    process.stderr.write(`  Manual download: https://github.com/${REPO}/releases\n\n`);
   }
 }
 

--- a/mcp-server/scripts/postinstall.cjs
+++ b/mcp-server/scripts/postinstall.cjs
@@ -59,12 +59,12 @@ function drawProgress(downloaded, total, startTime) {
 }
 
 function printHeader() {
-  // Box inner width = 42. Full line before trailing ║ = 2(indent) + 1(║) + 42 = 45.
-  // 🐘 surrogate pair is 2 JS chars and 2 visual columns — no special handling needed.
+  // Box inner width = 42. Emoji line uses padEnd(44) — emoji is 2 visual cols
+  // but surrogate pair (2 code units) makes padEnd overcount by 1.
   process.stderr.write('\n');
   process.stderr.write('  \u2554\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2557\n');
-  process.stderr.write(`  \u2551   \uD83D\uDC18 shodh-memory v${VERSION}`.padEnd(45) + '\u2551\n');
-  process.stderr.write('  \u2551   Cognitive Memory for AI Agents         \u2551\n');
+  process.stderr.write(`  \u2551   \uD83D\uDC18 shodh-memory v${VERSION}`.padEnd(44) + '\u2551\n');
+  process.stderr.write('  \u2551   Cognitive Memory for AI Agents        \u2551\n');
   process.stderr.write('  \u255A\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u255D\n');
   process.stderr.write('\n');
 }

--- a/mcp-server/scripts/setup-hooks.cjs
+++ b/mcp-server/scripts/setup-hooks.cjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+/**
+ * Setup Claude Code hooks for shodh-memory.
+ *
+ * Copies memory-hook.ts to ~/.claude/hooks/shodh-memory/
+ * and merges hook configuration into ~/.claude/settings.json.
+ *
+ * Usage:
+ *   npx @shodh/memory-mcp setup-hooks
+ *   npx @shodh/memory-mcp setup-hooks --dry-run
+ *   npx @shodh/memory-mcp setup-hooks --uninstall
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync } = require('child_process');
+
+// ─── Paths ──────────────────────────────────────────────────────────────────
+
+const HOME = os.homedir();
+const CLAUDE_DIR = path.join(HOME, '.claude');
+const HOOKS_DEST = path.join(CLAUDE_DIR, 'hooks', 'shodh-memory');
+const SETTINGS_PATH = path.join(CLAUDE_DIR, 'settings.json');
+const HOOK_SOURCE = path.join(__dirname, '..', '..', 'hooks', 'memory-hook.ts');
+// Fallback: when installed via npm, hooks/ is not in the package.
+// In that case, we download it from GitHub.
+const REPO = 'varun29ankuS/shodh-memory';
+const VERSION = require('../package.json').version;
+const HOOK_URL = `https://raw.githubusercontent.com/${REPO}/v${VERSION}/hooks/memory-hook.ts`;
+
+// ─── Hook configuration to merge ────────────────────────────────────────────
+
+const HOOK_COMMAND_PREFIX = 'bun run';
+const HOOK_SCRIPT = path.join(HOOKS_DEST, 'memory-hook.ts');
+
+function makeCommand(event) {
+  // Use forward slashes for cross-platform compat in the command string
+  const scriptPath = HOOK_SCRIPT.replace(/\\/g, '/');
+  return `${HOOK_COMMAND_PREFIX} ${scriptPath} ${event}`;
+}
+
+function buildHookConfig() {
+  return {
+    SessionStart: [
+      {
+        matcher: {},
+        hooks: [{ type: 'command', command: makeCommand('SessionStart') }],
+      },
+    ],
+    UserPromptSubmit: [
+      {
+        matcher: {},
+        hooks: [{ type: 'command', command: makeCommand('UserPromptSubmit') }],
+      },
+    ],
+    Stop: [
+      {
+        matcher: {},
+        hooks: [{ type: 'command', command: makeCommand('Stop') }],
+      },
+    ],
+    PreToolUse: [
+      {
+        matcher: { tool_name: ['Edit', 'Write', 'Bash'] },
+        hooks: [{ type: 'command', command: makeCommand('PreToolUse') }],
+      },
+    ],
+    PostToolUse: [
+      {
+        matcher: { tool_name: ['Edit', 'Write', 'Bash', 'TodoWrite', 'Read', 'Task'] },
+        hooks: [{ type: 'command', command: makeCommand('PostToolUse') }],
+      },
+    ],
+    SubagentStop: [
+      {
+        matcher: {},
+        hooks: [{ type: 'command', command: makeCommand('SubagentStop') }],
+      },
+    ],
+  };
+}
+
+// ─── Visual helpers ─────────────────────────────────────────────────────────
+
+function printHeader() {
+  process.stderr.write('\n');
+  process.stderr.write('  \u2554\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2557\n');
+  process.stderr.write('  \u2551   \uD83D\uDC18 shodh-memory hooks setup              \u2551\n');
+  process.stderr.write('  \u2551   Automatic memory for Claude Code          \u2551\n');
+  process.stderr.write('  \u255A\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u255D\n');
+  process.stderr.write('\n');
+}
+
+// ─── Detect bun ─────────────────────────────────────────────────────────────
+
+function isBunInstalled() {
+  try {
+    execSync('bun --version', { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ─── Download hook file ─────────────────────────────────────────────────────
+
+function downloadFile(url, dest) {
+  return new Promise((resolve, reject) => {
+    const https = require('https');
+    const file = fs.createWriteStream(dest);
+
+    const request = (url) => {
+      https.get(url, (response) => {
+        if (response.statusCode === 301 || response.statusCode === 302) {
+          request(response.headers.location);
+          return;
+        }
+        if (response.statusCode !== 200) {
+          reject(new Error(`HTTP ${response.statusCode} downloading hook file`));
+          return;
+        }
+        response.pipe(file);
+        file.on('finish', () => { file.close(); resolve(); });
+      }).on('error', (err) => {
+        fs.unlink(dest, () => {});
+        reject(err);
+      });
+    };
+
+    request(url);
+  });
+}
+
+// ─── Merge hooks into settings.json ─────────────────────────────────────────
+
+/**
+ * Merges shodh hooks into existing settings.json without clobbering other hooks.
+ * For each event type, appends shodh entries to the array (deduplicates by command).
+ */
+function mergeHooks(existingSettings, newHooks) {
+  const settings = JSON.parse(JSON.stringify(existingSettings)); // deep clone
+  if (!settings.hooks) {
+    settings.hooks = {};
+  }
+
+  for (const [event, entries] of Object.entries(newHooks)) {
+    if (!settings.hooks[event]) {
+      settings.hooks[event] = [];
+    }
+
+    for (const entry of entries) {
+      const cmd = entry.hooks[0].command;
+      // Check if this exact command already exists
+      const alreadyExists = settings.hooks[event].some((existing) =>
+        existing.hooks && existing.hooks.some((h) => h.command === cmd)
+      );
+
+      if (!alreadyExists) {
+        settings.hooks[event].push(entry);
+      }
+    }
+  }
+
+  return settings;
+}
+
+/**
+ * Removes all shodh-memory hooks from settings.json.
+ */
+function removeHooks(existingSettings) {
+  const settings = JSON.parse(JSON.stringify(existingSettings));
+  if (!settings.hooks) return settings;
+
+  for (const [event, entries] of Object.entries(settings.hooks)) {
+    if (!Array.isArray(entries)) continue;
+    settings.hooks[event] = entries.filter((entry) => {
+      if (!entry.hooks || !Array.isArray(entry.hooks)) return true;
+      return !entry.hooks.some((h) => h.command && h.command.includes('shodh-memory'));
+    });
+    // Remove empty arrays
+    if (settings.hooks[event].length === 0) {
+      delete settings.hooks[event];
+    }
+  }
+
+  // Remove empty hooks object
+  if (Object.keys(settings.hooks).length === 0) {
+    delete settings.hooks;
+  }
+
+  return settings;
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const uninstall = args.includes('--uninstall');
+
+  printHeader();
+
+  // ── Uninstall mode ──────────────────────────────────────────────────────
+  if (uninstall) {
+    process.stderr.write('  Removing shodh-memory hooks...\n\n');
+
+    // Remove hook files
+    if (fs.existsSync(HOOKS_DEST)) {
+      if (!dryRun) {
+        fs.rmSync(HOOKS_DEST, { recursive: true, force: true });
+      }
+      process.stderr.write(`  \u2713 Removed ${HOOKS_DEST}\n`);
+    } else {
+      process.stderr.write('  - Hook directory not found (already removed)\n');
+    }
+
+    // Remove from settings.json
+    if (fs.existsSync(SETTINGS_PATH)) {
+      const settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf-8'));
+      const cleaned = removeHooks(settings);
+      if (!dryRun) {
+        fs.writeFileSync(SETTINGS_PATH, JSON.stringify(cleaned, null, 2) + '\n');
+      }
+      process.stderr.write(`  \u2713 Cleaned ${SETTINGS_PATH}\n`);
+    }
+
+    process.stderr.write('\n  Hooks removed. Memory capture is now inactive.\n\n');
+    return;
+  }
+
+  // ── Install mode ────────────────────────────────────────────────────────
+
+  // Step 1: Check for bun
+  if (!isBunInstalled()) {
+    process.stderr.write('  \u2717 bun is required but not installed.\n');
+    process.stderr.write('\n');
+    process.stderr.write('  Install bun:\n');
+    if (process.platform === 'win32') {
+      process.stderr.write('    powershell -c "irm bun.sh/install.ps1 | iex"\n');
+    } else {
+      process.stderr.write('    curl -fsSL https://bun.sh/install | bash\n');
+    }
+    process.stderr.write('\n  Then re-run: npx @shodh/memory-mcp setup-hooks\n\n');
+    process.exit(1);
+  }
+  process.stderr.write('  \u2713 bun detected\n');
+
+  // Step 2: Check Claude Code directory
+  if (!fs.existsSync(CLAUDE_DIR)) {
+    process.stderr.write(`  \u2717 Claude Code config not found at ${CLAUDE_DIR}\n`);
+    process.stderr.write('  Make sure Claude Code is installed and has been run at least once.\n\n');
+    process.exit(1);
+  }
+  process.stderr.write('  \u2713 Claude Code detected\n');
+
+  // Step 3: Copy hook file
+  fs.mkdirSync(HOOKS_DEST, { recursive: true });
+
+  const destFile = path.join(HOOKS_DEST, 'memory-hook.ts');
+
+  if (fs.existsSync(HOOK_SOURCE)) {
+    // Local source available (development or full repo clone)
+    if (!dryRun) {
+      fs.copyFileSync(HOOK_SOURCE, destFile);
+    }
+    process.stderr.write(`  \u2713 Hook copied to ${HOOKS_DEST}/\n`);
+  } else {
+    // Download from GitHub (npm install — hooks/ not in the package)
+    process.stderr.write('  Downloading hook script...');
+    try {
+      if (!dryRun) {
+        await downloadFile(HOOK_URL, destFile);
+      }
+      process.stderr.write(' \u2713\n');
+    } catch (err) {
+      process.stderr.write(` \u2717\n`);
+      process.stderr.write(`  Failed to download hook: ${err.message}\n`);
+      process.stderr.write(`  Manual download: https://github.com/${REPO}/blob/main/hooks/memory-hook.ts\n\n`);
+      process.exit(1);
+    }
+  }
+
+  // Step 4: Merge settings.json
+  let settings = {};
+  if (fs.existsSync(SETTINGS_PATH)) {
+    try {
+      settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf-8'));
+    } catch {
+      process.stderr.write(`  \u26A0 Could not parse ${SETTINGS_PATH} — creating fresh config\n`);
+      settings = {};
+    }
+  }
+
+  // Backup settings.json before modifying
+  if (fs.existsSync(SETTINGS_PATH) && !dryRun) {
+    const backupPath = SETTINGS_PATH + '.bak';
+    fs.copyFileSync(SETTINGS_PATH, backupPath);
+  }
+
+  const hookConfig = buildHookConfig();
+  const merged = mergeHooks(settings, hookConfig);
+
+  if (!dryRun) {
+    fs.writeFileSync(SETTINGS_PATH, JSON.stringify(merged, null, 2) + '\n');
+  }
+  process.stderr.write(`  \u2713 Settings updated at ${SETTINGS_PATH}\n`);
+
+  // Step 5: Summary
+  process.stderr.write('\n');
+
+  if (dryRun) {
+    process.stderr.write('  [DRY RUN] No files were modified.\n');
+    process.stderr.write('  The following changes would be made:\n');
+    process.stderr.write(`    - Copy memory-hook.ts to ${HOOKS_DEST}/\n`);
+    process.stderr.write(`    - Merge 6 hook events into ${SETTINGS_PATH}\n`);
+    process.stderr.write(`    - Backup existing settings to ${SETTINGS_PATH}.bak\n`);
+  } else {
+    process.stderr.write('  Hooks will activate on your next Claude Code session.\n');
+    process.stderr.write('  Shodh will automatically capture memories from conversations.\n');
+    process.stderr.write('\n');
+    process.stderr.write('  To remove: npx @shodh/memory-mcp setup-hooks --uninstall\n');
+  }
+
+  process.stderr.write('\n');
+}
+
+main().catch((err) => {
+  process.stderr.write(`\n  \u2717 Setup failed: ${err.message}\n\n`);
+  process.exit(1);
+});

--- a/mcp-server/scripts/setup-hooks.cjs
+++ b/mcp-server/scripts/setup-hooks.cjs
@@ -86,8 +86,8 @@ function buildHookConfig() {
 function printHeader() {
   process.stderr.write('\n');
   process.stderr.write('  \u2554\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2557\n');
-  process.stderr.write('  \u2551   \uD83D\uDC18 shodh-memory hooks setup              \u2551\n');
-  process.stderr.write('  \u2551   Automatic memory for Claude Code          \u2551\n');
+  process.stderr.write('  \u2551   \uD83D\uDC18 shodh-memory hooks setup             \u2551\n');
+  process.stderr.write('  \u2551   Automatic memory for Claude Code         \u2551\n');
   process.stderr.write('  \u255A\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u255D\n');
   process.stderr.write('\n');
 }

--- a/mcp-server/scripts/setup-hooks.cjs
+++ b/mcp-server/scripts/setup-hooks.cjs
@@ -22,7 +22,10 @@ const HOME = os.homedir();
 const CLAUDE_DIR = path.join(HOME, '.claude');
 const HOOKS_DEST = path.join(CLAUDE_DIR, 'hooks', 'shodh-memory');
 const SETTINGS_PATH = path.join(CLAUDE_DIR, 'settings.json');
-const HOOK_SOURCE = path.join(__dirname, '..', '..', 'hooks', 'memory-hook.ts');
+// Look for hook in package first (npm install), then repo root (dev)
+const HOOK_SOURCE_PKG = path.join(__dirname, '..', 'hooks', 'memory-hook.ts');
+const HOOK_SOURCE_REPO = path.join(__dirname, '..', '..', 'hooks', 'memory-hook.ts');
+const HOOK_SOURCE = fs.existsSync(HOOK_SOURCE_PKG) ? HOOK_SOURCE_PKG : HOOK_SOURCE_REPO;
 // Fallback: when installed via npm, hooks/ is not in the package.
 // In that case, we download it from GitHub.
 const REPO = 'varun29ankuS/shodh-memory';

--- a/mcp-server/scripts/setup-hooks.cjs
+++ b/mcp-server/scripts/setup-hooks.cjs
@@ -86,8 +86,8 @@ function buildHookConfig() {
 function printHeader() {
   process.stderr.write('\n');
   process.stderr.write('  \u2554\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2557\n');
-  process.stderr.write('  \u2551   \uD83D\uDC18 shodh-memory hooks setup             \u2551\n');
-  process.stderr.write('  \u2551   Automatic memory for Claude Code         \u2551\n');
+  process.stderr.write('  \u2551   \uD83D\uDC18 shodh-memory hooks setup           \u2551\n');
+  process.stderr.write('  \u2551   Automatic memory for Claude Code       \u2551\n');
   process.stderr.write('  \u255A\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u255D\n');
   process.stderr.write('\n');
 }

--- a/notebooks/shodh_memory_demo.ipynb
+++ b/notebooks/shodh_memory_demo.ipynb
@@ -17,20 +17,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "source": [
-    "# 🧠 Shodh Memory - Interactive Demo\n",
-    "\n",
-    "**Persistent memory for AI agents that learns with use.**\n",
-    "\n",
-    "This notebook demonstrates the core features of Shodh Memory:\n",
-    "- Store memories with semantic understanding\n",
-    "- Recall using natural language queries\n",
-    "- Memory types and importance scoring\n",
-    "- Hybrid retrieval modes\n",
-    "\n",
-    "[![GitHub](https://img.shields.io/badge/GitHub-shodh--memory-blue)](https://github.com/varun29ankuS/shodh-memory)\n",
-    "[![PyPI](https://img.shields.io/pypi/v/shodh-memory.svg)](https://pypi.org/project/shodh-memory/)"
-   ],
+   "source": "# 🐘 Shodh Memory - Interactive Demo\n\n**Persistent memory for AI agents that learns with use.**\n\nThis notebook demonstrates the core features of Shodh Memory:\n- Store memories with semantic understanding\n- Recall using natural language queries\n- Memory types and importance scoring\n- Hybrid retrieval modes\n\n[![GitHub](https://img.shields.io/badge/GitHub-shodh--memory-blue)](https://github.com/varun29ankuS/shodh-memory)\n[![PyPI](https://img.shields.io/pypi/v/shodh-memory.svg)](https://pypi.org/project/shodh-memory/)",
    "metadata": {
     "id": "intro"
    }

--- a/shodh-todoist/src/index.ts
+++ b/shodh-todoist/src/index.ts
@@ -27,7 +27,7 @@ async function showOverview(): Promise<void> {
 async function startDaemon(): Promise<void> {
   console.log("\n✅ shodh-todoist starting...");
   console.log(`🔑 Todoist: Connected`);
-  console.log(`🧠 Memory: ${config.shodh.apiUrl}`);
+  console.log(`🐘 Memory: ${config.shodh.apiUrl}`);
   console.log(`⏱️  Sync interval: ${config.sync.intervalMs / 1000}s`);
 
   await showOverview();

--- a/shodh-whatsapp/src/index.ts
+++ b/shodh-whatsapp/src/index.ts
@@ -48,7 +48,7 @@ async function connectToWhatsApp(): Promise<WASocket> {
 
   console.log(`\n🙏 Keshav starting...`);
   console.log(`📱 WhatsApp Web version: ${version.join(".")} (latest: ${isLatest})`);
-  console.log(`🧠 Memory: ${config.shodh.apiUrl}`);
+  console.log(`🐘 Memory: ${config.shodh.apiUrl}`);
   console.log(`🤖 LLM: ${config.llm.provider}`);
 
   if (config.whatsapp.autoReplyAll) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,6 +10,7 @@
 //!   shodh hook session-start  - Output session start hook JSON
 //!   shodh hook prompt <msg>   - Output prompt submit hook JSON
 //!   shodh claude [args...]    - Launch Claude Code with Shodh memory
+//!   shodh setup-hooks         - Print instructions for Claude Code hooks
 //!   shodh version             - Print version and build info
 
 #[global_allocator]
@@ -200,6 +201,13 @@ enum Commands {
             default_value = "sk-shodh-dev-local-testing-key"
         )]
         api_key: String,
+    },
+
+    /// Print instructions to set up Claude Code hooks for automatic memory
+    SetupHooks {
+        /// Also print the settings.json snippet as raw JSON (for piping)
+        #[arg(long)]
+        json: bool,
     },
 
     /// Print version and build information
@@ -420,6 +428,13 @@ async fn main() -> Result<()> {
         // =====================================================================
         // NEW: shodh version — version and build info
         // =====================================================================
+        // =====================================================================
+        // NEW: shodh setup-hooks — print Claude Code hooks setup guide
+        // =====================================================================
+        Commands::SetupHooks { json } => {
+            handle_setup_hooks(json);
+        }
+
         Commands::Version => {
             handle_version();
         }
@@ -718,6 +733,122 @@ fn handle_version() {
     eprintln!("  Arch:     {}", std::env::consts::ARCH);
     eprintln!("  License:  Apache-2.0");
     eprintln!("  Repo:     https://github.com/varun29ankuS/shodh-memory");
+}
+
+fn handle_setup_hooks(json: bool) {
+    let version = env!("CARGO_PKG_VERSION");
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("~"));
+    let claude_dir = home.join(".claude");
+    let hooks_dest = claude_dir
+        .join("hooks")
+        .join("shodh-memory")
+        .join("memory-hook.ts");
+    let settings_path = claude_dir.join("settings.json");
+
+    // Use forward slashes everywhere for cross-platform hook commands
+    let hook_path_str = hooks_dest.to_string_lossy().replace('\\', "/");
+
+    let hook_url = format!(
+        "https://raw.githubusercontent.com/varun29ankuS/shodh-memory/v{version}/hooks/memory-hook.ts"
+    );
+
+    if json {
+        // Machine-readable: print just the settings.json hooks snippet
+        let snippet = build_hooks_json(&hook_path_str);
+        println!("{snippet}");
+        return;
+    }
+
+    eprintln!();
+    eprintln!("  Shodh-Memory — Claude Code Hooks Setup");
+    eprintln!("  ═══════════════════════════════════════");
+    eprintln!();
+    eprintln!("  Follow these steps to enable automatic memory capture.");
+    eprintln!();
+
+    // Step 1: Prerequisites
+    eprintln!("  1. Install bun (needed to run the hook script):");
+    eprintln!();
+    if cfg!(target_os = "windows") {
+        eprintln!("     powershell -c \"irm bun.sh/install.ps1 | iex\"");
+    } else {
+        eprintln!("     curl -fsSL https://bun.sh/install | bash");
+    }
+    eprintln!();
+
+    // Step 2: Download hook file
+    eprintln!("  2. Download the hook script:");
+    eprintln!();
+    eprintln!("     mkdir -p {}", hooks_dest.parent().unwrap().display());
+    if cfg!(target_os = "windows") {
+        eprintln!("     curl -fsSL -o \"{}\" \\", hooks_dest.to_string_lossy());
+    } else {
+        eprintln!("     curl -fsSL -o {} \\", hooks_dest.display());
+    }
+    eprintln!("       {hook_url}");
+    eprintln!();
+
+    // Step 3: settings.json
+    eprintln!("  3. Add hooks to {}", settings_path.display());
+    eprintln!();
+    eprintln!("     Merge the following into your settings.json \"hooks\" object.");
+    eprintln!("     (Run `shodh setup-hooks --json` for copy-paste JSON.)");
+    eprintln!();
+
+    // Print compact hook overview
+    let events = [
+        "SessionStart",
+        "UserPromptSubmit",
+        "Stop",
+        "PreToolUse",
+        "PostToolUse",
+        "SubagentStop",
+    ];
+    for event in &events {
+        eprintln!("     {event}: bun run {hook_path_str} {event}");
+    }
+    eprintln!();
+
+    // Step 4: Verify
+    eprintln!("  4. Verify:");
+    eprintln!();
+    eprintln!("     Start a new Claude Code session — you should see");
+    eprintln!("     \"SessionStart hook success\" in the system output.");
+    eprintln!();
+
+    // Quick path
+    eprintln!("  ─── Or use the npm installer (does all steps automatically) ───");
+    eprintln!();
+    eprintln!("     npx @shodh/memory-mcp setup-hooks");
+    eprintln!();
+}
+
+fn build_hooks_json(hook_path: &str) -> String {
+    let events = [
+        ("SessionStart", "{}"),
+        ("UserPromptSubmit", "{}"),
+        ("Stop", "{}"),
+        ("PreToolUse", r#"{"tool_name": ["Edit", "Write", "Bash"]}"#),
+        (
+            "PostToolUse",
+            r#"{"tool_name": ["Edit", "Write", "Bash", "TodoWrite", "Read", "Task"]}"#,
+        ),
+        ("SubagentStop", "{}"),
+    ];
+
+    let mut entries = Vec::new();
+    for (event, matcher) in &events {
+        entries.push(format!(
+            r#"    "{event}": [
+      {{
+        "matcher": {matcher},
+        "hooks": [{{"type": "command", "command": "bun run {hook_path} {event}"}}]
+      }}
+    ]"#
+        ));
+    }
+
+    format!("{{\n  \"hooks\": {{\n{}\n  }}\n}}", entries.join(",\n"))
 }
 
 // =============================================================================

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1610,7 +1610,7 @@ async fn handle_claude_launch(port: u16, args: Vec<String>) -> Result<()> {
     let server_running = client.get(&health_url).send().await.is_ok();
 
     if !server_running {
-        eprintln!("🧠 Starting shodh-memory server on port {port}...");
+        eprintln!("🐘 Starting shodh-memory server on port {port}...");
 
         // Start server in background
         let exe_path = std::env::current_exe()?;
@@ -1664,7 +1664,7 @@ async fn handle_claude_launch(port: u16, args: Vec<String>) -> Result<()> {
             std::process::exit(1);
         }
     } else {
-        eprintln!("🧠 Shodh-memory server already running on port {port}");
+        eprintln!("🐘 Shodh-memory server already running on port {port}");
     }
 
     // Launch claude with ANTHROPIC_API_BASE pointing to Cortex proxy

--- a/src/embeddings/downloader.rs
+++ b/src/embeddings/downloader.rs
@@ -257,6 +257,66 @@ pub fn get_onnx_runtime_path() -> Option<PathBuf> {
 /// Download progress callback type (Arc for clonability)
 pub type ProgressCallback = Arc<dyn Fn(u64, u64) + Send + Sync>;
 
+// ─── Visual progress bar for stderr ─────────────────────────────────────────
+
+const BAR_WIDTH: usize = 30;
+const FILLED: char = '\u{2588}'; // █
+const EMPTY: char = '\u{2591}'; // ░
+
+fn format_bytes(bytes: u64) -> String {
+    if bytes < 1024 {
+        format!("{bytes} B")
+    } else if bytes < 1024 * 1024 {
+        format!("{} KB", bytes / 1024)
+    } else {
+        format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+    }
+}
+
+/// Create a progress callback that renders a visual progress bar to stderr.
+///
+/// The `label` is printed once before the bar starts (e.g. "MiniLM-L6 (23 MB)").
+/// The bar updates in-place using `\r` carriage return.
+pub fn make_stderr_progress(label: String) -> ProgressCallback {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    let header_printed = Arc::new(AtomicBool::new(false));
+
+    Arc::new(move |downloaded: u64, total: u64| {
+        // Print label once
+        if !header_printed.swap(true, Ordering::Relaxed) {
+            eprint!("     {label:<24}");
+        }
+
+        if total == 0 {
+            eprint!("\r     {:<24} {}...", label, format_bytes(downloaded));
+            return;
+        }
+
+        let pct = (downloaded as f64 / total as f64).min(1.0);
+        let filled = (pct * BAR_WIDTH as f64).round() as usize;
+        let bar: String = std::iter::repeat_n(FILLED, filled)
+            .chain(std::iter::repeat_n(EMPTY, BAR_WIDTH - filled))
+            .collect();
+        let pct_str = format!("{:>3}%", (pct * 100.0).round() as u32);
+
+        if downloaded >= total {
+            // Completion — overwrite with checkmark
+            eprint!(
+                "\r     {:<24}{bar}  {pct_str} | {} \u{2713}\n",
+                label,
+                format_bytes(total)
+            );
+        } else {
+            eprint!(
+                "\r     {:<24}{bar}  {pct_str} | {} / {}",
+                label,
+                format_bytes(downloaded),
+                format_bytes(total)
+            );
+        }
+    })
+}
+
 /// Verify SHA-256 checksum of a file
 /// Used for model integrity verification when checksum values are provided
 fn verify_checksum(path: &Path, expected: &str) -> Result<bool> {
@@ -451,13 +511,18 @@ pub fn download_models_internal(
         model_checksum,
     )?;
 
-    // Download tokenizer (~700KB)
+    // Download tokenizer (~700KB) — use a separate progress bar
     let tokenizer_path = models_dir.join("tokenizer.json");
     tracing::info!("Downloading tokenizer.json");
+    let tokenizer_progress: Option<ProgressCallback> = if progress.is_some() {
+        Some(make_stderr_progress("Tokenizer (700 KB)".to_string()))
+    } else {
+        None
+    };
     download_file_with_checksum(
         TOKENIZER_URL,
         &tokenizer_path,
-        progress.as_ref().map(|p| p.as_ref()),
+        tokenizer_progress.as_ref().map(|p| p.as_ref()),
         ModelChecksums::TOKENIZER,
     )?;
 

--- a/src/embeddings/minilm.rs
+++ b/src/embeddings/minilm.rs
@@ -264,10 +264,12 @@ impl MiniLMEmbedder {
             return Err("ONNX Runtime not found and SHODH_OFFLINE=true".to_string());
         }
 
-        eprintln!("[shodh] ONNX Runtime not found. Downloading...");
+        eprintln!();
+        eprintln!("  \u{1F4E6} Downloading runtime (first run only)...");
+        let progress = super::downloader::make_stderr_progress("ONNX Runtime".to_string());
         let onnx_path =
-            super::downloader::download_onnx_runtime(None).map_err(|e| e.to_string())?;
-        eprintln!("[shodh] Downloaded ONNX Runtime to: {:?}", onnx_path);
+            super::downloader::download_onnx_runtime(Some(progress)).map_err(|e| e.to_string())?;
+        eprintln!();
         // SAFETY: This is called once via OnceLock, before other threads start
         std::env::set_var("ORT_DYLIB_PATH", &onnx_path);
         Ok(onnx_path)
@@ -364,21 +366,11 @@ impl MiniLMEmbedder {
                 config.model_path.parent().unwrap_or(&config.model_path)
             );
 
-            match super::downloader::download_models(Some(std::sync::Arc::new(
-                |downloaded, total| {
-                    if total > 0 {
-                        let percent = (downloaded as f64 / total as f64 * 100.0) as u32;
-                        if percent.is_multiple_of(10) {
-                            tracing::info!(
-                                "Downloading models: {}% ({}/{})",
-                                percent,
-                                downloaded,
-                                total
-                            );
-                        }
-                    }
-                },
-            ))) {
+            eprintln!();
+            eprintln!("  \u{1F4E6} Downloading models (first run only)...");
+            match super::downloader::download_models(Some(
+                super::downloader::make_stderr_progress("MiniLM-L6 (23 MB)".to_string()),
+            )) {
                 Ok(models_dir) => {
                     tracing::info!("Models downloaded to {:?}", models_dir);
 

--- a/src/embeddings/minilm.rs
+++ b/src/embeddings/minilm.rs
@@ -368,9 +368,9 @@ impl MiniLMEmbedder {
 
             eprintln!();
             eprintln!("  \u{1F4E6} Downloading models (first run only)...");
-            match super::downloader::download_models(Some(
-                super::downloader::make_stderr_progress("MiniLM-L6 (23 MB)".to_string()),
-            )) {
+            match super::downloader::download_models(Some(super::downloader::make_stderr_progress(
+                "MiniLM-L6 (23 MB)".to_string(),
+            ))) {
                 Ok(models_dir) => {
                     tracing::info!("Models downloaded to {:?}", models_dir);
 

--- a/src/handlers/graph_view.html
+++ b/src/handlers/graph_view.html
@@ -214,7 +214,7 @@
 </head>
 <body>
     <div id="header">
-        <h1>🧠 Shodh Memory Graph</h1>
+        <h1>🐘 Shodh Memory Graph</h1>
         <div id="mode-toggle">
             <button class="mode-btn" id="btn-2d">2D</button>
             <button class="mode-btn active" id="btn-3d">3D</button>

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1042,7 +1042,7 @@ async fn handle_claude_launch(port: u16, args: Vec<String>) -> Result<()> {
     let server_running = client.get(&health_url).send().await.is_ok();
 
     if !server_running {
-        eprintln!("🧠 Starting shodh-memory server on port {port}...");
+        eprintln!("🐘 Starting shodh-memory server on port {port}...");
 
         // Start server in background
         let exe_path = std::env::current_exe()?;
@@ -1097,7 +1097,7 @@ async fn handle_claude_launch(port: u16, args: Vec<String>) -> Result<()> {
             std::process::exit(1);
         }
     } else {
-        eprintln!("🧠 Shodh-memory server already running on port {port}");
+        eprintln!("🐘 Shodh-memory server already running on port {port}");
     }
 
     // Launch claude with ANTHROPIC_API_BASE pointing to Cortex proxy

--- a/src/server.rs
+++ b/src/server.rs
@@ -600,7 +600,12 @@ fn print_banner() {
     let right_pad = inner_width.saturating_sub(left_pad + content_visual);
 
     eprintln!("  ╔{}╗", "═".repeat(inner_width));
-    eprintln!("  ║{}{}{}║", " ".repeat(left_pad), title_content, " ".repeat(right_pad));
+    eprintln!(
+        "  ║{}{}{}║",
+        " ".repeat(left_pad),
+        title_content,
+        " ".repeat(right_pad)
+    );
     eprintln!("  ║       Cognitive Memory for AI Agents              ║");
     eprintln!("  ╚{}╝", "═".repeat(inner_width));
     eprintln!();

--- a/src/server.rs
+++ b/src/server.rs
@@ -587,13 +587,22 @@ async fn run_shutdown_cleanup(manager: AppState) {
 
 fn print_banner() {
     eprintln!();
-    eprintln!("  ╔═══════════════════════════════════════════════════╗");
-    eprintln!(
-        "  ║         🐘 Shodh-Memory Server v{}          ║",
-        env!("CARGO_PKG_VERSION")
-    );
+    let version = env!("CARGO_PKG_VERSION");
+    // Box inner width = 49 visual columns.
+    // 🐘 is 1 Rust char but 2 visual columns — need 1 extra pad space to compensate.
+    let title_content = format!("🐘 Shodh-Memory Server v{version}");
+    // visual width: 2 (emoji) + 1 (space) + 22 + ver_len = 25 + ver_len
+    // Rust .len() on the format string counts bytes (emoji = 4 bytes), but we need char-based padding.
+    // Simpler: compute pad from known visual widths.
+    let content_visual = 2 + 1 + 22 + version.len(); // emoji(2) + " Shodh-Memory Server v" + version
+    let inner_width: usize = 49;
+    let left_pad: usize = 9; // spaces before emoji
+    let right_pad = inner_width.saturating_sub(left_pad + content_visual);
+
+    eprintln!("  ╔{}╗", "═".repeat(inner_width));
+    eprintln!("  ║{}{}{}║", " ".repeat(left_pad), title_content, " ".repeat(right_pad));
     eprintln!("  ║       Cognitive Memory for AI Agents              ║");
-    eprintln!("  ╚═══════════════════════════════════════════════════╝");
+    eprintln!("  ╚{}╝", "═".repeat(inner_width));
     eprintln!();
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -589,7 +589,7 @@ fn print_banner() {
     eprintln!();
     eprintln!("  ╔═══════════════════════════════════════════════════╗");
     eprintln!(
-        "  ║         🧠 Shodh-Memory Server v{}          ║",
+        "  ║         🐘 Shodh-Memory Server v{}          ║",
         env!("CARGO_PKG_VERSION")
     );
     eprintln!("  ║       Cognitive Memory for AI Agents              ║");

--- a/src/server.rs
+++ b/src/server.rs
@@ -589,14 +589,11 @@ fn print_banner() {
     eprintln!();
     let version = env!("CARGO_PKG_VERSION");
     // Box inner width = 49 visual columns.
-    // 🐘 is 1 Rust char but 2 visual columns — need 1 extra pad space to compensate.
+    // 🐘 is 1 Rust char but 2 terminal columns — add 1 to visual width to compensate.
     let title_content = format!("🐘 Shodh-Memory Server v{version}");
-    // visual width: 2 (emoji) + 1 (space) + 22 + ver_len = 25 + ver_len
-    // Rust .len() on the format string counts bytes (emoji = 4 bytes), but we need char-based padding.
-    // Simpler: compute pad from known visual widths.
-    let content_visual = 2 + 1 + 22 + version.len(); // emoji(2) + " Shodh-Memory Server v" + version
+    let content_visual = 2 + 1 + 22 + version.len() + 1; // +1 for wide emoji
     let inner_width: usize = 49;
-    let left_pad: usize = 9; // spaces before emoji
+    let left_pad: usize = 9;
     let right_pad = inner_width.saturating_sub(left_pad + content_visual);
 
     eprintln!("  ╔{}╗", "═".repeat(inner_width));
@@ -606,7 +603,7 @@ fn print_banner() {
         title_content,
         " ".repeat(right_pad)
     );
-    eprintln!("  ║       Cognitive Memory for AI Agents              ║");
+    eprintln!("  ║       Cognitive Memory for AI Agents            ║");
     eprintln!("  ╚{}╝", "═".repeat(inner_width));
     eprintln!();
 }


### PR DESCRIPTION
## Summary

- **Visual postinstall**: npm install now shows a Unicode progress bar during binary download with percentage, MB counter, and ETA — no more "is it frozen?"
- **Visible model downloads**: First server startup shows progress bars for ONNX Runtime (~50MB), MiniLM model (~23MB), and tokenizer (~700KB). Previously silent.
- **`npx shodh-setup-hooks`**: One command copies hooks to `~/.claude/hooks/` and merges config into `settings.json`. Supports `--dry-run` and `--uninstall`. Backs up settings before modifying.
- **Elephant rebrand**: 🧠 → 🐘 across all user-facing output (server banner, CLI, MCP, integrations, docs)

## What users see after this

**npm install:**
```
  ╔══════════════════════════════════════════╗
  ║   🐘 shodh-memory v0.2.0               ║
  ║   Cognitive Memory for AI Agents        ║
  ╚══════════════════════════════════════════╝

  ████████████████████████████████  100% | 50.3 MB ✓
  ✓ Binary installed

  Next step — enable automatic memory:
    npx shodh-setup-hooks
```

**First server start:**
```
  📦 Downloading models (first run only)...
     MiniLM-L6 (23 MB)      ████████████████████████████████  100% ✓
     Tokenizer (700 KB)     ████████████████████████████████  100% ✓
```

**Hooks setup:**
```
  ✓ bun detected
  ✓ Claude Code detected
  ✓ Hook copied to ~/.claude/hooks/shodh-memory/
  ✓ Settings updated at ~/.claude/settings.json
```

## Test plan

- [x] `cargo check` — clean
- [x] `cargo clippy` — zero warnings
- [x] `cargo test --lib` — 596 passed, 0 failed
- [x] `node -c setup-hooks.cjs` — syntax valid
- [x] `node setup-hooks.cjs --dry-run` — produces expected output
- [ ] CI passes