### PR TITLE
feat(recall): RH-10 + RH-11 — determinism in retrieval + Rig 1 gate

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1249,7 +1249,11 @@ impl MemorySystem {
             let temporal_b = Self::calculate_temporal_relevance(age_days_b);
             let score_b = b.importance() * temporal_b;
 
-            score_b.total_cmp(&score_a)
+            // Score desc → recency desc → MemoryId asc for deterministic ordering.
+            score_b
+                .total_cmp(&score_a)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+                .then_with(|| a.id.cmp(&b.id))
         });
 
         memories.truncate(query.max_results);
@@ -2024,7 +2028,8 @@ impl MemorySystem {
                         )
                     })
                     .collect();
-                r.sort_by(|a, b| b.1.total_cmp(&a.1));
+                // Score desc; tie-break by MemoryId asc for deterministic graph candidate order.
+                r.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
                 r.truncate(200);
                 if !r.is_empty() {
                     tracing::debug!(
@@ -2557,7 +2562,11 @@ impl MemorySystem {
             // Only look up graph entities for the top 2x max_results candidates,
             // not all fused results (avoids 100s of RocksDB reads).
             let mut res: Vec<_> = fused.into_iter().collect();
-            res.sort_by(|a, b| b.1.total_cmp(&a.1));
+            // Score desc; tie-break by MemoryId for stable rerank-budget cutoff.
+            // The cutoff at `rerank_budget` makes order at the boundary semantically
+            // important — without tie-break, equal-score boundary candidates can swap
+            // in/out of the rerank window across runs.
+            res.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
             let rerank_budget = query.max_results * 2;
 
             if use_ontology_rerank && !onto_intent.expected_labels.is_empty() {
@@ -2609,8 +2618,9 @@ impl MemorySystem {
                             onto_intent.expected_labels
                         );
                     }
-                    // Re-sort after boosting since ranks may have changed
-                    res.sort_by(|a, b| b.1.total_cmp(&a.1));
+                    // Re-sort after boosting since ranks may have changed.
+                    // Tie-break by MemoryId — same rationale as the pre-rerank sort above.
+                    res.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
                 }
             }
 
@@ -2997,7 +3007,11 @@ impl MemorySystem {
                     + Self::linguistic_boost(&a.experience.content, &query_analysis) * 0.05;
                 let score_b = b.score.unwrap_or(0.0)
                     + Self::linguistic_boost(&b.experience.content, &query_analysis) * 0.05;
-                score_b.total_cmp(&score_a)
+                // Score desc → recency desc → MemoryId asc for stable rank order.
+                score_b
+                    .total_cmp(&score_a)
+                    .then_with(|| b.created_at.cmp(&a.created_at))
+                    .then_with(|| a.id.cmp(&b.id))
             });
         }
 
@@ -3124,7 +3138,14 @@ impl MemorySystem {
         // Re-sort by score and trim to max_results after expansion.
         // Expanded memories must compete on score, not get a free pass.
         if memories.len() > query.max_results {
-            memories.sort_by(|a, b| b.score.unwrap_or(0.0).total_cmp(&a.score.unwrap_or(0.0)));
+            // Score desc → recency desc → MemoryId asc — deterministic competition cutoff.
+            memories.sort_by(|a, b| {
+                b.score
+                    .unwrap_or(0.0)
+                    .total_cmp(&a.score.unwrap_or(0.0))
+                    .then_with(|| b.created_at.cmp(&a.created_at))
+                    .then_with(|| a.id.cmp(&b.id))
+            });
             memories.truncate(query.max_results);
         }
 
@@ -3151,7 +3172,12 @@ impl MemorySystem {
                     .filter(|(id, _)| final_ids.contains(id))
                     .map(|(_, attr)| attr)
                     .collect();
-                attrs.sort_by(|a, b| b.final_score.total_cmp(&a.final_score));
+                // Tie-break by memory_id so attribution rows have a stable order across runs.
+                attrs.sort_by(|a, b| {
+                    b.final_score
+                        .total_cmp(&a.final_score)
+                        .then_with(|| a.memory_id.cmp(&b.memory_id))
+                });
                 s.score_attributions = Some(attrs);
             }
         }

--- a/src/memory/retrieval.rs
+++ b/src/memory/retrieval.rs
@@ -908,9 +908,11 @@ impl RetrievalEngine {
             }
         }
 
-        // Convert to vec and sort by similarity descending (highest first)
+        // Convert to vec and sort by similarity descending (highest first).
+        // Tie-break by MemoryId for deterministic rank order across runs/CPUs.
+        // (created_at is unavailable here — we only have ids + scores.)
         let mut memory_ids: Vec<(MemoryId, f32)> = best_scores.into_iter().collect();
