### PR TITLE
RH-8: per-pipeline-layer attribution mode (#270)

### DIFF
--- a/scripts/recall_diff.py
+++ b/scripts/recall_diff.py
@@ -122,6 +122,55 @@ def render(baseline: dict[str, Any], current: dict[str, Any], tolerance_pct: flo
             )
     lines.append("")
 
+    # RH-8 (#270): per-pipeline-layer attribution. The harness can run the
+    # smoke suite under up to six cumulative modes; render a delta table
+    # only for modes shared between baseline and current. When only `full`
+    # is present (the default CI path), this section gracefully degrades.
+    # Mode order is the production pipeline order, not BTreeMap order, so
+    # ndcg deltas read top-to-bottom as additive stages.
+    PIPELINE_MODE_ORDER = (
+        "vamana_only",
+        "+spreading",
+        "+bm25",
+        "+rerank",
+        "+facts",
+        "full",
+    )
+    base_layers = baseline.get("layers", {})
+    cur_layers = current.get("layers", {})
+    shared_modes = [m for m in PIPELINE_MODE_ORDER if m in base_layers and m in cur_layers]
+    # Surface this section only when there is something beyond `full` to
+    # show — otherwise it duplicates the gated table above.
+    if len(shared_modes) > 1:
+        lines.append("### Per-layer attribution `ndcg@10` / `recall@10`")
+        lines.append("")
+        lines.append(
+            "Cumulative modes (each row adds one stage to the row above). "
+            "Per-layer numbers are diagnostic — only `full` is gated by CI. "
+            "`+rerank` covers the ontological re-ranker at Layer 4.9; this "
+            "codebase has no cross-encoder despite the spec label."
+        )
+        lines.append("")
+        lines.append("| mode | `ndcg@10` (Δ) | `recall@10` (Δ) |")
+        lines.append("| ---- | ------------- | --------------- |")
+        for m in shared_modes:
+            b_layer = base_layers.get(m, {})
+            c_layer = cur_layers.get(m, {})
+            ndcg = fmt_metric(
+                b_layer.get("ndcg@10", 0.0),
+                c_layer.get("ndcg@10", 0.0),
+                tolerance_pct,
+                gating=False,
+            )
+            recall = fmt_metric(
+                b_layer.get("recall@10", 0.0),
+                c_layer.get("recall@10", 0.0),
+                tolerance_pct,
+                gating=False,
+            )
+            lines.append(f"| `{m}` | {ndcg} | {recall} |")
+        lines.append("")
+
     base_cats = baseline.get("by_category", {})
     cur_cats = current.get("by_category", {})
     cats = sorted(set(base_cats) | set(cur_cats))

--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -237,12 +237,7 @@ fn summarise(report: &Report) {
         if let Some(layer) = report.layers.get(name) {
             eprintln!(
                 "  {:<12} ndcg@10={:.4} recall@10={:.4} mrr={:.4} p@1={:.4} map={:.4}",
-                name,
-                layer.ndcg_at_10,
-                layer.recall_at_10,
-                layer.mrr,
-                layer.p_at_1,
-                layer.map
+                name, layer.ndcg_at_10, layer.recall_at_10, layer.mrr, layer.p_at_1, layer.map
             );
         }
     }

--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -18,6 +18,7 @@ use std::process::Command;
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 
+use shodh_memory::memory::types::LayerMode;
 use shodh_memory::recall_harness::report::{compare_to_baseline, Report};
 use shodh_memory::recall_harness::runner::{run_smoke_suite, RunInputs};
 
@@ -37,6 +38,48 @@ impl Suite {
     fn as_str(self) -> &'static str {
         match self {
             Suite::Smoke => "smoke",
+        }
+    }
+}
+
+/// Per-pipeline-layer attribution selector. RH-8 (#270).
+///
+/// `all` runs the full ladder of cumulative modes (vamana-only → full),
+/// emitting one entry per mode in the report's `layers` map. CI gating
+/// remains keyed on `full` so per-layer numbers are diagnostic, not gated.
+///
+/// Naming note: the `+rerank` mode in the spec is a misnomer for this
+/// codebase — there is no cross-encoder. The gate covers the ontological
+/// re-ranker at Layer 4.9 instead. The label is preserved for spec fidelity.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+enum LayerArg {
+    /// All six modes, ascending. Use for diagnostic per-layer attribution.
+    All,
+    /// Layer 3 vector ANN only.
+    VamanaOnly,
+    /// + Layer 2 graph spreading activation.
+    PlusSpreading,
+    /// + Layer 4 BM25/RRF fusion.
+    PlusBm25,
+    /// + Layer 4.9 ontological rerank (spec calls this `+rerank`).
+    PlusRerank,
+    /// + Layer 0.7/4.8 fact-source boost.
+    PlusFacts,
+    /// Production pipeline — every stage on. CI gates on this mode only.
+    Full,
+}
+
+impl LayerArg {
+    fn to_modes(self) -> Vec<LayerMode> {
+        match self {
+            LayerArg::All => LayerMode::ALL.to_vec(),
+            LayerArg::VamanaOnly => vec![LayerMode::VamanaOnly],
+            LayerArg::PlusSpreading => vec![LayerMode::PlusSpreading],
+            LayerArg::PlusBm25 => vec![LayerMode::PlusBm25],
+            LayerArg::PlusRerank => vec![LayerMode::PlusRerank],
+            LayerArg::PlusFacts => vec![LayerMode::PlusFacts],
+            LayerArg::Full => vec![LayerMode::Full],
         }
     }
 }
