### PR TITLE
fix: type-aware graph scoring for recall quality (PIPE-8)

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1295,6 +1295,68 @@ pub const MEMORY_TIER_GRAPH_MULT_LONGTERM: f32 = 1.0;
 pub const MEMORY_TIER_GRAPH_MULT_ARCHIVE: f32 = 1.2;
 
 // =============================================================================
+// RECALL QUALITY: TYPE-AWARE SCORING (PIPE-8)
+// Hook-generated memories (CodeEdit, Command) outnumber intentional memories
+// ~6:1 in edge creation volume. Without type-awareness, they dominate graph
+// traversal through sheer volume. These constants modulate signal at both
+// write-time (edge creation) and read-time (spreading activation + Layer 5).
+// =============================================================================
+
+/// Edge weight multiplier by ExperienceType at graph ingestion time.
+/// Applied multiplicatively to `L1Working.initial_weight()` in
+/// `process_experience_into_graph`. Intentional types get full weight;
+/// auto-generated noise types get dampened.
+///
+/// Reference: Signal detection theory (Green & Swets, 1966)
+pub const EDGE_WEIGHT_MULT_DECISION: f32 = 1.0;
+pub const EDGE_WEIGHT_MULT_LEARNING: f32 = 1.0;
+pub const EDGE_WEIGHT_MULT_DISCOVERY: f32 = 1.0;
+pub const EDGE_WEIGHT_MULT_ERROR: f32 = 0.9;
+pub const EDGE_WEIGHT_MULT_PATTERN: f32 = 1.0;
+pub const EDGE_WEIGHT_MULT_OBSERVATION: f32 = 0.8;
+pub const EDGE_WEIGHT_MULT_CONTEXT: f32 = 0.7;
+pub const EDGE_WEIGHT_MULT_TASK: f32 = 0.8;
+pub const EDGE_WEIGHT_MULT_CONVERSATION: f32 = 0.5;
+pub const EDGE_WEIGHT_MULT_CODE_EDIT: f32 = 0.3;
+pub const EDGE_WEIGHT_MULT_FILE_ACCESS: f32 = 0.25;
+pub const EDGE_WEIGHT_MULT_SEARCH: f32 = 0.25;
+pub const EDGE_WEIGHT_MULT_COMMAND: f32 = 0.3;
+pub const EDGE_WEIGHT_MULT_INTENTION: f32 = 0.9;
+
+/// Activation multiplier for spreading activation retrieval (read-time).
+/// Applied to `final_score` when resolving episodes to memories.
+/// Complementary to write-time dampening — stacks multiplicatively.
+///
+/// Effective combined signal: CodeEdit = 0.3 × 0.4 = 0.12x of Decision.
+/// CodeEdit memories still surface through vector search (Layer 1/3)
+/// when semantically relevant; only the graph path is dampened.
+pub const ACTIVATION_MULT_DECISION: f32 = 1.0;
+pub const ACTIVATION_MULT_LEARNING: f32 = 1.0;
+pub const ACTIVATION_MULT_DISCOVERY: f32 = 1.0;
+pub const ACTIVATION_MULT_ERROR: f32 = 0.95;
+pub const ACTIVATION_MULT_PATTERN: f32 = 1.0;
+pub const ACTIVATION_MULT_OBSERVATION: f32 = 0.85;
+pub const ACTIVATION_MULT_CONTEXT: f32 = 0.75;
+pub const ACTIVATION_MULT_TASK: f32 = 0.85;
+pub const ACTIVATION_MULT_CONVERSATION: f32 = 0.6;
+pub const ACTIVATION_MULT_CODE_EDIT: f32 = 0.4;
+pub const ACTIVATION_MULT_FILE_ACCESS: f32 = 0.35;
+pub const ACTIVATION_MULT_SEARCH: f32 = 0.35;
+pub const ACTIVATION_MULT_COMMAND: f32 = 0.4;
+pub const ACTIVATION_MULT_INTENTION: f32 = 0.95;
+
+/// Importance floor for `strengthen_with_importance()`.
+/// Even low-importance memories get this fraction of the full Hebbian boost,
+/// preventing complete starvation of auto-generated edge strengthening.
+pub const STRENGTHEN_IMPORTANCE_FLOOR: f32 = 0.2;
+
+/// Layer 5 tag penalties for auto-generated content.
+/// Multiplicative on final unified score.
+/// Combined penalty for assistant-response + auto-captured = 0.85 × 0.90 = 0.765.
+pub const AUTO_CAPTURED_TAG_PENALTY: f32 = 0.85;
+pub const ASSISTANT_RESPONSE_TAG_PENALTY: f32 = 0.90;
+
+// =============================================================================
 // LONG-TERM POTENTIATION (LTP) CONSTANTS
 // Based on synaptic plasticity and Hebbian learning theory
 // =============================================================================

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -7388,6 +7388,111 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_strengthen_with_importance_scales_boost() {
+        // Verify: high-importance strengthening produces stronger edges than low-importance,
+        // and low-importance still strengthens (floor = STRENGTHEN_IMPORTANCE_FLOOR = 0.2).
+        let temp_dir = tempfile::tempdir().unwrap();
+        let graph = GraphMemory::new(temp_dir.path(), None).unwrap();
+
+        let from_uuid = Uuid::new_v4();
+        let to_uuid = Uuid::new_v4();
+
+        for (uuid, name) in [(from_uuid, "ImportanceFrom"), (to_uuid, "ImportanceTo")] {
+            let entity = EntityNode {
+                uuid,
+                name: name.to_string(),
+                labels: vec![EntityLabel::Concept],
+                created_at: Utc::now(),
+                last_seen_at: Utc::now(),
+                mention_count: 1,
+                summary: String::new(),
+                attributes: std::collections::HashMap::new(),
+                name_embedding: None,
+                salience: 0.5,
+                is_proper_noun: false,
+                selectivity: None,
+            };
+            graph.add_entity(entity).unwrap();
+        }
+
+        let initial_strength = 0.3;
+
+        // Create two identical edges — one will get high-importance, one low-importance
+        let mut make_edge = || RelationshipEdge {
+            uuid: Uuid::new_v4(),
+            from_entity: from_uuid,
+            to_entity: to_uuid,
+            relation_type: RelationType::RelatedTo,
+            strength: initial_strength,
+            created_at: Utc::now(),
+            valid_at: Utc::now(),
+            invalidated_at: None,
+            source_episode_id: None,
+            context: "importance test".to_string(),
+            last_activated: Utc::now(),
+            activation_count: 1,
+            ltp_status: LtpStatus::None,
+            activation_timestamps: None,
+            tier: EdgeTier::L2Episodic,
+            entity_confidence: None,
+            forman_curvature: None,
+            endpoint_selectivity: None,
+        };
+
+        let high_edge_uuid = graph.add_relationship(make_edge()).unwrap();
+        let low_edge_uuid = graph.add_relationship(make_edge()).unwrap();
+
+        // Strengthen with high importance (1.0) — should get full boost
+        graph
+            .batch_strengthen_synapses_with_importance(&[high_edge_uuid], 1.0)
+            .unwrap();
+
+        // Strengthen with low importance (0.0) — should get floor boost (0.2x)
+        graph
+            .batch_strengthen_synapses_with_importance(&[low_edge_uuid], 0.0)
+            .unwrap();
+
+        let high_edge = graph.get_relationship(&high_edge_uuid).unwrap().unwrap();
+        let low_edge = graph.get_relationship(&low_edge_uuid).unwrap().unwrap();
+
+        // Both should be stronger than initial
+        assert!(
+            high_edge.strength > initial_strength,
+            "High-importance edge should strengthen: {} > {}",
+            high_edge.strength,
+            initial_strength
+        );
+        assert!(
+            low_edge.strength > initial_strength,
+            "Low-importance edge should still strengthen (floor=0.2): {} > {}",
+            low_edge.strength,
+            initial_strength
+        );
+
+        // High-importance should be stronger than low-importance
+        assert!(
+            high_edge.strength > low_edge.strength,
+            "High-importance edge should be stronger: {} > {}",
+            high_edge.strength,
+            low_edge.strength
+        );
+
+        // Verify the ratio roughly matches expected scaling:
+        // high boost ≈ base * 1.0, low boost ≈ base * 0.2
+        let high_delta = high_edge.strength - initial_strength;
+        let low_delta = low_edge.strength - initial_strength;
+        let ratio = high_delta / low_delta;
+        // Expected ratio ≈ 1.0 / 0.2 = 5.0 (not exact due to (1-strength) term)
+        assert!(
+            ratio > 3.0 && ratio < 7.0,
+            "Boost ratio should be ~5x (floor=0.2), got {:.2}x (high_delta={:.4}, low_delta={:.4})",
+            ratio,
+            high_delta,
+            low_delta
+        );
+    }
+
     // =========================================================================
     // Forman-Ricci Curvature Tests
     // Reference: Leal, Restrepo, Stadler, Jost (2018) arXiv:1811.07825

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -7395,10 +7395,19 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let graph = GraphMemory::new(temp_dir.path(), None).unwrap();
 
