### PR TITLE
feat(recall): RH-5 + RH-10 + RH-11 — CI gate + determinism + Rig 1

### DIFF
--- a/.github/workflows/recall.yml
+++ b/.github/workflows/recall.yml
@@ -1,0 +1,182 @@
+name: Recall Harness
+
+# RH-5 (#267): gate PRs on retrieval-quality regressions against the
+# checked-in `tests/recall/baseline.json`. The `recall-eval` binary owns
+# the comparison and exit code; this workflow's job is just to:
+#
+#   1. Build the binary (release).
+#   2. Run the smoke suite with `--baseline tests/recall/baseline.json`.
+#   3. Render a markdown diff table.
+#   4. Post that table as a PR comment (idempotent — edits its own prior
+#      comment instead of stacking).
+#   5. Upload the JSON report as an artifact for offline inspection.
+#
+# Runtime budget: cold ~12 min (LLVM + cold release build), warm ~3-4 min.
+# The "<2 min" target in #267 is unrealistic without building on a
+# dedicated runner — flagged in the PR description.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/recall/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/recall.yml'
+      - 'scripts/recall_diff.py'
+  workflow_dispatch:
+    inputs:
+      tolerance:
+        description: 'Allowed regression in percent of baseline'
+        required: false
+        default: '2.0'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: recall-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  TOLERANCE: ${{ github.event.inputs.tolerance || '2.0' }}
+
+jobs:
+  smoke:
+    name: L1 Smoke Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: recall-eval
+          # Cache the recall-eval binary specifically; debug profile is unused here.
+          cache-targets: 'true'
+          cache-on-failure: 'true'
+
+      - name: Install LLVM
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm-dev libclang-dev clang
+
+      - name: Verify baseline is checked in
+        run: |
+          if [ ! -f tests/recall/baseline.json ]; then
+            echo "::error::tests/recall/baseline.json is missing — see tests/recall/README.md to regenerate."
+            exit 1
+          fi
+          BASELINE_SHA=$(jq -r '.git_sha' tests/recall/baseline.json)
+          BASELINE_EMBEDDER=$(jq -r '.embedder' tests/recall/baseline.json)
+          echo "Baseline: sha=$BASELINE_SHA embedder=$BASELINE_EMBEDDER"
+          echo "BASELINE_SHA=$BASELINE_SHA" >> $GITHUB_ENV
+          echo "BASELINE_EMBEDDER=$BASELINE_EMBEDDER" >> $GITHUB_ENV
+
+      - name: Build recall-eval
+        run: cargo build --release --bin recall-eval
+
+      - name: Run L1 smoke suite vs. baseline
+        id: run_eval
+        run: |
+          set +e
+          ./target/release/recall-eval \
+            --suite smoke \
+            --output current.json \
+            --baseline tests/recall/baseline.json \
+            --tolerance "${TOLERANCE}" \
+            --storage ./recall-storage 2>&1 | tee recall-eval.log
+          EXIT=${PIPESTATUS[0]}
+          set -e
+          echo "exit_code=$EXIT" >> $GITHUB_OUTPUT
+          # Don't fail the job yet — we want the comment-posting step to run first
+          # so reviewers see the diff even on regression.
+          exit 0
+
+      - name: Render diff table
+        id: render
+        if: always() && hashFiles('current.json') != ''
+        run: |
+          python3 scripts/recall_diff.py \
+            tests/recall/baseline.json \
+            current.json \
+            --tolerance "${TOLERANCE}" > recall-diff.md
+          {
+            echo 'body<<RECALL_DIFF_EOF'
+            cat recall-diff.md
+            echo 'RECALL_DIFF_EOF'
+          } >> "$GITHUB_OUTPUT"
+          cat recall-diff.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload JSON report
+        if: always() && hashFiles('current.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: recall-eval-report
+          path: |
+            current.json
+            recall-eval.log
+            recall-diff.md
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Post or update PR comment
+        if: |
+          always()
+          && github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name == github.repository
+          && hashFiles('recall-diff.md') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Stable HTML-comment marker rendered by `scripts/recall_diff.py`
+          # (kept in sync with `COMMENT_MARKER` in that file). Plain ASCII
+          # so it survives shell quoting unchanged.
+          MARKER: '<!-- recall-harness-comment-marker:rh-5 -->'
+        run: |
+          # Find an existing comment by this workflow (identified by the
+          # marker line) and edit it; otherwise create a new one. Keeps
+          # noisy PRs from accumulating one comment per push.
+          EXISTING_ID=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            | jq --arg marker "$MARKER" '.[] | select(.body | contains($marker)) | .id' \
+            | head -n1)
+          if [ -n "$EXISTING_ID" ]; then
+            echo "Editing existing comment $EXISTING_ID"
+            gh api \
+              --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_ID}" \
+              -F body="@recall-diff.md"
+          else
+            echo "Creating new PR comment"
+            gh pr comment "$PR_NUMBER" --body-file recall-diff.md
+          fi
+
+      - name: Enforce gate
+        if: always()
+        env:
+          EXIT: ${{ steps.run_eval.outputs.exit_code }}
+        run: |
+          case "$EXIT" in
+            0)
+              echo "::notice::Recall gate passed within ${TOLERANCE}% tolerance."
+              ;;
+            1)
+              echo "::error::Recall regression detected — see PR comment / artifact for details."
+              exit 1
+              ;;
+            2)
+              echo "::error::Recall harness infrastructure failure — see recall-eval.log artifact."
+              exit 1
+              ;;
+            *)
+              echo "::error::recall-eval exited with unexpected code $EXIT."
+              exit 1
+              ;;
+          esac