-        memory_ids.sort_by(|a, b| b.1.total_cmp(&a.1));
+        memory_ids.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         memory_ids.truncate(limit);
 
         Ok(memory_ids)
@@ -974,9 +976,10 @@ impl RetrievalEngine {
             }
         }
 
-        // Convert to vec and sort by similarity descending (highest first)
+        // Convert to vec and sort by similarity descending (highest first).
+        // Tie-break by MemoryId for deterministic rank order across runs/CPUs.
         let mut memory_ids: Vec<(MemoryId, f32)> = best_scores.into_iter().collect();
-        memory_ids.sort_by(|a, b| b.1.total_cmp(&a.1));
+        memory_ids.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         memory_ids.truncate(limit);
 
         Ok(memory_ids)
@@ -1109,10 +1112,13 @@ impl RetrievalEngine {
                     .as_ref()
                     .and_then(|c| c.episode.sequence_number)
                     .unwrap_or(0);
-                seq_a.cmp(&seq_b)
+                // Tie-break by MemoryId so memories without sequence_number
+                // (both unwrap to 0) still produce a stable order.
+                seq_a.cmp(&seq_b).then_with(|| a.id.cmp(&b.id))
             });
         } else {
-            memories.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+            // Newest first; tie-break by MemoryId on identical timestamps.
+            memories.sort_by(|a, b| b.created_at.cmp(&a.created_at).then_with(|| a.id.cmp(&b.id)));
         }
 
         memories.truncate(limit);
@@ -1211,7 +1217,14 @@ impl RetrievalEngine {
             })
             .collect();
 
-        sorted.sort_by(|a, b| b.0.total_cmp(&a.0));
+        // Score desc → recency desc → MemoryId asc. Two layers of tie-break:
+        // recency carries product meaning ("newer wins on equal score"), id is the
+        // deterministic backstop for nanosecond-collision timestamps.
+        sorted.sort_by(|a, b| {
+            b.0.total_cmp(&a.0)
+                .then_with(|| b.1.created_at.cmp(&a.1.created_at))
+                .then_with(|| a.1.id.cmp(&b.1.id))
+        });
 
         Ok(sorted.into_iter().take(limit).map(|(_, m)| m).collect())
     }
