### PR TITLE
Fix/scheduled backup wrong path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,9 +56,10 @@ RUN mkdir -p /models/minilm-l6 /models/bert-tiny-ner \
     && echo "d241a60d5e8f04cc1b2b3e9ef7a4921b27bf526d9f6050ab90f9267a1f9e5c66  /models/bert-tiny-ner/tokenizer.json" | sha256sum -c -
 
 # Create dummy sources to build and cache dependencies
-RUN mkdir -p src benches tests \
+RUN mkdir -p src src/bin benches tests \
     && echo "fn main() {}" > src/main.rs \
     && echo "fn main() {}" > src/cli.rs \
+    && echo "fn main() {}" > src/bin/recall_eval.rs \
     && touch src/lib.rs \
     && awk -F '"' '/name = ".*benchmarks"/ {print "echo \"fn main() {}\" > benches/" $2 ".rs"}' Cargo.toml | sh \
     && touch tests/dummy.rs \

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -2598,7 +2598,10 @@ impl MultiUserMemoryManager {
                     continue;
                 }
 
-                let db_path = path.join("memory.db");
+                // Check for RocksDB storage directory (the actual data store).
+                // Previously checked for "memory.db" which doesn't exist —
+                // RocksDB stores data in a "storage/" directory, not a single file.
+                let db_path = path.join("storage");
                 if !db_path.exists() {
                     continue;
                 }


### PR DESCRIPTION
## Description

`run_backup_all_users()` in `state.rs:2601` checks for `memory.db` to determine if a user directory contains valid data, but Shodh uses RocksDB which stores data in a `storage/` directory. `memory.db` never exists, so the scheduled backup silently skips all users and creates zero backups.

The manual backup API (`POST /api/backup/create`) works correctly because it takes an explicit `user_id` and bypasses this directory scan.

Also fixes the Dockerfile's dependency caching step which was missing a dummy for the `recall-eval` binary target.

## Type of Change
- [x] Bug fix

## Root Cause

`state.rs:2601` — `path.join("memory.db")` should be `path.join("storage")`.
Confirmed by `migration.rs:170` and `consolidation.rs:595` which both correctly reference `storage/`.

## Testing
- Deployed patched binary via Docker on Proxmox LXC
- Set SHODH_BACKUP_INTERVAL=180 (3 min) for testing
- Verified: scheduled backup now creates backup files automatically
- Before fix: "Starting scheduled backup run..." with 0 users backed up
- After fix: "Scheduled backup completed: 1 users backed up"