--- a/scripts/recall_diff.py
+++ b/scripts/recall_diff.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Format a markdown diff table comparing a recall-eval baseline to a current run.
+
+Used by the RH-5 CI gate (`.github/workflows/recall.yml`) to post a
+human-readable summary as a PR comment. Intentionally stdlib-only so the
+workflow does not need a `pip install` step.
+
+Usage:
+    python scripts/recall_diff.py <baseline.json> <current.json> [--tolerance 2.0]
+
+Exits 0 always; the gating decision belongs to the `recall-eval` binary's
+exit code, not to this formatter.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+GATING_METRICS = ("ndcg@10", "recall@10", "mrr", "p@1")
+INFO_METRICS = ("map", "precision@10")
+LATENCY_METRICS = ("latency_p50_ms", "latency_p95_ms", "latency_p99_ms")
+
+
+def load_report(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def fmt_metric(base: float, cur: float, tolerance_pct: float, gating: bool) -> str:
+    """Render `base → cur (Δ)` with a status marker for gating metrics."""
+    delta = cur - base
+    delta_str = f"{delta:+.4f}"
+    base_str = f"{base:.4f}"
+    cur_str = f"{cur:.4f}"
+    if not gating or base <= 0.0:
+        return f"{base_str} → {cur_str} ({delta_str})"
+    allowed_drop = base * (tolerance_pct / 100.0)
+    # Match the rust comparator exactly: regression iff cur + allowed_drop < base.
+    if cur + allowed_drop < base:
+        marker = "❌"
+    elif delta < 0.0:
+        marker = "⚠️"
+    else:
+        marker = "✅"
+    return f"{base_str} → {cur_str} ({delta_str}) {marker}"
+
+
+def fmt_latency(base: float, cur: float) -> str:
+    delta = cur - base
+    return f"{base:.1f} → {cur:.1f} ({delta:+.1f})"
+
+
+# Stable marker so the CI workflow can find and edit its own prior comment
+# instead of stacking a fresh comment per push. Kept as an HTML comment so it
+# is invisible in the rendered PR view.
+COMMENT_MARKER = "<!-- recall-harness-comment-marker:rh-5 -->"
+
+
+def render(baseline: dict[str, Any], current: dict[str, Any], tolerance_pct: float) -> str:
+    lines: list[str] = []
+    lines.append(COMMENT_MARKER)
+    lines.append("## Recall harness — smoke suite")
+    lines.append("")
+    lines.append(
+        f"Baseline `{baseline.get('git_sha', '?')[:7]}` "
+        f"({baseline.get('embedder', '?')}) → "
+        f"current `{current.get('git_sha', '?')[:7]}` "
+        f"({current.get('embedder', '?')}) · tolerance **{tolerance_pct:.1f}%**"
+    )
+    lines.append("")
+
+    base_full = baseline.get("layers", {}).get("full", {})
+    cur_full = current.get("layers", {}).get("full", {})
+    if not base_full or not cur_full:
+        lines.append("> **Infrastructure failure:** one or both reports are missing the `full` layer.")
+        return "\n".join(lines)
+
+    lines.append("### Quality (gated)")
+    lines.append("")
+    lines.append("| metric | baseline → current (Δ) |")
+    lines.append("| ------ | ---------------------- |")
+    for m in GATING_METRICS:
+        lines.append(
+            f"| `{m}` | {fmt_metric(base_full.get(m, 0.0), cur_full.get(m, 0.0), tolerance_pct, gating=True)} |"
+        )
+    for m in INFO_METRICS:
+        lines.append(
+            f"| `{m}` | {fmt_metric(base_full.get(m, 0.0), cur_full.get(m, 0.0), tolerance_pct, gating=False)} |"
+        )
+    lines.append("")
+
+    lines.append("### Latency (informational)")
+    lines.append("")
+    lines.append("| metric | baseline → current (Δ ms) |")
+    lines.append("| ------ | ------------------------- |")
+    for m in LATENCY_METRICS:
+        lines.append(f"| `{m}` | {fmt_latency(base_full.get(m, 0.0), cur_full.get(m, 0.0))} |")
+    lines.append("")
+
+    base_cats = baseline.get("by_category", {})
+    cur_cats = current.get("by_category", {})
+    cats = sorted(set(base_cats) | set(cur_cats))
+    if cats:
+        lines.append("### Per-category `ndcg@10`")
+        lines.append("")
+        lines.append("| category | baseline → current (Δ) |")
+        lines.append("| -------- | ---------------------- |")
+        for c in cats:
+            b = base_cats.get(c, {}).get("ndcg@10", 0.0)
+            cur_v = cur_cats.get(c, {}).get("ndcg@10", 0.0)
+            lines.append(f"| `{c}` | {fmt_metric(b, cur_v, tolerance_pct, gating=False)} |")
+        lines.append("")
+
+    failures = current.get("failures") or []
+    regressions = [f for f in failures if f.get("kind") == "regression"]
+    infra = [f for f in failures if f.get("kind") == "infrastructure"]
+    cases = [f for f in failures if f.get("kind") == "case"]
+
+    if regressions:
+        lines.append(f"### ❌ Regressions ({len(regressions)})")
+        lines.append("")
+        for f in regressions:
+            lines.append(f"- {f.get('detail', '')}")
+        lines.append("")
+    if infra:
+        lines.append(f"### ⚠️ Infrastructure failures ({len(infra)})")
+        lines.append("")
+        for f in infra:
+            lines.append(f"- {f.get('detail', '')}")
+        lines.append("")
+    if cases:
+        lines.append(f"### ⚠️ Per-case failures ({len(cases)})")
+        lines.append("")
+        for f in cases[:10]:
+            lines.append(f"- {f.get('detail', '')}")
+        if len(cases) > 10:
+            lines.append(f"- …and {len(cases) - 10} more")
+        lines.append("")
+
+    if not (regressions or infra or cases):
+        lines.append("### ✅ No regressions")
+        lines.append("")
+        lines.append(f"All {len(GATING_METRICS)} gated metrics within {tolerance_pct:.1f}% tolerance.")
+        lines.append("")
+
+    lines.append("<sub>Generated by `.github/workflows/recall.yml` (RH-5, #267).</sub>")
+    return "\n".join(lines)
+
+
+__all__ = ["COMMENT_MARKER", "render", "load_report"]
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("baseline", type=Path)
+    p.add_argument("current", type=Path)
+    p.add_argument("--tolerance", type=float, default=2.0)
+    args = p.parse_args()
+
+    baseline = load_report(args.baseline)
+    current = load_report(args.current)
+    sys.stdout.write(render(baseline, current, args.tolerance))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -400,6 +400,59 @@ pub const HYBRID_GRAPH_WEIGHT: f32 = 0.35;
 pub const HYBRID_LINGUISTIC_WEIGHT: f32 = 0.15;
 
 // =============================================================================
+// POLAR / NEGATION-AWARE RETRIEVAL (RH-14)
+// =============================================================================
+// MiniLM-L6-v2 (and most bi-encoders) project "we use X" and "we do not use X"
+// within ~5° cosine — bi-encoder polarity blindness, documented in:
+//   - Ettinger 2020, "What BERT Is Not" (TACL)
+//   - "Negation is Not Semantic: Diagnosing Dense Retrieval Failure Modes"
+//     (arXiv 2603.17580, 2026) — proposes deeper lexical pool + NegEx filtering
+//   - Chapman et al. 2001, "A simple algorithm for identifying negated findings
+//     and diseases" (NegEx) — i2b2 clinical NLP standard
+//
+// Strategy (combined): when a query is polar (yes/no auxiliary leader) or
+// contains explicit negation tokens, (a) deepen BM25 candidate pool, (b) augment
+// the BM25 query with negation cue terms so passages containing "not"/"no"/etc.
+// near the focal entity float up, and (c) compute a second vector embedding
+// using a templated negated form of the polar question. This gets the right
+// negating passage INTO the candidate pool — pure post-fusion reranking cannot
+// rescue a passage that was never retrieved.
+
+/// Auxiliary verb leaders that mark a polar (yes/no) question.
+///
+/// Used by `query_parser::is_polar_question()` to detect queries like
+/// "Are we using HNSW?" / "Did learning history move to postcard?" where the
+/// expected answer carries explicit negation ("we use Vamana, not HNSW").
+pub const POLAR_QUESTION_LEADERS: &[&str] = &[
+    "are", "is", "am", "was", "were", "do", "does", "did", "have", "has", "had", "can", "could",
+    "will", "would", "should", "shall", "may", "might", "must",
+];
+
+/// BM25 candidate pool depth multiplier for polarity-sensitive queries.
+///
+/// When polar/negation query detected, multiply `hybrid_search.candidate_count`
+/// by this factor to ensure passages containing negation tokens enter the pool.
+/// arXiv 2603.17580 uses K=1000 (10x) for biomedical contradiction detection;
+/// we use 3x as a conservative starting point given much smaller corpora.
+pub const POLAR_QUERY_BM25_POOL_MULTIPLIER: usize = 3;
+
+/// Vector candidate pool depth multiplier for polarity-sensitive queries.
+///
+/// Same rationale as `POLAR_QUERY_BM25_POOL_MULTIPLIER` but for the dense leg.
+/// Combined with the negated-form embedding (HyDE-style), this widens the pool
+/// to capture passages the positive-form query alone would rank below cutoff.
+pub const POLAR_QUERY_VECTOR_POOL_MULTIPLIER: usize = 2;
+
+/// Negation cue tokens injected into the BM25 query for polarity-sensitive queries.
+///
+/// These low-IDF terms add a small additive BM25 score to passages containing
+/// negation markers near the focal entity (e.g., "We use Vamana, **not** HNSW").
+/// Per-token contribution is small by design — this is candidate-pool engineering,
+/// not score domination.
+pub const POLAR_BM25_NEGATION_CUES: &[&str] =
+    &["not", "no", "never", "without", "instead", "actually"];
+
+// =============================================================================
 // DENSITY-DEPENDENT RETRIEVAL WEIGHTS (SHO-26)
 // Based on GraphRAG Survey (arXiv 2408.08921) - hybrid KG-Vector improves 13.1%
 // Biological model: Dense graphs = noisy (fresh L1 edges), Sparse = curated (pruned)

--- a/src/memory/hybrid_search.rs
+++ b/src/memory/hybrid_search.rs
@@ -575,6 +575,15 @@ impl HybridSearchEngine {
         self.bm25_index.commit()
     }
 
+    /// Configured BM25 candidate pool depth (top-K passed to Tantivy by default).
+    ///
+    /// Exposed so callers (e.g., the polarity-aware retrieval path in
+    /// `MemorySystem::semantic_retrieve_inner`, RH-14) can derive overrides
+    /// proportional to the configured baseline rather than hardcoding a value.
+    pub fn candidate_count(&self) -> usize {
+        self.config.candidate_count
+    }
+
     /// Reload BM25 reader to see committed changes immediately
     pub fn reload(&self) -> Result<()> {
         self.bm25_index.reload()
@@ -695,7 +704,7 @@ impl HybridSearchEngine {
         &self,
         query: &str,
         vector_results: Vec<(MemoryId, f32)>,
-        _get_content: F,
+        get_content: F,
         term_weights: Option<&HashMap<String, f32>>,
         phrase_boosts: Option<&[(String, f32)]>,
         keyword_discriminativeness: Option<f32>,
@@ -703,10 +712,44 @@ impl HybridSearchEngine {
     where
         F: Fn(&MemoryId) -> Option<String>,
     {
+        self.search_with_dynamic_weights_pool(
+            query,
+            vector_results,
+            get_content,
+            term_weights,
+            phrase_boosts,
+            keyword_discriminativeness,
+            None,
+        )
+    }
+
+    /// Variant of `search_with_dynamic_weights` that allows the caller to
+    /// override the BM25 candidate pool depth.
+    ///
+    /// Used by the polarity-aware retrieval path (RH-14): when the query is
+    /// polar/negation-sensitive, the pool is multiplied by
+    /// `POLAR_QUERY_BM25_POOL_MULTIPLIER` so that passages containing negation
+    /// markers near the focal entity have a chance to enter the candidate set.
+    /// Pure post-fusion reranking cannot rescue passages that were never
+    /// retrieved — see arXiv 2603.17580 ("Negation is Not Semantic").
+    pub fn search_with_dynamic_weights_pool<F>(
+        &self,
+        query: &str,
+        vector_results: Vec<(MemoryId, f32)>,
+        _get_content: F,
+        term_weights: Option<&HashMap<String, f32>>,
+        phrase_boosts: Option<&[(String, f32)]>,
+        keyword_discriminativeness: Option<f32>,
+        bm25_pool_override: Option<usize>,
+    ) -> Result<Vec<HybridSearchResult>>
+    where
+        F: Fn(&MemoryId) -> Option<String>,
+    {
         // 1. BM25 search with IC-weighted term boosting AND phrase matching
+        let bm25_pool = bm25_pool_override.unwrap_or(self.config.candidate_count);
         let bm25_results = self.bm25_index.search_with_term_and_phrase_weights(
             query,
-            self.config.candidate_count,
+            bm25_pool,
             term_weights,
             phrase_boosts,
         )?;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1852,6 +1852,56 @@ impl MemorySystem {
                 }
             };
 
+        // ===========================================================================
+        // POLARITY-AWARE NEGATED-FORM EMBEDDING (RH-14)
+        // ===========================================================================
+        // For polar/negation-sensitive queries, generate a second embedding from
+        // the templated negated form ("Are we using HNSW?" → "we are not using
+        // HNSW"). The negated-form embedding lands much closer in MiniLM space
+        // to passages that overtly contradict the polar premise (e.g.,
+        // "We use Vamana, not HNSW") than the original positive-form embedding
+        // does. Used downstream to widen the vector candidate pool. See
+        // `query_parser::polar_to_negated_form` and arXiv 2603.17580.
+        let polar_negated_embedding: Option<Vec<f32>> = if query_analysis.polarity_sensitive()
+            && !embedding_query_text.is_empty()
+        {
+            if let Some(neg_text) =
+                crate::memory::query_parser::polar_to_negated_form(&embedding_query_text)
+            {
+                let neg_hash = Self::sha256_hash(&neg_text);
+                if let Some(cached) = self.query_cache.get(&neg_hash) {
+                    EMBEDDING_CACHE_QUERY.with_label_values(&["hit"]).inc();
+                    Some(cached.clone())
+                } else {
+                    EMBEDDING_CACHE_QUERY.with_label_values(&["miss"]).inc();
+                    match self.embedder.as_ref().encode(&neg_text) {
+                        Ok(emb) => {
+                            self.query_cache.insert(neg_hash, emb.clone());
+                            EMBEDDING_CACHE_QUERY_SIZE.set(self.query_cache.entry_count() as i64);
+                            tracing::debug!(
+                                "Polar negated-form embedding generated: '{}' → '{}'",
+                                &*embedding_query_text,
+                                neg_text
+                            );
+                            Some(emb)
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Polar negated-form encode failed for '{}': {}",
+                                neg_text,
+                                e
+                            );
+                            None
+                        }
+                    }
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         let t_embedding = recall_start.elapsed();
         tracing::info!(
             embedding_ms = format!(
@@ -1859,6 +1909,8 @@ impl MemorySystem {
                 (t_embedding - t_query_analysis).as_secs_f64() * 1000.0
             ),
             cumulative_ms = format!("{:.2}", t_embedding.as_secs_f64() * 1000.0),
+            polarity_sensitive = query_analysis.polarity_sensitive(),
+            polar_neg_embedding = polar_negated_embedding.is_some(),
             "recall [layer:embedding] query embedding (cache miss logged above if any)"
         );
         if let Some(ref mut s) = stats {
@@ -2109,11 +2161,50 @@ impl MemorySystem {
         };
 
         // ===========================================================================
-        // LAYER 3: VECTOR SEARCH (Vamana Index)
+        // LAYER 3: VECTOR SEARCH (Vamana Index) — polarity-aware union (RH-14)
         // ===========================================================================
-        let vr = self
-            .retriever
-            .search_ids(&vector_query, query.max_results * 3)?;
+        // For polarity-sensitive queries the candidate pool is widened in two
+        // ways: (a) the per-leg top-k is multiplied by
+        // POLAR_QUERY_VECTOR_POOL_MULTIPLIER, and (b) a second search is run
+        // using the negated-form embedding when available. Results are unioned
+        // by MemoryId, keeping the *best* (largest) similarity score and
+        // rebuilding a deterministic descending order. This ensures passages
+        // that overtly contradict a polar premise enter the BM25/RRF fusion
+        // pool downstream — they cannot be rescued by post-fusion reranking
+        // alone, since the bi-encoder ranks them below the cutoff.
+        let polar_vec_mul = if query_analysis.polarity_sensitive() {
+            crate::constants::POLAR_QUERY_VECTOR_POOL_MULTIPLIER.max(1)
+        } else {
+            1
+        };
+        let vector_top_k = query.max_results * 3 * polar_vec_mul;
+        let vr_pos = self.retriever.search_ids(&vector_query, vector_top_k)?;
+        let vr = if let Some(neg_emb) = polar_negated_embedding.as_ref() {
+            let mut neg_query = vector_query.clone();
+            neg_query.query_embedding = Some(neg_emb.clone());
+            let vr_neg = self
+                .retriever
+                .search_ids(&neg_query, vector_top_k)
+                .unwrap_or_default();
+            // Union by MemoryId, keep best score per id; deterministic ordering
+            // by (score desc, id asc) — matches RH-10 stable tie-break.
+            let mut best: std::collections::HashMap<MemoryId, f32> =
+                std::collections::HashMap::with_capacity(vr_pos.len() + vr_neg.len());
+            for (id, score) in vr_pos.into_iter().chain(vr_neg.into_iter()) {
+                best.entry(id)
+                    .and_modify(|s| {
+                        if score > *s {
+                            *s = score;
+                        }
+                    })
+                    .or_insert(score);
+            }
+            let mut merged: Vec<(MemoryId, f32)> = best.into_iter().collect();
+            merged.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+            merged
+        } else {
+            vr_pos
+        };
         let vector_results: Vec<(MemoryId, f32)> = if let Some(ref c) = episode_candidates {
             vr.into_iter().filter(|(id, _)| c.contains(id)).collect()
         } else {
@@ -2176,15 +2267,48 @@ impl MemorySystem {
             } else {
                 None
             };
+
+            // Polarity-aware BM25 augmentation (RH-14):
+            //  • Augment the query string with low-IDF negation cue tokens so
+            //    passages containing "not"/"no"/"never"/etc. near the focal
+            //    entity gain a small additive BM25 score (e.g. ssm-056 says
+            //    "We use Vamana, not HNSW" — adding "not" to the BM25 query
+            //    for "Are we using HNSW?" floats it up).
+            //  • Deepen the BM25 candidate pool so the augmented terms have
+            //    room to surface borderline-relevant passages.
+            // See `constants::POLAR_BM25_NEGATION_CUES` and
+            // `constants::POLAR_QUERY_BM25_POOL_MULTIPLIER`.
+            let polarity_sensitive = query_analysis.polarity_sensitive();
+            let bm25_query_owned: String;
+            let bm25_query_text: &str = if polarity_sensitive {
+                bm25_query_owned = format!(
+                    "{} {}",
+                    query_text,
+                    crate::constants::POLAR_BM25_NEGATION_CUES.join(" ")
+                );
+                &bm25_query_owned
+            } else {
+                query_text
+            };
+            let bm25_pool_override = if polarity_sensitive {
+                Some(
+                    self.hybrid_search
+                        .candidate_count()
+                        .saturating_mul(crate::constants::POLAR_QUERY_BM25_POOL_MULTIPLIER),
+                )
+            } else {
+                None
+            };
             let hybrid_ids = self
                 .hybrid_search
-                .search_with_dynamic_weights(
-                    query_text,
+                .search_with_dynamic_weights_pool(
+                    bm25_query_text,
                     vector_results.clone(),
                     get_content,
                     term_weights,
                     phrases,
                     disc_opt,
+                    bm25_pool_override,
                 )
                 .map(|r| {
                     r.into_iter()

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1249,7 +1249,11 @@ impl MemorySystem {
             let temporal_b = Self::calculate_temporal_relevance(age_days_b);
             let score_b = b.importance() * temporal_b;
 
-            score_b.total_cmp(&score_a)
+            // Score desc → recency desc → MemoryId asc for deterministic ordering.
+            score_b
+                .total_cmp(&score_a)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+                .then_with(|| a.id.cmp(&b.id))
         });
 
         memories.truncate(query.max_results);
@@ -2024,7 +2028,8 @@ impl MemorySystem {
                         )
                     })
                     .collect();
-                r.sort_by(|a, b| b.1.total_cmp(&a.1));
+                // Score desc; tie-break by MemoryId asc for deterministic graph candidate order.
+                r.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
                 r.truncate(200);
                 if !r.is_empty() {
                     tracing::debug!(
@@ -2557,7 +2562,11 @@ impl MemorySystem {
             // Only look up graph entities for the top 2x max_results candidates,
             // not all fused results (avoids 100s of RocksDB reads).
             let mut res: Vec<_> = fused.into_iter().collect();
-            res.sort_by(|a, b| b.1.total_cmp(&a.1));
+            // Score desc; tie-break by MemoryId for stable rerank-budget cutoff.
+            // The cutoff at `rerank_budget` makes order at the boundary semantically
+            // important — without tie-break, equal-score boundary candidates can swap
+            // in/out of the rerank window across runs.
+            res.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
             let rerank_budget = query.max_results * 2;
 
             if use_ontology_rerank && !onto_intent.expected_labels.is_empty() {
@@ -2609,8 +2618,9 @@ impl MemorySystem {
                             onto_intent.expected_labels
                         );
                     }
-                    // Re-sort after boosting since ranks may have changed
-                    res.sort_by(|a, b| b.1.total_cmp(&a.1));
+                    // Re-sort after boosting since ranks may have changed.
+                    // Tie-break by MemoryId — same rationale as the pre-rerank sort above.
+                    res.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
                 }
             }
 
@@ -2997,7 +3007,11 @@ impl MemorySystem {
                     + Self::linguistic_boost(&a.experience.content, &query_analysis) * 0.05;
                 let score_b = b.score.unwrap_or(0.0)
                     + Self::linguistic_boost(&b.experience.content, &query_analysis) * 0.05;
-                score_b.total_cmp(&score_a)
+                // Score desc → recency desc → MemoryId asc for stable rank order.
+                score_b
+                    .total_cmp(&score_a)
+                    .then_with(|| b.created_at.cmp(&a.created_at))
+                    .then_with(|| a.id.cmp(&b.id))
             });
         }
 
@@ -3124,7 +3138,14 @@ impl MemorySystem {
         // Re-sort by score and trim to max_results after expansion.
         // Expanded memories must compete on score, not get a free pass.
         if memories.len() > query.max_results {
-            memories.sort_by(|a, b| b.score.unwrap_or(0.0).total_cmp(&a.score.unwrap_or(0.0)));
+            // Score desc → recency desc → MemoryId asc — deterministic competition cutoff.
+            memories.sort_by(|a, b| {
+                b.score
+                    .unwrap_or(0.0)
+                    .total_cmp(&a.score.unwrap_or(0.0))
+                    .then_with(|| b.created_at.cmp(&a.created_at))
+                    .then_with(|| a.id.cmp(&b.id))
+            });
             memories.truncate(query.max_results);
         }
 
@@ -3151,7 +3172,12 @@ impl MemorySystem {
                     .filter(|(id, _)| final_ids.contains(id))
                     .map(|(_, attr)| attr)
                     .collect();
-                attrs.sort_by(|a, b| b.final_score.total_cmp(&a.final_score));
+                // Tie-break by memory_id so attribution rows have a stable order across runs.
+                attrs.sort_by(|a, b| {
+                    b.final_score
+                        .total_cmp(&a.final_score)
+                        .then_with(|| a.memory_id.cmp(&b.memory_id))
+                });
                 s.score_attributions = Some(attrs);
             }
         }

--- a/src/memory/query_parser.rs
+++ b/src/memory/query_parser.rs
@@ -2154,6 +2154,12 @@ pub struct QueryAnalysis {
     /// True if query contains negation
     pub has_negation: bool,
 
+    /// True if query is a polar (yes/no) question — leads with an English
+    /// auxiliary verb like "Are/Is/Do/Did/Have/Can/...". Polar questions are
+    /// negation-blind for bi-encoders even when they contain no overt negation
+    /// token (RH-14, see `constants::POLAR_QUESTION_LEADERS`).
+    pub is_polar: bool,
+
     /// Detected query intent for retrieval strategy selection (SHO-D6)
     pub intent: QueryIntent,
 }
@@ -2438,6 +2444,7 @@ pub fn analyze_query(query_text: &str) -> QueryAnalysis {
             compound_nouns: Vec::new(),
             original_query: query_text.to_string(),
             has_negation: false,
+            is_polar: is_polar_question(query_text),
             intent: QueryIntent::Hybrid,
         };
     }
@@ -2524,7 +2531,122 @@ pub fn analyze_query(query_text: &str) -> QueryAnalysis {
         compound_nouns,
         original_query: query_text.to_string(),
         has_negation,
+        is_polar: is_polar_question(query_text),
         intent,
+    }
+}
+
+/// Detect a polar (yes/no) question by leading auxiliary verb.
+///
+/// Examples that return `true`:
+///   - "Are we using HNSW for vector search?"
+///   - "Is GitHub auto-merge enabled?"
+///   - "Did learning history records also move to postcard?"
+///   - "Do we call OpenAI's embedding API?"
+///
+/// Examples that return `false`:
+///   - "What is the latest commit?" (interrogative, not polar)
+///   - "How does the cache work?"
+///   - bare statements
+///
+/// Polar questions are flagged because bi-encoder retrievers (MiniLM, DPR) are
+/// negation-blind: the embedding for "Are we using HNSW?" lands semantically
+/// near passages about HNSW regardless of polarity, while the actual answer
+/// passage may say "We use Vamana, *not* HNSW" — and never enter the top-K.
+/// See `constants::POLAR_QUESTION_LEADERS` and RH-14.
+pub fn is_polar_question(query_text: &str) -> bool {
+    let trimmed = query_text.trim_start();
+    let first_word: String = trimmed
+        .chars()
+        .take_while(|c| c.is_alphabetic())
+        .flat_map(char::to_lowercase)
+        .collect();
+    if first_word.is_empty() {
+        return false;
+    }
+    crate::constants::POLAR_QUESTION_LEADERS
+        .iter()
+        .any(|leader| *leader == first_word.as_str())
+}
+
+/// Template-based decontextualization of a polar question into its negated
+/// declarative form, suitable for re-embedding via the same encoder.
+///
+/// Transform: "Are X Y?" → "X are not Y"
+///   - "Are we using HNSW?" → "we are not using HNSW"
+///   - "Do we call OpenAI's embedding API?" → "we do not call OpenAI's embedding API"
+///   - "Did learning history records also move to postcard?"
+///        → "learning history records did not also move to postcard"
+///   - "Is GitHub auto-merge enabled?" → "GitHub auto-merge is not enabled"
+///
+/// Returns `None` when:
+///   - The query is not polar (no leader detected)
+///   - The query is too short (< subject + verb after the leader)
+///   - The query already contains an explicit "not" / "no" negation token
+///     (no transform needed; downstream will treat the original as negation-
+///     bearing already)
+///
+/// This is the dense-retrieval analogue of NegEx-driven query rewriting from
+/// Chapman et al. 2001 (clinical NLP) and the Amazon polar-question rewrite
+/// paper (COLING 2025).
+pub fn polar_to_negated_form(query_text: &str) -> Option<String> {
+    let trimmed = query_text.trim().trim_end_matches(['?', '.', '!']);
+    let words: Vec<&str> = trimmed.split_whitespace().collect();
+    if words.len() < 3 {
+        return None;
+    }
+    let leader_lc = words[0].to_lowercase();
+    if !crate::constants::POLAR_QUESTION_LEADERS
+        .iter()
+        .any(|l| *l == leader_lc.as_str())
+    {
+        return None;
+    }
+    // Skip if the original already contains an overt negation token — the
+    // pipeline will boost via `has_negation` directly.
+    let has_overt = words[1..]
+        .iter()
+        .any(|w| is_negation(&w.to_lowercase()) || w.to_lowercase().ends_with("n't"));
+    if has_overt {
+        return None;
+    }
+
+    // Subject NP boundary detection: scan words[1..] for the first content
+    // verb. Tokens before it form the subject NP, tokens from the verb onward
+    // form the predicate. Falls back to a single-word subject when no verb
+    // indicator is found (e.g., copular questions like "Is GitHub auto-merge
+    // enabled?" where "enabled" is a past-participle adjective, not in
+    // VERB_INDICATORS). The output is intended for re-embedding via MiniLM,
+    // which is robust to minor word-order imperfections — exact grammar is
+    // not required for the HyDE-style pseudo-document anchor to work.
+    let verb_idx = words[1..].iter().position(|w| is_verb(&w.to_lowercase()));
+    let (subject, predicate) = match verb_idx {
+        Some(0) => {
+            // Verb immediately follows the leader (e.g., "Did move?") — too
+            // short to template meaningfully.
+            return None;
+        }
+        Some(k) => {
+            let subj = words[1..1 + k].join(" ");
+            let pred = words[1 + k..].join(" ");
+            (subj, pred)
+        }
+        None => {
+            // No content verb found — single-word subject fallback.
+            (words[1].to_string(), words[2..].join(" "))
+        }
+    };
+
+    Some(format!("{subject} {leader_lc} not {predicate}"))
+}
+
+impl QueryAnalysis {
+    /// Returns `true` when this query is sensitive to candidate-passage polarity:
+    /// either it contains explicit negation (`has_negation`) or it is a polar
+    /// (yes/no) question (`is_polar`). Used to gate the deeper-pool +
+    /// negated-form-embedding retrieval path (RH-14).
+    pub fn polarity_sensitive(&self) -> bool {
+        self.has_negation || self.is_polar
     }
 }
 
@@ -4059,6 +4181,118 @@ pub fn infer_ontological_intent(query_text: &str, analysis: &QueryAnalysis) -> O
         expected_labels,
         relation_types,
         confidence: confidence.min(1.0),
+    }
+}
+
+#[cfg(test)]
+mod polar_negation_tests {
+    use super::*;
+
+    #[test]
+    fn polar_question_detected_for_auxiliary_leaders() {
+        // Real smoke-suite negation queries, all of which are polar yes/no
+        // questions WITHOUT overt negation tokens.
+        assert!(is_polar_question(
+            "Are we using HNSW for vector search anywhere?"
+        ));
+        assert!(is_polar_question(
+            "Is GitHub auto-merge enabled on this repository?"
+        ));
+        assert!(is_polar_question(
+            "Did learning history records also move to postcard?"
+        ));
+        assert!(is_polar_question("Do we call OpenAI's embedding API?"));
+        assert!(is_polar_question(
+            "Are we using Tokio's mutex for the per-user init guards?"
+        ));
+
+        // Modal leaders should also be detected.
+        assert!(is_polar_question("Can we cache the embedding?"));
+        assert!(is_polar_question("Should I commit this change?"));
+        assert!(is_polar_question("Will the migration delete old data?"));
+    }
+
+    #[test]
+    fn non_polar_queries_are_not_flagged() {
+        // Information-seeking / wh-questions are not polar.
+        assert!(!is_polar_question("What is the latest commit on main?"));
+        assert!(!is_polar_question("How does the embedding cache work?"));
+        assert!(!is_polar_question("Why did consolidation fire twice?"));
+        // Plain statements / commands.
+        assert!(!is_polar_question("commit the changes"));
+        assert!(!is_polar_question("show retrieval diagnostics"));
+        // Empty / whitespace.
+        assert!(!is_polar_question(""));
+        assert!(!is_polar_question("   "));
+    }
+
+    #[test]
+    fn polar_to_negated_form_inserts_not_after_subject() {
+        // Single-word subject + verb immediately after — clean template.
+        assert_eq!(
+            polar_to_negated_form("Are we using HNSW for vector search anywhere?").as_deref(),
+            Some("we are not using HNSW for vector search anywhere")
+        );
+        assert_eq!(
+            polar_to_negated_form("Do we call OpenAI's embedding API?").as_deref(),
+            Some("we do not call OpenAI's embedding API")
+        );
+        // Multi-word subject NP detected via is_verb scan ("move" triggers
+        // the boundary; tokens before it form the subject including "also").
+        assert_eq!(
+            polar_to_negated_form("Did learning history records also move to postcard?").as_deref(),
+            Some("learning history records also did not move to postcard")
+        );
+        // No content verb in the rest → single-word subject fallback. The
+        // resulting form is mildly ungrammatical ("auto-merge enabled" is a
+        // past-participle adjective phrase) but still anchors the embedding
+        // toward negating passages — sufficient for HyDE-style retrieval.
+        assert_eq!(
+            polar_to_negated_form("Is GitHub auto-merge enabled?").as_deref(),
+            Some("GitHub is not auto-merge enabled")
+        );
+        // Verb scan picks up "using" — multi-word subject works.
+        assert_eq!(
+            polar_to_negated_form("Are we using Tokio's mutex for the per-user init guards?")
+                .as_deref(),
+            Some("we are not using Tokio's mutex for the per-user init guards")
+        );
+    }
+
+    #[test]
+    fn polar_to_negated_form_skips_already_negated_or_non_polar() {
+        // Already negated — no transform.
+        assert_eq!(
+            polar_to_negated_form("Are we not using HNSW anywhere?"),
+            None
+        );
+        assert_eq!(polar_to_negated_form("Don't we call OpenAI?"), None);
+        // Non-polar — no transform.
+        assert_eq!(polar_to_negated_form("What is the latest commit?"), None);
+        // Too short to template — no transform.
+        assert_eq!(polar_to_negated_form("Are we?"), None);
+        assert_eq!(polar_to_negated_form(""), None);
+    }
+
+    #[test]
+    fn polarity_sensitive_combines_negation_and_polar_signals() {
+        // Polar question, no overt negation token.
+        let a = analyze_query("Are we using HNSW for vector search anywhere?");
+        assert!(a.is_polar);
+        assert!(!a.has_negation);
+        assert!(a.polarity_sensitive());
+
+        // Overt negation, not polar.
+        let b = analyze_query("memory not stored in cache after restart");
+        assert!(!b.is_polar);
+        assert!(b.has_negation);
+        assert!(b.polarity_sensitive());
+
+        // Neither — wh-question.
+        let c = analyze_query("what is the latest commit on main");
+        assert!(!c.is_polar);
+        assert!(!c.has_negation);
+        assert!(!c.polarity_sensitive());
     }
 }
 

--- a/src/memory/retrieval.rs
+++ b/src/memory/retrieval.rs
@@ -908,9 +908,11 @@ impl RetrievalEngine {
             }
         }
 
-        // Convert to vec and sort by similarity descending (highest first)
+        // Convert to vec and sort by similarity descending (highest first).
+        // Tie-break by MemoryId for deterministic rank order across runs/CPUs.
+        // (created_at is unavailable here — we only have ids + scores.)
         let mut memory_ids: Vec<(MemoryId, f32)> = best_scores.into_iter().collect();
-        memory_ids.sort_by(|a, b| b.1.total_cmp(&a.1));
+        memory_ids.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         memory_ids.truncate(limit);
 
         Ok(memory_ids)
@@ -974,9 +976,10 @@ impl RetrievalEngine {
             }
         }
 
-        // Convert to vec and sort by similarity descending (highest first)
+        // Convert to vec and sort by similarity descending (highest first).
+        // Tie-break by MemoryId for deterministic rank order across runs/CPUs.
         let mut memory_ids: Vec<(MemoryId, f32)> = best_scores.into_iter().collect();
-        memory_ids.sort_by(|a, b| b.1.total_cmp(&a.1));
+        memory_ids.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         memory_ids.truncate(limit);
 
         Ok(memory_ids)
@@ -1109,10 +1112,13 @@ impl RetrievalEngine {
                     .as_ref()
                     .and_then(|c| c.episode.sequence_number)
                     .unwrap_or(0);
-                seq_a.cmp(&seq_b)
+                // Tie-break by MemoryId so memories without sequence_number
+                // (both unwrap to 0) still produce a stable order.
+                seq_a.cmp(&seq_b).then_with(|| a.id.cmp(&b.id))
             });
         } else {
-            memories.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+            // Newest first; tie-break by MemoryId on identical timestamps.
+            memories.sort_by(|a, b| b.created_at.cmp(&a.created_at).then_with(|| a.id.cmp(&b.id)));
         }
 
         memories.truncate(limit);