@@ -1244,7 +1257,7 @@ impl RetrievalEngine {
         // Apply additional filters
         memories.retain(|m| self.matches_filters(m, query));
 
-        // Sort by distance (closest first)
+        // Sort by distance (closest first), tie-break by recency then id for determinism.
         memories.sort_by(|a, b| {
             let dist_a = match a.experience.geo_location {
                 Some(geo) => geo_filter.haversine_distance(geo[0], geo[1]),
@@ -1254,7 +1267,10 @@ impl RetrievalEngine {
                 Some(geo) => geo_filter.haversine_distance(geo[0], geo[1]),
                 None => f64::MAX,
             };
-            dist_a.total_cmp(&dist_b)
+            dist_a
+                .total_cmp(&dist_b)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+                .then_with(|| a.id.cmp(&b.id))
         });
 
         memories.truncate(limit);
@@ -1281,8 +1297,8 @@ impl RetrievalEngine {
         // Apply additional filters
         memories.retain(|m| self.matches_filters(m, query));
 
-        // Sort by timestamp (chronological order for mission replay)
-        memories.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        // Sort by timestamp (chronological order for mission replay), tie-break by id.
+        memories.sort_by(|a, b| a.created_at.cmp(&b.created_at).then_with(|| a.id.cmp(&b.id)));
 
         memories.truncate(limit);
         Ok(memories)
@@ -1309,11 +1325,15 @@ impl RetrievalEngine {
         // Apply additional filters (action_type, robot_id, etc.)
         memories.retain(|m| self.matches_filters(m, query));
 
-        // Sort by reward (highest first for learning from best outcomes)
+        // Sort by reward (highest first for learning from best outcomes).
+        // Tie-break: recency desc, then id asc — deterministic across runs.
         memories.sort_by(|a, b| {
             let reward_a = a.experience.reward.unwrap_or(0.0);
             let reward_b = b.experience.reward.unwrap_or(0.0);
-            reward_b.total_cmp(&reward_a)
+            reward_b
+                .total_cmp(&reward_a)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+                .then_with(|| a.id.cmp(&b.id))
         });
 
         memories.truncate(limit);

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -47,6 +47,34 @@ pub struct RunInputs {
     pub git_sha: String,
 }
 
+/// One case's retrieved rank list, in score-descending order.
+///
+/// Used by the determinism gate (RH-11) to assert byte-identical
+/// rank lists across consecutive runs of the same suite.
+///
+/// `retrieved` holds **corpus item IDs** (stable string handles from the
+/// fixture), not the random UUIDs assigned by `MemorySystem::remember`.
+/// UUIDs are freshly generated per ingest and therefore differ across
+/// runs even when the rank order is byte-identical; comparing them would
+/// guarantee a false negative. Items that were retrieved but do not
+/// belong to the corpus (e.g. system-injected memories) are emitted as
+/// `"<unknown:...>"` sentinels so divergence in those slots is still
+/// observable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaseRankList {
+    pub case_id: String,
+    pub retrieved: Vec<String>,
+}
+
+/// Wrapper around [`Report`] plus the per-case rank lists. Returned by
+/// [`run_smoke_suite_with_ranks`]; the ranks are stripped by the public
+/// [`run_smoke_suite`] wrapper to preserve the simpler caller contract.
+#[derive(Debug, Clone)]
+pub struct ReportWithRanks {
+    pub report: Report,
+    pub ranks: Vec<CaseRankList>,
+}
+
 /// Run the smoke suite end-to-end and return a populated [`Report`].
 ///
 /// On infrastructure errors (corpus parse failure, system init failure,
@@ -54,6 +82,16 @@ pub struct RunInputs {
 /// recorded as `Failure { kind = "case", .. }` entries so a single broken
 /// query does not abort the whole run.
 pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
+    run_smoke_suite_with_ranks(inputs).map(|rwr| rwr.report)
+}
+
+/// Same as [`run_smoke_suite`] but also returns the per-case rank lists.
+///
+/// Exists for the RH-11 determinism gate: two consecutive calls with
+/// identical inputs must return byte-identical [`CaseRankList`]s. If they
+/// don't, there is a non-deterministic source somewhere in the retrieval
+/// pipeline that the tie-break + thread pinning failed to cover.
+pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks> {
     // ------------------------------------------------------------------
     // Determinism: pin every parallel runtime to a single thread before
     // any work touches ONNX or rayon. Multi-threaded float reductions
@@ -89,11 +127,20 @@ pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
 
     let system = build_system(&inputs.storage_path)?;
     let id_map = ingest_corpus(&system, &corpus)?;
+    // Reverse map: random per-run UUIDs → stable corpus item IDs. The
+    // determinism gate (RH-11) compares rank lists across runs, so we MUST
+    // emit stable handles. Comparing UUIDs would always diverge because
+    // each ingest assigns a fresh `Uuid::new_v4()`.
+    let uuid_to_corpus_id: HashMap<Uuid, String> = id_map
+        .iter()
+        .map(|(corpus_id, uuid)| (*uuid, corpus_id.clone()))
+        .collect();
 
     let mut per_case = Vec::with_capacity(cases.len());
     let mut latencies_ms = Vec::with_capacity(cases.len());
     let mut by_category_cases: HashMap<SmokeCategory, Vec<Metrics>> = HashMap::new();
     let mut failures: Vec<Failure> = Vec::new();
+    let mut ranks: Vec<CaseRankList> = Vec::with_capacity(cases.len());
 
     for case in &cases {
         let query = Query {
@@ -120,6 +167,24 @@ pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
         };
 
         let retrieved_uuids: Vec<Uuid> = memories.iter().map(|m| m.id.0).collect();
+        // Translate to stable corpus IDs for the determinism gate. Items
+        // that were not part of the ingested corpus (defensive: should
+        // never happen on a fresh harness storage dir) are surfaced as
+        // `<unknown:UUID>` so any divergence in those slots is still
+        // observable instead of silently masked by a string fallback.
+        let retrieved_corpus_ids: Vec<String> = retrieved_uuids
+            .iter()
+            .map(|u| {
+                uuid_to_corpus_id
+                    .get(u)
+                    .cloned()
+                    .unwrap_or_else(|| format!("<unknown:{u}>"))
+            })
+            .collect();
+        ranks.push(CaseRankList {
+            case_id: case.id.clone(),
+            retrieved: retrieved_corpus_ids,
+        });
         let relevance = build_relevance_map(case, &id_map);
 
         if relevance.is_empty() {
@@ -153,7 +218,7 @@ pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
         );
     }
 
-    Ok(Report {
+    let report = Report {
         suite: inputs.suite.clone(),
         embedder: EMBEDDER_ID.to_string(),
         git_sha: inputs.git_sha.clone(),
@@ -162,7 +227,9 @@ pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
         by_category,
         case_count: cases.len(),
         failures,
-    })
+    };
+
+    Ok(ReportWithRanks { report, ranks })
 }
 
 /// Pin parallel runtimes to a single thread for the harness process.

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -54,6 +54,22 @@ pub struct RunInputs {
 /// recorded as `Failure { kind = "case", .. }` entries so a single broken
 /// query does not abort the whole run.
 pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
+    // ------------------------------------------------------------------
+    // Determinism: pin every parallel runtime to a single thread before
+    // any work touches ONNX or rayon. Multi-threaded float reductions
+    // accumulate in non-deterministic order, which flips ranks on the
+    // recall harness even when no source code has changed.
+    //
+    // - SHODH_ONNX_THREADS=1 → MiniLM/NER intra-op runs single-threaded
+    //   (already plumbed through src/embeddings/{minilm,ner}.rs).
+    // - RAYON_NUM_THREADS=1  → any par_iter() in scoring runs serially.
+    //
+    // We only set these vars if the caller hasn't pinned them already,
+    // so production callers (which never invoke the harness) stay
+    // unaffected.
+    // ------------------------------------------------------------------
+    pin_harness_threads();
+
     let corpus_path = inputs
         .corpus_path
         .clone()
@@ -147,6 +163,32 @@ pub fn run_smoke_suite(inputs: &RunInputs) -> Result<Report> {
         case_count: cases.len(),
         failures,
     })
+}
+
+/// Pin parallel runtimes to a single thread for the harness process.
+///
+/// Recall harness reproducibility requires that two runs of the same query
+/// produce byte-identical rank lists. Multi-threaded float reductions
+/// (RAYON par_iter) and ONNX intra-op parallelism both accumulate sums in
+/// non-deterministic order, which is enough to flip ranks at the
+/// fourth-decimal level.
+///
+/// This function only sets each variable when it is currently unset, so a
+/// caller that explicitly chose a different value (e.g. for a benchmark)
+/// keeps their override.
+fn pin_harness_threads() {
+    // SAFETY: env mutation is process-wide. The harness is the sole entry
+    // point that calls this; the production server never invokes the
+    // recall harness, so we are not racing other readers in any deployed
+    // binary. The recall-eval CLI is single-threaded at startup.
+    unsafe {
+        if std::env::var_os("SHODH_ONNX_THREADS").is_none() {
+            std::env::set_var("SHODH_ONNX_THREADS", "1");
+        }
+        if std::env::var_os("RAYON_NUM_THREADS").is_none() {
+            std::env::set_var("RAYON_NUM_THREADS", "1");
+        }
+    }
 }
 
 /// Construct an isolated `MemorySystem` rooted at `storage_path`.

--- a/src/relevance.rs
+++ b/src/relevance.rs
@@ -900,8 +900,14 @@ impl RelevanceEngine {
             )
             .collect();
 
-        // Sort by relevance score (descending)
-        results.sort_by(|a, b| b.relevance_score.total_cmp(&a.relevance_score));
+        // Sort by relevance score (descending). Tie-break: recency desc, then id asc
+        // — keeps order deterministic when scores collide (a common case at high RRF k).
+        results.sort_by(|a, b| {
+            b.relevance_score
+                .total_cmp(&a.relevance_score)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+                .then_with(|| a.id.cmp(&b.id))
+        });
 
         // Quality-based filtering: only return memories above minimum relevance
         // This prevents returning low-quality matches just to fill max_results
@@ -1303,7 +1309,10 @@ impl RelevanceEngine {
                 if !candidate_ids.is_empty() {
                     // Sort by score descending and take top candidates
                     let mut sorted_candidates: Vec<_> = candidate_ids.into_iter().collect();
-                    sorted_candidates.sort_by(|a, b| b.1 .0.total_cmp(&a.1 .0));
+                    // Score desc; tie-break by Uuid asc for deterministic candidate selection
+                    // (created_at is not yet known at the candidate stage — fetched below).
+                    sorted_candidates
+                        .sort_by(|a, b| b.1 .0.total_cmp(&a.1 .0).then_with(|| a.0.cmp(&b.0)));
 
                     for (memory_id, (score, matched)) in
                         sorted_candidates.into_iter().take(max_candidates)

--- a/src/vector_db/pq.rs
+++ b/src/vector_db/pq.rs
@@ -457,8 +457,9 @@ impl CompressedVectorStore {
             .map(|(&id, codes)| (id, self.quantizer.distance_with_table(&table, codes)))
             .collect();
 
-        // Sort by distance and take top k
-        distances.sort_by(|a, b| a.1.total_cmp(&b.1));
+        // Sort by distance and take top k. Tie-break by id makes order deterministic
+        // even though `self.codes` (HashMap) yields entries in arbitrary order.
+        distances.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
         distances.truncate(k);
 
         Ok(distances)

--- a/src/vector_db/spann.rs
+++ b/src/vector_db/spann.rs
@@ -571,7 +571,8 @@ impl SpannIndex {
             .map(|(i, c)| (i, self.compute_distance(query, c)))
             .collect();
 
-        partition_distances.sort_by(|a, b| a.1.total_cmp(&b.1));
+        // Tie-break by partition index keeps probe selection deterministic across runs.
+        partition_distances.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
         let probe_partitions: Vec<usize> = partition_distances
             .iter()
             .take(self.config.num_probes)
@@ -657,9 +658,9 @@ impl SpannIndex {
             }
         }
 
-        // Convert heap to sorted results (smallest distance first)
+        // Convert heap to sorted results (smallest distance first), tie-break by id
         let mut results: Vec<(u32, f32)> = heap.into_iter().map(|(d, id)| (id, d.0)).collect();
-        results.sort_by(|a, b| a.1.total_cmp(&b.1));
+        results.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
 
         Ok(results)
     }

--- a/src/vector_db/vamana.rs
+++ b/src/vector_db/vamana.rs
@@ -670,9 +670,13 @@ impl VamanaIndex {
         let storage = self.vectors.read(); // Hold lock for entire prune operation
         let node_slice = Self::get_slice_from_storage(&storage, node_id)?;
 
-        // Sort candidates by distance (NaN values sort to end)
+        // Sort candidates by distance (NaN values sort to end), tie-break by id for determinism
         let mut sorted_candidates = candidates.to_vec();
-        sorted_candidates.sort_by(|a, b| a.distance.total_cmp(&b.distance));
+        sorted_candidates.sort_by(|a, b| {
+            a.distance
+                .total_cmp(&b.distance)
+                .then_with(|| a.id.cmp(&b.id))
+        });
 
         // Pre-load all candidate vectors to avoid repeated storage lookups
         // This trades memory for CPU - worth it for the O(n²) inner loop
@@ -918,8 +922,8 @@ impl VamanaIndex {
                         })
                         .collect();
 
-                    // Sort by distance (lower = closer for all metrics)
-                    neighbor_distances.sort_by(|a, b| a.1.total_cmp(&b.1));
+                    // Sort by distance (lower = closer for all metrics), tie-break by id
+                    neighbor_distances.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
 
                     // Keep only max_degree closest neighbors
                     graph[neighbor_id as usize].neighbors = neighbor_distances
@@ -1152,7 +1156,7 @@ impl VamanaIndex {
             distances.push((id, dist));
         }
 
-        distances.sort_by(|a, b| a.1.total_cmp(&b.1));
+        distances.sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
         distances.truncate(k);
 
         Ok(distances)
@@ -1634,7 +1638,12 @@ impl Eq for SearchCandidate {}
 
 impl Ord for SearchCandidate {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.distance.total_cmp(&other.distance)
+        // Stable tie-break by id ensures deterministic rank order across runs and machines.
+        // Without this, equal-distance candidates can swap positions based on float
+        // accumulation order, causing rank flips on the recall harness between CPUs.
+        self.distance
+            .total_cmp(&other.distance)
+            .then_with(|| self.id.cmp(&other.id))
     }
 }
 

--- a/tests/adaptive_memory_tests.rs
+++ b/tests/adaptive_memory_tests.rs
@@ -985,10 +985,12 @@ fn test_reinforcement_stats_structure() {
     let stats = ReinforcementStats {
         memories_processed: 5,
         associations_strengthened: 10,
+        entity_edges_reinforced: 0,
         importance_boosts: 3,
         importance_decays: 2,
         outcome: RetrievalOutcome::Helpful,
         persist_failures: 0,
+        prediction_error_multiplier: 1.0,
     };
 
     assert_eq!(stats.memories_processed, 5);

--- a/tests/graph_memory_tests.rs
+++ b/tests/graph_memory_tests.rs
@@ -51,6 +51,7 @@ fn create_entity_from_ner(ner: &NeuralNer, text: &str) -> Vec<EntityNode> {
             name_embedding: None,
             salience: entity.confidence,
             is_proper_noun: true,
+            selectivity: None,
         })
         .collect()
 }
@@ -81,6 +82,7 @@ fn create_entity(
         name_embedding: None,
         salience,
         is_proper_noun: is_proper,
+        selectivity: None,
     }
 }
 
@@ -109,6 +111,8 @@ fn create_relationship(
         tier: EdgeTier::L1Working,
         activation_timestamps: None,
         entity_confidence: None,
+        endpoint_selectivity: None,
+        forman_curvature: None,
     }
 }
 
