### PR TITLE
fix(security): harden webhooks, rate limiting, errors, and HTTP boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3710,9 +3710,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,3 +29,20 @@ If you discover a security vulnerability in shodh-memory, please report it priva
 - Disclose publicly before a fix is available
 
 We appreciate responsible disclosure.
+
+## Secure Defaults & Hardening
+
+shodh-memory ships secure-by-default. Each behavior below is enforced unless an
+operator explicitly opts out via an environment variable.
+
+| Area | Secure default | Override (use only if you understand the risk) |
+|------|----------------|-------------------------------------------------|
+| **Webhooks** | `/webhook/*` requests are rejected (HTTP 503) unless the matching `LINEAR_WEBHOOK_SECRET` / `GITHUB_WEBHOOK_SECRET` is configured, so every webhook is HMAC-verified. | `SHODH_ALLOW_UNSIGNED_WEBHOOKS=true` processes unsigned webhooks. |
+| **Rate limiting** | Public routes (webhooks, context status, graph viewer) are rate-limited. Health probe routes (`/health*`) are never rate-limited. | `SHODH_PUBLIC_RATE_LIMIT=false` exempts public routes; `SHODH_RATE_LIMIT=0` disables rate limiting entirely. |
+| **Metrics** | `/metrics` requires API-key authentication (`X-API-Key` or `Authorization: Bearer <key>`). | `SHODH_METRICS_PUBLIC=true` exposes `/metrics` without auth. |
+| **Integration API URLs** | An insecure `http://` override of `GITHUB_API_URL` / `LINEAR_API_URL` for a non-localhost host is warned about. | `SHODH_ENFORCE_HTTPS=true` rejects such overrides and uses the secure default. |
+| **Error responses** | In production (`SHODH_ENV=production`) 5xx responses return a generic message; full detail is logged server-side only. | — |
+| **API authentication** | All `/api/*` routes require an API key. Production refuses authenticated requests when no key is configured. | — |
+| **Transport** | Security headers (`X-Frame-Options`, CSP, `X-Content-Type-Options`, and HSTS in production) are always set. TLS is strongly recommended for any non-localhost deployment. | — |
+
+See the configuration documentation for the full list of variables.

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -154,9 +154,36 @@ const MAX_LIMIT = 250;              // Max results per query
 // TOKEN TRACKING - Context window awareness (SHO-115)
 // =============================================================================
 
-// Token budget configuration (default 100k tokens, ~400k chars)
-const TOKEN_BUDGET = parseInt(process.env.SHODH_TOKEN_BUDGET || "100000", 10);
-const ALERT_THRESHOLD = parseFloat(process.env.SHODH_ALERT_THRESHOLD || "0.9");
+// Parse a numeric env var with validation. A malformed (NaN) or out-of-range
+// value would otherwise silently break token tracking — e.g. a NaN budget makes
+// `tokens / budget` NaN so alerts never fire; a 0 budget makes it Infinity so
+// they always fire. Reject anything outside [min, max] and use the default.
+function parseEnvNumber(
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < min || n > max) {
+    console.error(
+      `[shodh-memory] Invalid numeric env value "${raw}" (expected ${min}..${max}) — using default ${fallback}.`,
+    );
+    return fallback;
+  }
+  return n;
+}
+
+// Token budget configuration (default 100k tokens, ~400k chars).
+// Budget: a positive integer. Alert threshold: a fraction in (0, 1].
+const TOKEN_BUDGET = parseEnvNumber(
+  process.env.SHODH_TOKEN_BUDGET,
+  100_000,
+  1,
+  Number.MAX_SAFE_INTEGER,
+);
+const ALERT_THRESHOLD = parseEnvNumber(process.env.SHODH_ALERT_THRESHOLD, 0.9, 0.01, 1);
 
 // Content-aware token tracker (replaces naive len/4 with CJK/code/prose heuristic)
 const tokenTracker = new TokenTracker(TOKEN_BUDGET, ALERT_THRESHOLD);