@@ -1211,7 +1217,14 @@ impl RetrievalEngine {
             })
             .collect();
 
-        sorted.sort_by(|a, b| b.0.total_cmp(&a.0));
+        // Score desc → recency desc → MemoryId asc. Two layers of tie-break:
+        // recency carries product meaning ("newer wins on equal score"), id is the
+        // deterministic backstop for nanosecond-collision timestamps.
+        sorted.sort_by(|a, b| {
+            b.0.total_cmp(&a.0)
+                .then_with(|| b.1.created_at.cmp(&a.1.created_at))
+                .then_with(|| a.1.id.cmp(&b.1.id))
+        });
 
         Ok(sorted.into_iter().take(limit).map(|(_, m)| m).collect())
     }
@@ -1244,7 +1257,7 @@ impl RetrievalEngine {
         // Apply additional filters
         memories.retain(|m| self.matches_filters(m, query));
 
-        // Sort by distance (closest first)
+        // Sort by distance (closest first), tie-break by recency then id for determinism.
         memories.sort_by(|a, b| {
             let dist_a = match a.experience.geo_location {
                 Some(geo) => geo_filter.haversine_distance(geo[0], geo[1]),
@@ -1254,7 +1267,10 @@ impl RetrievalEngine {
                 Some(geo) => geo_filter.haversine_distance(geo[0], geo[1]),
                 None => f64::MAX,
             };
-            dist_a.total_cmp(&dist_b)
+            dist_a
+                .total_cmp(&dist_b)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+                .then_with(|| a.id.cmp(&b.id))
         });
 
         memories.truncate(limit);
@@ -1281,8 +1297,8 @@ impl RetrievalEngine {
         // Apply additional filters
         memories.retain(|m| self.matches_filters(m, query));
 
-        // Sort by timestamp (chronological order for mission replay)
-        memories.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        // Sort by timestamp (chronological order for mission replay), tie-break by id.
+        memories.sort_by(|a, b| a.created_at.cmp(&b.created_at).then_with(|| a.id.cmp(&b.id)));
 
         memories.truncate(limit);
         Ok(memories)
@@ -1309,11 +1325,15 @@ impl RetrievalEngine {
         // Apply additional filters (action_type, robot_id, etc.)
         memories.retain(|m| self.matches_filters(m, query));
 
-        // Sort by reward (highest first for learning from best outcomes)
+        // Sort by reward (highest first for learning from best outcomes).
+        // Tie-break: recency desc, then id asc — deterministic across runs.
         memories.sort_by(|a, b| {
             let reward_a = a.experience.reward.unwrap_or(0.0);
             let reward_b = b.experience.reward.unwrap_or(0.0);
-            reward_b.total_cmp(&reward_a)
+            reward_b
+                .total_cmp(&reward_a)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+                .then_with(|| a.id.cmp(&b.id))
         });
 
         memories.truncate(limit);

--- a/src/memory/retrieval.rs
+++ b/src/memory/retrieval.rs
@@ -1118,7 +1118,11 @@ impl RetrievalEngine {
             });
         } else {
             // Newest first; tie-break by MemoryId on identical timestamps.
-            memories.sort_by(|a, b| b.created_at.cmp(&a.created_at).then_with(|| a.id.cmp(&b.id)));
+            memories.sort_by(|a, b| {
+                b.created_at
+                    .cmp(&a.created_at)
+                    .then_with(|| a.id.cmp(&b.id))
+            });
         }
 
         memories.truncate(limit);
@@ -1298,7 +1302,11 @@ impl RetrievalEngine {
         memories.retain(|m| self.matches_filters(m, query));
 
         // Sort by timestamp (chronological order for mission replay), tie-break by id.
-        memories.sort_by(|a, b| a.created_at.cmp(&b.created_at).then_with(|| a.id.cmp(&b.id)));
+        memories.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.id.cmp(&b.id))
+        });
 
         memories.truncate(limit);
         Ok(memories)

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -47,6 +47,34 @@ pub struct RunInputs {
     pub git_sha: String,
 }
 