-        let from_uuid = Uuid::new_v4();
-        let to_uuid = Uuid::new_v4();
+        // Use separate entity pairs so add_relationship doesn't dedup
+        // (same from+to+relation_type gets merged into existing edge)
+        let high_from = Uuid::new_v4();
+        let high_to = Uuid::new_v4();
+        let low_from = Uuid::new_v4();
+        let low_to = Uuid::new_v4();
 
-        for (uuid, name) in [(from_uuid, "ImportanceFrom"), (to_uuid, "ImportanceTo")] {
+        for (uuid, name) in [
+            (high_from, "HighFrom"),
+            (high_to, "HighTo"),
+            (low_from, "LowFrom"),
+            (low_to, "LowTo"),
+        ] {
             let entity = EntityNode {
                 uuid,
                 name: name.to_string(),
@@ -7418,11 +7427,10 @@ mod tests {
 
         let initial_strength = 0.3;
 
-        // Create two identical edges — one will get high-importance, one low-importance
-        let mut make_edge = || RelationshipEdge {
+        let make_edge = |from: Uuid, to: Uuid| RelationshipEdge {
             uuid: Uuid::new_v4(),
-            from_entity: from_uuid,
-            to_entity: to_uuid,
+            from_entity: from,
+            to_entity: to,
             relation_type: RelationType::RelatedTo,
             strength: initial_strength,
             created_at: Utc::now(),
@@ -7440,8 +7448,8 @@ mod tests {
             endpoint_selectivity: None,
         };
 
-        let high_edge_uuid = graph.add_relationship(make_edge()).unwrap();
-        let low_edge_uuid = graph.add_relationship(make_edge()).unwrap();
+        let high_edge_uuid = graph.add_relationship(make_edge(high_from, high_to)).unwrap();
+        let low_edge_uuid = graph.add_relationship(make_edge(low_from, low_to)).unwrap();
 
         // Strengthen with high importance (1.0) — should get full boost
         graph

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -635,8 +635,7 @@ impl RelationshipEdge {
     pub fn strengthen_with_importance(&mut self, importance: f32) -> Option<(String, String)> {
         use crate::constants::*;
 
-        let scale =
-            STRENGTHEN_IMPORTANCE_FLOOR + importance * (1.0 - STRENGTHEN_IMPORTANCE_FLOOR);
+        let scale = STRENGTHEN_IMPORTANCE_FLOOR + importance * (1.0 - STRENGTHEN_IMPORTANCE_FLOOR);
 
         let now = Utc::now();
         self.activation_count += 1;
@@ -7448,7 +7447,9 @@ mod tests {
             endpoint_selectivity: None,
         };
 
-        let high_edge_uuid = graph.add_relationship(make_edge(high_from, high_to)).unwrap();
+        let high_edge_uuid = graph
+            .add_relationship(make_edge(high_from, high_to))
+            .unwrap();
         let low_edge_uuid = graph.add_relationship(make_edge(low_from, low_to)).unwrap();
 
         // Strengthen with high importance (1.0) — should get full boost

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -622,6 +622,112 @@ impl RelationshipEdge {
         promotion_result
     }
 
+    /// Importance-gated Hebbian strengthening.
+    ///
+    /// Identical to `strengthen()` but scales the Hebbian boost by source memory
+    /// importance. The importance is mapped to [`STRENGTHEN_IMPORTANCE_FLOOR`, 1.0],
+    /// so even low-importance memories still strengthen edges (preventing starvation),
+    /// but high-importance memories get disproportionately stronger edges — making
+    /// them win during spreading activation traversal.
+    ///
+    /// Use this instead of `strengthen()` when the source memory importance is known
+    /// (e.g., in `reinforce_recall` where recalled memory IDs are available).
+    pub fn strengthen_with_importance(&mut self, importance: f32) -> Option<(String, String)> {
+        use crate::constants::*;
+
+        let scale =
+            STRENGTHEN_IMPORTANCE_FLOOR + importance * (1.0 - STRENGTHEN_IMPORTANCE_FLOOR);
+
+        let now = Utc::now();
+        self.activation_count += 1;
+        self.last_activated = now;
+
+        self.record_activation_timestamp(now);
+
+        let tier_boost = match self.tier {
+            EdgeTier::L1Working => TIER_CO_ACCESS_BOOST,
+            EdgeTier::L2Episodic => TIER_CO_ACCESS_BOOST * 0.8,
+            EdgeTier::L3Semantic => TIER_CO_ACCESS_BOOST * 0.5,
+        };
+        // Scale the boost by importance: high-importance → full boost, low → 20% floor
+        let boost = (LTP_LEARNING_RATE + tier_boost) * (1.0 - self.strength) * scale;
+        self.strength = (self.strength + boost).min(1.0);
+
+        // LTP detection (same as strengthen — only upgrade, never downgrade)
+        let new_ltp_status = self.detect_ltp_status(now);
+        if new_ltp_status.priority() > self.ltp_status.priority() {
+            let old_status = self.ltp_status;
+            self.ltp_status = new_ltp_status;
+
+            let bonus = match new_ltp_status {
+                LtpStatus::Burst { .. } => 0.05,
+                LtpStatus::Weekly => 0.1,
+                LtpStatus::Full => 0.2,
+                LtpStatus::None => 0.0,
+            };
+            self.strength = (self.strength + bonus).min(1.0);
+
+            tracing::debug!(
+                "Edge {} LTP upgrade: {:?} → {:?} (activations: {}, age: {} days)",
+                self.uuid,
+                old_status,
+                self.ltp_status,
+                self.activation_count,
+                (now - self.created_at).num_days()
+            );
+        }
+
+        if self.ltp_status.is_burst_expired() {
+            let weekly_check = self.detect_weekly_pattern();
+            if weekly_check {
+                self.ltp_status = LtpStatus::Weekly;
+            } else {
+                self.ltp_status = LtpStatus::None;
+            }
+        }
+
+        // Tier promotion
+        let mut promotion_result = None;
+        if let Some(threshold) = self.tier.promotion_threshold() {
+            if self.strength >= threshold {
+                if let Some(next_tier) = self.tier.next_tier() {
+                    let old_tier = self.tier;
+                    self.tier = next_tier;
+                    self.strength = self.strength.max(next_tier.initial_weight());
+
+                    if old_tier == EdgeTier::L1Working {
+                        self.activation_timestamps =
+                            Some(VecDeque::with_capacity(ACTIVATION_HISTORY_L2_CAPACITY));
+                        if let Some(ref mut ts) = self.activation_timestamps {
+                            ts.push_back(now);
+                        }
+                    }
+
+                    if old_tier == EdgeTier::L2Episodic {
+                        if let Some(ref mut ts) = self.activation_timestamps {
+                            let current = ts.capacity();
+                            if current < ACTIVATION_HISTORY_L3_CAPACITY {
+                                ts.reserve(ACTIVATION_HISTORY_L3_CAPACITY - current);
+                            }
+                        }
+                    }
+
+                    tracing::debug!(
+                        "Edge {} promoted: {:?} → {:?}",
+                        self.uuid,
+                        old_tier,
+                        self.tier
+                    );
+
+                    promotion_result =
+                        Some((format!("{:?}", old_tier), format!("{:?}", self.tier)));
+                }
+            }
+        }
+
+        promotion_result
+    }
+
     /// Record an activation timestamp (PIPE-4)
     ///
     /// Only records for L2+ edges. Maintains capacity limits.
@@ -3215,6 +3321,64 @@ impl GraphMemory {
         }
 
         // Atomic write of all updates
+        if strengthened > 0 {
+            self.db.write(batch)?;
+        }
+
+        Ok(strengthened)
+    }
+
+    /// Importance-gated batch strengthening.
+    ///
+    /// Same as `batch_strengthen_synapses` but calls `strengthen_with_importance(importance)`
+    /// instead of `strengthen()`. The importance value scales the Hebbian boost
+    /// from [`STRENGTHEN_IMPORTANCE_FLOOR`, 1.0].
+    pub fn batch_strengthen_synapses_with_importance(
+        &self,
+        edge_uuids: &[Uuid],
+        importance: f32,
+    ) -> Result<usize> {
+        if edge_uuids.is_empty() {
+            return Ok(0);
+        }
+
+        let _guard = self
+            .synapse_update_lock
+            .try_lock_for(std::time::Duration::from_secs(5))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "synapse_update_lock timeout in batch_strengthen_synapses_with_importance"
+                )
+            })?;
+
+        let keys: Vec<[u8; 16]> = edge_uuids.iter().map(|u| *u.as_bytes()).collect();
+        let key_refs: Vec<&[u8]> = keys.iter().map(|k| k.as_slice()).collect();
+        let results = self
+            .db
+            .batched_multi_get_cf(self.relationships_cf(), &key_refs, false);
+
+        let mut batch = WriteBatch::default();
+        let mut strengthened = 0;
+
+        for (i, result) in results.into_iter().enumerate() {
+            if let Ok(Some(value)) = result {
+                if let Ok((mut edge, _)) =
+                    crate::serialization::try_decode::<RelationshipEdge>(&value)
+                {
+                    let _ = edge.strengthen_with_importance(importance);
+                    match crate::serialization::encode(&edge) {
+                        Ok(encoded) => {
+                            batch.put_cf(self.relationships_cf(), keys[i], encoded);
+                            strengthened += 1;
+                        }
+                        Err(e) => {
+                            tracing::debug!("Failed to serialize edge {}: {}", edge_uuids[i], e);
+                        }
+                    }
+                }
+            }
+        }
+
         if strengthened > 0 {
             self.db.write(batch)?;
         }

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -3064,6 +3064,11 @@ impl MultiUserMemoryManager {
             base_strength
         };
 
+        // Type-aware edge dampening: noise types (CodeEdit, Command, FileAccess, Search)
+        // create weaker edges to prevent their ~6:1 volume advantage over intentional
+        // memories from dominating graph traversal. Stacks with reward modulation above.
+        let edge_strength = edge_strength * experience.experience_type.edge_weight_multiplier();
+
         for i in 0..entity_uuids.len() {
             for j in (i + 1)..entity_uuids.len() {
                 // Edge quality gate using graph reputation

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -940,7 +940,12 @@ pub fn spreading_activation_retrieve_with_stats(
                 .map(|c| (c.source.credibility - 0.5).max(0.0) * 0.1)
                 .unwrap_or(0.0);
 
-            let final_score = hybrid_score + recency_boost + arousal_boost + credibility_boost;
+            // Type-aware activation dampening: noise types (CodeEdit, Command, etc.)
+            // get reduced activation scores so intentional memories rank higher.
+            // This is the read-time complement to write-time edge dampening.
+            let type_dampening = memory.experience.experience_type.activation_multiplier();
+            let final_score =
+                (hybrid_score + recency_boost + arousal_boost + credibility_boost) * type_dampening;
 
             scored_memories.push(ActivatedMemory {
                 memory,

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -5347,7 +5347,29 @@ impl MemorySystem {
                 Ok(edge_uuids) if !edge_uuids.is_empty() => {
                     let result = match outcome {
                         RetrievalOutcome::Helpful => {
-                            graph.read().batch_strengthen_synapses(&edge_uuids)
+                            // Importance-gated strengthening: high-importance recalled
+                            // memories get stronger Hebbian boosts on their graph edges.
+                            let avg_importance = {
+                                let mut total = 0.0_f32;
+                                let mut count = 0_usize;
+                                for id in memory_ids {
+                                    if let Ok(mem) = self.long_term_memory.get(id) {
+                                        total += mem.importance();
+                                        count += 1;
+                                    }
+                                }
+                                if count > 0 {
+                                    total / count as f32
+                                } else {
+                                    0.5
+                                }
+                            };
+                            graph
+                                .read()
+                                .batch_strengthen_synapses_with_importance(
+                                    &edge_uuids,
+                                    avg_importance,
+                                )
                         }
                         RetrievalOutcome::Misleading => graph
                             .read()

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -5386,12 +5386,10 @@ impl MemorySystem {
                                     0.5
                                 }
                             };
-                            graph
-                                .read()
-                                .batch_strengthen_synapses_with_importance(
-                                    &edge_uuids,
-                                    avg_importance,
-                                )
+                            graph.read().batch_strengthen_synapses_with_importance(
+                                &edge_uuids,
+                                avg_importance,
+                            )
                         }
                         RetrievalOutcome::Misleading => graph
                             .read()

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -2741,7 +2741,29 @@ impl MemorySystem {
                 // on the base. This preserves RRF ranking while allowing signals to modulate.
                 let combined_boost =
                     1.0 + recency_factor + arousal_factor + credibility_factor + temporal_factor;
-                let final_score = base * importance_factor * combined_boost * feedback_multiplier;
+
+                // AUTO-CAPTURED TAG PENALTY (PIPE-8)
+                // Hook-ingested memories carry "auto-captured" tag; assistant responses
+                // carry "assistant-response". Apply multiplicative penalty so they don't
+                // outrank intentional memories when volume gives them a ranking edge.
+                let tag_penalty = {
+                    let mut penalty = 1.0_f32;
+                    for tag in &mem.experience.tags {
+                        match tag.as_str() {
+                            "auto-captured" => {
+                                penalty *= crate::constants::AUTO_CAPTURED_TAG_PENALTY
+                            }
+                            "assistant-response" => {
+                                penalty *= crate::constants::ASSISTANT_RESPONSE_TAG_PENALTY
+                            }
+                            _ => {}
+                        }
+                    }
+                    penalty
+                };
+
+                let final_score =
+                    base * importance_factor * combined_boost * feedback_multiplier * tag_penalty;
 
                 let mut cloned: Memory = mem.as_ref().clone();
                 cloned.set_score(final_score);

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -4536,7 +4536,7 @@ mod tests {
 
     #[test]
     fn test_auto_captured_tag_penalty_bounds() {
-        use crate::constants::{AUTO_CAPTURED_TAG_PENALTY, ASSISTANT_RESPONSE_TAG_PENALTY};
+        use crate::constants::{ASSISTANT_RESPONSE_TAG_PENALTY, AUTO_CAPTURED_TAG_PENALTY};
 
         // Individual penalties should be in (0.8, 1.0) — meaningful but not devastating
         assert!(

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -52,6 +52,63 @@ pub enum ExperienceType {
     Intention,
 }
 
+impl ExperienceType {
+    /// Write-time edge weight multiplier for graph ingestion.
+    ///
+    /// Intentional types (Decision, Learning, Discovery) get full weight.
+    /// Auto-generated noise types (CodeEdit, Command, FileAccess, Search) get
+    /// dampened to prevent their 6:1 volume advantage from dominating graph
+    /// traversal over intentional memories.
+    ///
+    /// Applied multiplicatively to `L1Working.initial_weight()` in
+    /// `process_experience_into_graph`.
+    pub fn edge_weight_multiplier(&self) -> f32 {
+        use crate::constants::*;
+        match self {
+            Self::Decision => EDGE_WEIGHT_MULT_DECISION,
+            Self::Learning => EDGE_WEIGHT_MULT_LEARNING,
+            Self::Discovery => EDGE_WEIGHT_MULT_DISCOVERY,
+            Self::Error => EDGE_WEIGHT_MULT_ERROR,
+            Self::Pattern => EDGE_WEIGHT_MULT_PATTERN,
+            Self::Observation => EDGE_WEIGHT_MULT_OBSERVATION,
+            Self::Context => EDGE_WEIGHT_MULT_CONTEXT,
+            Self::Task => EDGE_WEIGHT_MULT_TASK,
+            Self::Conversation => EDGE_WEIGHT_MULT_CONVERSATION,
+            Self::CodeEdit => EDGE_WEIGHT_MULT_CODE_EDIT,
+            Self::FileAccess => EDGE_WEIGHT_MULT_FILE_ACCESS,
+            Self::Search => EDGE_WEIGHT_MULT_SEARCH,
+            Self::Command => EDGE_WEIGHT_MULT_COMMAND,
+            Self::Intention => EDGE_WEIGHT_MULT_INTENTION,
+        }
+    }
+
+    /// Retrieval-time activation multiplier for spreading activation.
+    ///
+    /// Applied to `final_score` when resolving episodes to memories during
+    /// graph-based retrieval. Complementary to write-time dampening — stacks
+    /// multiplicatively. CodeEdit memories still surface through vector search
+    /// (Layers 1/3) when semantically relevant; only the graph path is dampened.
+    pub fn activation_multiplier(&self) -> f32 {
+        use crate::constants::*;
+        match self {
+            Self::Decision => ACTIVATION_MULT_DECISION,
+            Self::Learning => ACTIVATION_MULT_LEARNING,
+            Self::Discovery => ACTIVATION_MULT_DISCOVERY,
+            Self::Error => ACTIVATION_MULT_ERROR,
+            Self::Pattern => ACTIVATION_MULT_PATTERN,
+            Self::Observation => ACTIVATION_MULT_OBSERVATION,
+            Self::Context => ACTIVATION_MULT_CONTEXT,
+            Self::Task => ACTIVATION_MULT_TASK,
+            Self::Conversation => ACTIVATION_MULT_CONVERSATION,
+            Self::CodeEdit => ACTIVATION_MULT_CODE_EDIT,
+            Self::FileAccess => ACTIVATION_MULT_FILE_ACCESS,
+            Self::Search => ACTIVATION_MULT_SEARCH,
+            Self::Command => ACTIVATION_MULT_COMMAND,
+            Self::Intention => ACTIVATION_MULT_INTENTION,
+        }
+    }
+}
+
 /// Default experience type for minimal API calls
 fn default_experience_type() -> ExperienceType {
     ExperienceType::Observation
@@ -4397,5 +4454,83 @@ mod tests {
         assert!(query.geo_filter.is_some());
         assert_eq!(query.action_type, Some("landing".to_string()));
         assert_eq!(query.reward_range, Some((0.5, 1.0)));
+    }
+
+    #[test]
+    fn test_edge_weight_multiplier_intentional_types_full_weight() {
+        assert_eq!(ExperienceType::Decision.edge_weight_multiplier(), 1.0);
+        assert_eq!(ExperienceType::Learning.edge_weight_multiplier(), 1.0);
+        assert_eq!(ExperienceType::Discovery.edge_weight_multiplier(), 1.0);
+        assert_eq!(ExperienceType::Pattern.edge_weight_multiplier(), 1.0);
+    }
+
+    #[test]
+    fn test_edge_weight_multiplier_noise_types_dampened() {
+        let noise_types = [
+            ExperienceType::CodeEdit,
+            ExperienceType::Command,
+            ExperienceType::FileAccess,
+            ExperienceType::Search,
+        ];
+        for t in &noise_types {
+            let m = t.edge_weight_multiplier();
+            assert!(
+                m > 0.0 && m < 0.5,
+                "{:?} edge_weight_multiplier should be in (0.0, 0.5), got {}",
+                t,
+                m
+            );
+        }
+    }
+
+    #[test]
+    fn test_edge_weight_multiplier_mid_tier_types() {
+        // Conversation, Observation, Context, Task: intermediate dampening
+        assert!(ExperienceType::Conversation.edge_weight_multiplier() >= 0.4);
+        assert!(ExperienceType::Conversation.edge_weight_multiplier() <= 0.6);
+        assert!(ExperienceType::Observation.edge_weight_multiplier() >= 0.7);
+        assert!(ExperienceType::Task.edge_weight_multiplier() >= 0.7);
+    }
+
+    #[test]
+    fn test_activation_multiplier_intentional_types_full() {
+        assert_eq!(ExperienceType::Decision.activation_multiplier(), 1.0);
+        assert_eq!(ExperienceType::Learning.activation_multiplier(), 1.0);
+        assert_eq!(ExperienceType::Discovery.activation_multiplier(), 1.0);
+        assert_eq!(ExperienceType::Pattern.activation_multiplier(), 1.0);
+    }
+
+    #[test]
+    fn test_activation_multiplier_noise_types_dampened() {
+        let noise_types = [
+            ExperienceType::CodeEdit,
+            ExperienceType::Command,
+            ExperienceType::FileAccess,
+            ExperienceType::Search,
+        ];
+        for t in &noise_types {
+            let m = t.activation_multiplier();
+            assert!(
+                m > 0.0 && m < 0.5,
+                "{:?} activation_multiplier should be in (0.0, 0.5), got {}",
+                t,
+                m
+            );
+        }
+    }
+
+    #[test]
+    fn test_combined_dampening_effective() {
+        // Combined write × read dampening for CodeEdit should be < 0.15x of Decision
+        let code_edit_combined = ExperienceType::CodeEdit.edge_weight_multiplier()
+            * ExperienceType::CodeEdit.activation_multiplier();
+        let decision_combined = ExperienceType::Decision.edge_weight_multiplier()
+            * ExperienceType::Decision.activation_multiplier();
+        assert!(
+            code_edit_combined < 0.15,
+            "CodeEdit combined dampening should be < 0.15x, got {}",
+            code_edit_combined
+        );
+        assert_eq!(decision_combined, 1.0);
     }
 }

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -4533,4 +4533,59 @@ mod tests {
         );
         assert_eq!(decision_combined, 1.0);
     }
+
+    #[test]
+    fn test_auto_captured_tag_penalty_bounds() {
+        use crate::constants::{AUTO_CAPTURED_TAG_PENALTY, ASSISTANT_RESPONSE_TAG_PENALTY};
+
+        // Individual penalties should be in (0.8, 1.0) — meaningful but not devastating
+        assert!(
+            AUTO_CAPTURED_TAG_PENALTY > 0.80 && AUTO_CAPTURED_TAG_PENALTY < 1.0,
+            "AUTO_CAPTURED_TAG_PENALTY should be in (0.80, 1.0), got {}",
+            AUTO_CAPTURED_TAG_PENALTY
+        );
+        assert!(
+            ASSISTANT_RESPONSE_TAG_PENALTY > 0.80 && ASSISTANT_RESPONSE_TAG_PENALTY < 1.0,
+            "ASSISTANT_RESPONSE_TAG_PENALTY should be in (0.80, 1.0), got {}",
+            ASSISTANT_RESPONSE_TAG_PENALTY
+        );
+
+        // Combined penalty (both tags) should still be >= 0.5 — no cliff
+        let combined = AUTO_CAPTURED_TAG_PENALTY * ASSISTANT_RESPONSE_TAG_PENALTY;
+        assert!(
+            combined >= 0.5,
+            "Combined tag penalty should be >= 0.5, got {}",
+            combined
+        );
+    }
+
+    #[test]
+    fn test_full_pipeline_signal_reduction() {
+        // End-to-end: CodeEdit through graph + tag penalty vs Decision
+        // CodeEdit: edge_weight(0.3) × activation(0.4) × tag(0.85) = ~0.102
+        // Decision: edge_weight(1.0) × activation(1.0) × tag(1.0) = 1.0
+        use crate::constants::AUTO_CAPTURED_TAG_PENALTY;
+
+        let code_edit_full = ExperienceType::CodeEdit.edge_weight_multiplier()
+            * ExperienceType::CodeEdit.activation_multiplier()
+            * AUTO_CAPTURED_TAG_PENALTY;
+        let decision_full = ExperienceType::Decision.edge_weight_multiplier()
+            * ExperienceType::Decision.activation_multiplier()
+            * 1.0; // Decision has no auto-captured tag
+
+        assert!(
+            code_edit_full < 0.15,
+            "CodeEdit full pipeline should be < 0.15x, got {:.4}",
+            code_edit_full
+        );
+        assert_eq!(decision_full, 1.0);
+
+        // Signal ratio: Decision should be at least 6x stronger than CodeEdit
+        let ratio = decision_full / code_edit_full;
+        assert!(
+            ratio > 6.0,
+            "Decision/CodeEdit signal ratio should be > 6x, got {:.1}x",
+            ratio
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Hook-generated memories (CodeEdit, Command, FileAccess, Search) dominate graph traversal through sheer volume (~6:1 edge ratio over intentional memories). The graph pipeline was completely type-blind — every memory type created edges with identical weights, strengthening, and traversal treatment.

This PR makes the graph pipeline type-aware at both write-time and read-time:

- **Write-time edge dampening**: `ExperienceType::edge_weight_multiplier()` scales initial edge strength in `process_experience_into_graph` (Decision=1.0, CodeEdit=0.3)
- **Read-time activation dampening**: `ExperienceType::activation_multiplier()` scales `final_score` in spreading activation (Decision=1.0, CodeEdit=0.4)
- **Importance-gated Hebbian strengthening**: `strengthen_with_importance()` scales boost by source memory importance [0.2, 1.0] floor, so high-importance memories get stronger edge reinforcement
- **Auto-captured tag penalty**: Layer 5 multiplicative penalty for "auto-captured" (0.85x) and "assistant-response" (0.90x) tagged memories

### Effective signal reduction

| Memory type | Write | Read | Tag | Combined |
|---|---|---|---|---|
| Decision | 1.0 | 1.0 | 1.0 | **1.0x** |
| Learning | 1.0 | 1.0 | 1.0 | **1.0x** |
| CodeEdit (hook) | 0.3 | 0.4 | 0.85 | **~0.10x** |
| Command (hook) | 0.3 | 0.4 | 0.85 | **~0.10x** |
| Conversation | 0.5 | 0.6 | 0.85×0.90 | **~0.23x** |

CodeEdit memories still surface through vector search (Layers 1/3) when semantically relevant — only the graph path is dampened.

## Files changed

| File | Changes |
|---|---|
| `src/constants.rs` | 30+ new constants (PIPE-8 section) |
| `src/memory/types.rs` | `edge_weight_multiplier()`, `activation_multiplier()` + 6 tests |
| `src/handlers/state.rs` | 1-line edge dampening in `process_experience_into_graph` |
| `src/graph_memory.rs` | `strengthen_with_importance()` + batch variant + test |
| `src/memory/mod.rs` | Importance-gated feedback + Layer 5 tag penalty |
| `src/memory/graph_retrieval.rs` | Type dampening in spreading activation |

## Test plan

- [x] `cargo check` after each commit
- [x] `cargo clippy` clean
- [ ] `cargo test` (CI)
- [ ] Manual: `recall` with mode=associative — Learning should rank above CodeEdit
- [ ] Manual: `recall` with mode=hybrid — verify intentional memories dominate