@@ -4605,7 +4632,10 @@ server.setRequestHandler(GetPromptRequestSchema, async (request) => {
       }
 
       case "recent_memories": {
-        const count = parseInt((args.count as string) || "10", 10);
+        // Guard against a non-numeric or non-positive `count` arg (parseInt → NaN
+        // would serialize to JSON null and silently fall back to the server default).
+        const countRaw = parseInt((args.count as string) || "10", 10);
+        const count = Number.isFinite(countRaw) && countRaw > 0 ? countRaw : 10;
         const result = await apiCall<{ memories: Memory[] }>("/api/memories", "POST", {
           user_id: USER_ID,
           limit: count,

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -35,6 +35,26 @@ import { TokenTracker } from "./token-tracking";
 const __filename = (typeof import.meta !== "undefined" && import.meta.url) ? fileURLToPath(import.meta.url) : "";
 const __dirname = __filename ? path.dirname(__filename) : process.cwd();
 
+// Resolve the package version from package.json so it cannot drift from the
+// published version. Tries the build layout (dist/index.js -> ../package.json)
+// then the dev layout (index.ts -> ./package.json); falls back to "unknown".
+function resolveVersion(): string {
+  const candidates = [
+    path.join(__dirname, "..", "package.json"),
+    path.join(__dirname, "package.json"),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(candidate, "utf-8"));
+      if (typeof pkg.version === "string" && pkg.version) return pkg.version;
+    } catch {
+      // try next candidate
+    }
+  }
+  return "unknown";
+}
+const SERVER_VERSION = resolveVersion();
+
 // Configuration
 // Priority: SHODH_API_URL (full URL) > SHODH_HOST+SHODH_PORT (constructed) > localhost default
 function resolveApiUrl(): string {
@@ -463,7 +483,12 @@ async function apiCall<T>(
 ): Promise<T> {
   let lastError: Error | null = null;
 
-  for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt++) {
+  // Only idempotent GET requests are retried. Retrying a write (POST/PUT/DELETE)
+  // after a committed-but-unacknowledged response would create duplicate
+  // memories — fail fast instead and let the caller decide whether to re-issue.
+  const maxAttempts = method === "GET" ? RETRY_ATTEMPTS : 1;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       const controller = new AbortController();
       const timeout = method === "GET" ? REQUEST_TIMEOUT_MS : WRITE_TIMEOUT_MS;
@@ -509,7 +534,7 @@ async function apiCall<T>(
       }
 
       // Log retry attempt
-      if (attempt < RETRY_ATTEMPTS) {
+      if (attempt < maxAttempts) {
         console.error(`Attempt ${attempt} failed: ${lastError.message}. Retrying in ${RETRY_DELAY_MS}ms...`);
         await sleep(RETRY_DELAY_MS * attempt); // Exponential backoff
       }
@@ -524,7 +549,7 @@ async function apiCall<T>(
       `Start the server with: shodh-memory-server`
     );
   }
-  throw new Error(`Failed after ${RETRY_ATTEMPTS} attempts: ${errMsg}`);
+  throw new Error(`Failed after ${maxAttempts} attempt${maxAttempts === 1 ? "" : "s"}: ${errMsg}`);
 }
 
 // Check if server is available
@@ -548,7 +573,7 @@ async function isServerAvailable(): Promise<boolean> {
 const server = new Server(
   {
     name: "shodh-memory",
-    version: "0.1.90",
+    version: SERVER_VERSION,
   },
   {
     capabilities: {
@@ -2702,23 +2727,31 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         lastUserContext = cleanedContext;
 
         // Single API call to the full proactive context pipeline:
-        // feedback loop, coactivation, segmented ingest, semantic todos, context reminders
-        const result = await apiCall<ProactiveContextResponse>("/api/proactive_context", "POST", {
-          user_id: USER_ID,
-          context: cleanedContext,
-          max_results,
-          semantic_threshold,
-          entity_match_weight,
-          recency_weight,
-          memory_types,
-          auto_ingest,
-          // Implicit feedback: send previous response so backend can evaluate which memories helped.
-          // Skipped if another proactive_context call was in-flight (prevents corrupted feedback).
-          previous_response: skipFeedback ? undefined : (lastProactiveResponse || undefined),
-          user_followup: (skipFeedback || !lastProactiveResponse) ? undefined : (previousUserContext || undefined),
-          // Tool-aware feedback attribution: causal signal from tool/actuator actions
-          ...(tool_actions.length > 0 ? { tool_actions } : {}),
-        });
+        // feedback loop, coactivation, segmented ingest, semantic todos, context reminders.
+        // Wrapped so a thrown apiCall resets the in-flight guard — otherwise the
+        // flag would stay true forever and permanently disable the feedback loop.
+        let result: ProactiveContextResponse;
+        try {
+          result = await apiCall<ProactiveContextResponse>("/api/proactive_context", "POST", {
+            user_id: USER_ID,
+            context: cleanedContext,
+            max_results,
+            semantic_threshold,
+            entity_match_weight,
+            recency_weight,
+            memory_types,
+            auto_ingest,
+            // Implicit feedback: send previous response so backend can evaluate which memories helped.
+            // Skipped if another proactive_context call was in-flight (prevents corrupted feedback).
+            previous_response: skipFeedback ? undefined : (lastProactiveResponse || undefined),
+            user_followup: (skipFeedback || !lastProactiveResponse) ? undefined : (previousUserContext || undefined),
+            // Tool-aware feedback attribution: causal signal from tool/actuator actions
+            ...(tool_actions.length > 0 ? { tool_actions } : {}),
+          });
+        } catch (e) {
+          proactiveCallInFlight = false;
+          throw e;
+        }
 
         const memories = result.memories || [];
         const entities = result.detected_entities || [];
@@ -4973,7 +5006,7 @@ async function main() {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("Shodh-Memory MCP server v0.1.90 running");
+  console.error(`Shodh-Memory MCP server v${SERVER_VERSION} running`);
   console.error(`Connecting to: ${API_URL}`);
   console.error(`User ID: ${USER_ID}`);
   console.error(`Streaming: ${STREAM_ENABLED ? "enabled" : "disabled"}`);

--- a/src/config.rs
+++ b/src/config.rs
@@ -267,6 +267,11 @@ pub struct ServerConfig {
     /// Rate limit: burst size (default: 8000 - allows rapid agent bursts)
     pub rate_limit_burst: u32,
 
+    /// Whether non-probe public routes (webhooks, context status, graph view)
+    /// are rate-limited (default: true). Health probe routes (`/health*`) are
+    /// never rate-limited. Set SHODH_PUBLIC_RATE_LIMIT=false to opt out.
+    pub public_rate_limit: bool,
+
     /// Maximum concurrent requests (default: 200)
     pub max_concurrent_requests: usize,
 
@@ -329,6 +334,7 @@ impl Default for ServerConfig {
             audit_retention_days: 30,
             rate_limit_per_second: 4000,
             rate_limit_burst: 8000,
+            public_rate_limit: true,
             max_concurrent_requests: 200,
             request_timeout_secs: 60,
             is_production: false,
@@ -408,6 +414,13 @@ impl ServerConfig {
             if let Ok(n) = val.parse() {
                 config.rate_limit_burst = n;
             }
+        }
+
+        // Public-route rate limiting is on by default; only an explicit
+        // false/0 disables it (any other value keeps the secure default).
+        if let Ok(val) = env::var("SHODH_PUBLIC_RATE_LIMIT") {
+            let v = val.to_lowercase();
+            config.public_rate_limit = !(v == "false" || v == "0");
         }
 
         // Concurrency
@@ -584,6 +597,14 @@ pub fn print_env_help() {
     println!("  SHODH_REQUEST_TIMEOUT  - Request timeout in seconds (default: 60)");
     println!("  SHODH_AUDIT_MAX_ENTRIES    - Max audit entries per user (default: 10000)");
     println!("  SHODH_AUDIT_RETENTION_DAYS - Audit log retention days (default: 30)");
+    println!();
+    println!("Security (secure defaults — override only if you understand the risk):");
+    println!("  SHODH_ALLOW_UNSIGNED_WEBHOOKS - Accept webhooks when no *_WEBHOOK_SECRET is set (default: false = reject)");
+    println!(
+        "  SHODH_PUBLIC_RATE_LIMIT       - Rate-limit non-probe public routes (default: true)"
+    );
+    println!("  SHODH_ENFORCE_HTTPS           - Reject insecure http:// integration API URL overrides (default: false = warn)");
+    println!("  SHODH_METRICS_PUBLIC          - Expose /metrics without authentication (default: false = require API key)");
     println!();
     println!("Integration APIs:");
     println!("  LINEAR_API_URL         - Linear GraphQL API URL (default: https://api.linear.app/graphql)");

--- a/src/embeddings/downloader.rs
+++ b/src/embeddings/downloader.rs
@@ -21,6 +21,7 @@ use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 /// URLs for MiniLM model files (hosted on HuggingFace)
 /// Full model is 90MB, quantized is 23MB - we download quantized for edge devices
@@ -367,6 +368,12 @@ fn compute_checksum(path: &Path) -> Result<String> {
     Ok(hex::encode(hasher.finalize()))
 }
 
+/// Overall timeout for a single model / ONNX-runtime download.
+///
+/// A backstop so a stalled connection cannot hang the download (and first-use
+/// initialisation) forever. Generous enough for a ~50MB artefact on a slow link.
+const DOWNLOAD_TIMEOUT_SECS: u64 = 600;
+
 /// Download a file from URL to path with progress and optional checksum verification
 fn download_file(
     url: &str,
@@ -390,8 +397,13 @@ fn download_file_with_checksum(
         fs::create_dir_all(parent).context("Failed to create cache directory")?;
     }
 
-    // Use ureq for simple HTTP downloads (blocking, no async runtime needed)
+    // Use ureq for simple HTTP downloads (blocking, no async runtime needed).
+    // timeout_global bounds the whole call (connect + headers + body) so a
+    // stalled connection cannot hang the download indefinitely.
     let response = ureq::get(url)
+        .config()
+        .timeout_global(Some(Duration::from_secs(DOWNLOAD_TIMEOUT_SECS)))
+        .build()
         .call()
         .context(format!("Failed to download from {url}"))?;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -204,11 +204,27 @@ impl AppError {
         }
     }
 
+    /// Client-facing message.
+    ///
+    /// 4xx errors are returned verbatim — they are client-actionable and carry
+    /// no internal detail. 5xx errors may embed internal specifics (database
+    /// paths, `anyhow` chains, lock state); in production those are replaced
+    /// with a generic message, and the full detail is logged server-side
+    /// (see the `IntoResponse` impl). In development the full message is kept
+    /// to aid debugging.
+    pub fn client_message(&self) -> String {
+        if self.status_code().is_server_error() && crate::auth::is_production_mode() {
+            "An internal server error occurred; details have been logged server-side.".to_string()
+        } else {
+            self.message()
+        }
+    }
+
     /// Convert to structured error response
     pub fn to_response(&self) -> ErrorResponse {
         ErrorResponse {
             code: self.code().to_string(),
-            message: self.message(),
+            message: self.client_message(),
             details: None,
             request_id: None,
         }
@@ -218,7 +234,7 @@ impl AppError {
     pub fn to_response_with_request_id(&self, request_id: Option<String>) -> ErrorResponse {
         ErrorResponse {
             code: self.code().to_string(),
-            message: self.message(),
+            message: self.client_message(),
             details: None,
             request_id,
         }
@@ -244,8 +260,19 @@ impl From<anyhow::Error> for AppError {
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let status = self.status_code();
-        let body = self.to_response();
 
+        // Log server-side (5xx) errors at full detail BEFORE the response body
+        // is sanitised. In production the client only sees a generic message,
+        // so this log line is the sole record of what actually went wrong.
+        if status.is_server_error() {
+            tracing::error!(
+                error_code = self.code(),
+                "Request failed with internal error: {}",
+                self.message()
+            );
+        }
+
+        let body = self.to_response();
         (status, Json(body)).into_response()
     }
 }

--- a/src/handlers/integrations.rs
+++ b/src/handlers/integrations.rs
@@ -13,6 +13,20 @@ use std::sync::Arc;
 
 type AppState = Arc<MultiUserMemoryManager>;
 
+/// Whether the server accepts webhooks when no signing secret is configured.
+///
+/// Secure default is `false` — without a secret the webhook is unverifiable and
+/// is rejected (fail closed). Operators who genuinely need unsigned webhooks can
+/// opt in with `SHODH_ALLOW_UNSIGNED_WEBHOOKS=true`.
+fn allow_unsigned_webhooks() -> bool {
+    std::env::var("SHODH_ALLOW_UNSIGNED_WEBHOOKS")
+        .map(|v| {
+            let v = v.to_lowercase();
+            v == "true" || v == "1"
+        })
+        .unwrap_or(false)
+}
+
 /// POST /webhook/linear - Linear webhook receiver
 #[tracing::instrument(skip(state, body, headers))]
 pub async fn linear_webhook(
@@ -50,7 +64,21 @@ pub async fn linear_webhook(
             });
         }
         (false, _) => {
-            tracing::warn!("No LINEAR_WEBHOOK_SECRET configured, skipping signature verification");
+            if allow_unsigned_webhooks() {
+                tracing::warn!(
+                    "No LINEAR_WEBHOOK_SECRET configured — processing this webhook UNSIGNED \
+                     because SHODH_ALLOW_UNSIGNED_WEBHOOKS is set (insecure)."
+                );
+            } else {
+                tracing::error!(
+                    "Rejecting Linear webhook: LINEAR_WEBHOOK_SECRET is not configured. \
+                     Set it to enable HMAC verification, or set SHODH_ALLOW_UNSIGNED_WEBHOOKS=true \
+                     to accept unsigned webhooks (insecure)."
+                );
+                return Err(AppError::ServiceUnavailable(
+                    "Webhook signature verification is not configured on this server".to_string(),
+                ));
+            }
         }
     }
 
@@ -266,7 +294,21 @@ pub async fn github_webhook(
             });
         }
         (false, _) => {
-            tracing::warn!("No GITHUB_WEBHOOK_SECRET configured, skipping signature verification");
+            if allow_unsigned_webhooks() {
+                tracing::warn!(
+                    "No GITHUB_WEBHOOK_SECRET configured — processing this webhook UNSIGNED \
+                     because SHODH_ALLOW_UNSIGNED_WEBHOOKS is set (insecure)."
+                );
+            } else {
+                tracing::error!(
+                    "Rejecting GitHub webhook: GITHUB_WEBHOOK_SECRET is not configured. \
+                     Set it to enable HMAC verification, or set SHODH_ALLOW_UNSIGNED_WEBHOOKS=true \
+                     to accept unsigned webhooks (insecure)."
+                );
+                return Err(AppError::ServiceUnavailable(
+                    "Webhook signature verification is not configured on this server".to_string(),
+                ));
+            }
         }
     }
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -56,6 +56,8 @@ pub mod ab_testing;
 pub mod test_helpers;
 
 // Re-export commonly used items
-pub use router::{build_protected_routes, build_public_routes, build_router, AppState};
+pub use router::{
+    build_probe_routes, build_protected_routes, build_public_routes, build_router, AppState,
+};
 pub use state::MultiUserMemoryManager;
 pub use types::*;

--- a/src/handlers/router.rs
+++ b/src/handlers/router.rs
@@ -19,26 +19,46 @@ use super::{
 /// Application state type alias
 pub type AppState = Arc<MultiUserMemoryManager>;
 
-/// Build the public routes (no authentication required)
+/// Whether `/metrics` is served without authentication.
 ///
-/// These routes must always be accessible for:
-/// - Health checks (Kubernetes probes)
-/// - Metrics (Prometheus scraping)
-/// - Context status (local Claude Code status line script)
-/// - External webhooks (have their own signature verification)
-pub fn build_public_routes(state: AppState) -> Router {
+/// Secure default is `false` — `/metrics` is registered under the authenticated
+/// routes. Set `SHODH_METRICS_PUBLIC=true` to expose it to unauthenticated
+/// scrapers (it is still rate-limited as a public route).
+fn metrics_is_public() -> bool {
+    std::env::var("SHODH_METRICS_PUBLIC")
+        .map(|v| {
+            let v = v.to_lowercase();
+            v == "true" || v == "1"
+        })
+        .unwrap_or(false)
+}
+
+/// Build the health/liveness probe routes.
+///
+/// These are kept separate from the other public routes because they must
+/// NEVER be rate-limited — a throttled `/health` would cause spurious
+/// Kubernetes restarts. The caller merges this router WITHOUT a rate-limit
+/// layer, regardless of `SHODH_PUBLIC_RATE_LIMIT`.
+pub fn build_probe_routes(state: AppState) -> Router {
     Router::new()
-        // =================================================================
-        // HEALTH & KUBERNETES PROBES
-        // =================================================================
         .route("/health", get(health::health))
         .route("/health/live", get(health::health_live))
         .route("/health/ready", get(health::health_ready))
         .route("/health/index", get(health::health_index))
-        // =================================================================
-        // METRICS (PROMETHEUS)
-        // =================================================================
-        .route("/metrics", get(health::metrics_endpoint))
+        .with_state(state)
+}
+
+/// Build the public routes (no authentication required, but rate-limited).
+///
+/// Unlike the probe routes, the caller applies a rate-limit layer to these
+/// (subject to `SHODH_PUBLIC_RATE_LIMIT`). Routes:
+/// - Context status (local Claude Code status line script)
+/// - External webhooks (verified by HMAC signature internally)
+/// - Graph visualization HTML viewer
+/// - Metrics — ONLY when `SHODH_METRICS_PUBLIC=true`; otherwise `/metrics` is
+///   an authenticated route in `build_protected_routes`.
+pub fn build_public_routes(state: AppState) -> Router {
+    let mut router = Router::new()
         // =================================================================
         // CONTEXT STATUS (LOCAL SCRIPT - NO AUTH)
         // =================================================================
@@ -55,11 +75,15 @@ pub fn build_public_routes(state: AppState) -> Router {
         // =================================================================
         // GRAPH VISUALIZATION (PUBLIC - HTML VIEWER ONLY)
         // =================================================================
-        .route("/graph/view", get(visualization::graph_view))
-        // =================================================================
-        // STATE
-        // =================================================================
-        .with_state(state)
+        .route("/graph/view", get(visualization::graph_view));
+
+    // /metrics is an authenticated route by default; expose it here only when
+    // the operator has explicitly opted in via SHODH_METRICS_PUBLIC.
+    if metrics_is_public() {
+        router = router.route("/metrics", get(health::metrics_endpoint));
+    }
+
+    router.with_state(state)
 }
 
 /// Build the protected API routes (authentication required)
@@ -67,7 +91,7 @@ pub fn build_public_routes(state: AppState) -> Router {
 /// These routes require API key authentication and are rate-limited.
 /// The auth middleware and rate limiter should be applied by the caller.
 pub fn build_protected_routes(state: AppState) -> Router {
-    Router::new()
+    let mut router = Router::new()
         // =================================================================
         // REMEMBER/RECORD ENDPOINTS
         // =================================================================
@@ -424,20 +448,29 @@ pub fn build_protected_routes(state: AppState) -> Router {
         // =================================================================
         .route("/api/export/mif", post(mif::export_mif))
         .route("/api/import/mif", post(mif::import_mif))
-        .route("/api/mif/adapters", get(mif::list_adapters))
-        // =================================================================
-        // STATE
-        // =================================================================
-        .with_state(state)
+        .route("/api/mif/adapters", get(mif::list_adapters));
+
+    // /metrics requires authentication unless SHODH_METRICS_PUBLIC=true, in
+    // which case build_public_routes serves it instead (exactly-one placement).
+    if !metrics_is_public() {
+        router = router.route("/metrics", get(health::metrics_endpoint));
+    }
+
+    // =================================================================
+    // STATE
+    // =================================================================
+    router.with_state(state)
 }
 
-/// Build the complete router with both public and protected routes
+/// Build the complete router with probe, public, and protected routes.
 ///
 /// Note: This function does NOT apply auth middleware or rate limiting.
-/// The caller (main.rs) should apply those layers as needed.
+/// The caller (server.rs) should apply those layers as needed — in particular
+/// the probe routes must be merged WITHOUT a rate-limit layer.
 pub fn build_router(state: AppState) -> Router {
+    let probe = build_probe_routes(state.clone());
     let public = build_public_routes(state.clone());
     let protected = build_protected_routes(state);
 
-    Router::new().merge(public).merge(protected)
+    Router::new().merge(probe).merge(public).merge(protected)
 }

--- a/src/integrations/github.rs
+++ b/src/integrations/github.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result};
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
+use std::time::Duration;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -252,7 +253,15 @@ impl GitHubWebhook {
         // GitHub signature format: "sha256=<hex>"
         let expected_sig = signature.strip_prefix("sha256=").unwrap_or(signature);
 
-        let expected_bytes = hex::decode(expected_sig).context("Invalid signature format")?;
+        // A malformed (non-hex) signature is simply an invalid signature, not a
+        // server error — return false so the caller responds 400, not 500.
+        let expected_bytes = match hex::decode(expected_sig) {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                tracing::warn!("GitHub webhook signature is not valid hex — rejecting");
+                return Ok(false);
+            }
+        };
 
         Ok(mac.verify_slice(&expected_bytes).is_ok())
     }
@@ -621,13 +630,20 @@ pub struct GitHubClient {
 impl GitHubClient {
     const DEFAULT_API_URL: &'static str = "https://api.github.com";
 
+    /// Timeout for a single GitHub API request. Without it, a hung upstream
+    /// connection would only be bounded by the global axum request timeout.
+    const HTTP_TIMEOUT_SECS: u64 = 30;
+
     pub fn new(token: String) -> Self {
         let api_url =
-            std::env::var("GITHUB_API_URL").unwrap_or_else(|_| Self::DEFAULT_API_URL.to_string());
+            crate::integrations::resolve_api_url_override("GITHUB_API_URL", Self::DEFAULT_API_URL);
         Self {
             token,
             api_url,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(Self::HTTP_TIMEOUT_SECS))
+                .build()
+                .expect("Failed to build GitHub HTTP client"),
         }
     }
 

--- a/src/integrations/linear.rs
+++ b/src/integrations/linear.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result};
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
+use std::time::Duration;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -214,7 +215,15 @@ impl LinearWebhook {
         // Linear signature format: "sha256=<hex>"
         let expected_sig = signature.strip_prefix("sha256=").unwrap_or(signature);
 
-        let expected_bytes = hex::decode(expected_sig).context("Invalid signature format")?;
+        // A malformed (non-hex) signature is simply an invalid signature, not a
+        // server error — return false so the caller responds 400, not 500.
+        let expected_bytes = match hex::decode(expected_sig) {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                tracing::warn!("Linear webhook signature is not valid hex — rejecting");
+                return Ok(false);
+            }
+        };
 
         Ok(mac.verify_slice(&expected_bytes).is_ok())
     }
@@ -403,16 +412,88 @@ pub struct LinearClient {
     client: reqwest::Client,
 }
 
+/// Parameterized GraphQL query for fetching issues.
+///
+/// `$first` and `$filter` are bound via the request's `variables` object — the
+/// query text itself is a fixed constant, so no caller input is ever spliced
+/// into it. `IssueFilter` is Linear's input type for the `issues` connection.
+const LINEAR_ISSUES_QUERY: &str = r#"
+query Issues($first: Int!, $filter: IssueFilter) {
+  issues(first: $first, filter: $filter) {
+    nodes {
+      id
+      identifier
+      title
+      description
+      priority
+      priorityLabel
+      url
+      createdAt
+      updatedAt
+      completedAt
+      canceledAt
+      dueDate
+      estimate
+      state { id name color type }
+      assignee { id name email }
+      creator { id name email }
+      labels { nodes { id name color } }
+      team { id name key }
+      project { id name }
+      cycle { id name number }
+      parent { id identifier title }
+    }
+  }
+}
+"#;
+
+/// Build the GraphQL `variables` object for [`LINEAR_ISSUES_QUERY`].
+///
+/// `team_id` / `updated_after` are placed inside a JSON value (the `IssueFilter`)
+/// — they are data, never query syntax, so a value containing quotes/braces
+/// cannot escape into the query. An empty filter is sent as JSON `null`.
+fn build_issues_variables(
+    team_id: Option<&str>,
+    updated_after: Option<&str>,
+    limit: usize,
+) -> serde_json::Value {
+    let mut filter = serde_json::Map::new();
+    if let Some(tid) = team_id {
+        filter.insert(
+            "team".to_string(),
+            serde_json::json!({ "id": { "eq": tid } }),
+        );
+    }
+    if let Some(after) = updated_after {
+        filter.insert("updatedAt".to_string(), serde_json::json!({ "gte": after }));
+    }
+
+    let filter_value = if filter.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::Value::Object(filter)
+    };
+
+    serde_json::json!({ "first": limit, "filter": filter_value })
+}
+
 impl LinearClient {
     const DEFAULT_API_URL: &'static str = "https://api.linear.app/graphql";
 
+    /// Timeout for a single Linear API request. Without it, a hung upstream
+    /// connection would only be bounded by the global axum request timeout.
+    const HTTP_TIMEOUT_SECS: u64 = 30;
+
     pub fn new(api_key: String) -> Self {
         let api_url =
-            std::env::var("LINEAR_API_URL").unwrap_or_else(|_| Self::DEFAULT_API_URL.to_string());
+            crate::integrations::resolve_api_url_override("LINEAR_API_URL", Self::DEFAULT_API_URL);
         Self {
             api_key,
             api_url,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(Self::HTTP_TIMEOUT_SECS))
+                .build()
+                .expect("Failed to build Linear HTTP client"),
         }
     }
 
@@ -425,94 +506,20 @@ impl LinearClient {
     ) -> Result<Vec<LinearIssueData>> {
         let limit = limit.unwrap_or(250);
 
-        // Build filter
-        let mut filters = Vec::new();
-        if let Some(tid) = team_id {
-            filters.push(format!(r#"team: {{ id: {{ eq: "{}" }} }}"#, tid));
-        }
-        if let Some(after) = updated_after {
-            filters.push(format!(r#"updatedAt: {{ gte: "{}" }}"#, after));
-        }
-
-        let filter_str = if filters.is_empty() {
-            String::new()
-        } else {
-            format!("filter: {{ {} }}", filters.join(", "))
-        };
-
-        let query = format!(
-            r#"
-            query {{
-                issues(first: {}, {}) {{
-                    nodes {{
-                        id
-                        identifier
-                        title
-                        description
-                        priority
-                        priorityLabel
-                        url
-                        createdAt
-                        updatedAt
-                        completedAt
-                        canceledAt
-                        dueDate
-                        estimate
-                        state {{
-                            id
-                            name
-                            color
-                            type
-                        }}
-                        assignee {{
-                            id
-                            name
-                            email
-                        }}
-                        creator {{
-                            id
-                            name
-                            email
-                        }}
-                        labels {{
-                            nodes {{
-                                id
-                                name
-                                color
-                            }}
-                        }}
-                        team {{
-                            id
-                            name
-                            key
-                        }}
-                        project {{
-                            id
-                            name
-                        }}
-                        cycle {{
-                            id
-                            name
-                            number
-                        }}
-                        parent {{
-                            id
-                            identifier
-                            title
-                        }}
-                    }}
-                }}
-            }}
-        "#,
-            limit, filter_str
-        );
+        // The query is a fixed parameterized string; caller-supplied team_id /
+        // updated_after travel through GraphQL `variables`, never interpolated
+        // into the query text — so they cannot inject GraphQL.
+        let variables = build_issues_variables(team_id, updated_after, limit);
 
         let response = self
             .client
             .post(&self.api_url)
             .header("Authorization", &self.api_key)
             .header("Content-Type", "application/json")
-            .json(&serde_json::json!({ "query": query }))
+            .json(&serde_json::json!({
+                "query": LINEAR_ISSUES_QUERY,
+                "variables": variables,
+            }))
             .send()
             .await
             .context("Failed to send request to Linear API")?;
@@ -655,5 +662,57 @@ mod tests {
         assert!(tags.contains(&"Feature".to_string()));
         assert!(tags.contains(&"In Progress".to_string()));
         assert!(tags.contains(&"SHO".to_string()));
+    }
+
+    #[test]
+    fn issues_query_is_parameterized() {
+        // The query must declare GraphQL variables, not interpolate caller input.
+        assert!(LINEAR_ISSUES_QUERY.contains("$first: Int!"));
+        assert!(LINEAR_ISSUES_QUERY.contains("$filter: IssueFilter"));
+        assert!(LINEAR_ISSUES_QUERY.contains("issues(first: $first, filter: $filter)"));
+    }
+
+    #[test]
+    fn build_issues_variables_empty_filter_is_null() {
+        let vars = build_issues_variables(None, None, 250);
+        assert_eq!(vars["first"], serde_json::json!(250));
+        assert_eq!(vars["filter"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn build_issues_variables_carries_filter_as_data() {
+        let vars = build_issues_variables(Some("team-123"), Some("2026-01-01"), 50);
+        assert_eq!(vars["first"], serde_json::json!(50));
+        assert_eq!(
+            vars["filter"]["team"]["id"]["eq"],
+            serde_json::json!("team-123")
+        );
+        assert_eq!(
+            vars["filter"]["updatedAt"]["gte"],
+            serde_json::json!("2026-01-01")
+        );
+    }
+
+    #[test]
+    fn build_issues_variables_injection_attempt_stays_data() {
+        // A team_id crafted to break out of a string stays a JSON string value —
+        // it never becomes query syntax.
+        let malicious = r#"x" }) { id } } injected: issues(first: 9999) { nodes { id"#;
+        let vars = build_issues_variables(Some(malicious), None, 10);
+
+        // The payload is confined to the `eq` value verbatim.
+        assert_eq!(
+            vars["filter"]["team"]["id"]["eq"],
+            serde_json::json!(malicious)
+        );
+
+        // It did NOT create sibling fields — variables has exactly `first` + `filter`.
+        let obj = vars.as_object().expect("variables is an object");
+        assert_eq!(obj.len(), 2);
+        assert!(obj.contains_key("first") && obj.contains_key("filter"));
+
+        // On the wire the embedded quote is JSON-escaped, so it is data, not syntax.
+        let serialized = serde_json::to_string(&vars).unwrap();
+        assert!(serialized.contains(r#"\""#));
     }
 }

--- a/src/integrations/mod.rs
+++ b/src/integrations/mod.rs
@@ -9,3 +9,75 @@ pub mod linear;
 
 pub use github::{GitHubSyncRequest, GitHubSyncResponse, GitHubWebhook, GitHubWebhookPayload};
 pub use linear::{LinearSyncRequest, LinearSyncResponse, LinearWebhook, LinearWebhookPayload};
+
+/// Resolve an integration API URL from an environment override.
+///
+/// If `env_var` is unset/empty, returns `default_url`. If it is set to an
+/// insecure `http://` URL pointing at a non-localhost host, credentials would
+/// travel in cleartext: when `SHODH_ENFORCE_HTTPS` is enabled the override is
+/// rejected and the secure default is used instead; otherwise it is used as-is
+/// with a warning. This is a flag-gated enforcement, not a blanket http ban —
+/// localhost http (proxies, test servers) is always allowed.
+pub(crate) fn resolve_api_url_override(env_var: &str, default_url: &str) -> String {
+    let override_url = match std::env::var(env_var) {
+        Ok(u) if !u.trim().is_empty() => u.trim().to_string(),
+        _ => return default_url.to_string(),
+    };
+
+    if is_insecure_remote_url(&override_url) {
+        let enforce_https = std::env::var("SHODH_ENFORCE_HTTPS")
+            .map(|v| {
+                let v = v.to_lowercase();
+                v == "true" || v == "1"
+            })
+            .unwrap_or(false);
+
+        if enforce_https {
+            tracing::error!(
+                "{env_var} points at an insecure http:// non-localhost URL and \
+                 SHODH_ENFORCE_HTTPS is enabled — ignoring the override and using \
+                 the secure default ({default_url})."
+            );
+            return default_url.to_string();
+        }
+
+        tracing::warn!(
+            "{env_var} uses an insecure http:// URL for a non-localhost host — \
+             the API token will be transmitted in cleartext. Use https:// or set \
+             SHODH_ENFORCE_HTTPS=true to reject insecure overrides."
+        );
+    }
+
+    override_url
+}
+
+/// Returns true if `url` is an `http://` URL whose host is NOT a loopback/local
+/// address — i.e. a configuration that would leak credentials over the network.
+fn is_insecure_remote_url(url: &str) -> bool {
+    let Some(rest) = url.strip_prefix("http://") else {
+        return false; // https:// (or anything else) — not an insecure-http override
+    };
+    // Host is everything before the first '/', ':' (port), or '?'. This does
+    // not unwrap `user:pass@host` userinfo — such a URL yields the userinfo as
+    // the "host" and is treated as insecure-remote. That errs toward
+    // warning/rejecting (the safe direction), so it is acceptable.
+    let host = rest.split(['/', ':', '?']).next().unwrap_or("");
+    !(host == "localhost" || host == "::1" || host == "0.0.0.0" || host.starts_with("127."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_insecure_remote_url;
+
+    #[test]
+    fn insecure_remote_url_detection() {
+        assert!(is_insecure_remote_url("http://api.github.com"));
+        assert!(is_insecure_remote_url("http://example.com:8080/graphql"));
+        // Loopback / local hosts over http are allowed (dev proxies, test servers)
+        assert!(!is_insecure_remote_url("http://localhost:11434"));
+        assert!(!is_insecure_remote_url("http://127.0.0.1:3030"));
+        assert!(!is_insecure_remote_url("http://127.1.2.3"));
+        // https is always fine
+        assert!(!is_insecure_remote_url("https://api.linear.app/graphql"));
+    }
+}

--- a/src/query_parsing/llm_parser.rs
+++ b/src/query_parsing/llm_parser.rs
@@ -398,13 +398,16 @@ fn extract_json(output: &str) -> String {
     if let Some(start) = cleaned.find('{') {
         let mut depth = 0;
         let mut end = start;
-        for (i, c) in cleaned[start..].chars().enumerate() {
+        // Use char_indices so `i` is a BYTE offset. `chars().enumerate()` would
+        // yield a char COUNT, which is wrong for multi-byte UTF-8 — using it as
+        // a byte index can land mid-codepoint and panic the `[start..end]` slice.
+        for (i, c) in cleaned[start..].char_indices() {
             match c {
                 '{' => depth += 1,
                 '}' => {
                     depth -= 1;
                     if depth == 0 {
-                        end = start + i + 1;
+                        end = start + i + c.len_utf8();
                         break;
                     }
                 }
@@ -417,11 +420,16 @@ fn extract_json(output: &str) -> String {
     }
 }
 
-/// Simple stemming using rust_stemmers
+/// Simple stemming using rust_stemmers.
+///
+/// The `Stemmer` is cached per-thread — building one per call is avoidable work
+/// on the query-parsing path (`convert_llm_output` stems every entity/event).
 fn stem_word(word: &str) -> String {
     use rust_stemmers::{Algorithm, Stemmer};
-    let stemmer = Stemmer::create(Algorithm::English);
-    stemmer.stem(&word.to_lowercase()).to_string()
+    thread_local! {
+        static STEMMER: Stemmer = Stemmer::create(Algorithm::English);
+    }
+    STEMMER.with(|stemmer| stemmer.stem(&word.to_lowercase()).to_string())
 }
 
 /// Parse entity type string

--- a/src/server.rs
+++ b/src/server.rs
@@ -187,7 +187,21 @@ async fn async_main() -> Result<()> {
 
     // Configure rate limiting (0 = disabled, for localhost/embedded use)
     let rate_limit_enabled = server_config.rate_limit_per_second > 0;
-    let governor_layer = if rate_limit_enabled {
+    if rate_limit_enabled {
+        let rps = server_config.rate_limit_per_second.max(1);
+        let cell_interval = std::time::Duration::from_nanos(1_000_000_000 / rps);
+        info!(
+            "Rate limiting: {} req/sec (cell interval: {:?}), burst of {}",
+            server_config.rate_limit_per_second, cell_interval, server_config.rate_limit_burst
+        );
+    } else {
+        info!("Rate limiting: disabled (SHODH_RATE_LIMIT=0)");
+    }
+
+    // Builds a fresh GovernorLayer on each call. Each call yields independent
+    // per-IP rate-limit buckets, so public and protected routes can both be
+    // limited without depending on GovernorLayer being Clone.
+    let make_governor_layer = || {
         let rps = server_config.rate_limit_per_second.max(1);
         let cell_interval = std::time::Duration::from_nanos(1_000_000_000 / rps);
         let governor_conf = GovernorConfigBuilder::default()
@@ -195,20 +209,18 @@ async fn async_main() -> Result<()> {
             .burst_size(server_config.rate_limit_burst)
             .finish()
             .expect("Failed to build governor rate limiter configuration");
-        info!(
-            "Rate limiting: {} req/sec (cell interval: {:?}), burst of {}",
-            server_config.rate_limit_per_second, cell_interval, server_config.rate_limit_burst
-        );
-        Some(GovernorLayer::new(governor_conf))
-    } else {
-        info!("Rate limiting: disabled (SHODH_RATE_LIMIT=0)");
-        None
+        GovernorLayer::new(governor_conf)
     };
 
     // Build CORS layer
     let cors = server_config.cors.to_layer();
 
-    // Build routes using handlers module
+    // Build routes using handlers module.
+    //
+    // Probe routes (/health*) are merged WITHOUT a rate-limit layer — a
+    // throttled health check would cause spurious Kubernetes restarts.
+    let probe_routes = handlers::build_probe_routes(Arc::clone(&manager));
+
     let public_routes = handlers::build_public_routes(Arc::clone(&manager)).route(
         "/",
         axum::routing::get(|| async {
@@ -229,18 +241,32 @@ async fn async_main() -> Result<()> {
         }),
     );
 
-    let protected_routes = if let Some(governor) = governor_layer {
-        handlers::build_protected_routes(Arc::clone(&manager))
-            .layer(axum::middleware::from_fn(auth::auth_middleware))
-            .layer(governor)
+    // Public (non-probe) routes are rate-limited unless SHODH_PUBLIC_RATE_LIMIT
+    // is disabled. Webhooks in particular are an unauthenticated write surface.
+    let limit_public = rate_limit_enabled && server_config.public_rate_limit;
+    let public_routes = if limit_public {
+        public_routes.layer(make_governor_layer())
     } else {
-        handlers::build_protected_routes(Arc::clone(&manager))
-            .layer(axum::middleware::from_fn(auth::auth_middleware))
+        public_routes
+    };
+    if rate_limit_enabled && !server_config.public_rate_limit {
+        info!("Public-route rate limiting: disabled (SHODH_PUBLIC_RATE_LIMIT=false)");
+    }
+
+    let protected_routes = {
+        let routes = handlers::build_protected_routes(Arc::clone(&manager))
+            .layer(axum::middleware::from_fn(auth::auth_middleware));
+        if rate_limit_enabled {
+            routes.layer(make_governor_layer())
+        } else {
+            routes
+        }
     };
 
     // Combine routes with global middleware
     let request_timeout = std::time::Duration::from_secs(server_config.request_timeout_secs);
     let app = axum::Router::new()
+        .merge(probe_routes)
         .merge(public_routes)
         .merge(protected_routes)
         .layer(

--- a/src/zenoh_transport/config.rs
+++ b/src/zenoh_transport/config.rs
@@ -270,6 +270,21 @@ impl ZenohConfig {
                  bind to 127.0.0.1 for local-only deployments."
             );
         }
+
+        // Auto-topics ingest third-party payloads (e.g. a robot's status feed)
+        // that cannot carry shodh's `api_key`, so `authenticate_payload` is
+        // intentionally NOT applied to them — this holds even when
+        // SHODH_ZENOH_API_KEY is set. Make that trust boundary explicit so an
+        // operator does not assume the key protects every Zenoh ingestion path.
+        if binds_all_interfaces && !self.auto_topics.is_empty() {
+            tracing::warn!(
+                "{} Zenoh auto-topic(s) configured while listening on all interfaces — \
+                 auto-topic payloads are ingested WITHOUT SHODH_ZENOH_API_KEY authentication \
+                 (their security relies on Zenoh-fabric access control, not shodh). \
+                 Restrict the Zenoh network or bind to 127.0.0.1 if untrusted peers can reach it.",
+                self.auto_topics.len()
+            );
+        }
     }
 }
 

--- a/src/zenoh_transport/mod.rs
+++ b/src/zenoh_transport/mod.rs
@@ -846,6 +846,12 @@ async fn register_auto_topic(
                 sample = subscriber.recv_async() => {
                     match sample {
                         Ok(sample) => {
+                            // Auto-topic payloads are deliberately NOT passed through
+                            // handlers::authenticate_payload: they are third-party feeds on an
+                            // operator-configured key_expr (e.g. a robot status topic) and
+                            // cannot carry shodh's api_key. Access control for these keys is
+                            // the Zenoh fabric's responsibility — see ZenohConfig::validate,
+                            // which warns when auto-topics are exposed on a public interface.
                             let payload_str = match sample.payload().try_to_string() {
                                 Ok(s) => s.into_owned(),
                                 Err(e) => {


### PR DESCRIPTION
## Summary

Fixes security, correctness, and resilience findings surfaced by a
`portll-security` walk-tree audit and a `breakers` audit. Every
behavior-changing fix is **secure-by-default with an explicit override flag**,
so no existing deployment silently breaks.

Headline issues: webhooks processed **unsigned payloads** when no
`*_WEBHOOK_SECRET` was configured (unauthenticated memory poisoning), and
public routes had **no rate limiting** (unauthenticated flood vector).

## Override flags (secure default → opt-out)

| Variable | Default | Effect |
|----------|---------|--------|
| `SHODH_ALLOW_UNSIGNED_WEBHOOKS` | `false` | Webhooks are rejected (503) when no secret is set. `true` restores permissive processing. |
| `SHODH_PUBLIC_RATE_LIMIT` | `true` | Public routes are rate-limited. `false` exempts them (probe routes are never limited regardless). |
| `SHODH_METRICS_PUBLIC` | `false` | `/metrics` requires auth. `true` exposes it to unauthenticated scrapers. |
| `SHODH_ENFORCE_HTTPS` | `false` | `true` rejects insecure `http://` `GITHUB_API_URL`/`LINEAR_API_URL` overrides. |

## Fixes

**Security**
- **Webhooks fail closed**: `/webhook/{linear,github}` reject unsigned requests when no secret is configured, instead of processing them with only a warning.
- **Public-route rate limiting**: the governor is applied to public routes (webhooks, context status, graph viewer). Health probe routes are split into a dedicated router that is *never* rate-limited (avoids spurious k8s restarts).
- **`/metrics` authenticated** by default (Prometheus can authenticate via `Authorization: Bearer`).
- **GraphQL injection fixed**: Linear `fetch_issues` passes `team_id`/`updated_after` through GraphQL `variables` instead of string-interpolating them into the query.
- **5xx responses sanitised**: in production, internal errors return a generic message and log full detail server-side; 4xx errors are unchanged.
- **Malformed webhook signatures** return 400, not 500.

**Correctness / resilience**
- Fixed a **UTF-8 panic** in `extract_json` (a char-count was used as a byte offset → mid-codepoint slice).
- HTTP client timeouts (30s) on the GitHub/Linear clients; a 600s overall-timeout backstop on model/runtime downloads.
- MCP server: non-idempotent writes are no longer retried (duplicate-memory risk); the `proactive_context` in-flight guard is reset on error; the server version is read from `package.json`.
- `Stemmer` is cached per-thread instead of rebuilt per call.

**Docs**
- `SECURITY.md` gains a secure-defaults table; the new `SHODH_*` flags are documented in the configuration help output.

## Verification

- `cargo fmt`, `cargo check` — pass.
- `cargo clippy` — changed files are warning-free (pre-existing warnings in untouched files remain).
- Full `cargo test` was **not** run locally (memory-constrained environment) — CI should run it. New unit tests cover `is_insecure_remote_url` and the Linear query/variable construction (including an injection-attempt test).

## Follow-ups (deferred — out of scope here)

- Automatic re-embedding sweep for memories embedded while the embedding circuit breaker is open (feature-sized).
- CORS production deny-by-default (would break existing deployments).
- `GitHubClient`/`LinearClient` token zeroize-on-drop.

## Live-test gate

The Linear `fetch_issues` rewrite uses a parameterized query; the `$filter: IssueFilter` type name should be confirmed against the live Linear API in a sync test. The inner filter field names (`team`/`id`/`eq`/`updatedAt`/`gte`) are unchanged from the prior working query.