+/// One case's retrieved rank list, in score-descending order.
+///
+/// Used by the determinism gate (RH-11) to assert byte-identical
+/// rank lists across consecutive runs of the same suite.
+///
+/// `retrieved` holds **corpus item IDs** (stable string handles from the
+/// fixture), not the random UUIDs assigned by `MemorySystem::remember`.
+/// UUIDs are freshly generated per ingest and therefore differ across
+/// runs even when the rank order is byte-identical; comparing them would
+/// guarantee a false negative. Items that were retrieved but do not
+/// belong to the corpus (e.g. system-injected memories) are emitted as
+/// `"<unknown:...>"` sentinels so divergence in those slots is still
+/// observable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaseRankList {
+    pub case_id: String,
+    pub retrieved: Vec<String>,
+}
+
+/// Wrapper around [`Report`] plus the per-case rank lists. Returned by
+/// [`run_smoke_suite_with_ranks`]; the ranks are stripped by the public
+/// [`run_smoke_suite`] wrapper to preserve the simpler caller contract.
+#[derive(Debug, Clone)]
+pub struct ReportWithRanks {
+    pub report: Report,
+    pub ranks: Vec<CaseRankList>,
+}
+
 /// Run the smoke suite end-to-end and return a populated [`Report`].
 ///
 /// On infrastructure errors (corpus parse failure, system init failure,
