### PR TITLE
feat(recall): RH-4 — recall-eval binary + JSON report schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,10 @@ path = "src/main.rs"
 name = "shodh"
 path = "src/cli.rs"
 
+[[bin]]
+name = "recall-eval"
+path = "src/bin/recall_eval.rs"
+
 [dependencies]
 # MCP Protocol
 rmcp = { version = "0.12", features = ["server", "macros", "transport-io"] }

--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -1,0 +1,209 @@
+//! `recall-eval` — run the L1 smoke suite and emit a machine-diffable report.
+//!
+//! Used by:
+//! - **RH-5 CI gate** to fail PRs that regress recall by more than the
+//!   tolerance against the checked-in baseline.
+//! - **RH-6 baseline capture** to record the current production numbers on
+//!   `main`.
+//! - **Humans** comparing embedder swaps, scoring tweaks, and pipeline
+//!   refactors via JSON diff.
+//!
+//! See issue #266 for the full schema and acceptance criteria. RH-8 will
+//! widen this binary with `--layer` once per-pipeline-layer attribution is
+//! plumbed through `MemorySystem`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use clap::{Parser, ValueEnum};
+
+use shodh_memory::recall_harness::report::{compare_to_baseline, Report};
+use shodh_memory::recall_harness::runner::{run_smoke_suite, RunInputs};
+
+/// Exit codes — kept stable so CI scripts can branch on them.
+const EXIT_PASS: i32 = 0;
+const EXIT_REGRESSION: i32 = 1;
+const EXIT_INFRASTRUCTURE: i32 = 2;
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+enum Suite {
+    /// L1 smoke suite — 30 hand-crafted shodh queries (see issue #265).
+    Smoke,
+}
+
+impl Suite {
+    fn as_str(self) -> &'static str {
+        match self {
+            Suite::Smoke => "smoke",
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "recall-eval",
+    about = "Run the recall harness and emit a JSON report."
+)]
+struct Args {
+    /// Suite to run. Only `smoke` is implemented today; `regression` and
+    /// `deep` ship with RH-7.
+    #[arg(long, value_enum, default_value_t = Suite::Smoke)]
+    suite: Suite,
+
+    /// Path to write the JSON report to.
+    #[arg(long)]
+    output: PathBuf,
+
+    /// Optional baseline report to compare against. When provided, a
+    /// regression in any gating metric beyond `--tolerance` exits with
+    /// status `1`.
+    #[arg(long)]
+    baseline: Option<PathBuf>,
+
+    /// Allowed regression in percent of baseline. Default: 2.0%.
+    #[arg(long, default_value_t = 2.0)]
+    tolerance: f64,
+
+    /// Optional storage directory for the harness's `MemorySystem`. When
+    /// omitted, a unique directory under the system temp dir is used and
+    /// kept on disk so a failed run can be inspected.
+    #[arg(long)]
+    storage: Option<PathBuf>,
+}
+
+fn main() {
+    let args = Args::parse();
+    let exit = match run(&args) {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("recall-eval: infrastructure failure: {e:#}");
+            EXIT_INFRASTRUCTURE
+        }
+    };
+    std::process::exit(exit);
+}
+
+fn run(args: &Args) -> Result<i32> {
+    let storage_path = args
+        .storage
+        .clone()
+        .unwrap_or_else(|| default_storage_dir(args.suite.as_str()));
+
+    let git_sha = current_git_sha().unwrap_or_else(|_| "unknown".to_string());
+
+    let inputs = RunInputs {
+        storage_path: storage_path.clone(),
+        corpus_path: None,
+        cases_path: None,
+        suite: args.suite.as_str().to_string(),
+        git_sha,
+    };
+
+    let mut report = run_smoke_suite(&inputs).context("running smoke suite")?;
+
+    if let Some(baseline_path) = &args.baseline {
+        let baseline_bytes = std::fs::read(baseline_path)
+            .with_context(|| format!("reading baseline {}", baseline_path.display()))?;
+        let baseline: Report = serde_json::from_slice(&baseline_bytes)
+            .with_context(|| format!("parsing baseline {}", baseline_path.display()))?;
+        let mut regressions = compare_to_baseline(&baseline, &report, args.tolerance);
+        report.failures.append(&mut regressions);
+    }
+
+    write_report(&args.output, &report)?;
+
+    eprintln!(
+        "recall-eval: storage retained at {} (delete manually after inspection)",
+        storage_path.display()
+    );
+
+    let regression_count = report
+        .failures
+        .iter()
+        .filter(|f| f.kind == "regression")
+        .count();
+    let infra_count = report
+        .failures
+        .iter()
+        .filter(|f| f.kind == "infrastructure")
+        .count();
+
+    summarise(&report);
+
+    if infra_count > 0 {
+        Ok(EXIT_INFRASTRUCTURE)
+    } else if regression_count > 0 {
+        Ok(EXIT_REGRESSION)
+    } else {
+        Ok(EXIT_PASS)
+    }
+}
+
+fn write_report(path: &std::path::Path, report: &Report) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating output dir {}", parent.display()))?;
+        }
+    }
+    let json = serde_json::to_vec_pretty(report).context("serialising report to JSON")?;
+    std::fs::write(path, &json).with_context(|| format!("writing report to {}", path.display()))?;
+    Ok(())
+}
+
+fn summarise(report: &Report) {
+    let full = report.layers.get("full");
+    eprintln!(
+        "recall-eval: suite={} cases={} embedder={} sha={}",
+        report.suite, report.case_count, report.embedder, report.git_sha
+    );
+    if let Some(layer) = full {
+        eprintln!(
+            "  full   ndcg@10={:.4} recall@10={:.4} mrr={:.4} p@1={:.4} map={:.4}",
+            layer.ndcg_at_10, layer.recall_at_10, layer.mrr, layer.p_at_1, layer.map
+        );
+        eprintln!(
+            "  latency p50={:.1}ms p95={:.1}ms p99={:.1}ms",
+            layer.latency_p50_ms, layer.latency_p95_ms, layer.latency_p99_ms
+        );
+    }
+    for (name, cat) in &report.by_category {
+        eprintln!(
+            "  {:<10} ndcg@10={:.4} recall@10={:.4} mrr={:.4}",
+            name, cat.ndcg_at_10, cat.recall_at_10, cat.mrr
+        );
+    }
+    if !report.failures.is_empty() {
+        eprintln!("  failures ({}):", report.failures.len());
+        for f in &report.failures {
+            eprintln!("    [{}] {}", f.kind, f.detail);
+        }
+    }
+}
+
+/// Resolve the current git SHA by shelling out. Returns an error rather
+/// than panicking so the binary can still produce a report when run from a
+/// non-git checkout (e.g. a release tarball).
+fn current_git_sha() -> Result<String> {
+    let out = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .context("running `git rev-parse HEAD`")?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "`git rev-parse HEAD` failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Build a unique storage path under the system temp dir. Caller is
+/// responsible for cleanup; we deliberately do not delete on success so
+/// CI logs can preserve the storage state for debugging.
+fn default_storage_dir(suite: &str) -> PathBuf {
+    let id = uuid::Uuid::new_v4().simple().to_string();
+    std::env::temp_dir().join(format!("shodh-recall-eval-{suite}-{id}"))
+}

--- a/src/recall_harness/mod.rs
+++ b/src/recall_harness/mod.rs
@@ -7,7 +7,10 @@
 //! Submodules are added incrementally as the project lands:
 //! - `metrics` — NDCG@k, recall@k, precision@k, MRR, P@1, MAP (RH-2)
 //! - `fixtures` — L1 smoke suite loader + structural validation (RH-3)
-//! - Future: `runner` (RH-4), `report` (RH-4)
+//! - `runner` — end-to-end smoke runner against `MemorySystem` (RH-4)
+//! - `report` — JSON schema + baseline comparison (RH-4)
 
 pub mod fixtures;
 pub mod metrics;
+pub mod report;
+pub mod runner;

--- a/src/recall_harness/report.rs
+++ b/src/recall_harness/report.rs
@@ -1,0 +1,344 @@
+//! Recall-eval report types and JSON schema.
+//!
+//! These types are the contract consumed by the CI gate (RH-5) and by
+//! humans via baseline diffs. They are deliberately self-contained and
+//! `serde`-serialisable so a report file can be diffed across runs and
+//! across embedder swaps without touching the engine code.
+//!
+//! See issue #266 for the schema.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::metrics::Metrics;
+
+/// `k` value used by the L1 smoke suite for top-`k` metrics.
+pub const SMOKE_K: usize = 10;
+
+/// Top-level recall-eval report.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Report {
+    /// Suite identifier — `"smoke"` for the L1 suite.
+    pub suite: String,
+    /// Embedding model name, e.g. `"minilm-l6-v2"`.
+    pub embedder: String,
+    /// Git SHA of the working tree the run was produced from.
+    pub git_sha: String,
+    /// RFC3339 timestamp at the start of the run.
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+    /// Per-pipeline-layer aggregates. RH-4 emits a single `"full"` layer;
+    /// RH-8 will widen this map.
+    pub layers: BTreeMap<String, LayerReport>,
+    /// Per-category aggregates for the `full` layer.
+    pub by_category: BTreeMap<String, CategoryReport>,
+    /// Total number of cases run.
+    pub case_count: usize,
+    /// Cases or metrics that failed validation or regression.
+    pub failures: Vec<Failure>,
+}
+
+/// Aggregate metrics for one pipeline layer across all cases.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LayerReport {
+    #[serde(rename = "ndcg@10")]
+    pub ndcg_at_10: f64,
+    #[serde(rename = "recall@10")]
+    pub recall_at_10: f64,
+    #[serde(rename = "precision@10")]
+    pub precision_at_10: f64,
+    pub mrr: f64,
+    #[serde(rename = "p@1")]
+    pub p_at_1: f64,
+    pub map: f64,
+    pub latency_p50_ms: f64,
+    pub latency_p95_ms: f64,
+    pub latency_p99_ms: f64,
+}
+
+/// Aggregate metrics for one category — same fields as `LayerReport` minus
+/// latency, since the relevant signal at category granularity is quality.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CategoryReport {
+    #[serde(rename = "ndcg@10")]
+    pub ndcg_at_10: f64,
+    #[serde(rename = "recall@10")]
+    pub recall_at_10: f64,
+    #[serde(rename = "precision@10")]
+    pub precision_at_10: f64,
+    pub mrr: f64,
+    #[serde(rename = "p@1")]
+    pub p_at_1: f64,
+    pub map: f64,
+    pub case_count: usize,
+}
+
+/// A failure entry in the report.
+///
+/// Two flavours are emitted:
+/// - `kind = "regression"` when a baseline comparison exceeds the tolerance.
+/// - `kind = "case"` when a single case has zero relevant retrievals at all.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Failure {
+    pub kind: String,
+    pub detail: String,
+}
+
+/// Compute (p50, p95, p99) over a vector of latencies in milliseconds.
+///
+/// Uses nearest-rank percentile on a sorted copy. Returns `(0.0, 0.0, 0.0)`
+/// for an empty input. With small N (e.g. 30 smoke cases) p95 and p99 are
+/// noisy by construction; the harness reports them anyway because their
+/// trend across runs is still informative.
+pub fn latency_percentiles(samples: &[f64]) -> (f64, f64, f64) {
+    if samples.is_empty() {
+        return (0.0, 0.0, 0.0);
+    }
+    let mut sorted = samples.to_vec();
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    (
+        nearest_rank(&sorted, 0.50),
+        nearest_rank(&sorted, 0.95),
+        nearest_rank(&sorted, 0.99),
+    )
+}
+
+fn nearest_rank(sorted: &[f64], p: f64) -> f64 {
+    debug_assert!(!sorted.is_empty(), "caller checks emptiness");
+    debug_assert!((0.0..=1.0).contains(&p), "p must be in [0,1]");
+    // Nearest-rank: index = ceil(p * N) - 1, clamped to [0, N-1].
+    let n = sorted.len();
+    let idx = ((p * n as f64).ceil() as usize)
+        .saturating_sub(1)
+        .min(n - 1);
+    sorted[idx]
+}
+
+/// Aggregate per-case metrics into a [`LayerReport`] (mean of each metric).
+pub fn aggregate_layer(per_case: &[Metrics], latencies_ms: &[f64]) -> LayerReport {
+    let n = per_case.len() as f64;
+    let mean = |sel: fn(&Metrics) -> f64| -> f64 {
+        if n == 0.0 {
+            0.0
+        } else {
+            per_case.iter().map(sel).sum::<f64>() / n
+        }
+    };
+    let (p50, p95, p99) = latency_percentiles(latencies_ms);
+    LayerReport {
+        ndcg_at_10: mean(|m| m.ndcg_at_k),
+        recall_at_10: mean(|m| m.recall_at_k),
+        precision_at_10: mean(|m| m.precision_at_k),
+        mrr: mean(|m| m.mrr),
+        p_at_1: mean(|m| m.p_at_1),
+        map: mean(|m| m.map),
+        latency_p50_ms: p50,
+        latency_p95_ms: p95,
+        latency_p99_ms: p99,
+    }
+}
+
+/// Aggregate per-case metrics for one category into a [`CategoryReport`].
+pub fn aggregate_category(per_case: &[Metrics]) -> CategoryReport {
+    let n = per_case.len();
+    let div = n as f64;
+    let mean = |sel: fn(&Metrics) -> f64| -> f64 {
+        if div == 0.0 {
+            0.0
+        } else {
+            per_case.iter().map(sel).sum::<f64>() / div
+        }
+    };
+    CategoryReport {
+        ndcg_at_10: mean(|m| m.ndcg_at_k),
+        recall_at_10: mean(|m| m.recall_at_k),
+        precision_at_10: mean(|m| m.precision_at_k),
+        mrr: mean(|m| m.mrr),
+        p_at_1: mean(|m| m.p_at_1),
+        map: mean(|m| m.map),
+        case_count: n,
+    }
+}
+
+/// Compare the `full` layer of `current` against `baseline`.
+///
+/// Returns the list of regressions where `current < baseline - tolerance_pct%
+/// of baseline` for any of the gating metrics: `ndcg@10`, `recall@10`,
+/// `mrr`, `p@1`. Latency is reported but not gated because per-run hardware
+/// noise dominates.
+pub fn compare_to_baseline(
+    baseline: &Report,
+    current: &Report,
+    tolerance_pct: f64,
+) -> Vec<Failure> {
+    let Some(base_full) = baseline.layers.get("full") else {
+        return vec![Failure {
+            kind: "infrastructure".to_string(),
+            detail: "baseline report has no `full` layer".to_string(),
+        }];
+    };
+    let Some(cur_full) = current.layers.get("full") else {
+        return vec![Failure {
+            kind: "infrastructure".to_string(),
+            detail: "current report has no `full` layer".to_string(),
+        }];
+    };
+
+    let mut failures = Vec::new();
+    let frac = tolerance_pct / 100.0;
+    let mut check = |name: &str, base: f64, cur: f64| {
+        // Treat baselines at zero as a special case: any drop below zero is
+        // impossible, any non-zero current is an improvement, and zero current
+        // is a no-op. So nothing to gate.
+        if base <= 0.0 {
+            return;
+        }
+        let allowed_drop = base * frac;
+        if cur + allowed_drop < base {
+            failures.push(Failure {
+                kind: "regression".to_string(),
+                detail: format!(
+                    "{name}: baseline {base:.4}, current {cur:.4}, allowed drop {allowed_drop:.4}"
+                ),
+            });
+        }
+    };
+
+    check("ndcg@10", base_full.ndcg_at_10, cur_full.ndcg_at_10);
+    check("recall@10", base_full.recall_at_10, cur_full.recall_at_10);
+    check("mrr", base_full.mrr, cur_full.mrr);
+    check("p@1", base_full.p_at_1, cur_full.p_at_1);
+
+    failures
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metrics(values: f64) -> Metrics {
+        Metrics {
+            ndcg_at_k: values,
+            recall_at_k: values,
+            precision_at_k: values,
+            mrr: values,
+            p_at_1: values,
+            map: values,
+        }
+    }
+
+    #[test]
+    fn percentiles_empty_is_zero() {
+        assert_eq!(latency_percentiles(&[]), (0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn percentiles_single_sample() {
+        assert_eq!(latency_percentiles(&[42.0]), (42.0, 42.0, 42.0));
+    }
+
+    #[test]
+    fn percentiles_known_values() {
+        // Samples 1..=100, sorted. Nearest-rank: p50→50, p95→95, p99→99.
+        let s: Vec<f64> = (1..=100).map(|x| x as f64).collect();
+        let (p50, p95, p99) = latency_percentiles(&s);
+        assert_eq!(p50, 50.0);
+        assert_eq!(p95, 95.0);
+        assert_eq!(p99, 99.0);
+    }
+
+    #[test]
+    fn aggregate_layer_means_each_metric() {
+        let cases = [metrics(0.0), metrics(0.5), metrics(1.0)];
+        let r = aggregate_layer(&cases, &[10.0, 20.0, 30.0]);
+        assert!((r.ndcg_at_10 - 0.5).abs() < 1e-12);
+        assert!((r.mrr - 0.5).abs() < 1e-12);
+        assert_eq!(r.latency_p50_ms, 20.0);
+    }
+
+    #[test]
+    fn aggregate_layer_handles_empty() {
+        let r = aggregate_layer(&[], &[]);
+        assert_eq!(r.ndcg_at_10, 0.0);
+        assert_eq!(r.latency_p50_ms, 0.0);
+    }
+
+    #[test]
+    fn aggregate_category_records_count() {
+        let cases = [metrics(0.5), metrics(0.5)];
+        let r = aggregate_category(&cases);
+        assert_eq!(r.case_count, 2);
+        assert!((r.recall_at_10 - 0.5).abs() < 1e-12);
+    }
+
+    fn report_with_full(ndcg: f64, recall: f64, mrr: f64, p1: f64) -> Report {
+        let mut layers = BTreeMap::new();
+        layers.insert(
+            "full".to_string(),
+            LayerReport {
+                ndcg_at_10: ndcg,
+                recall_at_10: recall,
+                precision_at_10: 0.2,
+                mrr,
+                p_at_1: p1,
+                map: 0.5,
+                latency_p50_ms: 0.0,
+                latency_p95_ms: 0.0,
+                latency_p99_ms: 0.0,
+            },
+        );
+        Report {
+            suite: "smoke".to_string(),
+            embedder: "test".to_string(),
+            git_sha: "deadbeef".to_string(),
+            timestamp: chrono::Utc::now(),
+            layers,
+            by_category: BTreeMap::new(),
+            case_count: 30,
+            failures: vec![],
+        }
+    }
+
+    #[test]
+    fn no_regressions_when_metrics_match() {
+        let baseline = report_with_full(0.6, 0.7, 0.5, 0.4);
+        let current = report_with_full(0.6, 0.7, 0.5, 0.4);
+        assert!(compare_to_baseline(&baseline, &current, 2.0).is_empty());
+    }
+
+    #[test]
+    fn small_drop_within_tolerance_is_accepted() {
+        // 1% drop in ndcg with 2% tolerance is fine.
+        let baseline = report_with_full(0.60, 0.70, 0.50, 0.40);
+        let current = report_with_full(0.594, 0.70, 0.50, 0.40);
+        assert!(compare_to_baseline(&baseline, &current, 2.0).is_empty());
+    }
+
+    #[test]
+    fn drop_beyond_tolerance_is_flagged() {
+        // 5% drop with 2% tolerance fails.
+        let baseline = report_with_full(0.60, 0.70, 0.50, 0.40);
+        let current = report_with_full(0.57, 0.70, 0.50, 0.40);
+        let failures = compare_to_baseline(&baseline, &current, 2.0);
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].kind, "regression");
+        assert!(failures[0].detail.contains("ndcg@10"));
+    }
+
+    #[test]
+    fn improvements_are_not_flagged() {
+        let baseline = report_with_full(0.60, 0.70, 0.50, 0.40);
+        let current = report_with_full(0.80, 0.90, 0.70, 0.60);
+        assert!(compare_to_baseline(&baseline, &current, 2.0).is_empty());
+    }
+
+    #[test]
+    fn missing_baseline_full_layer_emits_infra_failure() {
+        let mut baseline = report_with_full(0.6, 0.7, 0.5, 0.4);
+        baseline.layers.clear();
+        let current = report_with_full(0.6, 0.7, 0.5, 0.4);
+        let failures = compare_to_baseline(&baseline, &current, 2.0);
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].kind, "infrastructure");
+    }
+}

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -1,0 +1,303 @@
+//! End-to-end runner for the L1 smoke suite.
+//!
+//! Loads fixtures via [`crate::recall_harness::fixtures`], stands up a
+//! `MemorySystem` against an isolated storage directory, ingests the corpus,
+//! runs every smoke case through `MemorySystem::recall`, and emits a
+//! [`Report`] aggregating per-case [`Metrics`] into per-layer and
+//! per-category sections.
+//!
+//! See issue #266 for the runner's CLI and acceptance criteria.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use uuid::Uuid;
+
+use crate::memory::types::ExperienceType;
+use crate::memory::{Experience, MemoryConfig, MemorySystem, Query};
+
+use super::fixtures::{
+    self, CorpusItem, SmokeCase, SmokeCategory, SMOKE_CASES_PATH, SMOKE_CORPUS_PATH,
+};
+use super::metrics::Metrics;
+use super::report::{
+    aggregate_category, aggregate_layer, CategoryReport, Failure, LayerReport, Report, SMOKE_K,
+};
+
+/// Embedder identifier emitted in the report. Matches the model wired into
+/// `MemorySystem::new` today; bump when the embedder changes.
+pub const EMBEDDER_ID: &str = "minilm-l6-v2";
+
+/// Inputs to [`run_smoke_suite`].
+#[derive(Debug, Clone)]
+pub struct RunInputs {
+    /// Storage directory for the harness's `MemorySystem`. The directory
+    /// must be writeable; the runner does not delete it on completion so
+    /// callers can inspect state after a failed run.
+    pub storage_path: PathBuf,
+    /// Optional path overrides; if `None` the canonical fixture paths are used.
+    pub corpus_path: Option<PathBuf>,
+    pub cases_path: Option<PathBuf>,
+    /// Suite identifier echoed into the report. Currently fixed to `"smoke"`.
+    pub suite: String,
+    /// Git SHA of the working tree the run was produced from. Caller is
+    /// responsible for resolution because the runner does not shell out.
+    pub git_sha: String,
+}
+
+/// Run the smoke suite end-to-end and return a populated [`Report`].
+///
+/// On infrastructure errors (corpus parse failure, system init failure,
+/// remember failure) the call returns `Err`. Per-case recall errors are
+/// recorded as `Failure { kind = "case", .. }` entries so a single broken
+/// query does not abort the whole run.
+pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
+    let corpus_path = inputs
+        .corpus_path
+        .clone()
+        .unwrap_or_else(|| fixtures::manifest_path(SMOKE_CORPUS_PATH));
+    let cases_path = inputs
+        .cases_path
+        .clone()
+        .unwrap_or_else(|| fixtures::manifest_path(SMOKE_CASES_PATH));
+
+    let corpus = fixtures::load_corpus(&corpus_path)
+        .with_context(|| format!("loading smoke corpus from {}", corpus_path.display()))?;
+    let cases = fixtures::load_smoke_cases(&cases_path)
+        .with_context(|| format!("loading smoke cases from {}", cases_path.display()))?;
+
+    fixtures::validate_smoke_suite(&corpus, &cases)
+        .context("smoke suite failed structural validation — fix the JSONL fixtures")?;
+
+    let system = build_system(&inputs.storage_path)?;
+    let id_map = ingest_corpus(&system, &corpus)?;
+
+    let mut per_case = Vec::with_capacity(cases.len());
+    let mut latencies_ms = Vec::with_capacity(cases.len());
+    let mut by_category_cases: HashMap<SmokeCategory, Vec<Metrics>> = HashMap::new();
+    let mut failures: Vec<Failure> = Vec::new();
+
+    for case in &cases {
+        let query = Query {
+            query_text: Some(case.query.clone()),
+            max_results: SMOKE_K,
+            ..Default::default()
+        };
+
+        let started = Instant::now();
+        let result = system.recall(&query);
+        let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
+        latencies_ms.push(elapsed_ms);
+
+        let memories = match result {
+            Ok(m) => m,
+            Err(e) => {
+                failures.push(Failure {
+                    kind: "case".to_string(),
+                    detail: format!("recall failed for {}: {e:#}", case.id),
+                });
+                // Treat as zero-recall so aggregates keep their denominator.
+                Vec::new()
+            }
+        };
+
+        let retrieved_uuids: Vec<Uuid> = memories.iter().map(|m| m.id.0).collect();
+        let relevance = build_relevance_map(case, &id_map);
+
+        if relevance.is_empty() {
+            failures.push(Failure {
+                kind: "case".to_string(),
+                detail: format!(
+                    "case {}: every relevant corpus item was missing from id_map (ingest skipped them)",
+                    case.id
+                ),
+            });
+        }
+
+        let metrics = Metrics::compute(&retrieved_uuids, &relevance, SMOKE_K);
+        by_category_cases
+            .entry(case.category)
+            .or_default()
+            .push(metrics);
+        per_case.push(metrics);
+    }
+
+    let layer_report = aggregate_layer(&per_case, &latencies_ms);
+    let mut layers: BTreeMap<String, LayerReport> = BTreeMap::new();
+    layers.insert("full".to_string(), layer_report);
+
+    let mut by_category: BTreeMap<String, CategoryReport> = BTreeMap::new();
+    for cat in SmokeCategory::ALL {
+        let cases_for_cat = by_category_cases.remove(&cat).unwrap_or_default();
+        by_category.insert(
+            category_name(cat).to_string(),
+            aggregate_category(&cases_for_cat),
+        );
+    }
+
+    Ok(Report {
+        suite: inputs.suite.clone(),
+        embedder: EMBEDDER_ID.to_string(),
+        git_sha: inputs.git_sha.clone(),
+        timestamp: chrono::Utc::now(),
+        layers,
+        by_category,
+        case_count: cases.len(),
+        failures,
+    })
+}
+
+/// Construct an isolated `MemorySystem` rooted at `storage_path`.
+fn build_system(storage_path: &Path) -> Result<MemorySystem> {
+    std::fs::create_dir_all(storage_path)
+        .with_context(|| format!("creating storage dir {}", storage_path.display()))?;
+    let config = MemoryConfig {
+        storage_path: storage_path.to_path_buf(),
+        ..MemoryConfig::default()
+    };
+    MemorySystem::new(config, None).context("initialising MemorySystem for recall harness")
+}
+
+/// Ingest the corpus into `system`, returning the `string handle → Uuid` map
+/// used to translate ground-truth references to system memory IDs.
+pub fn ingest_corpus(
+    system: &MemorySystem,
+    corpus: &[CorpusItem],
+) -> Result<HashMap<String, Uuid>> {
+    let mut map = HashMap::with_capacity(corpus.len());
+    for item in corpus {
+        let experience = Experience {
+            experience_type: experience_type_for(&item.memory_type),
+            content: item.content.clone(),
+            entities: item.tags.clone(),
+            ..Default::default()
+        };
+        let memory_id = system
+            .remember(experience, Some(item.created_at))
+            .with_context(|| format!("remembering corpus item {}", item.id))?;
+        map.insert(item.id.clone(), memory_id.0);
+    }
+    Ok(map)
+}
+
+/// Map a corpus item's `memory_type` string to an `ExperienceType` variant.
+///
+/// Unknown types fall back to `Observation`, which is the most neutral
+/// option in the existing taxonomy. This keeps fixture authoring lenient
+/// while still flowing real type information through the pipeline when it
+/// is recognised.
+fn experience_type_for(s: &str) -> ExperienceType {
+    match s.to_ascii_lowercase().as_str() {
+        "decision" => ExperienceType::Decision,
+        "task" => ExperienceType::Task,
+        "conversation" => ExperienceType::Conversation,
+        "error" => ExperienceType::Error,
+        "learning" => ExperienceType::Learning,
+        "discovery" => ExperienceType::Discovery,
+        "pattern" => ExperienceType::Pattern,
+        "context" => ExperienceType::Context,
+        "event" | "reference" | "observation" => ExperienceType::Observation,
+        _ => ExperienceType::Observation,
+    }
+}
+
+/// Build the graded relevance map for a single case using the ingest id map.
+///
+/// Items that did not make it into `id_map` are silently skipped here; the
+/// caller logs a `case` failure if the resulting map is empty.
+fn build_relevance_map(case: &SmokeCase, id_map: &HashMap<String, Uuid>) -> HashMap<Uuid, f32> {
+    let mut out = HashMap::with_capacity(case.relevant.len());
+    for r in &case.relevant {
+        if let Some(uuid) = id_map.get(&r.corpus_item_id) {
+            out.insert(*uuid, r.grade as f32);
+        }
+    }
+    out
+}
+
+fn category_name(c: SmokeCategory) -> &'static str {
+    match c {
+        SmokeCategory::Decision => "decision",
+        SmokeCategory::Code => "code",
+        SmokeCategory::Temporal => "temporal",
+        SmokeCategory::Entity => "entity",
+        SmokeCategory::MultiHop => "multi_hop",
+        SmokeCategory::Negation => "negation",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_storage_dir(label: &str) -> PathBuf {
+        let id = Uuid::new_v4().simple().to_string();
+        std::env::temp_dir().join(format!("shodh-recall-{label}-{id}"))
+    }
+
+    /// Smoke test the full runner end-to-end against the canonical fixtures.
+    ///
+    /// Asserts only that the report is well-formed: 30 cases, six categories
+    /// represented, full layer present. Quality numbers themselves are
+    /// captured by RH-6 baseline runs, not by unit tests.
+    #[test]
+    fn runner_executes_smoke_suite_and_produces_well_formed_report() {
+        let storage = unique_storage_dir("runner");
+        let inputs = RunInputs {
+            storage_path: storage.clone(),
+            corpus_path: None,
+            cases_path: None,
+            suite: "smoke".to_string(),
+            git_sha: "test-sha".to_string(),
+        };
+        let report = run_smoke_suite(&inputs).expect("runner must succeed");
+        let _ = std::fs::remove_dir_all(&storage);
+
+        assert_eq!(report.case_count, 30);
+        assert_eq!(report.suite, "smoke");
+        assert_eq!(report.embedder, EMBEDDER_ID);
+        assert!(report.layers.contains_key("full"));
+        for cat in [
+            "decision",
+            "code",
+            "temporal",
+            "entity",
+            "multi_hop",
+            "negation",
+        ] {
+            let cr = report
+                .by_category
+                .get(cat)
+                .expect("category must be present");
+            assert_eq!(cr.case_count, 5, "category {cat} must have 5 cases");
+        }
+        // No infrastructure-level failures expected on the canonical fixtures.
+        assert!(
+            report.failures.iter().all(|f| f.kind == "case"),
+            "no infrastructure failures expected, got {:?}",
+            report.failures
+        );
+    }
+
+    #[test]
+    fn experience_type_recognises_known_strings() {
+        assert!(matches!(
+            experience_type_for("decision"),
+            ExperienceType::Decision
+        ));
+        assert!(matches!(
+            experience_type_for("Reference"),
+            ExperienceType::Observation
+        ));
+        assert!(matches!(
+            experience_type_for("event"),
+            ExperienceType::Observation
+        ));
+        assert!(matches!(
+            experience_type_for("nonsense"),
+            ExperienceType::Observation
+        ));
+    }
+}