@@ -82,6 +125,14 @@ struct Args {
     /// still produces a true median for IQR calculation.
     #[arg(long, default_value_t = 5)]
     repeats: usize,
+
+    /// Per-pipeline-layer attribution mode. RH-8 (#270). `full` (default)
+    /// runs only the production pipeline and reproduces the pre-RH-8
+    /// behavior bit-for-bit. `all` runs every mode and emits one entry
+    /// per mode in the report's `layers` map for diagnostic attribution.
+    /// CI keys on `full` only — per-layer numbers are not gated.
+    #[arg(long, value_enum, default_value_t = LayerArg::Full)]
+    layer: LayerArg,
 }
 
 fn main() {
@@ -111,6 +162,7 @@ fn run(args: &Args) -> Result<i32> {
         suite: args.suite.as_str().to_string(),
         git_sha,
         repeats: args.repeats,
+        layer_modes: args.layer.to_modes(),
     };
 
     let mut report = run_smoke_suite(&inputs).context("running smoke suite")?;
@@ -166,18 +218,37 @@ fn write_report(path: &std::path::Path, report: &Report) -> Result<()> {
 }
 
 fn summarise(report: &Report) {
-    let full = report.layers.get("full");
     eprintln!(
         "recall-eval: suite={} cases={} repeats={} embedder={} sha={}",
         report.suite, report.case_count, report.repeats, report.embedder, report.git_sha
     );
-    if let Some(layer) = full {
+    // Print modes in pipeline order (vamana_only → full), not BTreeMap order.
+    // Match against the canonical mode keys so any unknown key just falls
+    // through to the BTreeMap iteration at the bottom.
+    let mode_order = [
+        "vamana_only",
+        "+spreading",
+        "+bm25",
+        "+rerank",
+        "+facts",
+        "full",
+    ];
+    for name in mode_order {
+        if let Some(layer) = report.layers.get(name) {
+            eprintln!(
+                "  {:<12} ndcg@10={:.4} recall@10={:.4} mrr={:.4} p@1={:.4} map={:.4}",
+                name,
+                layer.ndcg_at_10,
+                layer.recall_at_10,
+                layer.mrr,
+                layer.p_at_1,
+                layer.map
+            );
+        }
+    }
+    if let Some(layer) = report.layers.get("full") {
         eprintln!(
-            "  full   ndcg@10={:.4} recall@10={:.4} mrr={:.4} p@1={:.4} map={:.4}",
-            layer.ndcg_at_10, layer.recall_at_10, layer.mrr, layer.p_at_1, layer.map
-        );
-        eprintln!(
-            "  latency p50={:.1}ms p95={:.1}ms p99={:.1}ms (per-case median)",
+            "  latency p50={:.1}ms p95={:.1}ms p99={:.1}ms (per-case median, full mode)",
             layer.latency_p50_ms, layer.latency_p95_ms, layer.latency_p99_ms
         );
         eprintln!(

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1773,34 +1773,35 @@ impl MemorySystem {
 
             if layer_facts {
                 if let Some(user_id) = &query.user_id {
-                let entity_names: Vec<String> = query_analysis
-                    .focal_entities
-                    .iter()
-                    .map(|e| e.text.to_lowercase())
-                    .collect();
+                    let entity_names: Vec<String> = query_analysis
+                        .focal_entities
+                        .iter()
+                        .map(|e| e.text.to_lowercase())
+                        .collect();
 
-                if !entity_names.is_empty() {
-                    if let Ok(facts) = self.get_facts_for_graph_entities(user_id, &entity_names, 5)
-                    {
-                        for fact in &facts {
-                            if fact.confidence < 0.5 || fact.support_count < 3 {
-                                continue;
+                    if !entity_names.is_empty() {
+                        if let Ok(facts) =
+                            self.get_facts_for_graph_entities(user_id, &entity_names, 5)
+                        {
+                            for fact in &facts {
+                                if fact.confidence < 0.5 || fact.support_count < 3 {
+                                    continue;
+                                }
+                                let per_fact_boost = fact.confidence * 0.08;
+                                for src_id in &fact.source_memories {
+                                    let entry = boosts.entry(src_id.clone()).or_insert(0.0);
+                                    *entry = (*entry + per_fact_boost).min(0.3);
+                                }
                             }
-                            let per_fact_boost = fact.confidence * 0.08;
-                            for src_id in &fact.source_memories {
-                                let entry = boosts.entry(src_id.clone()).or_insert(0.0);
-                                *entry = (*entry + per_fact_boost).min(0.3);
+                            if !boosts.is_empty() {
+                                tracing::debug!(
+                                    "Layer 0.7: Pre-fetched {} fact-source boosts from {} facts",
+                                    boosts.len(),
+                                    facts.len()
+                                );
                             }
-                        }
-                        if !boosts.is_empty() {
-                            tracing::debug!(
-                                "Layer 0.7: Pre-fetched {} fact-source boosts from {} facts",
-                                boosts.len(),
-                                facts.len()
-                            );
                         }
                     }
-                }
                 }
             }
             boosts
@@ -2624,62 +2625,64 @@ impl MemorySystem {
             // RH-8 gate: prospective signal boost only runs in `Full` mode.
             if layer_full {
                 if let Some(ref signals) = query.prospective_signals {
-                if !signals.is_empty() {
-                    use crate::constants::{PROSPECTIVE_BOOST_MAX, PROSPECTIVE_BOOST_PER_MATCH};
+                    if !signals.is_empty() {
+                        use crate::constants::{
+                            PROSPECTIVE_BOOST_MAX, PROSPECTIVE_BOOST_PER_MATCH,
+                        };
 
-                    // Tokenize all signals into unique terms (skip noise words < 3 chars)
-                    let signal_terms: std::collections::HashSet<String> = signals
-                        .iter()
-                        .flat_map(|s| {
-                            s.to_lowercase()
-                                .split_whitespace()
-                                .filter(|w| w.len() >= 3)
-                                .map(|w| w.to_string())
-                                .collect::<Vec<_>>()
-                        })
-                        .collect();
+                        // Tokenize all signals into unique terms (skip noise words < 3 chars)
+                        let signal_terms: std::collections::HashSet<String> = signals
+                            .iter()
+                            .flat_map(|s| {
+                                s.to_lowercase()
+                                    .split_whitespace()
+                                    .filter(|w| w.len() >= 3)
+                                    .map(|w| w.to_string())
+                                    .collect::<Vec<_>>()
+                            })
+                            .collect();
 
-                    if !signal_terms.is_empty() {
-                        let mut boosted_count = 0;
-                        let ids: Vec<MemoryId> = fused.keys().cloned().collect();
+                        if !signal_terms.is_empty() {
+                            let mut boosted_count = 0;
+                            let ids: Vec<MemoryId> = fused.keys().cloned().collect();
 
-                        for id in &ids {
-                            if let Some(content) = get_content(id) {
-                                let content_lower = content.to_lowercase();
-                                let content_words = tokenize_words(&content_lower);
-                                let match_count = signal_terms
-                                    .iter()
-                                    .filter(|term| content_words.contains(term.as_str()))
-                                    .count();
+                            for id in &ids {
+                                if let Some(content) = get_content(id) {
+                                    let content_lower = content.to_lowercase();
+                                    let content_words = tokenize_words(&content_lower);
+                                    let match_count = signal_terms
+                                        .iter()
+                                        .filter(|term| content_words.contains(term.as_str()))
+                                        .count();
 
-                                if match_count > 0 {
-                                    // Sqrt scaling: diminishing returns for additional matches
-                                    let boost_factor = 1.0
-                                        + (PROSPECTIVE_BOOST_PER_MATCH
-                                            * (match_count as f32).sqrt())
-                                        .min(PROSPECTIVE_BOOST_MAX);
-                                    if let Some(score) = fused.get_mut(id) {
-                                        *score *= boost_factor;
-                                        boosted_count += 1;
-                                        if let Some(ref mut attr_map) = attributions {
-                                            if let Some(attr) = attr_map.get_mut(id) {
-                                                attr.prospective_boost = boost_factor;
+                                    if match_count > 0 {
+                                        // Sqrt scaling: diminishing returns for additional matches
+                                        let boost_factor = 1.0
+                                            + (PROSPECTIVE_BOOST_PER_MATCH
+                                                * (match_count as f32).sqrt())
+                                            .min(PROSPECTIVE_BOOST_MAX);
+                                        if let Some(score) = fused.get_mut(id) {
+                                            *score *= boost_factor;
+                                            boosted_count += 1;
+                                            if let Some(ref mut attr_map) = attributions {
+                                                if let Some(attr) = attr_map.get_mut(id) {
+                                                    attr.prospective_boost = boost_factor;
+                                                }
                                             }
                                         }
                                     }
                                 }
                             }
-                        }
 
-                        if boosted_count > 0 {
-                            tracing::info!(
+                            if boosted_count > 0 {
+                                tracing::info!(
                                 "Layer 4.7: Boosted {} memories from {} prospective signal terms",
                                 boosted_count,
                                 signal_terms.len()
                             );
+                            }
                         }
                     }
-                }
                 }
             }
 
@@ -3158,29 +3161,29 @@ impl MemorySystem {
         // RH-8 gate: quality multiplier only applies in `Full` mode — lower modes
         // expose the raw fused score so per-layer attribution isn't masked.
         if layer_full {
-        for mem in &mut memories {
-            let content_len = mem.experience.content.len() as f32;
-            let has_entities = !mem.experience.entities.is_empty();
-            let has_context = mem.experience.context.is_some();
-            let quality = (content_len / 200.0).min(1.0)
-                * (1.0
-                    + if has_entities { 0.1 } else { 0.0 }
-                    + if has_context { 0.1 } else { 0.0 });
-            let quality_factor = quality.max(crate::constants::ELABORATION_QUALITY_MIN);
-            if let Some(score) = mem.score {
-                let mut cloned: Memory = mem.as_ref().clone();
-                cloned.set_score(score * quality_factor);
-                *mem = Arc::new(cloned);
+            for mem in &mut memories {
+                let content_len = mem.experience.content.len() as f32;
+                let has_entities = !mem.experience.entities.is_empty();
+                let has_context = mem.experience.context.is_some();
+                let quality = (content_len / 200.0).min(1.0)
+                    * (1.0
+                        + if has_entities { 0.1 } else { 0.0 }
+                        + if has_context { 0.1 } else { 0.0 });
+                let quality_factor = quality.max(crate::constants::ELABORATION_QUALITY_MIN);
+                if let Some(score) = mem.score {
+                    let mut cloned: Memory = mem.as_ref().clone();
+                    cloned.set_score(score * quality_factor);
+                    *mem = Arc::new(cloned);
 
-                // Track quality gate in attribution
-                if let Some(ref mut attr_map) = attributions {
-                    if let Some(attr) = attr_map.get_mut(&mem.id) {
-                        attr.quality_gate = quality_factor;
-                        attr.final_score = score * quality_factor;
+                    // Track quality gate in attribution
+                    if let Some(ref mut attr_map) = attributions {
+                        if let Some(attr) = attr_map.get_mut(&mem.id) {
+                            attr.quality_gate = quality_factor;
+                            attr.final_score = score * quality_factor;
+                        }
                     }
                 }
             }
-        }
         }
 
         // Linguistic analysis: additive boost (5% of IC weight), not a full re-sort

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1384,6 +1384,21 @@ impl MemorySystem {
     ) -> Result<RetrievalResult> {
         let recall_start = std::time::Instant::now();
 
+        // ===========================================================================
+        // RH-8 (#270): per-pipeline-layer attribution gate flags
+        // ===========================================================================
+        // Production callers leave `query.layers` at the default (`Full`) and get
+        // the existing behavior — every gate below evaluates true. The recall
+        // harness passes lower modes to attribute quality deltas to specific
+        // stages. Cumulative ordering: VamanaOnly < PlusSpreading < PlusBm25 <
+        // PlusRerank < PlusFacts < Full. See `LayerMode` in `types.rs`.
+        let layer_mode = query.layers;
+        let layer_full = layer_mode >= types::LayerMode::Full;
+        let layer_facts = layer_mode >= types::LayerMode::PlusFacts;
+        let layer_rerank = layer_mode >= types::LayerMode::PlusRerank;
+        let layer_bm25 = layer_mode >= types::LayerMode::PlusBm25;
+        let layer_spreading = layer_mode >= types::LayerMode::PlusSpreading;
+
         // Diagnostic accumulators — only allocated when collect_diagnostics=true
         let mut stats = if collect_diagnostics {
             Some(RetrievalStats {
@@ -1457,7 +1472,11 @@ impl MemorySystem {
         // pre-fetch memories from the matching date range via SearchCriteria::ByDate.
         // These IDs are collected as candidates for boosting at Layer 4.45.
         // NOT exclusive — memories outside the range still enter via Vamana/BM25.
-        let temporal_prefilter_ids: HashSet<MemoryId> = if temporal_ctx.is_filtering_query {
+        // RH-8 gate: Layer 0.4 only runs in `Full` mode. Lower modes get an empty set,
+        // which makes the Layer 4.45 temporal boost a no-op without changing its code path.
+        let temporal_prefilter_ids: HashSet<MemoryId> = if layer_full
+            && temporal_ctx.is_filtering_query
+        {
             if let Some((start_date, end_date)) = temporal_ctx.date_range {
                 // Convert NaiveDate to DateTime<Utc> (start of first day, end of last day)
                 let start_dt = start_date
@@ -1559,8 +1578,9 @@ impl MemorySystem {
             crate::metrics::ONTOLOGICAL_DENSITY_SKIP_TOTAL.inc();
         }
 
-        let attribute_boost_ids: HashSet<MemoryId> = match &query_type {
-            query_parser::QueryType::Attribute(attr_query) => {
+        // RH-8 gate: Layer 0.5 attribute query detection only in `Full` mode.
+        let attribute_boost_ids: HashSet<MemoryId> = match (layer_full, &query_type) {
+            (true, query_parser::QueryType::Attribute(attr_query)) => {
                 tracing::debug!(
                     "Layer 0.5: Attribute query detected - entity='{}', attribute='{}', synonyms={:?}",
                     attr_query.entity,
@@ -1650,7 +1670,8 @@ impl MemorySystem {
         // 3. Look up temporal facts matching these
         // 4. Boost the source memories of matching facts
         // Temporal fact lookup - boost source memories of matching facts in Layer 4.5
-        let temporal_fact_boost_ids: HashSet<MemoryId> = if has_temporal_query {
+        // RH-8 gate: Layer 0.6 only runs in `Full` mode.
+        let temporal_fact_boost_ids: HashSet<MemoryId> = if layer_full && has_temporal_query {
             if let Some(user_id) = &query.user_id {
                 // Get entity name (first focal entity)
                 let entity = query_analysis
@@ -1745,11 +1766,13 @@ impl MemorySystem {
         // Pre-fetch facts by query entities to boost their source memories in Layer 4.8.
         // Facts represent consolidated knowledge — their source memories contain the
         // richest context for that knowledge and should rank higher.
+        // RH-8 gate: Layer 0.7 fact source pre-fetch only runs in `PlusFacts` and above.
         let fact_source_boosts: std::collections::HashMap<MemoryId, f32> = {
             let mut boosts: std::collections::HashMap<MemoryId, f32> =
                 std::collections::HashMap::new();
 
-            if let Some(user_id) = &query.user_id {
+            if layer_facts {
+                if let Some(user_id) = &query.user_id {
                 let entity_names: Vec<String> = query_analysis
                     .focal_entities
                     .iter()
@@ -1777,6 +1800,7 @@ impl MemorySystem {
                             );
                         }
                     }
+                }
                 }
             }
             boosts
@@ -1946,10 +1970,14 @@ impl MemorySystem {
         // ===========================================================================
         // LAYER 2: GRAPH EXPANSION (Knowledge Graph Traversal)
         // ===========================================================================
-        let use_graph = matches!(
-            query.retrieval_mode,
-            RetrievalMode::Hybrid | RetrievalMode::Associative | RetrievalMode::Causal
-        );
+        // RH-8 gate: Layer 2 graph spreading activation only runs in `PlusSpreading` and above.
+        // When gated off, the fallback branch yields an empty graph result vector while
+        // still producing IC weights and phrase boosts (cheap query-side analysis).
+        let use_graph = layer_spreading
+            && matches!(
+                query.retrieval_mode,
+                RetrievalMode::Hybrid | RetrievalMode::Associative | RetrievalMode::Causal
+            );
         #[allow(clippy::type_complexity)]
         let (
             graph_results,
@@ -2158,6 +2186,7 @@ impl MemorySystem {
             session_id: query.session_id.clone(),
             prospective_signals: query.prospective_signals.clone(),
             recency_weight: query.recency_weight,
+            layers: query.layers,
         };
 
         // ===========================================================================
@@ -2299,23 +2328,29 @@ impl MemorySystem {
             } else {
                 None
             };
-            let hybrid_ids = self
-                .hybrid_search
-                .search_with_dynamic_weights_pool(
-                    bm25_query_text,
-                    vector_results.clone(),
-                    get_content,
-                    term_weights,
-                    phrases,
-                    disc_opt,
-                    bm25_pool_override,
-                )
-                .map(|r| {
-                    r.into_iter()
-                        .map(|x| (x.memory_id, x.score))
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or(vector_results);
+            // RH-8 gate: BM25 hybrid fusion only runs in `PlusBm25` and above.
+            // Lower modes pass the vector candidate set straight through, which makes the
+            // RRF fusion below a one- or two-leg fusion (vector ± graph) instead of three-leg.
+            let hybrid_ids = if layer_bm25 {
+                self.hybrid_search
+                    .search_with_dynamic_weights_pool(
+                        bm25_query_text,
+                        vector_results.clone(),
+                        get_content,
+                        term_weights,
+                        phrases,
+                        disc_opt,
+                        bm25_pool_override,
+                    )
+                    .map(|r| {
+                        r.into_iter()
+                            .map(|x| (x.memory_id, x.score))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or(vector_results)
+            } else {
+                vector_results
+            };
 
             // ===========================================================================
             // LAYER 4: RRF FUSION WITH DENSITY-BASED WEIGHTS (PIPE-11)
@@ -2530,7 +2565,8 @@ impl MemorySystem {
             // - High interference + high activation = "survivor" → boost (1.0-1.5x)
             // - High interference + low activation = "chronic loser" → suppress (0.5-1.0x)
             // - No interference history → neutral (1.0x)
-            {
+            // RH-8 gate: interference adjustments only run in `Full` mode.
+            if layer_full {
                 let detector = self.interference_detector.read();
 
                 // Compute max score once for normalization
@@ -2585,7 +2621,9 @@ impl MemorySystem {
             //
             // Signals come from ProspectiveTasks that matched the current query
             // via keyword or semantic similarity (built in recall handler C5).
-            if let Some(ref signals) = query.prospective_signals {
+            // RH-8 gate: prospective signal boost only runs in `Full` mode.
+            if layer_full {
+                if let Some(ref signals) = query.prospective_signals {
                 if !signals.is_empty() {
                     use crate::constants::{PROSPECTIVE_BOOST_MAX, PROSPECTIVE_BOOST_PER_MATCH};
 
@@ -2642,6 +2680,7 @@ impl MemorySystem {
                         }
                     }
                 }
+                }
             }
 
             // ===========================================================================
@@ -2693,7 +2732,12 @@ impl MemorySystem {
             res.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
             let rerank_budget = query.max_results * 2;
 
-            if use_ontology_rerank && !onto_intent.expected_labels.is_empty() {
+            // RH-8 gate: ontological rerank only runs in `PlusRerank` and above.
+            // NOTE (#270 spec discrepancy): the spec calls this mode "+rerank" with the
+            // expectation of a cross-encoder. This codebase has no cross-encoder; the only
+            // rerank present is the ontological label-match boost below. The mode label is
+            // preserved for spec fidelity. See plan/PR for details.
+            if layer_rerank && use_ontology_rerank && !onto_intent.expected_labels.is_empty() {
                 if let Some(graph) = self.graph_memory.as_ref() {
                     let g = graph.read();
                     let mut boosted_count = 0usize;
@@ -2795,13 +2839,24 @@ impl MemorySystem {
 
         for (memory_id, score) in memory_ids {
             // Hebbian boost from learned graph weights (multiplicative)
+            // RH-8 gate: Hebbian association boost only applies in `Full` mode.
             let hebbian_boost = hebbian_scores.get(&memory_id).copied().unwrap_or(0.0);
-            let base_score =
-                score * (1.0 + hebbian_boost * crate::constants::HEBBIAN_ASSOCIATION_WEIGHT);
+            let base_score = if layer_full {
+                score * (1.0 + hebbian_boost * crate::constants::HEBBIAN_ASSOCIATION_WEIGHT)
+            } else {
+                score
+            };
 
             // Helper to apply unified scoring (all multiplicative on base score)
             let recency_scale_override = query.recency_weight;
             let with_unified_score = |mem: &SharedMemory, base: f32| -> SharedMemory {
+                // RH-8 gate: lower modes pass the raw fused score through unchanged so
+                // per-layer attribution measures retrieval signal, not cognitive overlay.
+                if !layer_full {
+                    let mut cloned: Memory = mem.as_ref().clone();
+                    cloned.set_score(base);
+                    return Arc::new(cloned);
+                }
                 use crate::constants::*;
 
                 // Recency: exponential decay, multiplicative factor
@@ -3100,6 +3155,9 @@ impl MemorySystem {
         // Quality gate: multiplicative factor based on content richness.
         // Prevents empty/trivial memories from surfacing on recency or graph boost alone.
         // Same formula as proactive_context (Berntsen elaboration quality).
+        // RH-8 gate: quality multiplier only applies in `Full` mode — lower modes
+        // expose the raw fused score so per-layer attribution isn't masked.
+        if layer_full {
         for mem in &mut memories {
             let content_len = mem.experience.content.len() as f32;
             let has_entities = !mem.experience.entities.is_empty();
@@ -3123,9 +3181,11 @@ impl MemorySystem {
                 }
             }
         }
+        }
 
         // Linguistic analysis: additive boost (5% of IC weight), not a full re-sort
-        if !query_analysis.focal_entities.is_empty() {
+        // RH-8 gate: linguistic re-sort only runs in `Full` mode.
+        if layer_full && !query_analysis.focal_entities.is_empty() {
             memories.sort_by(|a, b| {
                 let score_a = a.score.unwrap_or(0.0)
                     + Self::linguistic_boost(&a.experience.content, &query_analysis) * 0.05;
@@ -3148,7 +3208,9 @@ impl MemorySystem {
         // PIPE-10: Competition must happen BEFORE coactivation - we only want to
         // strengthen associations between memories that "won" the competition.
         // Suppressed memories should not be coactivated (Hebbian "losers don't learn").
-        if memories.len() >= 2 {
+        // RH-8 gate: retrieval competition mutates interference state — only run in `Full` mode
+        // so per-layer attribution runs in `--layer all` don't pollute state across modes.
+        if layer_full && memories.len() >= 2 {
             // Use actual pipeline scores for competition, not position-based proxies.
             // Previously used 1.0 - (i/n)*0.3 which compressed all scores to [0.7, 1.0],
             // making suppression (ratio > 0.9) almost impossible.
@@ -3211,8 +3273,11 @@ impl MemorySystem {
 
         // Update access counts with instrumentation for consolidation events
         // (only for memories that survived competition)
-        for memory in &memories {
-            self.update_access_count_instrumented(memory, StrengtheningReason::Recalled);
+        // RH-8 gate: access count mutates persistent state — only in `Full` mode.
+        if layer_full {
+            for memory in &memories {
+                self.update_access_count_instrumented(memory, StrengtheningReason::Recalled);
+            }
         }
 
         // PIPE-10: Hebbian learning AFTER competition - only coactivate winners
@@ -3220,7 +3285,8 @@ impl MemorySystem {
         // form/strengthen edges in the memory graph. Suppressed memories don't
         // participate in coactivation (biological: "neurons that fire together
         // wire together" but suppressed neurons don't fire).
-        if memories.len() >= 2 {
+        // RH-8 gate: Hebbian coactivation mutates graph state — only in `Full` mode.
+        if layer_full && memories.len() >= 2 {
             if let Some(graph) = &self.graph_memory {
                 let memory_uuids: Vec<uuid::Uuid> = memories.iter().map(|m| m.id.0).collect();
                 match graph.read().record_memory_coactivation(&memory_uuids) {
@@ -3250,14 +3316,21 @@ impl MemorySystem {
         }
 
         // Increment and persist retrieval counter
-        if let Ok(count) = self.long_term_memory.increment_retrieval_count() {
-            self.stats.write().total_retrievals = count;
+        // RH-8 gate: retrieval counter mutates persistent state — only in `Full` mode.
+        if layer_full {
+            if let Ok(count) = self.long_term_memory.increment_retrieval_count() {
+                self.stats.write().total_retrievals = count;
+            }
         }
 
         // Expand with hierarchy context (parent chain + children)
         // This ensures semantic search also surfaces contextually related memories
-        let mut seen_ids: HashSet<MemoryId> = memories.iter().map(|m| m.id.clone()).collect();
-        self.expand_with_hierarchy(&mut memories, &mut seen_ids);
+        // RH-8 gate: hierarchy expansion adds candidates outside the layer's scope —
+        // only in `Full` mode so per-layer ranks reflect that layer's retrieval signal.
+        if layer_full {
+            let mut seen_ids: HashSet<MemoryId> = memories.iter().map(|m| m.id.clone()).collect();
+            self.expand_with_hierarchy(&mut memories, &mut seen_ids);
+        }
 
         // Re-sort by score and trim to max_results after expansion.
         // Expanded memories must compete on score, not get a free pass.

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -2048,6 +2048,13 @@ pub struct Query {
     // === Pagination (SHO-69) ===
     /// Offset for pagination (skip first N results)
     pub offset: usize,
+
+    // === Pipeline-Layer Attribution (RH-8, #270) ===
+    /// Which slice of the recall pipeline to run. Production callers leave
+    /// this at the default (`Full`) and get the existing behavior. The
+    /// recall harness sets lower modes to attribute quality deltas to
+    /// specific stages. See `LayerMode` docs.
+    pub layers: LayerMode,
 }
 
 /// Paginated search results with metadata for "load more" patterns (SHO-69)
@@ -2129,6 +2136,7 @@ impl Default for Query {
             max_results: DEFAULT_MAX_RESULTS,
             retrieval_mode: RetrievalMode::Hybrid,
             offset: 0,
+            layers: LayerMode::Full,
         }
     }
 }
@@ -2418,6 +2426,74 @@ pub enum RetrievalMode {
     Spatial,       // Geo-location based retrieval
     Mission,       // Mission context retrieval
     ActionOutcome, // Reward-based learning retrieval
+}
+
+/// Pipeline-layer attribution mode for the recall harness (RH-8, #270).
+///
+/// Cumulative — each variant turns on one more pipeline stage on top of the
+/// prior. Production code never touches this; the default is `Full`. The
+/// recall harness drives lower modes from its CLI to attribute quality
+/// deltas to specific pipeline stages.
+///
+/// Ordering reflects "how much pipeline is active":
+/// `VamanaOnly < PlusSpreading < PlusBm25 < PlusRerank < PlusFacts < Full`.
+/// Stage gates inside `semantic_retrieve_inner` use `mode >= LayerMode::X`
+/// to enable the corresponding stage.
+///
+/// **Note on `PlusRerank`:** issue #270 labels this `+rerank` and describes
+/// it as "+ cross-encoder". This codebase has **no cross-encoder**. The only
+/// rerank present is the ontological rerank at Layer 4.9 (multiplicative
+/// boost when episode entity types match expected ontology labels). The
+/// label is preserved for spec fidelity; the documented stage is what
+/// actually runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub enum LayerMode {
+    /// Layer 3 vector ANN only. Score is raw cosine. No graph, no BM25,
+    /// no Layer 5 cognitive adjustments, no retrieval competition.
+    VamanaOnly,
+    /// + Layer 2 graph spreading activation. Ranking is the union of
+    /// vector and graph candidates ordered by raw fused score.
+    PlusSpreading,
+    /// + Layer 4 lexical/RRF fusion (vector + graph + BM25 via three-way
+    /// reciprocal rank fusion).
+    PlusBm25,
+    /// + Layer 4.9 ontological rerank (multiplicative entity-type boost).
+    /// Spec-aliased as `+rerank` in #270 — see enum-level docs.
+    PlusRerank,
+    /// + Layer 0.7 fact source pre-fetch and Layer 4.8 fact-source boost.
+    PlusFacts,
+    /// Production. Everything: temporal pre-filter (Layer 0.4), attribute
+    /// detection (0.5), temporal facts (0.6), Layer 5 unified scoring,
+    /// retrieval competition + Hebbian coactivation.
+    #[default]
+    Full,
+}
+
+impl LayerMode {
+    /// Stable string identifier emitted into the recall harness JSON
+    /// report. Matches the labels used in #270 exactly so downstream
+    /// tooling (markdown diff, dashboards) can rely on them.
+    pub fn report_key(self) -> &'static str {
+        match self {
+            Self::VamanaOnly => "vamana_only",
+            Self::PlusSpreading => "+spreading",
+            Self::PlusBm25 => "+bm25",
+            Self::PlusRerank => "+rerank",
+            Self::PlusFacts => "+facts",
+            Self::Full => "full",
+        }
+    }
+
+    /// All variants in ascending pipeline coverage order. Used by the
+    /// `--layer all` CLI expansion in the recall harness.
+    pub const ALL: [LayerMode; 6] = [
+        LayerMode::VamanaOnly,
+        LayerMode::PlusSpreading,
+        LayerMode::PlusBm25,
+        LayerMode::PlusRerank,
+        LayerMode::PlusFacts,
+        LayerMode::Full,
+    ];
 }
 
 /// Criteria for forgetting memories
@@ -4587,5 +4663,58 @@ mod tests {
             "Decision/CodeEdit signal ratio should be > 6x, got {:.1}x",
             ratio
         );
+    }
+
+    // -------------------- RH-8 (#270) -----------------------------------
+    //
+    // LayerMode is the gate the recall harness uses to attribute quality
+    // deltas to specific pipeline stages. Production code never touches
+    // it — these tests pin the contract used by the harness CLI and the
+    // stage gates in `mod.rs`.
+
+    #[test]
+    fn layer_mode_default_is_full() {
+        assert_eq!(LayerMode::default(), LayerMode::Full);
+        // The Query default must also resolve to Full so existing call
+        // sites get unchanged behavior.
+        assert_eq!(Query::default().layers, LayerMode::Full);
+    }
+
+    #[test]
+    fn layer_mode_ordering_is_cumulative() {
+        // The whole point of the cumulative enum is that downstream code
+        // can write `if mode >= LayerMode::PlusBm25 { … }` and have BM25
+        // turn on for PlusBm25, PlusRerank, PlusFacts and Full.
+        assert!(LayerMode::VamanaOnly < LayerMode::PlusSpreading);
+        assert!(LayerMode::PlusSpreading < LayerMode::PlusBm25);
+        assert!(LayerMode::PlusBm25 < LayerMode::PlusRerank);
+        assert!(LayerMode::PlusRerank < LayerMode::PlusFacts);
+        assert!(LayerMode::PlusFacts < LayerMode::Full);
+    }
+
+    #[test]
+    fn layer_mode_report_keys_match_spec() {
+        // These string handles are part of the JSON schema consumed by
+        // `scripts/recall_diff.py` and the dashboard. They MUST match
+        // the labels in #270 character-for-character.
+        assert_eq!(LayerMode::VamanaOnly.report_key(), "vamana_only");
+        assert_eq!(LayerMode::PlusSpreading.report_key(), "+spreading");
+        assert_eq!(LayerMode::PlusBm25.report_key(), "+bm25");
+        assert_eq!(LayerMode::PlusRerank.report_key(), "+rerank");
+        assert_eq!(LayerMode::PlusFacts.report_key(), "+facts");
+        assert_eq!(LayerMode::Full.report_key(), "full");
+    }
+
+    #[test]
+    fn layer_mode_all_is_in_ascending_pipeline_order() {
+        // ALL must be sorted, contain every variant exactly once, and
+        // start at the smallest (VamanaOnly) — the harness relies on
+        // that order when iterating `--layer all`.
+        assert_eq!(LayerMode::ALL.len(), 6);
+        for w in LayerMode::ALL.windows(2) {
+            assert!(w[0] < w[1], "ALL must be strictly ascending");
+        }
+        assert_eq!(LayerMode::ALL.first().copied(), Some(LayerMode::VamanaOnly));
+        assert_eq!(LayerMode::ALL.last().copied(), Some(LayerMode::Full));
     }
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -801,6 +801,7 @@ impl PyMemorySystem {
             max_results: limit,
             retrieval_mode,
             offset: 0,
+            layers: crate::memory::types::LayerMode::Full,
         };
 
         let memories = self
@@ -1838,6 +1839,7 @@ impl PyMemorySystem {
             max_results: max_results * 2, // Get more for filtering
             retrieval_mode: RetrievalMode::Hybrid,
             offset: 0,
+            layers: crate::memory::types::LayerMode::Full,
         };
 
         let memories = self

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 use anyhow::{Context, Result};
 use uuid::Uuid;
 
-use crate::memory::types::ExperienceType;
+use crate::memory::types::{ExperienceType, LayerMode};
 use crate::memory::{Experience, MemoryConfig, MemorySystem, Query};
 
 use super::fixtures::{
@@ -58,6 +58,21 @@ pub struct RunInputs {
     ///
     /// Default in the CLI is `5`. Setting `0` is treated as `1`.
     pub repeats: usize,
+
+    /// Per-pipeline-layer attribution modes to run. RH-8 (#270). Each mode
+    /// is a cumulative subset of the production retrieval pipeline; running
+    /// the same query set under multiple modes lets us attribute quality
+    /// deltas to specific stages rather than treating the pipeline as a
+    /// single number. Within one repeat, ingest runs once and the case loop
+    /// runs once per mode (cost ≈ ingest + N_modes × queries).
+    ///
+    /// CI gating still keys on `LayerMode::Full` only; the other modes are
+    /// diagnostic. A single-element vec containing `Full` reproduces the
+    /// pre-RH-8 behavior bit-for-bit.
+    ///
+    /// An empty vec is treated as `[LayerMode::Full]` so callers that don't
+    /// care about per-layer attribution don't have to populate this.
+    pub layer_modes: Vec<LayerMode>,
 }
 
 /// One case's retrieved rank list, in score-descending order.
@@ -139,6 +154,16 @@ pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks>
         .context("smoke suite failed structural validation — fix the JSONL fixtures")?;
 
     let repeats = inputs.repeats.max(1);
+    // RH-8 (#270): default to `[Full]` when caller passed an empty vec so
+    // the existing single-mode contract is preserved by construction.
+    let layer_modes: Vec<LayerMode> = if inputs.layer_modes.is_empty() {
+        vec![LayerMode::Full]
+    } else {
+        let mut m = inputs.layer_modes.clone();
+        m.sort();
+        m.dedup();
+        m
+    };
 
     // Run N independent ingest+query passes against fresh storage
     // directories. RH-12 (#272): per-case latency is the median across
@@ -146,6 +171,9 @@ pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks>
     // every pass. The for-loop is intentionally serial — running passes
     // in parallel would defeat the determinism check, since concurrent
     // RocksDB instances under the same root would race on file handles.
+    //
+    // RH-8: within each pass, ingest happens once and the case loop runs
+    // once per `LayerMode`. Determinism check is per-mode.
     let mut passes: Vec<OnePassResult> = Vec::with_capacity(repeats);
     for i in 0..repeats {
         let pass_storage = if repeats == 1 {
@@ -155,7 +183,7 @@ pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks>
         } else {
             inputs.storage_path.join(format!("repeat_{i}"))
         };
-        let pass = run_one_pass(&pass_storage, &corpus, &cases)
+        let pass = run_one_pass(&pass_storage, &corpus, &cases, &layer_modes)
             .with_context(|| format!("repeat {i} of {repeats}"))?;
         passes.push(pass);
     }
@@ -163,49 +191,79 @@ pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks>
     // ------------------------------------------------------------------
     // Determinism check across repeats. Two passes against the same
     // fixtures, with thread pinning + the RH-10/11 tie-break in place,
-    // MUST produce byte-identical rank lists. If they don't, something
-    // upstream regressed (e.g. a new sort touched a non-determinism
-    // source). Surface every diverging case as an `infrastructure`
-    // failure so reviewers see the full picture, not just the first.
+    // MUST produce byte-identical rank lists per mode. If they don't,
+    // something upstream regressed. Surface every diverging case as an
+    // `infrastructure` failure so reviewers see the full picture.
     // ------------------------------------------------------------------
     let mut failures: Vec<Failure> = passes[0].failures.clone();
     if repeats > 1 {
-        for (i, pass) in passes.iter().enumerate().skip(1) {
-            for (k, ref_rank) in passes[0].ranks.iter().enumerate() {
-                let cur_rank = &pass.ranks[k];
-                debug_assert_eq!(ref_rank.case_id, cur_rank.case_id);
-                if ref_rank.retrieved != cur_rank.retrieved {
-                    failures.push(Failure {
-                        kind: "infrastructure".to_string(),
-                        detail: format!(
-                            "non-determinism: case {} rank list diverged between repeat 0 and repeat {i} \
-                             — repeat 0 = {:?}, repeat {i} = {:?}",
-                            ref_rank.case_id, ref_rank.retrieved, cur_rank.retrieved
-                        ),
-                    });
+        for mode in &layer_modes {
+            let ref_pass = passes[0]
+                .per_mode
+                .get(mode)
+                .expect("repeat 0 must have all modes");
+            for (i, pass) in passes.iter().enumerate().skip(1) {
+                let cur_pass = pass
+                    .per_mode
+                    .get(mode)
+                    .expect("every repeat must have every mode");
+                for (k, ref_rank) in ref_pass.ranks.iter().enumerate() {
+                    let cur_rank = &cur_pass.ranks[k];
+                    debug_assert_eq!(ref_rank.case_id, cur_rank.case_id);
+                    if ref_rank.retrieved != cur_rank.retrieved {
+                        failures.push(Failure {
+                            kind: "infrastructure".to_string(),
+                            detail: format!(
+                                "non-determinism [mode={}]: case {} rank list diverged between repeat 0 and repeat {i} \
+                                 — repeat 0 = {:?}, repeat {i} = {:?}",
+                                mode.report_key(), ref_rank.case_id, ref_rank.retrieved, cur_rank.retrieved
+                            ),
+                        });
+                    }
                 }
             }
         }
     }
 
-    // Quality metrics: take from repeat 0. The determinism check above
-    // guarantees they would be identical across repeats; if it didn't
-    // pass, the caller exits with `EXIT_INFRASTRUCTURE` anyway and the
-    // metrics don't matter.
-    let per_case = &passes[0].per_case;
-    let by_category_cases = &passes[0].by_category_cases;
-
-    // Per-case median latency: collect samples from every pass, take median.
-    let mut latencies_median_ms: Vec<f64> = Vec::with_capacity(cases.len());
-    for k in 0..cases.len() {
-        let samples: Vec<f64> = passes.iter().map(|p| p.latencies_ms[k]).collect();
-        latencies_median_ms.push(median(&samples));
+    // Quality metrics: per-mode aggregation. Take per-case metrics from
+    // repeat 0; per-case latency is the median across repeats.
+    let mut layers: BTreeMap<String, LayerReport> = BTreeMap::new();
+    for mode in &layer_modes {
+        let per_case = &passes[0]
+            .per_mode
+            .get(mode)
+            .expect("repeat 0 must have mode")
+            .per_case;
+        let mut latencies_median_ms: Vec<f64> = Vec::with_capacity(cases.len());
+        for k in 0..cases.len() {
+            let samples: Vec<f64> = passes
+                .iter()
+                .map(|p| {
+                    p.per_mode
+                        .get(mode)
+                        .expect("every repeat must have every mode")
+                        .latencies_ms[k]
+                })
+                .collect();
+            latencies_median_ms.push(median(&samples));
+        }
+        layers.insert(
+            mode.report_key().to_string(),
+            aggregate_layer(per_case, &latencies_median_ms),
+        );
     }
 
-    let layer_report = aggregate_layer(per_case, &latencies_median_ms);
-    let mut layers: BTreeMap<String, LayerReport> = BTreeMap::new();
-    layers.insert("full".to_string(), layer_report);
-
+    // Per-category breakdown is reported for the highest mode present
+    // (typically `Full`). Lower modes' per-category numbers are encoded
+    // implicitly via the per-layer ndcg/recall tables; surfacing six
+    // category-mode crosstabs would explode the report without adding
+    // signal at the current corpus size.
+    let highest_mode = layer_modes.last().copied().unwrap_or(LayerMode::Full);
+    let by_category_cases = &passes[0]
+        .per_mode
+        .get(&highest_mode)
+        .expect("repeat 0 must have highest mode")
+        .by_category_cases;
     let mut by_category: BTreeMap<String, CategoryReport> = BTreeMap::new();
     for cat in SmokeCategory::ALL {
         let cases_for_cat = by_category_cases.get(&cat).cloned().unwrap_or_default();
@@ -227,35 +285,53 @@ pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks>
         failures,
     };
 
-    // The public ranks output is the repeat-0 rank list — that is what
-    // existing RH-11 tests expect. Cross-repeat divergence is already
-    // surfaced via `failures` above.
-    let ranks = passes.into_iter().next().expect("repeats >= 1").ranks;
+    // The public ranks output is the repeat-0 rank list for the highest
+    // mode — that matches existing RH-11 test expectations (which assume
+    // a single mode). Cross-repeat divergence is already surfaced via
+    // `failures` above on a per-mode basis.
+    let ranks = passes
+        .into_iter()
+        .next()
+        .expect("repeats >= 1")
+        .per_mode
+        .remove(&highest_mode)
+        .expect("repeat 0 must have highest mode")
+        .ranks;
 
     Ok(ReportWithRanks { report, ranks })
 }
 
-/// Output of one ingest+query pass over the fixture suite.
-///
-/// Kept private; the public surface aggregates across passes via
-/// [`run_smoke_suite_with_ranks`]. RH-12 (#272).
-struct OnePassResult {
+/// Per-case results for one `LayerMode` within a single ingest+query pass.
+struct ModePassResult {
     per_case: Vec<Metrics>,
     by_category_cases: HashMap<SmokeCategory, Vec<Metrics>>,
     latencies_ms: Vec<f64>,
     ranks: Vec<CaseRankList>,
+}
+
+/// Output of one ingest pass plus N mode-keyed query passes over the
+/// fixture suite. Ingest happens once per pass; the case loop runs once
+/// per `LayerMode` so per-mode quality and latency can be attributed
+/// without paying the ingest cost N times. RH-8 (#270), RH-12 (#272).
+struct OnePassResult {
+    per_mode: BTreeMap<LayerMode, ModePassResult>,
     failures: Vec<Failure>,
 }
 
-/// Run a single ingest + query pass against an isolated storage directory.
+/// Run a single ingest pass, then run the case loop once per `LayerMode`.
 ///
-/// The caller is responsible for choosing the storage dir so multiple passes
-/// in the same harness invocation get independent state. The corpus and
-/// cases are passed in by reference so we don't reload fixtures per pass.
+/// The caller is responsible for choosing the storage dir so multiple
+/// repeats in the same harness invocation get independent state. The
+/// corpus and cases are passed in by reference so we don't reload fixtures
+/// per pass. The system is built once and reused across modes — the modes
+/// themselves are pure read-side gates and do not mutate persisted state
+/// in lower modes (Hebbian/access-count/competition writes are gated to
+/// `Full`), so cross-mode contamination is impossible.
 fn run_one_pass(
     storage_path: &Path,
     corpus: &[CorpusItem],
     cases: &[SmokeCase],
+    layer_modes: &[LayerMode],
 ) -> Result<OnePassResult> {
     let system = build_system(storage_path)?;
     let id_map = ingest_corpus(&system, corpus)?;
@@ -268,82 +344,93 @@ fn run_one_pass(
         .map(|(corpus_id, uuid)| (*uuid, corpus_id.clone()))
         .collect();
 
-    let mut per_case = Vec::with_capacity(cases.len());
-    let mut latencies_ms = Vec::with_capacity(cases.len());
-    let mut by_category_cases: HashMap<SmokeCategory, Vec<Metrics>> = HashMap::new();
+    let mut per_mode: BTreeMap<LayerMode, ModePassResult> = BTreeMap::new();
     let mut failures: Vec<Failure> = Vec::new();
-    let mut ranks: Vec<CaseRankList> = Vec::with_capacity(cases.len());
 
-    for case in cases {
-        let query = Query {
-            query_text: Some(case.query.clone()),
-            max_results: SMOKE_K,
-            ..Default::default()
-        };
+    for mode in layer_modes {
+        let mut per_case = Vec::with_capacity(cases.len());
+        let mut latencies_ms = Vec::with_capacity(cases.len());
+        let mut by_category_cases: HashMap<SmokeCategory, Vec<Metrics>> = HashMap::new();
+        let mut ranks: Vec<CaseRankList> = Vec::with_capacity(cases.len());
 
-        let started = Instant::now();
-        let result = system.recall(&query);
-        let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
-        latencies_ms.push(elapsed_ms);
+        for case in cases {
+            let query = Query {
+                query_text: Some(case.query.clone()),
+                max_results: SMOKE_K,
+                layers: *mode,
+                ..Default::default()
+            };
 
-        let memories = match result {
-            Ok(m) => m,
-            Err(e) => {
+            let started = Instant::now();
+            let result = system.recall(&query);
+            let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
+            latencies_ms.push(elapsed_ms);
+
+            let memories = match result {
+                Ok(m) => m,
+                Err(e) => {
+                    failures.push(Failure {
+                        kind: "case".to_string(),
+                        detail: format!(
+                            "recall failed for {} [mode={}]: {e:#}",
+                            case.id,
+                            mode.report_key()
+                        ),
+                    });
+                    // Treat as zero-recall so aggregates keep their denominator.
+                    Vec::new()
+                }
+            };
+
+            let retrieved_uuids: Vec<Uuid> = memories.iter().map(|m| m.id.0).collect();
+            let retrieved_corpus_ids: Vec<String> = retrieved_uuids
+                .iter()
+                .map(|u| {
+                    uuid_to_corpus_id
+                        .get(u)
+                        .cloned()
+                        .unwrap_or_else(|| format!("<unknown:{u}>"))
+                })
+                .collect();
+            ranks.push(CaseRankList {
+                case_id: case.id.clone(),
+                retrieved: retrieved_corpus_ids,
+            });
+            let relevance = build_relevance_map(case, &id_map);
+
+            // Only emit the "missing relevance map" failure once across modes
+            // — the relevance map is a function of fixtures + ingest, not
+            // the mode, so duplicating it would clutter the failure list.
+            if relevance.is_empty() && *mode == layer_modes[0] {
                 failures.push(Failure {
                     kind: "case".to_string(),
-                    detail: format!("recall failed for {}: {e:#}", case.id),
+                    detail: format!(
+                        "case {}: every relevant corpus item was missing from id_map (ingest skipped them)",
+                        case.id
+                    ),
                 });
-                // Treat as zero-recall so aggregates keep their denominator.
-                Vec::new()
             }
-        };
 
-        let retrieved_uuids: Vec<Uuid> = memories.iter().map(|m| m.id.0).collect();
-        // Translate to stable corpus IDs for the determinism gate. Items
-        // that were not part of the ingested corpus (defensive: should
-        // never happen on a fresh harness storage dir) are surfaced as
-        // `<unknown:UUID>` so any divergence in those slots is still
-        // observable instead of silently masked by a string fallback.
-        let retrieved_corpus_ids: Vec<String> = retrieved_uuids
-            .iter()
-            .map(|u| {
-                uuid_to_corpus_id
-                    .get(u)
-                    .cloned()
-                    .unwrap_or_else(|| format!("<unknown:{u}>"))
-            })
-            .collect();
-        ranks.push(CaseRankList {
-            case_id: case.id.clone(),
-            retrieved: retrieved_corpus_ids,
-        });
-        let relevance = build_relevance_map(case, &id_map);
-
-        if relevance.is_empty() {
-            failures.push(Failure {
-                kind: "case".to_string(),
-                detail: format!(
-                    "case {}: every relevant corpus item was missing from id_map (ingest skipped them)",
-                    case.id
-                ),
-            });
+            let metrics = Metrics::compute(&retrieved_uuids, &relevance, SMOKE_K);
+            by_category_cases
+                .entry(case.category)
+                .or_default()
+                .push(metrics);
+            per_case.push(metrics);
         }
 
-        let metrics = Metrics::compute(&retrieved_uuids, &relevance, SMOKE_K);
-        by_category_cases
-            .entry(case.category)
-            .or_default()
-            .push(metrics);
-        per_case.push(metrics);
+        per_mode.insert(
+            *mode,
+            ModePassResult {
+                per_case,
+                by_category_cases,
+                latencies_ms,
+                ranks,
+            },
+        );
     }
 
-    Ok(OnePassResult {
-        per_case,
-        by_category_cases,
-        latencies_ms,
-        ranks,
-        failures,
-    })
+    Ok(OnePassResult { per_mode, failures })
 }
 
 /// Pin parallel runtimes to a single thread for the harness process.
@@ -475,6 +562,7 @@ mod tests {
             suite: "smoke".to_string(),
             git_sha: "test-sha".to_string(),
             repeats: 1,
+            layer_modes: vec![LayerMode::Full],
         };
         let report = run_smoke_suite(&inputs).expect("runner must succeed");
         let _ = std::fs::remove_dir_all(&storage);
@@ -554,6 +642,7 @@ mod tests {
             suite: "smoke".to_string(),
             git_sha: "test-sha".to_string(),
             repeats: 1,
+            layer_modes: vec![LayerMode::Full],
         };
         let inputs2 = RunInputs {
             storage_path: storage2.clone(),
@@ -562,6 +651,7 @@ mod tests {
             suite: "smoke".to_string(),
             git_sha: "test-sha".to_string(),
             repeats: 2,
+            layer_modes: vec![LayerMode::Full],
         };
 
         let r1 = run_smoke_suite(&inputs1).expect("repeats=1 must succeed");
@@ -608,6 +698,71 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&storage1);
         let _ = std::fs::remove_dir_all(&storage2);
+    }
+
+    /// RH-8 (#270): running the smoke suite with multiple `LayerMode`s
+    /// emits one `layers` entry per mode, in pipeline order, and per-mode
+    /// rank lists are byte-identical across repeats.
+    ///
+    /// Marked `#[ignore]` for the same reason as the other end-to-end
+    /// runner tests — it pays the ingest cost once and the query loop six
+    /// times. Run via `cargo test --release -- --ignored
+    /// runner_layer_all_emits_six_modes_with_per_mode_determinism`
+    /// before shipping changes that touch any layer gate.
+    #[test]
+    #[ignore = "expensive: runs the smoke suite with 6 modes (~6× query time). enable with --ignored before shipping layer-gate changes."]
+    fn runner_layer_all_emits_six_modes_with_per_mode_determinism() {
+        let storage = unique_storage_dir("layer-all");
+        let inputs = RunInputs {
+            storage_path: storage.clone(),
+            corpus_path: None,
+            cases_path: None,
+            suite: "smoke".to_string(),
+            git_sha: "test-sha".to_string(),
+            // Two repeats so the per-mode determinism check actually runs.
+            repeats: 2,
+            layer_modes: LayerMode::ALL.to_vec(),
+        };
+        let report = run_smoke_suite(&inputs).expect("layer-all run must succeed");
+        let _ = std::fs::remove_dir_all(&storage);
+
+        // Six modes, all present, in their canonical report-key form.
+        for mode in LayerMode::ALL {
+            assert!(
+                report.layers.contains_key(mode.report_key()),
+                "missing layer entry for {}",
+                mode.report_key()
+            );
+        }
+        assert_eq!(report.layers.len(), LayerMode::ALL.len());
+
+        // Per-mode determinism: any divergence would have been recorded
+        // as `infrastructure` failures by the runner.
+        let infra: Vec<_> = report
+            .failures
+            .iter()
+            .filter(|f| f.kind == "infrastructure")
+            .collect();
+        assert!(
+            infra.is_empty(),
+            "per-mode determinism violated: {:?}",
+            infra
+        );
+
+        // Sanity: `full` ndcg@10 must be >= `vamana_only` ndcg@10 on the
+        // canonical fixtures. This is the #270 acceptance invariant — if a
+        // future scoring change ever inverts it, that's a real signal.
+        let full = report.layers.get("full").expect("full layer present");
+        let vamana = report
+            .layers
+            .get("vamana_only")
+            .expect("vamana_only layer present");
+        assert!(
+            full.ndcg_at_10 + 1e-6 >= vamana.ndcg_at_10,
+            "full ndcg@10 ({}) must be >= vamana_only ndcg@10 ({}) on canonical fixtures",
+            full.ndcg_at_10,
+            vamana.ndcg_at_10
+        );
     }
 
     /// Direct unit test of the cross-repeat divergence detection logic.

--- a/tests/recall/README.md
+++ b/tests/recall/README.md
@@ -36,6 +36,68 @@ git diff tests/recall/baseline.json
 If a metric moved by more than ~2% in either direction, write a one-paragraph
 justification in the PR description so future bisects have context.
 
+## Per-pipeline-layer attribution (`--layer`)
+
+`recall-eval` accepts a `--layer` flag (RH-8, #270) that selects which
+subset of the retrieval pipeline runs. Modes are **cumulative**: each row
+adds one stage on top of the row above it.
+
+| Mode             | Stages added                                                           |
+| ---------------- | ---------------------------------------------------------------------- |
+| `vamana-only`    | Layer 3 vector ANN only (cosine + tie-break).                          |
+| `+spreading`     | + Layer 2 graph spreading activation (RRF over vector ⊕ graph).        |
+| `+bm25`          | + Layer 4 BM25 leg of three-way RRF fusion.                            |
+| `+rerank`        | + Layer 4.9 ontological re-rank (see naming caveat below).             |
+| `+facts`         | + Layer 0.7 / 4.8 fact-source boost from consolidated knowledge.       |
+| `full`           | + Layer 0.4/0.5/0.6 pre-filters, Layer 4.6 interference, Layer 4.7     |
+|                  | prospective signal, full Layer 5 unified scoring (recency × importance |
+|                  | × arousal × credibility × tags × feedback × quality), retrieval       |
+|                  | competition, Hebbian coactivation, hierarchy expansion.                |
+
+Pass `--layer all` to run every mode in one harness invocation:
+
+```bash
+cargo run --release --bin recall-eval -- \
+    --suite smoke \
+    --repeats 1 \
+    --layer all \
+    --output /tmp/rh8_all.json
+```
+
+The report's `layers` map gains one entry per mode; `scripts/recall_diff.py`
+renders a per-layer `ndcg@10`/`recall@10` delta table when both reports
+share more than `full`.
+
+### Caveats — read these before staring at the numbers
+
+1. **`+rerank` is a misnomer in this codebase.** Issue #270 specs the mode
+   as a cross-encoder rerank stage. shodh has no cross-encoder. The gate
+   wraps the **ontological re-ranker** at Layer 4.9 (multiplicative boost
+   when episode entity types match the query's expected ontology labels).
+   The label is preserved for spec fidelity; if a cross-encoder ever
+   lands, it joins this same gate.
+
+2. **Modes below `full` skip Layer 5 unified scoring.** Per-layer ndcg
+   numbers will look strictly *lower* than `full` for reasons that are
+   *not* "this stage didn't help" — they include the absence of recency,
+   importance, arousal, credibility, feedback, quality-gate, and Hebbian
+   multipliers. Read the table as **deltas between adjacent rows**, not
+   as standalone absolute values.
+
+3. **Cumulative-only by design.** You cannot ask for "BM25 without
+   spreading" or "rerank without facts" — `--layer` accepts only the six
+   cumulative modes. If you need a non-cumulative ablation, that's a
+   different feature, not this flag.
+
+4. **CI gating still keys on `full` only.** The `.github/workflows/recall.yml`
+   workflow runs `--layer full --repeats 5`; per-layer numbers are
+   diagnostic and not regression-gated. Lower modes have no baseline yet
+   because no production caller ever runs them.
+
+5. **30 cases is a small sample.** A single document rank flip moves
+   per-category recall by ~0.20 and per-mode ndcg by ~0.05. A `+0.01`
+   per-layer delta is noise; trust direction, not magnitude.
+
 ## Regeneration history
 
 | Date       | SHA       | Embedder       | Notes                          |

--- a/tests/recall_determinism.rs
+++ b/tests/recall_determinism.rs
@@ -49,6 +49,10 @@ fn run_inputs(tag: &str) -> RunInputs {
         // `runner_repeats_*` tests in `src/recall_harness/runner.rs`;
         // keep this test single-pass so it stays under the CI budget.
         repeats: 1,
+        // RH-8 (#270): determinism gate runs Full-only — per-mode
+        // determinism is exercised by dedicated unit tests so this gate
+        // stays focused on the production pipeline path.
+        layer_modes: vec![shodh_memory::memory::types::LayerMode::Full],
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a `LayerMode` cumulative enum to `Query` and gates ~12 retrieval stages on it so the recall harness can attribute quality deltas to specific pipeline stages instead of treating the pipeline as a single number. Closes #270.

## What changes

**Plumbing** (`src/memory/types.rs`, `src/memory/mod.rs`):
- `LayerMode` enum: `VamanaOnly < PlusSpreading < PlusBm25 < PlusRerank < PlusFacts < Full`. Default = `Full` so every existing call site is bit-identical to today by construction.
- `semantic_retrieve_inner` reads `query.layers` once at entry and gates each stage with a single `if layer_X { ... }` guard. No code duplication, no parallel pipeline.
- Side-effect stages (Hebbian coactivation, access-count writes, retrieval competition, retrieval counter, hierarchy expansion) gate on `Full` so running ` --layer all` cannot pollute graph state across modes within one repeat.

**Harness** (`src/recall_harness/runner.rs`):
- `RunInputs.layer_modes: Vec<LayerMode>` (empty = `[Full]` for back-compat).
- `run_one_pass` ingests once, then loops the case loop per mode (cost ≈ ingest + N_modes × queries instead of N_modes × ingest).
- Determinism check is per-mode — RH-11 violations under any mode hard-fail with `EXIT_INFRASTRUCTURE`.
- `Report.layers` (already a ` BTreeMap`) gains 1–6 keys depending on modes run.
- ` compare_to_baseline` still keys on ` \"full\"` only — per-layer numbers are diagnostic, not gated.

**CLI** (`src/bin/recall_eval.rs`):
- `recall-eval --layer {full|all|vamana-only|+spreading|+bm25|+rerank|+facts}`. Default `full` keeps the CI workflow unchanged.

**Tooling**:
- `scripts/recall_diff.py` renders a per-layer ndcg@10 / recall@10 delta table when both reports share more than `full`.
- `tests/recall/README.md` documents `--layer all` and the `+rerank` ↔ ontological-rerank discrepancy.

## Honest discrepancy with #270

The spec lists `+rerank` as \"+ cross-encoder\". This codebase has **no cross-encoder**; the only rerank present is the ontological label-match boost at Layer 4.9. The mode label is preserved for spec fidelity and called out in the README, the CLI help, and the inline gate comment so nobody stares at the metric wondering where the cross-encoder is. If a cross-encoder ever lands, it joins this same gate.

## Test plan

- [x] 4 unit tests on `LayerMode` (default, ordering, report keys, ALL ascending order) — all passing
- [x] All 56 existing recall-harness tests still pass (cargo test --lib recall_harness)
- [x] `cargo check --lib --bins --tests` clean
- [x] `cargo clippy` clean for all touched files (pre-existing clippy errors elsewhere are unrelated)
- [ ] End-to-end ignored test `runner_layer_all_emits_six_modes_with_per_mode_determinism` — runs with `--ignored` (~6× query cost). Asserts all six modes present, per-mode determinism, and `full.ndcg@10 >= vamana_only.ndcg@10` invariant from #270.
- [ ] Local smoke: `cargo run --release --bin recall-eval -- --suite smoke --repeats 1 --layer all --output /tmp/rh8_all.json && jq '.layers | keys' /tmp/rh8_all.json` should print all six mode keys.

## Risks

1. **Per-layer numbers will look strictly *lower* than `full`** for reasons that aren't \"this stage didn't help\" — they include the absence of recency/importance/credibility/tag-penalty multipliers (the entire Layer 5 stack). Read deltas between adjacent modes, not absolute values. Documented in README in plain English.
2. **30 cases is a small sample.** A single doc rank flip moves per-category recall by ~0.20, ndcg by ~0.05. Per-layer attribution at this corpus size shows direction, not magnitude. Don't trust a +0.01 layer delta as signal.
3. **Cumulative-only by design.** No \"BM25 without spreading\" — that's a different feature, not this flag.
4. CI workflow keeps `--layer full --repeats 5`; per-layer runtime cost is paid only on demand for diagnostic work.