@@ -54,6 +82,16 @@ pub struct RunInputs {
 /// recorded as `Failure { kind = "case", .. }` entries so a single broken
 /// query does not abort the whole run.
 pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
+    run_smoke_suite_with_ranks(inputs).map(|rwr| rwr.report)
+}
+
+/// Same as [`run_smoke_suite`] but also returns the per-case rank lists.
+///
+/// Exists for the RH-11 determinism gate: two consecutive calls with
+/// identical inputs must return byte-identical [`CaseRankList`]s. If they
+/// don't, there is a non-deterministic source somewhere in the retrieval
+/// pipeline that the tie-break + thread pinning failed to cover.
+pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks> {
     // ------------------------------------------------------------------
     // Determinism: pin every parallel runtime to a single thread before
     // any work touches ONNX or rayon. Multi-threaded float reductions
@@ -89,11 +127,20 @@ pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
 
     let system = build_system(&inputs.storage_path)?;
     let id_map = ingest_corpus(&system, &corpus)?;
+    // Reverse map: random per-run UUIDs → stable corpus item IDs. The
+    // determinism gate (RH-11) compares rank lists across runs, so we MUST
+    // emit stable handles. Comparing UUIDs would always diverge because
+    // each ingest assigns a fresh `Uuid::new_v4()`.
+    let uuid_to_corpus_id: HashMap<Uuid, String> = id_map
+        .iter()
+        .map(|(corpus_id, uuid)| (*uuid, corpus_id.clone()))
+        .collect();
 
     let mut per_case = Vec::with_capacity(cases.len());
     let mut latencies_ms = Vec::with_capacity(cases.len());
     let mut by_category_cases: HashMap<SmokeCategory, Vec<Metrics>> = HashMap::new();
     let mut failures: Vec<Failure> = Vec::new();
+    let mut ranks: Vec<CaseRankList> = Vec::with_capacity(cases.len());
 
     for case in &cases {
         let query = Query {
@@ -120,6 +167,24 @@ pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
         };
 
         let retrieved_uuids: Vec<Uuid> = memories.iter().map(|m| m.id.0).collect();
+        // Translate to stable corpus IDs for the determinism gate. Items
+        // that were not part of the ingested corpus (defensive: should
+        // never happen on a fresh harness storage dir) are surfaced as
+        // `<unknown:UUID>` so any divergence in those slots is still
+        // observable instead of silently masked by a string fallback.
+        let retrieved_corpus_ids: Vec<String> = retrieved_uuids
+            .iter()
+            .map(|u| {
+                uuid_to_corpus_id
+                    .get(u)
+                    .cloned()
+                    .unwrap_or_else(|| format!("<unknown:{u}>"))
+            })
+            .collect();
+        ranks.push(CaseRankList {
+            case_id: case.id.clone(),
+            retrieved: retrieved_corpus_ids,
+        });
         let relevance = build_relevance_map(case, &id_map);
 
         if relevance.is_empty() {
@@ -153,7 +218,7 @@ pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
         );
     }
 
-    Ok(Report {
+    let report = Report {
         suite: inputs.suite.clone(),
         embedder: EMBEDDER_ID.to_string(),
         git_sha: inputs.git_sha.clone(),
@@ -162,7 +227,9 @@ pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
         by_category,
         case_count: cases.len(),
         failures,
-    })
+    };
+
+    Ok(ReportWithRanks { report, ranks })
 }
 
 /// Pin parallel runtimes to a single thread for the harness process.

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -54,6 +54,22 @@ pub struct RunInputs {
 /// recorded as `Failure { kind = "case", .. }` entries so a single broken
 /// query does not abort the whole run.
 pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
+    // ------------------------------------------------------------------
+    // Determinism: pin every parallel runtime to a single thread before
+    // any work touches ONNX or rayon. Multi-threaded float reductions
+    // accumulate in non-deterministic order, which flips ranks on the
+    // recall harness even when no source code has changed.
+    //
+    // - SHODH_ONNX_THREADS=1 → MiniLM/NER intra-op runs single-threaded
+    //   (already plumbed through src/embeddings/{minilm,ner}.rs).
+    // - RAYON_NUM_THREADS=1  → any par_iter() in scoring runs serially.
+    //
+    // We only set these vars if the caller hasn't pinned them already,
+    // so production callers (which never invoke the harness) stay
+    // unaffected.
+    // ------------------------------------------------------------------
+    pin_harness_threads();
+
     let corpus_path = inputs
         .corpus_path
         .clone()
@@ -147,6 +163,32 @@ pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
         case_count: cases.len(),
         failures,
     })
