### PR TITLE
feat(recall): RH-12 — N-repeat ingest+query with per-case median latency

### DIFF
--- a/.github/workflows/recall.yml
+++ b/.github/workflows/recall.yml
@@ -48,7 +48,10 @@ jobs:
   smoke:
     name: L1 Smoke Suite
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # RH-12 (#272): with --repeats 5 the suite runs 5 independent
+    # ingest+query passes (~5-6min each on a warm runner) plus build.
+    # 60min keeps headroom for cold builds and unusually slow runners.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
@@ -85,8 +88,12 @@ jobs:
         id: run_eval
         run: |
           set +e
+          # RH-12 (#272): --repeats 5 → per-case latency is the median
+          # across 5 independent ingest+query passes; rank-list divergence
+          # across passes is hard-failed as `infrastructure`.
           ./target/release/recall-eval \
             --suite smoke \
+            --repeats 5 \
             --output current.json \
             --baseline tests/recall/baseline.json \
             --tolerance "${TOLERANCE}" \

--- a/scripts/recall_diff.py
+++ b/scripts/recall_diff.py
@@ -23,6 +23,9 @@ from typing import Any
 GATING_METRICS = ("ndcg@10", "recall@10", "mrr", "p@1")
 INFO_METRICS = ("map", "precision@10")
 LATENCY_METRICS = ("latency_p50_ms", "latency_p95_ms", "latency_p99_ms")
+# RH-12 (#272): per-case median latency distribution stats. Absent on
+# pre-RH-12 reports, so the renderer skips them when both sides are zero.
+LATENCY_DIST_METRICS = ("latency_min_ms", "latency_max_ms", "latency_iqr_ms")
 
 
 def load_report(path: Path) -> dict[str, Any]:
@@ -71,6 +74,13 @@ def render(baseline: dict[str, Any], current: dict[str, Any], tolerance_pct: flo
         f"current `{current.get('git_sha', '?')[:7]}` "
         f"({current.get('embedder', '?')}) · tolerance **{tolerance_pct:.1f}%**"
     )
+    base_repeats = baseline.get("repeats", 1)
+    cur_repeats = current.get("repeats", 1)
+    lines.append(
+        f"Repeats: baseline **{base_repeats}** → current **{cur_repeats}** "
+        f"(per-case latency is the median across repeats; rank lists must "
+        f"be byte-identical across all repeats — see RH-12, #272)"
+    )
     lines.append("")
 
     base_full = baseline.get("layers", {}).get("full", {})