--- a/tests/recall_eval_cli.rs
+++ b/tests/recall_eval_cli.rs
@@ -39,7 +39,13 @@ fn help_lists_every_public_flag() {
     );
 
     let stdout = String::from_utf8_lossy(&out.stdout);
-    for flag in ["--suite", "--output", "--baseline", "--tolerance", "--storage"] {
+    for flag in [
+        "--suite",
+        "--output",
+        "--baseline",
+        "--tolerance",
+        "--storage",
+    ] {
         assert!(
             stdout.contains(flag),
             "--help output is missing {flag}\nfull stdout:\n{stdout}"
@@ -75,7 +81,12 @@ fn missing_output_flag_is_a_parse_error() {
 #[test]
 fn unknown_suite_is_a_parse_error() {
     let out = Command::new(recall_eval_bin())
-        .args(["--suite", "definitely-not-a-suite", "--output", "ignored.json"])
+        .args([
+            "--suite",
+            "definitely-not-a-suite",
+            "--output",
+            "ignored.json",
+        ])
         .output()
         .expect("spawning recall-eval with bogus suite");
 
@@ -97,12 +108,7 @@ fn unknown_suite_is_a_parse_error() {
 #[test]
 fn non_numeric_tolerance_is_a_parse_error() {
     let out = Command::new(recall_eval_bin())
-        .args([
-            "--output",
-            "ignored.json",
-            "--tolerance",
-            "not-a-number",
-        ])
+        .args(["--output", "ignored.json", "--tolerance", "not-a-number"])
         .output()
         .expect("spawning recall-eval with bogus tolerance");
 

--- a/tests/recall_eval_cli.rs
+++ b/tests/recall_eval_cli.rs
@@ -1,0 +1,113 @@
+//! CLI surface tests for the `recall-eval` binary.
+//!
+//! These tests guard the command-line contract — flag names, defaults,
+//! required arguments, and exit codes — without spinning up the full
+//! `MemorySystem` (which loads ONNX models and is far too heavy for an
+//! integration test).
+//!
+//! Heavyweight end-to-end coverage of the suite itself lives in the
+//! `runner_executes_smoke_suite_and_produces_well_formed_report` unit test
+//! inside `src/recall_harness/runner.rs`.
+//!
+//! Cargo populates `CARGO_BIN_EXE_recall-eval` automatically for any
+//! integration test in this crate, so no `assert_cmd` dependency is needed.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Locate the compiled `recall-eval` binary. Cargo guarantees this env var
+/// for integration tests when the binary is declared in `Cargo.toml`.
+fn recall_eval_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_recall-eval"))
+}
+
+/// `--help` must exit 0 and advertise every public flag. This is the
+/// machine-checked contract for issue #266: CI scripts and humans both
+/// rely on these flag names.
+#[test]
+fn help_lists_every_public_flag() {
+    let out = Command::new(recall_eval_bin())
+        .arg("--help")
+        .output()
+        .expect("spawning recall-eval --help");
+
+    assert!(
+        out.status.success(),
+        "--help must exit 0, got {:?}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in ["--suite", "--output", "--baseline", "--tolerance", "--storage"] {
+        assert!(
+            stdout.contains(flag),
+            "--help output is missing {flag}\nfull stdout:\n{stdout}"
+        );
+    }
+}
+
+/// Missing the required `--output` flag must fail with a non-zero exit
+/// (clap parse error). This guards against an accidental change of
+/// `output` to `Option<PathBuf>` which would silently no-op the JSON
+/// report and break the CI gate.
+#[test]
+fn missing_output_flag_is_a_parse_error() {
+    let out = Command::new(recall_eval_bin())
+        .output()
+        .expect("spawning recall-eval with no args");
+
+    assert!(
+        !out.status.success(),
+        "running with no --output must fail; got success exit"
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--output"),
+        "parse error must mention --output, got:\n{stderr}"
+    );
+}
+
+/// An unknown `--suite` value must fail at parse time (before we spin up
+/// any MemorySystem). Guards the `Suite` enum from accidentally being
+/// loosened to a free-form string.
+#[test]
+fn unknown_suite_is_a_parse_error() {
+    let out = Command::new(recall_eval_bin())
+        .args(["--suite", "definitely-not-a-suite", "--output", "ignored.json"])
+        .output()
+        .expect("spawning recall-eval with bogus suite");
+
+    assert!(
+        !out.status.success(),
+        "unknown --suite value must fail at parse time"
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("suite") || stderr.contains("invalid value"),
+        "stderr should explain the bad --suite value, got:\n{stderr}"
+    );
+}
+
+/// Bogus `--tolerance` value (non-numeric) must fail at parse time.
+/// Guards the `f64` parser on the tolerance flag — silently coercing it
+/// to a default would let a typo accidentally bypass the CI gate.
+#[test]
+fn non_numeric_tolerance_is_a_parse_error() {
+    let out = Command::new(recall_eval_bin())
+        .args([
+            "--output",
+            "ignored.json",
+            "--tolerance",
+            "not-a-number",
+        ])
+        .output()
+        .expect("spawning recall-eval with bogus tolerance");
+
+    assert!(
+        !out.status.success(),
+        "non-numeric --tolerance must fail at parse time"
+    );
+}


### PR DESCRIPTION
Lands the runner that powers RH-5 (CI gate), RH-6 (baseline capture),
and embedder-swap workflows. Closes #266.

## What

- **`src/recall_harness/runner.rs`** — End-to-end runner. Loads L1
  fixtures, stands up an isolated `MemorySystem`, ingests the corpus,
  runs every case through `MemorySystem::recall`, and returns a
  populated `Report`.
- **`src/recall_harness/report.rs`** — `Report` / `LayerReport` /
  `CategoryReport` / `Failure` types with serde rename to keep
  `ndcg@10` / `recall@10` / `p@1` keys in JSON. Includes nearest-rank
  latency percentiles and `compare_to_baseline` for tolerance-gated
  regression detection on the four gating metrics
  (ndcg@10, recall@10, mrr, p@1).
- **`src/bin/recall_eval.rs`** — clap CLI:
    --suite smoke
    --output <path>
    [--baseline <path>] [--tolerance 2.0] [--storage <path>]
  Exit codes: **0 pass** / **1 regression** / **2 infrastructure**.
- **`tests/recall_eval_cli.rs`** — CLI surface tests guarding the
  public command-line contract (flag names, required args, exit codes)
  without spinning up the heavyweight `MemorySystem`.

## Real numbers (current main, debug build, Windows dev box)

```
suite=smoke cases=30 embedder=minilm-l6-v2
  full   ndcg@10=0.8065 recall@10=0.8500 mrr=0.8889 p@1=0.8333 map=0.7542
  latency p50=144ms p95=162ms p99=166ms
  code        ndcg@10=1.0000 recall@10=1.0000 mrr=1.0000
  decision    ndcg@10=0.8828 recall@10=0.9000 mrr=1.0000
  entity      ndcg@10=0.7649 recall@10=0.9000 mrr=1.0000
  multi_hop   ndcg@10=0.8265 recall@10=1.0000 mrr=0.8000
  negation    ndcg@10=0.6805 recall@10=0.5667 mrr=0.8667
  temporal    ndcg@10=0.6841 recall@10=0.7333 mrr=0.6667
```

`negation` and `temporal` are the weakest categories — exactly the
adversarial design intent. RH-6 will freeze these as baseline.json.
Latency is **reported but not gated** because hardware noise dominates.

## Tests

- `cargo test --lib recall_harness` — **47/47 pass** (20 metrics + 14
  fixtures + 11 report + 2 runner).
- `cargo test --test recall_eval_cli` — **4/4 pass** (--help contract,
  required-arg parse error, unknown-suite parse error, non-numeric
  --tolerance parse error).
- `cargo clippy --lib --bin recall-eval -- -D warnings` — clean.
- `cargo fmt --check` — clean.

## Out of scope (deliberately not stubs)

- `--layer` CLI flag arrives with RH-8 (per-pipeline-layer attribution).
- `regression` and `deep` suites arrive with RH-7.