@@ -143,6 +147,8 @@ fn create_relationship_with_plasticity(
         tier: EdgeTier::L2Episodic,
         activation_timestamps: None,
         entity_confidence: None,
+        endpoint_selectivity: None,
+        forman_curvature: None,
     }
 }
 

--- a/tests/recall_determinism.rs
+++ b/tests/recall_determinism.rs
@@ -1,0 +1,172 @@
+//! RH-11 — Determinism gate (Rig 1).
+//!
+//! Two consecutive runs of the L1 smoke suite, in the same process, against
+//! the same fixtures, against fresh storage directories, must produce
+//! byte-identical per-case rank lists.
+//!
+//! If this test ever fails, there is a non-deterministic source somewhere
+//! in the retrieval pipeline that the RH-10 tie-break + thread-pinning
+//! changes failed to cover. Do NOT relax this assertion — diagnose the
+//! source. Examples of what flips ranks if not pinned:
+//!
+//! * `total_cmp` on raw distance with no secondary key — equal-distance
+//!   candidates retain `HashMap` iteration order (random per process).
+//! * Multi-threaded ONNX intra-op or rayon par_iter — float reductions
+//!   accumulate sums in non-deterministic order, perturbing the
+//!   fourth-decimal of the score.
+//! * Wall-clock time leaking into a score (e.g. `Utc::now()` per-comparison
+//!   inside a sort comparator instead of captured once outside).
+//!
+//! This test is the canary. Aggregate metrics ALSO have to match; if rank
+//! lists are equal but metrics differ, the metric computation itself is
+//! non-deterministic.
+
+use std::path::PathBuf;
+
+use shodh_memory::recall_harness::runner::{run_smoke_suite_with_ranks, RunInputs};
+
+/// Build a `RunInputs` rooted at a unique storage path under the system
+/// temp dir. Each invocation gets a fresh directory so the harness is not
+/// reading state left over from a previous run.
+fn run_inputs(tag: &str) -> RunInputs {
+    let mut storage = std::env::temp_dir();
+    storage.push(format!(
+        "shodh-recall-determinism-{}-{}",
+        tag,
+        std::process::id()
+    ));
+    // Make sure we start clean even if a prior run crashed.
+    let _ = std::fs::remove_dir_all(&storage);
+
+    RunInputs {
+        storage_path: storage,
+        corpus_path: None,
+        cases_path: None,
+        suite: "smoke".to_string(),
+        git_sha: "determinism-test".to_string(),
+    }
+}
+
+/// Two consecutive runs of the smoke suite must return byte-identical
+/// rank lists.
+///
+/// This is the load-bearing assertion of RH-11. If it ever fires, do not
+/// patch the assertion — find the source of non-determinism and fix it.
+#[test]
+fn smoke_suite_produces_byte_identical_rank_lists_across_runs() {
+    let run1 = run_smoke_suite_with_ranks(&run_inputs("a"))
+        .expect("first smoke run should succeed");
+    let run2 = run_smoke_suite_with_ranks(&run_inputs("b"))
+        .expect("second smoke run should succeed");
+
+    assert_eq!(
+        run1.ranks.len(),
+        run2.ranks.len(),
+        "both runs must execute the same number of cases"
+    );
+
+    let mut diverged = Vec::new();
+    for (a, b) in run1.ranks.iter().zip(run2.ranks.iter()) {
+        assert_eq!(
+            a.case_id, b.case_id,
+            "runner must walk cases in the same order both times"
+        );
+        if a.retrieved != b.retrieved {
+            diverged.push(format!(
+                "case `{}` diverged:\n  run1: {:?}\n  run2: {:?}",
+                a.case_id, a.retrieved, b.retrieved
+            ));
+        }
+    }
+
+    assert!(
+        diverged.is_empty(),
+        "{} of {} cases produced different rank lists across runs:\n\n{}",
+        diverged.len(),
+        run1.ranks.len(),
+        diverged.join("\n\n")
+    );
+
+    // Cleanup — only on success so a failure leaves storage on disk for
+    // post-mortem inspection.
+    let _ = std::fs::remove_dir_all(PathBuf::from(format!(
+        "{}/shodh-recall-determinism-a-{}",
+        std::env::temp_dir().display(),
+        std::process::id()
+    )));
+    let _ = std::fs::remove_dir_all(PathBuf::from(format!(
+        "{}/shodh-recall-determinism-b-{}",
+        std::env::temp_dir().display(),
+        std::process::id()
+    )));
+}
+
+/// Aggregate metrics must also match bit-for-bit across runs.
+///
+/// If rank lists are equal (asserted above) but metrics differ, the metric
+/// computation has its own non-determinism — for example, summing in
+/// `HashMap` iteration order instead of fixture order.
+#[test]
+fn smoke_suite_produces_byte_identical_metrics_across_runs() {
+    let run1 = run_smoke_suite_with_ranks(&run_inputs("m1"))
+        .expect("first smoke run should succeed");
+    let run2 = run_smoke_suite_with_ranks(&run_inputs("m2"))
+        .expect("second smoke run should succeed");
+
+    // Compare every gating metric of the `full` layer with bit-exact
+    // equality. Latency and timestamp are excluded — they are wall-clock
+    // measurements, not deterministic functions of inputs.
+    let full1 = run1
+        .report
+        .layers
+        .get("full")
+        .expect("run1 must emit a `full` layer");
+    let full2 = run2
+        .report
+        .layers
+        .get("full")
+        .expect("run2 must emit a `full` layer");
+
+    assert_eq!(full1.ndcg_at_10.to_bits(), full2.ndcg_at_10.to_bits(), "ndcg@10");
+    assert_eq!(full1.recall_at_10.to_bits(), full2.recall_at_10.to_bits(), "recall@10");
+    assert_eq!(
+        full1.precision_at_10.to_bits(),
+        full2.precision_at_10.to_bits(),
+        "precision@10"
+    );
+    assert_eq!(full1.mrr.to_bits(), full2.mrr.to_bits(), "mrr");
+    assert_eq!(full1.p_at_1.to_bits(), full2.p_at_1.to_bits(), "p@1");
+    assert_eq!(full1.map.to_bits(), full2.map.to_bits(), "map");
+
+    // Per-category aggregates must match too.
+    assert_eq!(
+        run1.report.by_category.len(),
+        run2.report.by_category.len(),
+        "category set must match"
+    );
+    for (cat, c1) in &run1.report.by_category {
+        let c2 = run2
+            .report
+            .by_category
+            .get(cat)
+            .unwrap_or_else(|| panic!("run2 missing category `{}`", cat));
+        assert_eq!(c1.ndcg_at_10.to_bits(), c2.ndcg_at_10.to_bits(), "{} ndcg@10", cat);
+        assert_eq!(c1.recall_at_10.to_bits(), c2.recall_at_10.to_bits(), "{} recall@10", cat);
+        assert_eq!(c1.mrr.to_bits(), c2.mrr.to_bits(), "{} mrr", cat);
+        assert_eq!(c1.p_at_1.to_bits(), c2.p_at_1.to_bits(), "{} p@1", cat);
+        assert_eq!(c1.map.to_bits(), c2.map.to_bits(), "{} map", cat);
+        assert_eq!(c1.case_count, c2.case_count, "{} case_count", cat);
+    }
+
+    // Cleanup
+    let _ = std::fs::remove_dir_all(PathBuf::from(format!(
+        "{}/shodh-recall-determinism-m1-{}",
+        std::env::temp_dir().display(),
+        std::process::id()
+    )));
+    let _ = std::fs::remove_dir_all(PathBuf::from(format!(
+        "{}/shodh-recall-determinism-m2-{}",
+        std::env::temp_dir().display(),
+        std::process::id()
+    )));
+}