@@ -99,6 +109,17 @@ def render(baseline: dict[str, Any], current: dict[str, Any], tolerance_pct: flo
     lines.append("| ------ | ------------------------- |")
     for m in LATENCY_METRICS:
         lines.append(f"| `{m}` | {fmt_latency(base_full.get(m, 0.0), cur_full.get(m, 0.0))} |")
+    # RH-12 distribution stats: only render when at least one side reports
+    # them, so old baselines (all zeros) don't pollute the table.
+    has_dist_stats = any(
+        base_full.get(m, 0.0) != 0.0 or cur_full.get(m, 0.0) != 0.0
+        for m in LATENCY_DIST_METRICS
+    )
+    if has_dist_stats:
+        for m in LATENCY_DIST_METRICS:
+            lines.append(
+                f"| `{m}` | {fmt_latency(base_full.get(m, 0.0), cur_full.get(m, 0.0))} |"
+            )
     lines.append("")
 
     base_cats = baseline.get("by_category", {})

--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -71,6 +71,17 @@ struct Args {
     /// kept on disk so a failed run can be inspected.
     #[arg(long)]
     storage: Option<PathBuf>,
+
+    /// Number of independent ingest+query repeats. RH-12 (#272). Each
+    /// repeat stands up its own `MemorySystem` against a fresh storage
+    /// subdirectory, ingests the corpus, and runs every case. Per-case
+    /// latency in the report is the median across repeats; quality
+    /// metrics (ndcg/recall/mrr/p@1/map) MUST be byte-identical across
+    /// repeats — any divergence fails the run with `EXIT_INFRASTRUCTURE`.
+    /// Default `5` is the smallest N that survives a single outlier and
+    /// still produces a true median for IQR calculation.
+    #[arg(long, default_value_t = 5)]
+    repeats: usize,
 }
 
 fn main() {
@@ -99,6 +110,7 @@ fn run(args: &Args) -> Result<i32> {
         cases_path: None,
         suite: args.suite.as_str().to_string(),
         git_sha,
+        repeats: args.repeats,
     };
 
     let mut report = run_smoke_suite(&inputs).context("running smoke suite")?;
@@ -156,8 +168,8 @@ fn write_report(path: &std::path::Path, report: &Report) -> Result<()> {
 fn summarise(report: &Report) {
     let full = report.layers.get("full");
     eprintln!(
-        "recall-eval: suite={} cases={} embedder={} sha={}",
-        report.suite, report.case_count, report.embedder, report.git_sha
+        "recall-eval: suite={} cases={} repeats={} embedder={} sha={}",
+        report.suite, report.case_count, report.repeats, report.embedder, report.git_sha
     );
     if let Some(layer) = full {
         eprintln!(
@@ -165,8 +177,12 @@ fn summarise(report: &Report) {
             layer.ndcg_at_10, layer.recall_at_10, layer.mrr, layer.p_at_1, layer.map
         );
         eprintln!(
-            "  latency p50={:.1}ms p95={:.1}ms p99={:.1}ms",
+            "  latency p50={:.1}ms p95={:.1}ms p99={:.1}ms (per-case median)",
             layer.latency_p50_ms, layer.latency_p95_ms, layer.latency_p99_ms
+        );
+        eprintln!(
+            "  latency min={:.1}ms max={:.1}ms iqr={:.1}ms",
+            layer.latency_min_ms, layer.latency_max_ms, layer.latency_iqr_ms
         );
     }
     for (name, cat) in &report.by_category {

--- a/src/recall_harness/report.rs
+++ b/src/recall_harness/report.rs
@@ -34,8 +34,20 @@ pub struct Report {
     pub by_category: BTreeMap<String, CategoryReport>,
     /// Total number of cases run.
     pub case_count: usize,
+    /// Number of independent ingest+query passes the report aggregates over.
+    /// RH-12 (#272). For each case, latency is the median across this many
+    /// samples; quality metrics are taken from the first repeat after a
+    /// determinism check confirms identical rank lists across all repeats.
+    /// Defaults to `1` when reading reports written before RH-12 landed so
+    /// older baselines remain parseable.
+    #[serde(default = "default_repeats")]
+    pub repeats: usize,
     /// Cases or metrics that failed validation or regression.
     pub failures: Vec<Failure>,
+}
+
+fn default_repeats() -> usize {
+    1
 }
 
 /// Aggregate metrics for one pipeline layer across all cases.
@@ -54,6 +66,20 @@ pub struct LayerReport {
     pub latency_p50_ms: f64,
     pub latency_p95_ms: f64,
     pub latency_p99_ms: f64,
+    /// Smallest per-case median latency (ms) across the suite.
+    /// Defaults to `0.0` for back-compat with pre-RH-12 reports where
+    /// the field was absent. RH-12 (#272).
+    #[serde(default)]
+    pub latency_min_ms: f64,
+    /// Largest per-case median latency (ms) across the suite.
+    /// Defaults to `0.0` for back-compat. RH-12 (#272).
+    #[serde(default)]
+    pub latency_max_ms: f64,
+    /// Inter-quartile range (p75 − p25) of per-case median latencies.
+    /// A small IQR with stable medians is the signal we want; a wide IQR
+    /// means our timing is dominated by hardware noise. RH-12 (#272).
+    #[serde(default)]
+    pub latency_iqr_ms: f64,
 }
 
 /// Aggregate metrics for one category — same fields as `LayerReport` minus
@@ -103,6 +129,44 @@ pub fn latency_percentiles(samples: &[f64]) -> (f64, f64, f64) {
     )
 }
 
+/// Compute the median of a slice of f64 samples.
+///
+/// For odd-length slices returns the middle element. For even-length slices
+/// returns the arithmetic mean of the two middle elements (continuous
+/// median). Returns `0.0` for empty input — callers that care about
+/// emptiness handle it before calling.
+pub fn median(samples: &[f64]) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = samples.to_vec();
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    let n = sorted.len();
+    if n.is_multiple_of(2) {
+        (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+    } else {
+        sorted[n / 2]
+    }
+}
+
+/// Compute (min, max, iqr) over per-case median latencies.
+///
+/// IQR is `p75 − p25` using nearest-rank, matching the rest of the harness.
+/// Returns `(0.0, 0.0, 0.0)` for empty input. The trio is reported alongside
+/// p50/p95/p99 so reviewers can spot a tight median masking a wide spread —
+/// the exact failure mode RH-12 was opened to surface (issue #272).
+pub fn latency_distribution_stats(per_case_medians: &[f64]) -> (f64, f64, f64) {
+    if per_case_medians.is_empty() {
+        return (0.0, 0.0, 0.0);
+    }
+    let mut sorted = per_case_medians.to_vec();
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    let min = sorted[0];
+    let max = sorted[sorted.len() - 1];
+    let iqr = nearest_rank(&sorted, 0.75) - nearest_rank(&sorted, 0.25);
+    (min, max, iqr)
+}
+
 fn nearest_rank(sorted: &[f64], p: f64) -> f64 {
     debug_assert!(!sorted.is_empty(), "caller checks emptiness");
     debug_assert!((0.0..=1.0).contains(&p), "p must be in [0,1]");
@@ -115,6 +179,10 @@ fn nearest_rank(sorted: &[f64], p: f64) -> f64 {
 }
 
 /// Aggregate per-case metrics into a [`LayerReport`] (mean of each metric).
+///
+/// `latencies_ms` is the per-case representative latency — under RH-12 this
+/// is the median across `repeats` independent runs, not a raw sample. The
+/// percentile and distribution stats are computed over the same slice.
 pub fn aggregate_layer(per_case: &[Metrics], latencies_ms: &[f64]) -> LayerReport {
     let n = per_case.len() as f64;
     let mean = |sel: fn(&Metrics) -> f64| -> f64 {
@@ -125,6 +193,7 @@ pub fn aggregate_layer(per_case: &[Metrics], latencies_ms: &[f64]) -> LayerRepor
         }
     };
     let (p50, p95, p99) = latency_percentiles(latencies_ms);
+    let (lat_min, lat_max, lat_iqr) = latency_distribution_stats(latencies_ms);
     LayerReport {
         ndcg_at_10: mean(|m| m.ndcg_at_k),
         recall_at_10: mean(|m| m.recall_at_k),
@@ -135,6 +204,9 @@ pub fn aggregate_layer(per_case: &[Metrics], latencies_ms: &[f64]) -> LayerRepor
         latency_p50_ms: p50,
         latency_p95_ms: p95,
         latency_p99_ms: p99,
+        latency_min_ms: lat_min,
+        latency_max_ms: lat_max,
+        latency_iqr_ms: lat_iqr,
     }
 }
 
@@ -285,6 +357,9 @@ mod tests {
                 latency_p50_ms: 0.0,
                 latency_p95_ms: 0.0,
                 latency_p99_ms: 0.0,
+                latency_min_ms: 0.0,
+                latency_max_ms: 0.0,
+                latency_iqr_ms: 0.0,
             },
         );
         Report {
@@ -295,6 +370,7 @@ mod tests {
             layers,
             by_category: BTreeMap::new(),
             case_count: 30,
+            repeats: 1,
             failures: vec![],
         }
     }
@@ -340,5 +416,94 @@ mod tests {
         let failures = compare_to_baseline(&baseline, &current, 2.0);
         assert_eq!(failures.len(), 1);
         assert_eq!(failures[0].kind, "infrastructure");
+    }
+
+    // -------------------- RH-12 (#272) -------------------------------------
+    //
+    // The harness now reports per-case median latency aggregated over N
+    // independent ingest+query repeats. These tests pin the median helper,
+    // the distribution-stats helper, and the back-compat parser path so a
+    // stale baseline.json keeps loading after RH-12 ships.
+
+    #[test]
+    fn median_of_odd_length_picks_middle_element() {
+        assert!((median(&[10.0, 20.0, 30.0, 40.0, 50.0]) - 30.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn median_of_even_length_averages_middle_pair() {
+        assert!((median(&[10.0, 20.0, 30.0, 40.0]) - 25.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn median_of_unsorted_input_handles_order() {
+        assert!((median(&[40.0, 10.0, 30.0, 20.0, 50.0]) - 30.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn median_empty_is_zero() {
+        assert_eq!(median(&[]), 0.0);
+    }
+
+    #[test]
+    fn latency_distribution_stats_known_values() {
+        let s: Vec<f64> = (1..=100).map(|x| x as f64).collect();
+        let (min, max, iqr) = latency_distribution_stats(&s);
+        assert_eq!(min, 1.0);
+        assert_eq!(max, 100.0);
+        // Nearest-rank p75 = 75, p25 = 25 → IQR = 50.
+        assert_eq!(iqr, 50.0);
+    }
+
+    #[test]
+    fn latency_distribution_stats_empty_is_zero_triple() {
+        assert_eq!(latency_distribution_stats(&[]), (0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn report_serde_back_compat_old_baseline_has_no_repeats_field() {
+        // Mimic a pre-RH-12 baseline.json: no `repeats`, no latency_min/max/iqr.
+        // Must parse with default repeats=1 and zeroed latency stats.
+        let json = r#"{
+            "suite": "smoke",
+            "embedder": "minilm-l6-v2",
+            "git_sha": "abc123",
+            "timestamp": "2026-05-03T14:36:36.058394900Z",
+            "layers": {
+                "full": {
+                    "ndcg@10": 0.8,
+                    "recall@10": 0.85,
+                    "precision@10": 0.17,
+                    "mrr": 0.88,
+                    "p@1": 0.83,
+                    "map": 0.75,
+                    "latency_p50_ms": 130.0,
+                    "latency_p95_ms": 143.0,
+                    "latency_p99_ms": 145.0
+                }
+            },
+            "by_category": {},
+            "case_count": 30,
+            "failures": []
+        }"#;
+        let report: Report =
+            serde_json::from_str(json).expect("old baseline.json must still parse");
+        assert_eq!(report.repeats, 1);
+        let full = report.layers.get("full").expect("full layer present");
+        assert_eq!(full.latency_min_ms, 0.0);
+        assert_eq!(full.latency_max_ms, 0.0);
+        assert_eq!(full.latency_iqr_ms, 0.0);
+    }
+
+    #[test]
+    fn aggregate_layer_populates_latency_distribution_stats() {
+        let cases = [metrics(0.5), metrics(0.5), metrics(0.5), metrics(0.5)];
+        // Per-case median latencies: 10, 20, 30, 40 (already sorted).
+        let r = aggregate_layer(&cases, &[10.0, 20.0, 30.0, 40.0]);
+        assert_eq!(r.latency_min_ms, 10.0);
+        assert_eq!(r.latency_max_ms, 40.0);
+        // p75 = 30 (nearest-rank, ceil(0.75*4)-1 = 2 → 30)
+        // p25 = 10 (ceil(0.25*4)-1 = 0 → 10) → IQR = 20.
+        assert_eq!(r.latency_iqr_ms, 20.0);
     }
 }

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -23,7 +23,8 @@ use super::fixtures::{
 };
 use super::metrics::Metrics;
 use super::report::{
-    aggregate_category, aggregate_layer, CategoryReport, Failure, LayerReport, Report, SMOKE_K,
+    aggregate_category, aggregate_layer, median, CategoryReport, Failure, LayerReport, Report,
+    SMOKE_K,
 };
 
 /// Embedder identifier emitted in the report. Matches the model wired into
@@ -35,7 +36,11 @@ pub const EMBEDDER_ID: &str = "minilm-l6-v2";
 pub struct RunInputs {
     /// Storage directory for the harness's `MemorySystem`. The directory
     /// must be writeable; the runner does not delete it on completion so
-    /// callers can inspect state after a failed run.
+    /// callers can inspect state after a failed run. With `repeats > 1`
+    /// each repeat gets its own subdirectory `<storage_path>/repeat_<i>/`
+    /// so storage state is independent across repeats — that is what gives
+    /// the median across repeats meaning as a measure of cross-process
+    /// noise, not just within-process noise.
     pub storage_path: PathBuf,
     /// Optional path overrides; if `None` the canonical fixture paths are used.
     pub corpus_path: Option<PathBuf>,
@@ -45,6 +50,14 @@ pub struct RunInputs {
     /// Git SHA of the working tree the run was produced from. Caller is
     /// responsible for resolution because the runner does not shell out.
     pub git_sha: String,
+    /// Number of independent ingest+query repeats. RH-12 (#272). Each repeat
+    /// stands up its own isolated `MemorySystem`, ingests the corpus, and
+    /// runs all cases. Per-case latency is the median across repeats; quality
+    /// metrics must be byte-identical across repeats (any divergence is an
+    /// infrastructure failure that fails the run).
+    ///
+    /// Default in the CLI is `5`. Setting `0` is treated as `1`.
+    pub repeats: usize,
 }
 
 /// One case's retrieved rank list, in score-descending order.
@@ -125,8 +138,127 @@ pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks>
     fixtures::validate_smoke_suite(&corpus, &cases)
         .context("smoke suite failed structural validation — fix the JSONL fixtures")?;
 
-    let system = build_system(&inputs.storage_path)?;
-    let id_map = ingest_corpus(&system, &corpus)?;
+    let repeats = inputs.repeats.max(1);
+
+    // Run N independent ingest+query passes against fresh storage
+    // directories. RH-12 (#272): per-case latency is the median across
+    // these passes; rank lists are required to be byte-identical across
+    // every pass. The for-loop is intentionally serial — running passes
+    // in parallel would defeat the determinism check, since concurrent
+    // RocksDB instances under the same root would race on file handles.
+    let mut passes: Vec<OnePassResult> = Vec::with_capacity(repeats);
+    for i in 0..repeats {
+        let pass_storage = if repeats == 1 {
+            // Preserve the historical layout for single-repeat runs so
+            // existing CI artifacts and the integration test stay valid.
+            inputs.storage_path.clone()
+        } else {
+            inputs.storage_path.join(format!("repeat_{i}"))
+        };
+        let pass = run_one_pass(&pass_storage, &corpus, &cases)
+            .with_context(|| format!("repeat {i} of {repeats}"))?;
+        passes.push(pass);
+    }
+
+    // ------------------------------------------------------------------
+    // Determinism check across repeats. Two passes against the same
+    // fixtures, with thread pinning + the RH-10/11 tie-break in place,
+    // MUST produce byte-identical rank lists. If they don't, something
+    // upstream regressed (e.g. a new sort touched a non-determinism
+    // source). Surface every diverging case as an `infrastructure`
+    // failure so reviewers see the full picture, not just the first.
+    // ------------------------------------------------------------------
+    let mut failures: Vec<Failure> = passes[0].failures.clone();
+    if repeats > 1 {
+        for (i, pass) in passes.iter().enumerate().skip(1) {
+            for (k, ref_rank) in passes[0].ranks.iter().enumerate() {
+                let cur_rank = &pass.ranks[k];
+                debug_assert_eq!(ref_rank.case_id, cur_rank.case_id);
+                if ref_rank.retrieved != cur_rank.retrieved {
+                    failures.push(Failure {
+                        kind: "infrastructure".to_string(),
+                        detail: format!(
+                            "non-determinism: case {} rank list diverged between repeat 0 and repeat {i} \
+                             — repeat 0 = {:?}, repeat {i} = {:?}",
+                            ref_rank.case_id, ref_rank.retrieved, cur_rank.retrieved
+                        ),
+                    });
+                }
+            }
+        }
+    }
+
+    // Quality metrics: take from repeat 0. The determinism check above
+    // guarantees they would be identical across repeats; if it didn't
+    // pass, the caller exits with `EXIT_INFRASTRUCTURE` anyway and the
+    // metrics don't matter.
+    let per_case = &passes[0].per_case;
+    let by_category_cases = &passes[0].by_category_cases;
+
+    // Per-case median latency: collect samples from every pass, take median.
+    let mut latencies_median_ms: Vec<f64> = Vec::with_capacity(cases.len());
+    for k in 0..cases.len() {
+        let samples: Vec<f64> = passes.iter().map(|p| p.latencies_ms[k]).collect();
+        latencies_median_ms.push(median(&samples));
+    }
+
+    let layer_report = aggregate_layer(per_case, &latencies_median_ms);
+    let mut layers: BTreeMap<String, LayerReport> = BTreeMap::new();
+    layers.insert("full".to_string(), layer_report);
+
+    let mut by_category: BTreeMap<String, CategoryReport> = BTreeMap::new();
+    for cat in SmokeCategory::ALL {
+        let cases_for_cat = by_category_cases.get(&cat).cloned().unwrap_or_default();
+        by_category.insert(
+            category_name(cat).to_string(),
+            aggregate_category(&cases_for_cat),
+        );
+    }
+
+    let report = Report {
+        suite: inputs.suite.clone(),
+        embedder: EMBEDDER_ID.to_string(),
+        git_sha: inputs.git_sha.clone(),
+        timestamp: chrono::Utc::now(),
+        layers,
+        by_category,
+        case_count: cases.len(),
+        repeats,
+        failures,
+    };
+
+    // The public ranks output is the repeat-0 rank list — that is what
+    // existing RH-11 tests expect. Cross-repeat divergence is already
+    // surfaced via `failures` above.
+    let ranks = passes.into_iter().next().expect("repeats >= 1").ranks;
+
+    Ok(ReportWithRanks { report, ranks })
+}
+
+/// Output of one ingest+query pass over the fixture suite.
+///
+/// Kept private; the public surface aggregates across passes via
+/// [`run_smoke_suite_with_ranks`]. RH-12 (#272).
+struct OnePassResult {
+    per_case: Vec<Metrics>,
+    by_category_cases: HashMap<SmokeCategory, Vec<Metrics>>,
+    latencies_ms: Vec<f64>,
+    ranks: Vec<CaseRankList>,
+    failures: Vec<Failure>,
+}
+
+/// Run a single ingest + query pass against an isolated storage directory.
+///
+/// The caller is responsible for choosing the storage dir so multiple passes
+/// in the same harness invocation get independent state. The corpus and
+/// cases are passed in by reference so we don't reload fixtures per pass.
+fn run_one_pass(
+    storage_path: &Path,
+    corpus: &[CorpusItem],
+    cases: &[SmokeCase],
+) -> Result<OnePassResult> {
+    let system = build_system(storage_path)?;
+    let id_map = ingest_corpus(&system, corpus)?;
     // Reverse map: random per-run UUIDs → stable corpus item IDs. The
     // determinism gate (RH-11) compares rank lists across runs, so we MUST
     // emit stable handles. Comparing UUIDs would always diverge because
@@ -142,7 +274,7 @@ pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks>
     let mut failures: Vec<Failure> = Vec::new();
     let mut ranks: Vec<CaseRankList> = Vec::with_capacity(cases.len());
 
-    for case in &cases {
+    for case in cases {
         let query = Query {
             query_text: Some(case.query.clone()),
             max_results: SMOKE_K,
@@ -205,31 +337,13 @@ pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks>
         per_case.push(metrics);
     }
 
-    let layer_report = aggregate_layer(&per_case, &latencies_ms);
-    let mut layers: BTreeMap<String, LayerReport> = BTreeMap::new();
-    layers.insert("full".to_string(), layer_report);
-
-    let mut by_category: BTreeMap<String, CategoryReport> = BTreeMap::new();
-    for cat in SmokeCategory::ALL {
-        let cases_for_cat = by_category_cases.remove(&cat).unwrap_or_default();
-        by_category.insert(
-            category_name(cat).to_string(),
-            aggregate_category(&cases_for_cat),
-        );
-    }
-
-    let report = Report {
-        suite: inputs.suite.clone(),
-        embedder: EMBEDDER_ID.to_string(),
-        git_sha: inputs.git_sha.clone(),
-        timestamp: chrono::Utc::now(),
-        layers,
-        by_category,
-        case_count: cases.len(),
+    Ok(OnePassResult {
+        per_case,
+        by_category_cases,
+        latencies_ms,
+        ranks,
         failures,
-    };
-
-    Ok(ReportWithRanks { report, ranks })
+    })
 }
 
 /// Pin parallel runtimes to a single thread for the harness process.
@@ -360,11 +474,13 @@ mod tests {
             cases_path: None,
             suite: "smoke".to_string(),
             git_sha: "test-sha".to_string(),
+            repeats: 1,
         };
         let report = run_smoke_suite(&inputs).expect("runner must succeed");
         let _ = std::fs::remove_dir_all(&storage);
 
         assert_eq!(report.case_count, 30);
+        assert_eq!(report.repeats, 1);
         assert_eq!(report.suite, "smoke");
         assert_eq!(report.embedder, EMBEDDER_ID);
         assert!(report.layers.contains_key("full"));
@@ -408,5 +524,145 @@ mod tests {
             experience_type_for("nonsense"),
             ExperienceType::Observation
         ));
+    }
+
+    // -------------------- RH-12 (#272) -------------------------------------
+    //
+    // Run the full smoke suite with N=2 and verify (a) the report records
+    // repeats=2, (b) per-repeat storage subdirs exist, (c) quality metrics
+    // are bit-identical between the N=1 baseline run and the N=2 run.
+    //
+    // This test is the load-bearing assertion that RH-12 changed only the
+    // measurement, not the metric — if N=1 and N=2 disagree on quality,
+    // either the determinism guarantee broke OR `aggregate_layer` is no
+    // longer a pure function of its inputs.
+    //
+    // Marked `#[ignore]` because it pays the ingest cost twice (~12 min on
+    // a cold runner). Run via `cargo test --release -- --ignored
+    // runner_repeats_2_produces_same_quality_as_repeats_1` before shipping
+    // changes that touch the harness or scoring path.
+    #[test]
+    #[ignore = "expensive: runs the smoke suite twice (~12min). enable with --ignored before shipping harness changes."]
+    fn runner_repeats_2_produces_same_quality_as_repeats_1() {
+        let storage1 = unique_storage_dir("repeats1");
+        let storage2 = unique_storage_dir("repeats2");
+
+        let inputs1 = RunInputs {
+            storage_path: storage1.clone(),
+            corpus_path: None,
+            cases_path: None,
+            suite: "smoke".to_string(),
+            git_sha: "test-sha".to_string(),
+            repeats: 1,
+        };
+        let inputs2 = RunInputs {
+            storage_path: storage2.clone(),
+            corpus_path: None,
+            cases_path: None,
+            suite: "smoke".to_string(),
+            git_sha: "test-sha".to_string(),
+            repeats: 2,
+        };
+
+        let r1 = run_smoke_suite(&inputs1).expect("repeats=1 must succeed");
+        let r2 = run_smoke_suite(&inputs2).expect("repeats=2 must succeed");
+
+        assert_eq!(r1.repeats, 1);
+        assert_eq!(r2.repeats, 2);
+
+        // Quality metrics — bit-identical (RH-11 determinism).
+        let f1 = r1.layers.get("full").expect("r1 full");
+        let f2 = r2.layers.get("full").expect("r2 full");
+        assert_eq!(f1.ndcg_at_10.to_bits(), f2.ndcg_at_10.to_bits(), "ndcg@10");
+        assert_eq!(
+            f1.recall_at_10.to_bits(),
+            f2.recall_at_10.to_bits(),
+            "recall@10"
+        );
+        assert_eq!(f1.mrr.to_bits(), f2.mrr.to_bits(), "mrr");
+        assert_eq!(f1.p_at_1.to_bits(), f2.p_at_1.to_bits(), "p@1");
+        assert_eq!(f1.map.to_bits(), f2.map.to_bits(), "map");
+
+        // Per-repeat storage subdirs must have been created.
+        assert!(
+            storage2.join("repeat_0").exists(),
+            "repeat_0 storage missing"
+        );
+        assert!(
+            storage2.join("repeat_1").exists(),
+            "repeat_1 storage missing"
+        );
+
+        // No infrastructure failures (rank-list divergence) on the
+        // canonical fixtures — RH-11 guarantees byte-identical ranks.
+        let infra_failures: Vec<_> = r2
+            .failures
+            .iter()
+            .filter(|f| f.kind == "infrastructure")
+            .collect();
+        assert!(
+            infra_failures.is_empty(),
+            "no infrastructure failures expected on canonical fixtures, got {:?}",
+            infra_failures
+        );
+
+        let _ = std::fs::remove_dir_all(&storage1);
+        let _ = std::fs::remove_dir_all(&storage2);
+    }
+
+    /// Direct unit test of the cross-repeat divergence detection logic.
+    ///
+    /// Builds two synthetic `OnePassResult`s with one diverging case, then
+    /// runs the same comparison the public path uses. Cheap (no harness),
+    /// runs on every CI build.
+    #[test]
+    fn synthetic_rank_divergence_surfaces_infrastructure_failure() {
+        let pass_a_ranks = [
+            CaseRankList {
+                case_id: "smoke-001".to_string(),
+                retrieved: vec!["doc-a".to_string(), "doc-b".to_string()],
+            },
+            CaseRankList {
+                case_id: "smoke-002".to_string(),
+                retrieved: vec!["doc-c".to_string(), "doc-d".to_string()],
+            },
+        ];
+        let pass_b_ranks = [
+            CaseRankList {
+                case_id: "smoke-001".to_string(),
+                retrieved: vec!["doc-a".to_string(), "doc-b".to_string()],
+            },
+            CaseRankList {
+                // Divergence on smoke-002.
+                case_id: "smoke-002".to_string(),
+                retrieved: vec!["doc-d".to_string(), "doc-c".to_string()],
+            },
+        ];
+
+        // Re-implement the same comparison loop the public path uses,
+        // narrow to the assertion we care about. Keeps the test
+        // independent of harness setup cost.
+        let mut failures: Vec<Failure> = Vec::new();
+        for (k, ref_rank) in pass_a_ranks.iter().enumerate() {
+            let cur_rank = &pass_b_ranks[k];
+            assert_eq!(ref_rank.case_id, cur_rank.case_id);
+            if ref_rank.retrieved != cur_rank.retrieved {
+                failures.push(Failure {
+                    kind: "infrastructure".to_string(),
+                    detail: format!(
+                        "non-determinism: case {} rank list diverged",
+                        ref_rank.case_id
+                    ),
+                });
+            }
+        }
+
+        assert_eq!(failures.len(), 1, "exactly one divergence expected");
+        assert_eq!(failures[0].kind, "infrastructure");
+        assert!(
+            failures[0].detail.contains("smoke-002"),
+            "failure must name the diverging case: {}",
+            failures[0].detail
+        );
     }
 }

--- a/tests/recall_determinism.rs
+++ b/tests/recall_determinism.rs
@@ -44,6 +44,11 @@ fn run_inputs(tag: &str) -> RunInputs {
         cases_path: None,
         suite: "smoke".to_string(),
         git_sha: "determinism-test".to_string(),
+        // RH-11 (Rig 1) compares two consecutive single-pass runs. The
+        // RH-12 cross-repeat check is exercised separately by the
+        // `runner_repeats_*` tests in `src/recall_harness/runner.rs`;
+        // keep this test single-pass so it stays under the CI budget.
+        repeats: 1,
     }
 }
 


### PR DESCRIPTION
## Why

Single-sample latency in the L1 smoke suite swung **130 → 60 ms** between two CI runs of #277 with **no change to the latency path** (commits `4f6f543` → `0d8536d`). With a **2% gating tolerance**, single-run variance dwarfs signal — every gated metric has been theatre against measurement noise.

RH-12 fixes the measurement layer.

## What

- `recall-eval --repeats N` (default **5**): N independent ingest+query passes, each against `<storage>/repeat_<i>/` so storage state is fully isolated across passes (true cross-process noise, not within-process query repetition).
- Per-case latency in the report is the **median across passes**; latency percentiles (p50/p95/p99) are then computed over per-case medians.
- New `latency_min_ms` / `latency_max_ms` / `latency_iqr_ms` surface the distribution shape — wide IQR signals the runner is the unreliable layer, not the code under test.
- **Determinism gate built into every CI run.** RH-11 (#270) gives us a dedicated 2-run determinism job. RH-12 folds the same check into every repeat: if `passes[i].ranks[case_k] != passes[0].ranks[case_k]` for any `(i, k)`, emit `Failure { kind: "infrastructure" }` per divergence and exit `EXIT_INFRASTRUCTURE`. RH-11 stays as the dedicated signal; RH-12 means the gate fires on every PR with **N=5 chances per case** to catch flakiness.
- Quality metrics (ndcg/recall/mrr/p@1/map) come from pass 0. The determinism check above guarantees they are byte-identical across passes — taking from pass 0 is a labelling choice, not an aggregation.

## Schema

Additions are **additive** (`#[serde(default)]`) — the existing `tests/recall/baseline.json` still parses without regeneration. Quality gating is unchanged; only the measurement noise underneath it is fixed.

```rust
pub struct Report {
    // ...
    #[serde(default = "default_repeats")] pub repeats: usize, // default 1
}
pub struct LayerReport {
    // ...
    #[serde(default)] pub latency_min_ms: f64,
    #[serde(default)] pub latency_max_ms: f64,
    #[serde(default)] pub latency_iqr_ms: f64,
}
```

## CI

- `.github/workflows/recall.yml` invokes `--repeats 5`.
- `timeout-minutes` raised 30 → 60 (5 × ~6min suite + ~12min cold build ≈ 42min worst case, with headroom).
- `scripts/recall_diff.py` renders the new repeats line and conditionally shows latency min/max/IQR (graceful against pre-RH-12 baselines).

## Tests

- `report.rs`: median + IQR on known distributions, schema back-compat parsing of pre-RH-12 baselines.
- `runner.rs`: synthetic rank-list divergence surfaces an infrastructure failure; an `#[ignore]`d expensive test confirms quality is identical between N=1 and N=2 runs.
- `tests/recall_determinism.rs` updated for the new `RunInputs.repeats` field (set to 1 — RH-11 owns its own determinism comparison).

Local run: `cargo test --lib recall_harness` → 56 passed, 0 failed, 1 ignored.

## Risks / pushback

1. **CI runtime jumps from ~6 min to ~30 min.** Real DX cost on every PR. If too painful, drop the workflow flag to `--repeats 3` (CLI default stays 5 for local rigor); median-of-3 still survives a single outlier.
2. **`timeout-minutes: 60` is generous, not infinite.** Worth watching the first ~5 PRs for runner slowness.
3. **The latency-drift hypothesis may be wrong.** If N=5 medians are tight but means differ across branches, that's signal not noise — RH-12's IQR/min/max in the diff comment will tell us.

## Closes

- Resolves #272