+}
+
+/// Pin parallel runtimes to a single thread for the harness process.
+///
+/// Recall harness reproducibility requires that two runs of the same query
+/// produce byte-identical rank lists. Multi-threaded float reductions
+/// (RAYON par_iter) and ONNX intra-op parallelism both accumulate sums in
+/// non-deterministic order, which is enough to flip ranks at the
+/// fourth-decimal level.
+///
+/// This function only sets each variable when it is currently unset, so a
+/// caller that explicitly chose a different value (e.g. for a benchmark)
+/// keeps their override.
+fn pin_harness_threads() {
+    // SAFETY: env mutation is process-wide. The harness is the sole entry
+    // point that calls this; the production server never invokes the
+    // recall harness, so we are not racing other readers in any deployed
+    // binary. The recall-eval CLI is single-threaded at startup.
+    unsafe {
+        if std::env::var_os("SHODH_ONNX_THREADS").is_none() {
+            std::env::set_var("SHODH_ONNX_THREADS", "1");
+        }
+        if std::env::var_os("RAYON_NUM_THREADS").is_none() {
+            std::env::set_var("RAYON_NUM_THREADS", "1");
+        }
+    }
 }
 
 /// Construct an isolated `MemorySystem` rooted at `storage_path`.

--- a/src/relevance.rs
+++ b/src/relevance.rs
@@ -900,8 +900,14 @@ impl RelevanceEngine {
             )
             .collect();
 
-        // Sort by relevance score (descending)
-        results.sort_by(|a, b| b.relevance_score.total_cmp(&a.relevance_score));
+        // Sort by relevance score (descending). Tie-break: recency desc, then id asc
+        // — keeps order deterministic when scores collide (a common case at high RRF k).
+        results.sort_by(|a, b| {
+            b.relevance_score
+                .total_cmp(&a.relevance_score)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+                .then_with(|| a.id.cmp(&b.id))
+        });
 
         // Quality-based filtering: only return memories above minimum relevance
         // This prevents returning low-quality matches just to fill max_results
@@ -1303,7 +1309,10 @@ impl RelevanceEngine {
                 if !candidate_ids.is_empty() {
                     // Sort by score descending and take top candidates
                     let mut sorted_candidates: Vec<_> = candidate_ids.into_iter().collect();
-                    sorted_candidates.sort_by(|a, b| b.1 .0.total_cmp(&a.1 .0));
+                    // Score desc; tie-break by Uuid asc for deterministic candidate selection
+                    // (created_at is not yet known at the candidate stage — fetched below).
+                    sorted_candidates
+                        .sort_by(|a, b| b.1 .0.total_cmp(&a.1 .0).then_with(|| a.0.cmp(&b.0)));
 
                     for (memory_id, (score, matched)) in
                         sorted_candidates.into_iter().take(max_candidates)

--- a/src/vector_db/pq.rs
+++ b/src/vector_db/pq.rs
@@ -457,8 +457,9 @@ impl CompressedVectorStore {
             .map(|(&id, codes)| (id, self.quantizer.distance_with_table(&table, codes)))
             .collect();
 
-        // Sort by distance and take top k
-        distances.sort_by(|a, b| a.1.total_cmp(&b.1));
+        // Sort by distance and take top k. Tie-break by id makes order deterministic
+        // even though `self.codes` (HashMap) yields entries in arbitrary order.
+        distances.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
         distances.truncate(k);
 
         Ok(distances)

--- a/src/vector_db/spann.rs
+++ b/src/vector_db/spann.rs
@@ -571,7 +571,8 @@ impl SpannIndex {
             .map(|(i, c)| (i, self.compute_distance(query, c)))
             .collect();
 
-        partition_distances.sort_by(|a, b| a.1.total_cmp(&b.1));
+        // Tie-break by partition index keeps probe selection deterministic across runs.
+        partition_distances.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
         let probe_partitions: Vec<usize> = partition_distances
             .iter()
             .take(self.config.num_probes)
@@ -657,9 +658,9 @@ impl SpannIndex {
             }
         }
 
-        // Convert heap to sorted results (smallest distance first)
+        // Convert heap to sorted results (smallest distance first), tie-break by id
         let mut results: Vec<(u32, f32)> = heap.into_iter().map(|(d, id)| (id, d.0)).collect();
-        results.sort_by(|a, b| a.1.total_cmp(&b.1));
+        results.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
 
         Ok(results)
     }

--- a/src/vector_db/vamana.rs
+++ b/src/vector_db/vamana.rs
@@ -670,9 +670,13 @@ impl VamanaIndex {
         let storage = self.vectors.read(); // Hold lock for entire prune operation
         let node_slice = Self::get_slice_from_storage(&storage, node_id)?;
 
-        // Sort candidates by distance (NaN values sort to end)
+        // Sort candidates by distance (NaN values sort to end), tie-break by id for determinism
         let mut sorted_candidates = candidates.to_vec();
-        sorted_candidates.sort_by(|a, b| a.distance.total_cmp(&b.distance));
+        sorted_candidates.sort_by(|a, b| {
+            a.distance
+                .total_cmp(&b.distance)
+                .then_with(|| a.id.cmp(&b.id))
+        });
 
         // Pre-load all candidate vectors to avoid repeated storage lookups
         // This trades memory for CPU - worth it for the O(n²) inner loop
@@ -918,8 +922,8 @@ impl VamanaIndex {
                         })
                         .collect();
 
-                    // Sort by distance (lower = closer for all metrics)
-                    neighbor_distances.sort_by(|a, b| a.1.total_cmp(&b.1));
+                    // Sort by distance (lower = closer for all metrics), tie-break by id
+                    neighbor_distances.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
 
                     // Keep only max_degree closest neighbors
                     graph[neighbor_id as usize].neighbors = neighbor_distances
@@ -1152,7 +1156,7 @@ impl VamanaIndex {
             distances.push((id, dist));
         }
 
-        distances.sort_by(|a, b| a.1.total_cmp(&b.1));
+        distances.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
         distances.truncate(k);
 
         Ok(distances)
@@ -1634,7 +1638,12 @@ impl Eq for SearchCandidate {}
 
 impl Ord for SearchCandidate {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.distance.total_cmp(&other.distance)
+        // Stable tie-break by id ensures deterministic rank order across runs and machines.
+        // Without this, equal-distance candidates can swap positions based on float
+        // accumulation order, causing rank flips on the recall harness between CPUs.
+        self.distance
+            .total_cmp(&other.distance)
+            .then_with(|| self.id.cmp(&other.id))
     }
 }
 

--- a/src/vector_db/vamana.rs
+++ b/src/vector_db/vamana.rs
@@ -923,7 +923,8 @@ impl VamanaIndex {
                         .collect();
 
                     // Sort by distance (lower = closer for all metrics), tie-break by id
-                    neighbor_distances.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+                    neighbor_distances
+                        .sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
 
                     // Keep only max_degree closest neighbors
                     graph[neighbor_id as usize].neighbors = neighbor_distances

--- a/tests/adaptive_memory_tests.rs
+++ b/tests/adaptive_memory_tests.rs
@@ -985,10 +985,12 @@ fn test_reinforcement_stats_structure() {
     let stats = ReinforcementStats {
         memories_processed: 5,
         associations_strengthened: 10,
+        entity_edges_reinforced: 0,
         importance_boosts: 3,
         importance_decays: 2,
         outcome: RetrievalOutcome::Helpful,
         persist_failures: 0,
+        prediction_error_multiplier: 1.0,
     };
 
     assert_eq!(stats.memories_processed, 5);

--- a/tests/graph_memory_tests.rs
+++ b/tests/graph_memory_tests.rs
@@ -51,6 +51,7 @@ fn create_entity_from_ner(ner: &NeuralNer, text: &str) -> Vec<EntityNode> {
             name_embedding: None,
             salience: entity.confidence,
             is_proper_noun: true,
+            selectivity: None,
         })
         .collect()
 }
@@ -81,6 +82,7 @@ fn create_entity(
         name_embedding: None,
         salience,
         is_proper_noun: is_proper,
+        selectivity: None,
     }
 }
 