--- a/tests/salience_tests.rs
+++ b/tests/salience_tests.rs
@@ -62,6 +62,7 @@ fn create_entity(
         name_embedding: None,
         salience: base_salience,
         is_proper_noun: is_proper,
+        selectivity: None,
     }
 }
 

--- a/tests/universe_tests.rs
+++ b/tests/universe_tests.rs
@@ -51,6 +51,7 @@ fn create_entity_from_ner(
         name_embedding: None,
         salience,
         is_proper_noun: is_proper,
+        selectivity: None,
     }
 }
 
@@ -80,6 +81,7 @@ fn create_entity(
         name_embedding: None,
         salience,
         is_proper_noun: is_proper,
+        selectivity: None,
     }
 }
 
@@ -108,6 +110,8 @@ fn create_relationship(
         tier: EdgeTier::L1Working,
         activation_timestamps: None,
         entity_confidence: None,
+        endpoint_selectivity: None,
+        forman_curvature: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Closes the non-determinism in the retrieval pipeline that was making
the L1 smoke suite flap on cross-environment runs (the failure mode
that surfaced on PR #277). Two layers of fix plus a permanent gate.

### RH-10 — eliminate the sources of non-determinism

**Stable tie-breaks** at every sort site that ranks float scores. Where
two candidates have equal scores, \`f32::total_cmp\` leaves their order
to whatever the underlying container last produced — which is
\`HashMap\` iteration order in several places, i.e. random per process.

- Vector index layer (\`vector_db/{vamana,spann,pq}.rs\`): tie-break by
  \`id\` (the only stable key available cheaply at that depth).
- Retrieval layer (\`memory/retrieval.rs\`, \`memory/mod.rs\`,
  \`relevance.rs\`): score → \`created_at desc\` → \`id\`. Two-layer scheme
  because the index doesn't have timestamps but the retrieval layer
  does, and recency is a meaningful tiebreaker for users.

**Thread pinning** in the harness:

- \`SHODH_ONNX_THREADS=1\` — MiniLM/NER intra-op runs single-threaded.
- \`RAYON_NUM_THREADS=1\` — any \`par_iter()\` in scoring runs serially.

Multi-threaded float reductions accumulate sums in non-deterministic
order, which is enough to flip ranks at the fourth-decimal level even
without any source change. Both vars are only set if the caller hasn't
overridden them, so production callers are unaffected.

### RH-11 — Rig 1: determinism gate

\`tests/recall_determinism.rs\` runs the full L1 smoke suite **twice**
in the same process, against fresh storage dirs, and asserts:

1. **Byte-identical rank lists per case.** \`CaseRankList.retrieved\`
   carries **stable corpus item IDs**, not the random per-run UUIDs
   assigned by \`MemorySystem::remember\` — UUIDs would always diverge
   and would mask real determinism wins behind noise.
2. **Bit-exact metric aggregates.** \`f64::to_bits()\` equality on
   ndcg@10, recall@10, precision@10, mrr, p@1, map — including
   per-category aggregates. If rank lists are equal but metrics
   differ, the metric computation has its own non-determinism.

If the gate ever fires, do **not** relax it — diagnose the new source
of non-determinism. RH-5 (CI gate) and RH-13 (CI re-baseline) both
depend on byte-identical runs to be statistically meaningful.

### Local verification

Two consecutive \`recall-eval\` runs against the smoke fixture produced
**byte-identical** report metrics:

\`\`\`
ndcg@10:    0.8231 → 0.8231  (vs baseline 0.8065, +0.0167)
recall@10:  0.8833 → 0.8833  (vs baseline 0.8500, +0.0333)
p@1:        0.8333 → 0.8333  (vs baseline 0.8333, restored from 0.800
                              that was tripping PR #277's gate)
mrr:        0.9000 → 0.9000
map:        0.7653 → 0.7653
\`\`\`

The temporal category lifted +0.10 — a side-effect of the
\`created_at desc\` tiebreaker in the retrieval layer, which favours
recent memories on score ties (correct behaviour for "what did we
decide last week" style queries).

### Why a separate test for breakage fixes

\`fix(tests)\` lands four pre-existing E0063 errors that blocked the
test suite from compiling — \`EntityNode.selectivity\`,
\`RelationshipEdge.{endpoint_selectivity, forman_curvature}\`, and
\`ReinforcementStats.{entity_edges_reinforced, prediction_error_multiplier}\`.
These were added by upstream PRs (#258, #260, #261) but the test
files used struct literals so the additions broke them silently —
\`cargo test\` couldn't compile until each was filled with safe defaults.

## Commits

- \`8d83f86\` fix(vector_db): RH-10 stable tie-break in vamana/spann/pq
- \`ea7f3b8\` fix(retrieval): RH-10 score → recency → id tie-break
- \`c7cbf83\` fix(recall-harness): RH-10 pin ONNX & rayon to 1 thread
- \`1908177\` fix(tests): add missing struct fields after graph + reinforcement upgrades
- \`b97b125\` feat(recall-harness): RH-11 — determinism gate (Rig 1)

## Test plan

- [x] \`cargo check --tests\` clean
- [x] \`cargo clippy\` clean
- [x] \`cargo test --test recall_determinism\` passes locally (background run)
- [x] Two recall-eval runs produce byte-identical metrics
- [ ] CI: all build matrices green
- [ ] CI: \`recall_determinism\` test passes on Linux + macOS
- [ ] After merge: re-trigger PR #277 to confirm gate stops flapping