@@ -109,6 +111,8 @@ fn create_relationship(
         tier: EdgeTier::L1Working,
         activation_timestamps: None,
         entity_confidence: None,
+        endpoint_selectivity: None,
+        forman_curvature: None,
     }
 }
 
@@ -143,6 +147,8 @@ fn create_relationship_with_plasticity(
         tier: EdgeTier::L2Episodic,
         activation_timestamps: None,
         entity_confidence: None,
+        endpoint_selectivity: None,
+        forman_curvature: None,
     }
 }
 

--- a/tests/recall_determinism.rs
+++ b/tests/recall_determinism.rs
@@ -1,0 +1,172 @@
+//! RH-11 — Determinism gate (Rig 1).
+//!
+//! Two consecutive runs of the L1 smoke suite, in the same process, against
+//! the same fixtures, against fresh storage directories, must produce
+//! byte-identical per-case rank lists.
+//!
+//! If this test ever fails, there is a non-deterministic source somewhere
+//! in the retrieval pipeline that the RH-10 tie-break + thread-pinning
+//! changes failed to cover. Do NOT relax this assertion — diagnose the
+//! source. Examples of what flips ranks if not pinned:
+//!
+//! * `total_cmp` on raw distance with no secondary key — equal-distance
+//!   candidates retain `HashMap` iteration order (random per process).
+//! * Multi-threaded ONNX intra-op or rayon par_iter — float reductions
+//!   accumulate sums in non-deterministic order, perturbing the
+//!   fourth-decimal of the score.
+//! * Wall-clock time leaking into a score (e.g. `Utc::now()` per-comparison
+//!   inside a sort comparator instead of captured once outside).
+//!
+//! This test is the canary. Aggregate metrics ALSO have to match; if rank
+//! lists are equal but metrics differ, the metric computation itself is
+//! non-deterministic.
+
+use std::path::PathBuf;
+
+use shodh_memory::recall_harness::runner::{run_smoke_suite_with_ranks, RunInputs};
+
+/// Build a `RunInputs` rooted at a unique storage path under the system
+/// temp dir. Each invocation gets a fresh directory so the harness is not
+/// reading state left over from a previous run.
+fn run_inputs(tag: &str) -> RunInputs {
+    let mut storage = std::env::temp_dir();
+    storage.push(format!(
+        "shodh-recall-determinism-{}-{}",
+        tag,
+        std::process::id()
+    ));
+    // Make sure we start clean even if a prior run crashed.
+    let _ = std::fs::remove_dir_all(&storage);
+
+    RunInputs {
+        storage_path: storage,
+        corpus_path: None,
+        cases_path: None,
+        suite: "smoke".to_string(),
+        git_sha: "determinism-test".to_string(),
+    }
+}
+
+/// Two consecutive runs of the smoke suite must return byte-identical
+/// rank lists.
+///
+/// This is the load-bearing assertion of RH-11. If it ever fires, do not
+/// patch the assertion — find the source of non-determinism and fix it.
+#[test]
+fn smoke_suite_produces_byte_identical_rank_lists_across_runs() {
+    let run1 = run_smoke_suite_with_ranks(&run_inputs("a"))
+        .expect("first smoke run should succeed");
+    let run2 = run_smoke_suite_with_ranks(&run_inputs("b"))
+        .expect("second smoke run should succeed");
+
+    assert_eq!(
+        run1.ranks.len(),
+        run2.ranks.len(),
+        "both runs must execute the same number of cases"
+    );
+
+    let mut diverged = Vec::new();
+    for (a, b) in run1.ranks.iter().zip(run2.ranks.iter()) {
+        assert_eq!(
+            a.case_id, b.case_id,
+            "runner must walk cases in the same order both times"
+        );
+        if a.retrieved != b.retrieved {
+            diverged.push(format!(
+                "case `{}` diverged:\n  run1: {:?}\n  run2: {:?}",
+                a.case_id, a.retrieved, b.retrieved
+            ));
+        }
+    }
+
+    assert!(
+        diverged.is_empty(),
+        "{} of {} cases produced different rank lists across runs:\n\n{}",
+        diverged.len(),
+        run1.ranks.len(),
+        diverged.join("\n\n")
+    );
+
+    // Cleanup — only on success so a failure leaves storage on disk for
+    // post-mortem inspection.
+    let _ = std::fs::remove_dir_all(PathBuf::from(format!(
+        "{}/shodh-recall-determinism-a-{}",
+        std::env::temp_dir().display(),
+        std::process::id()
+    )));
+    let _ = std::fs::remove_dir_all(PathBuf::from(format!(
+        "{}/shodh-recall-determinism-b-{}",
+        std::env::temp_dir().display(),
+        std::process::id()
+    )));
+}
+
+/// Aggregate metrics must also match bit-for-bit across runs.
+///
+/// If rank lists are equal (asserted above) but metrics differ, the metric
+/// computation has its own non-determinism — for example, summing in
+/// `HashMap` iteration order instead of fixture order.
+#[test]
+fn smoke_suite_produces_byte_identical_metrics_across_runs() {
+    let run1 = run_smoke_suite_with_ranks(&run_inputs("m1"))
+        .expect("first smoke run should succeed");
+    let run2 = run_smoke_suite_with_ranks(&run_inputs("m2"))
+        .expect("second smoke run should succeed");
+
+    // Compare every gating metric of the `full` layer with bit-exact
+    // equality. Latency and timestamp are excluded — they are wall-clock
+    // measurements, not deterministic functions of inputs.
+    let full1 = run1
+        .report
+        .layers
+        .get("full")
+        .expect("run1 must emit a `full` layer");
+    let full2 = run2
+        .report
+        .layers
+        .get("full")
+        .expect("run2 must emit a `full` layer");
+
+    assert_eq!(full1.ndcg_at_10.to_bits(), full2.ndcg_at_10.to_bits(), "ndcg@10");
+    assert_eq!(full1.recall_at_10.to_bits(), full2.recall_at_10.to_bits(), "recall@10");
+    assert_eq!(
+        full1.precision_at_10.to_bits(),
+        full2.precision_at_10.to_bits(),
+        "precision@10"
+    );
+    assert_eq!(full1.mrr.to_bits(), full2.mrr.to_bits(), "mrr");
+    assert_eq!(full1.p_at_1.to_bits(), full2.p_at_1.to_bits(), "p@1");
+    assert_eq!(full1.map.to_bits(), full2.map.to_bits(), "map");
+
+    // Per-category aggregates must match too.
+    assert_eq!(
+        run1.report.by_category.len(),
+        run2.report.by_category.len(),
+        "category set must match"
+    );
+    for (cat, c1) in &run1.report.by_category {
+        let c2 = run2
+            .report
+            .by_category
+            .get(cat)
+            .unwrap_or_else(|| panic!("run2 missing category `{}`", cat));
+        assert_eq!(c1.ndcg_at_10.to_bits(), c2.ndcg_at_10.to_bits(), "{} ndcg@10", cat);
+        assert_eq!(c1.recall_at_10.to_bits(), c2.recall_at_10.to_bits(), "{} recall@10", cat);
+        assert_eq!(c1.mrr.to_bits(), c2.mrr.to_bits(), "{} mrr", cat);
+        assert_eq!(c1.p_at_1.to_bits(), c2.p_at_1.to_bits(), "{} p@1", cat);
+        assert_eq!(c1.map.to_bits(), c2.map.to_bits(), "{} map", cat);
+        assert_eq!(c1.case_count, c2.case_count, "{} case_count", cat);
+    }
+
+    // Cleanup
+    let _ = std::fs::remove_dir_all(PathBuf::from(format!(
+        "{}/shodh-recall-determinism-m1-{}",
+        std::env::temp_dir().display(),
+        std::process::id()
+    )));
+    let _ = std::fs::remove_dir_all(PathBuf::from(format!(
+        "{}/shodh-recall-determinism-m2-{}",
+        std::env::temp_dir().display(),
+        std::process::id()
+    )));
+}

--- a/tests/recall_determinism.rs
+++ b/tests/recall_determinism.rs
@@ -54,10 +54,10 @@ fn run_inputs(tag: &str) -> RunInputs {
 /// patch the assertion — find the source of non-determinism and fix it.
 #[test]
 fn smoke_suite_produces_byte_identical_rank_lists_across_runs() {
-    let run1 = run_smoke_suite_with_ranks(&run_inputs("a"))
-        .expect("first smoke run should succeed");
-    let run2 = run_smoke_suite_with_ranks(&run_inputs("b"))
-        .expect("second smoke run should succeed");
+    let run1 =
+        run_smoke_suite_with_ranks(&run_inputs("a")).expect("first smoke run should succeed");
+    let run2 =
+        run_smoke_suite_with_ranks(&run_inputs("b")).expect("second smoke run should succeed");
 
     assert_eq!(
         run1.ranks.len(),
@@ -108,10 +108,10 @@ fn smoke_suite_produces_byte_identical_rank_lists_across_runs() {
 /// `HashMap` iteration order instead of fixture order.
 #[test]
 fn smoke_suite_produces_byte_identical_metrics_across_runs() {
-    let run1 = run_smoke_suite_with_ranks(&run_inputs("m1"))
-        .expect("first smoke run should succeed");
-    let run2 = run_smoke_suite_with_ranks(&run_inputs("m2"))
-        .expect("second smoke run should succeed");
+    let run1 =
+        run_smoke_suite_with_ranks(&run_inputs("m1")).expect("first smoke run should succeed");
+    let run2 =
+        run_smoke_suite_with_ranks(&run_inputs("m2")).expect("second smoke run should succeed");
 
     // Compare every gating metric of the `full` layer with bit-exact
     // equality. Latency and timestamp are excluded — they are wall-clock
@@ -127,8 +127,16 @@ fn smoke_suite_produces_byte_identical_metrics_across_runs() {
         .get("full")
         .expect("run2 must emit a `full` layer");
 
-    assert_eq!(full1.ndcg_at_10.to_bits(), full2.ndcg_at_10.to_bits(), "ndcg@10");
-    assert_eq!(full1.recall_at_10.to_bits(), full2.recall_at_10.to_bits(), "recall@10");
+    assert_eq!(
+        full1.ndcg_at_10.to_bits(),
+        full2.ndcg_at_10.to_bits(),
+        "ndcg@10"
+    );
+    assert_eq!(
+        full1.recall_at_10.to_bits(),
+        full2.recall_at_10.to_bits(),
+        "recall@10"
+    );
     assert_eq!(
         full1.precision_at_10.to_bits(),
         full2.precision_at_10.to_bits(),
@@ -150,8 +158,18 @@ fn smoke_suite_produces_byte_identical_metrics_across_runs() {
             .by_category
             .get(cat)
             .unwrap_or_else(|| panic!("run2 missing category `{}`", cat));
-        assert_eq!(c1.ndcg_at_10.to_bits(), c2.ndcg_at_10.to_bits(), "{} ndcg@10", cat);
-        assert_eq!(c1.recall_at_10.to_bits(), c2.recall_at_10.to_bits(), "{} recall@10", cat);
+        assert_eq!(
+            c1.ndcg_at_10.to_bits(),
+            c2.ndcg_at_10.to_bits(),
+            "{} ndcg@10",
+            cat
+        );
+        assert_eq!(
+            c1.recall_at_10.to_bits(),
+            c2.recall_at_10.to_bits(),
+            "{} recall@10",
+            cat
+        );
         assert_eq!(c1.mrr.to_bits(), c2.mrr.to_bits(), "{} mrr", cat);
         assert_eq!(c1.p_at_1.to_bits(), c2.p_at_1.to_bits(), "{} p@1", cat);
         assert_eq!(c1.map.to_bits(), c2.map.to_bits(), "{} map", cat);

--- a/tests/salience_tests.rs
+++ b/tests/salience_tests.rs
@@ -62,6 +62,7 @@ fn create_entity(
         name_embedding: None,
         salience: base_salience,
         is_proper_noun: is_proper,
+        selectivity: None,
     }
 }
 

--- a/tests/universe_tests.rs
+++ b/tests/universe_tests.rs
@@ -51,6 +51,7 @@ fn create_entity_from_ner(
         name_embedding: None,
         salience,
         is_proper_noun: is_proper,
+        selectivity: None,
     }
 }
 
@@ -80,6 +81,7 @@ fn create_entity(
         name_embedding: None,
         salience,
         is_proper_noun: is_proper,
+        selectivity: None,
     }
 }
 
@@ -108,6 +110,8 @@ fn create_relationship(
         tier: EdgeTier::L1Working,
         activation_timestamps: None,
         entity_confidence: None,
+        endpoint_selectivity: None,
+        forman_curvature: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Three RH-* tasks landed together because they're load-bearing for each other:

- **RH-10** kills the non-determinism in the retrieval pipeline that
  was making the gate flap on cross-environment runs.
- **RH-11** adds the test that prevents non-determinism from coming back.
- **RH-5** wires the gate that fails the PR if recall drops >2%.

Splitting them costs more than it saves — the CI gate (RH-5) is
meaningless without RH-10/RH-11, and RH-10/RH-11 are uninteresting
without a gate consuming them.

## RH-10 — eliminate sources of non-determinism

**Stable tie-breaks** at every sort site that ranks float scores. With
\`f32::total_cmp\` alone, equal-score candidates retain the underlying
container's iteration order, which is \`HashMap\` (random per process)
in several places.

- Vector index layer (\`vector_db/{vamana,spann,pq}.rs\`): tie-break by
  \`id\` — the only stable key available cheaply at that depth.
- Retrieval layer (\`memory/retrieval.rs\`, \`memory/mod.rs\`,
  \`relevance.rs\`): \`score → created_at desc → id\`. Two-layer scheme:
  the index doesn't have timestamps but the retrieval layer does, and
  recency is a meaningful tiebreaker for users.

**Thread pinning** in the harness:

- \`SHODH_ONNX_THREADS=1\` — MiniLM/NER intra-op single-threaded.
- \`RAYON_NUM_THREADS=1\` — \`par_iter()\` in scoring runs serially.

Multi-threaded float reductions accumulate sums in non-deterministic
order, enough to flip ranks at the fourth decimal even with no source
change. Both vars are only set if the caller hasn't overridden them,
so production callers stay unaffected.

## RH-11 — Rig 1: determinism gate

\`tests/recall_determinism.rs\` runs the smoke suite **twice** in the
same process, against fresh storage dirs, and asserts:

1. **Byte-identical rank lists per case.** \`CaseRankList.retrieved\`
   carries **stable corpus item IDs**, not the random per-run UUIDs
   assigned by \`MemorySystem::remember\` — UUIDs would always diverge
   and would mask real determinism wins behind noise.
2. **Bit-exact metric aggregates.** \`f64::to_bits()\` equality on
   ndcg@10, recall@10, precision@10, mrr, p@1, map — including
   per-category aggregates. If rank lists are equal but metrics
   differ, the metric computation has its own non-determinism.

If the gate ever fires, do **not** relax it — diagnose the new source
of non-determinism. RH-13 (CI re-baseline) and RH-5 (this gate) both
depend on byte-identical runs to be statistically meaningful.

## RH-5 — CI gate

Workflow runs \`recall-eval\` on every PR, diffs against
\`tests/recall/baseline.json\`, and fails the PR if any of the gating
metrics (ndcg@10, recall@10, mrr, p@1, map) drops by more than 2%.
Markdown diff renderer attaches the result as a PR comment.

## Companion fix

\`fix(tests)\` lands four pre-existing E0063 errors that blocked the
test suite from compiling — \`EntityNode.selectivity\`,
\`RelationshipEdge.{endpoint_selectivity, forman_curvature}\`, and
\`ReinforcementStats.{entity_edges_reinforced, prediction_error_multiplier}\`.
These were added by upstream PRs (#258, #260, #261) but the test
files used struct literals so the additions broke compilation
silently.

## Local verification

Two consecutive recall-eval runs produced **byte-identical** metrics:

\`\`\`
ndcg@10:   0.8231 → 0.8231  (vs baseline 0.8065, +0.0167)
recall@10: 0.8833 → 0.8833  (vs baseline 0.8500, +0.0333)
p@1:       0.8333 → 0.8333  (restored from 0.800 that was tripping the gate)
mrr:       0.9000 → 0.9000
map:       0.7653 → 0.7653
\`\`\`

The temporal category lifted +0.10 — a side-effect of the
\`created_at desc\` tiebreaker, which favours recent memories on score
ties (correct behaviour for "what did we decide last week" style
queries).

## Test plan

- [x] \`cargo check --tests\` clean
- [x] \`cargo clippy\` clean
- [x] Two recall-eval runs produce byte-identical metrics locally
- [ ] CI: all build matrices green
- [ ] CI: \`recall_determinism\` test passes on Linux + macOS
- [ ] CI: L1 Smoke Suite gate passes (was the failure mode that motivated this PR)