### PR TITLE
chore: clean sweep of clippy 1.94 warnings across lib + tests

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -470,6 +470,7 @@ mod tests {
     // ── AuthError JSON response shape ──
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn auth_error_response_is_valid_json() {
         let _guard = ENV_LOCK.lock().unwrap();
         clear_auth_env();
@@ -485,6 +486,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn missing_key_dev_message_includes_help() {
         let _guard = ENV_LOCK.lock().unwrap();
         clear_auth_env();
@@ -505,6 +507,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn invalid_key_dev_message_includes_help() {
         let _guard = ENV_LOCK.lock().unwrap();
         clear_auth_env();
@@ -520,6 +523,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn missing_key_prod_message_is_terse() {
         let _guard = ENV_LOCK.lock().unwrap();
         clear_auth_env();
@@ -536,6 +540,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn invalid_key_prod_message_is_terse() {
         let _guard = ENV_LOCK.lock().unwrap();
         clear_auth_env();
@@ -561,6 +566,7 @@ mod tests {
     // ── Query parameter auth (WebSocket fallback) ──
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn auth_middleware_accepts_query_param_for_websocket() {
         use axum::body::Body;
         use axum::http::Request as HttpRequest;
@@ -594,6 +600,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn auth_middleware_ignores_query_param_without_websocket_upgrade() {
         use axum::body::Body;
         use axum::http::Request as HttpRequest;
@@ -626,6 +633,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn auth_middleware_rejects_invalid_websocket_query_param() {
         use axum::body::Body;
         use axum::http::Request as HttpRequest;

--- a/src/embeddings/chunking.rs
+++ b/src/embeddings/chunking.rs
@@ -660,7 +660,7 @@ mod tests {
         // Code-like content with more punctuation
         let code = "fn main() { println!(\"hello\"); }";
         let tokens = estimate_tokens(code);
-        assert!(tokens >= 5 && tokens <= 15, "Code tokens: {}", tokens);
+        assert!((5..=15).contains(&tokens), "Code tokens: {}", tokens);
 
         // No whitespace (falls back to char-based)
         assert_eq!(estimate_tokens("abcdefgh"), 2); // 8 chars / 4 = 2

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -3546,11 +3546,11 @@ mod tests {
 
     #[test]
     fn test_ner_confidence_floor_constant() {
-        assert!(
+        const _: () = assert!(
             crate::constants::NER_GRAPH_CONFIDENCE_FLOOR >= 0.6,
             "Confidence floor should be >= 0.6 to reject marginal entities"
         );
-        assert!(
+        const _: () = assert!(
             crate::constants::NER_GRAPH_CONFIDENCE_FLOOR < 0.8,
             "Confidence floor should be < 0.8 to not reject legitimate entities"
         );

--- a/src/handlers/test_helpers.rs
+++ b/src/handlers/test_helpers.rs
@@ -32,6 +32,12 @@ pub struct TestHarness {
     _temp_dir: TempDir,
 }
 
+impl Default for TestHarness {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TestHarness {
     /// Create a new harness with a fresh temp directory and default config.
     ///

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -1182,21 +1182,21 @@ mod tests {
         use crate::constants::*;
 
         // Relaxed threshold must be lower than strict threshold
-        assert!(SPREADING_RELAXED_THRESHOLD < SPREADING_ACTIVATION_THRESHOLD);
+        const _: () = assert!(SPREADING_RELAXED_THRESHOLD < SPREADING_ACTIVATION_THRESHOLD);
 
         // Min hops must be <= max hops
-        assert!(SPREADING_MIN_HOPS <= SPREADING_MAX_HOPS);
+        const _: () = assert!(SPREADING_MIN_HOPS <= SPREADING_MAX_HOPS);
 
         // Early termination ratio must be in (0, 1)
-        assert!(SPREADING_EARLY_TERMINATION_RATIO > 0.0);
-        assert!(SPREADING_EARLY_TERMINATION_RATIO < 1.0);
+        const _: () = assert!(SPREADING_EARLY_TERMINATION_RATIO > 0.0);
+        const _: () = assert!(SPREADING_EARLY_TERMINATION_RATIO < 1.0);
 
         // Normalization factor must be positive
-        assert!(SPREADING_NORMALIZATION_FACTOR > 0.0);
+        const _: () = assert!(SPREADING_NORMALIZATION_FACTOR > 0.0);
 
         // Min candidates for relaxation should be reasonable
-        assert!(SPREADING_MIN_CANDIDATES > 0);
-        assert!(SPREADING_MIN_CANDIDATES < SPREADING_EARLY_TERMINATION_CANDIDATES);
+        const _: () = assert!(SPREADING_MIN_CANDIDATES > 0);
+        const _: () = assert!(SPREADING_MIN_CANDIDATES < SPREADING_EARLY_TERMINATION_CANDIDATES);
     }
 
     #[test]
@@ -1269,23 +1269,23 @@ mod tests {
     #[test]
     fn test_bidirectional_constants_valid() {
         // Minimum entities must be at least 2 for bidirectional to make sense
-        assert!(BIDIRECTIONAL_MIN_ENTITIES >= 2);
+        const _: () = assert!(BIDIRECTIONAL_MIN_ENTITIES >= 2);
 
         // Intersection boost must be positive
-        assert!(BIDIRECTIONAL_INTERSECTION_BOOST > 1.0);
+        const _: () = assert!(BIDIRECTIONAL_INTERSECTION_BOOST > 1.0);
 
         // Intersection minimum must be below activation threshold
-        assert!(BIDIRECTIONAL_INTERSECTION_MIN < SPREADING_ACTIVATION_THRESHOLD);
+        const _: () = assert!(BIDIRECTIONAL_INTERSECTION_MIN < SPREADING_ACTIVATION_THRESHOLD);
 
         // Density thresholds must be ordered correctly
-        assert!(BIDIRECTIONAL_DENSITY_SPARSE < BIDIRECTIONAL_DENSITY_DENSE);
+        const _: () = assert!(BIDIRECTIONAL_DENSITY_SPARSE < BIDIRECTIONAL_DENSITY_DENSE);
 
         // Hop counts must be ordered: dense < medium < sparse
-        assert!(BIDIRECTIONAL_HOPS_DENSE < BIDIRECTIONAL_HOPS_MEDIUM);
-        assert!(BIDIRECTIONAL_HOPS_MEDIUM < BIDIRECTIONAL_HOPS_SPARSE);
+        const _: () = assert!(BIDIRECTIONAL_HOPS_DENSE < BIDIRECTIONAL_HOPS_MEDIUM);
+        const _: () = assert!(BIDIRECTIONAL_HOPS_MEDIUM < BIDIRECTIONAL_HOPS_SPARSE);
 
         // Medium hops × 2 should approximate max hops for unidirectional
-        assert!(BIDIRECTIONAL_HOPS_MEDIUM * 2 >= SPREADING_MAX_HOPS);
+        const _: () = assert!(BIDIRECTIONAL_HOPS_MEDIUM * 2 >= SPREADING_MAX_HOPS);
     }
 
     #[test]
@@ -1377,12 +1377,10 @@ mod tests {
     #[test]
     fn test_bidirectional_entity_split() {
         // Test alternating assignment distributes evenly
-        let entities = vec![
-            (Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
+        let entities = [(Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
             (Uuid::new_v4(), "entity2".to_string(), 1.0, 0.5),
             (Uuid::new_v4(), "entity3".to_string(), 1.0, 0.5),
-            (Uuid::new_v4(), "entity4".to_string(), 1.0, 0.5),
-        ];
+            (Uuid::new_v4(), "entity4".to_string(), 1.0, 0.5)];
 
         // With 4 entities, split should be 2-2
         let mut forward_count = 0;
@@ -1403,11 +1401,9 @@ mod tests {
     #[test]
     fn test_bidirectional_odd_entities() {
         // Test odd number of entities doesn't leave backward empty
-        let entities = vec![
-            (Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
+        let entities = [(Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
             (Uuid::new_v4(), "entity2".to_string(), 1.0, 0.5),
-            (Uuid::new_v4(), "entity3".to_string(), 1.0, 0.5),
-        ];
+            (Uuid::new_v4(), "entity3".to_string(), 1.0, 0.5)];
 
         // With 3 entities: indices 0,2 go forward, index 1 goes backward
         let mut forward_seeds = Vec::new();
@@ -1435,24 +1431,20 @@ mod tests {
         // Test when bidirectional is triggered vs unidirectional
 
         // 1 entity: unidirectional
-        let single_entity = vec![(Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5)];
+        let single_entity = [(Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5)];
         assert!(single_entity.len() < BIDIRECTIONAL_MIN_ENTITIES);
 
         // 2 entities: bidirectional
-        let two_entities = vec![
-            (Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
-            (Uuid::new_v4(), "entity2".to_string(), 1.0, 0.5),
-        ];
+        let two_entities = [(Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
+            (Uuid::new_v4(), "entity2".to_string(), 1.0, 0.5)];
         assert!(two_entities.len() >= BIDIRECTIONAL_MIN_ENTITIES);
 
         // 5 entities: bidirectional
-        let many_entities = vec![
-            (Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
+        let many_entities = [(Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
             (Uuid::new_v4(), "entity2".to_string(), 1.0, 0.5),
             (Uuid::new_v4(), "entity3".to_string(), 1.0, 0.5),
             (Uuid::new_v4(), "entity4".to_string(), 1.0, 0.5),
-            (Uuid::new_v4(), "entity5".to_string(), 1.0, 0.5),
-        ];
+            (Uuid::new_v4(), "entity5".to_string(), 1.0, 0.5)];
         assert!(many_entities.len() >= BIDIRECTIONAL_MIN_ENTITIES);
     }
 

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -1377,10 +1377,12 @@ mod tests {
     #[test]
     fn test_bidirectional_entity_split() {
         // Test alternating assignment distributes evenly
-        let entities = [(Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
+        let entities = [
+            (Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
             (Uuid::new_v4(), "entity2".to_string(), 1.0, 0.5),
             (Uuid::new_v4(), "entity3".to_string(), 1.0, 0.5),
-            (Uuid::new_v4(), "entity4".to_string(), 1.0, 0.5)];
+            (Uuid::new_v4(), "entity4".to_string(), 1.0, 0.5),
+        ];
 
         // With 4 entities, split should be 2-2
         let mut forward_count = 0;
@@ -1401,9 +1403,11 @@ mod tests {
     #[test]
     fn test_bidirectional_odd_entities() {
         // Test odd number of entities doesn't leave backward empty
-        let entities = [(Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
+        let entities = [
+            (Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
             (Uuid::new_v4(), "entity2".to_string(), 1.0, 0.5),
-            (Uuid::new_v4(), "entity3".to_string(), 1.0, 0.5)];
+            (Uuid::new_v4(), "entity3".to_string(), 1.0, 0.5),
+        ];
 
         // With 3 entities: indices 0,2 go forward, index 1 goes backward
         let mut forward_seeds = Vec::new();
@@ -1435,16 +1439,20 @@ mod tests {
         assert!(single_entity.len() < BIDIRECTIONAL_MIN_ENTITIES);
 
         // 2 entities: bidirectional
-        let two_entities = [(Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
-            (Uuid::new_v4(), "entity2".to_string(), 1.0, 0.5)];
+        let two_entities = [
+            (Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
+            (Uuid::new_v4(), "entity2".to_string(), 1.0, 0.5),
+        ];
         assert!(two_entities.len() >= BIDIRECTIONAL_MIN_ENTITIES);
 
         // 5 entities: bidirectional
-        let many_entities = [(Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
+        let many_entities = [
+            (Uuid::new_v4(), "entity1".to_string(), 1.0, 0.5),
             (Uuid::new_v4(), "entity2".to_string(), 1.0, 0.5),
             (Uuid::new_v4(), "entity3".to_string(), 1.0, 0.5),
             (Uuid::new_v4(), "entity4".to_string(), 1.0, 0.5),
-            (Uuid::new_v4(), "entity5".to_string(), 1.0, 0.5)];
+            (Uuid::new_v4(), "entity5".to_string(), 1.0, 0.5),
+        ];
         assert!(many_entities.len() >= BIDIRECTIONAL_MIN_ENTITIES);
     }
 

--- a/src/memory/hybrid_search.rs
+++ b/src/memory/hybrid_search.rs
@@ -658,13 +658,7 @@ impl HybridSearchEngine {
         phrase_boosts: Option<&[(String, f32)]>,
     ) -> Result<Vec<HybridSearchResult>> {
         // Use default discriminativeness (no dynamic weight adjustment)
-        self.search_with_dynamic_weights(
-            query,
-            vector_results,
-            term_weights,
-            phrase_boosts,
-            None,
-        )
+        self.search_with_dynamic_weights(query, vector_results, term_weights, phrase_boosts, None)
     }
 
     /// Perform hybrid search with dynamic BM25/vector weight adjustment

--- a/src/memory/hybrid_search.rs
+++ b/src/memory/hybrid_search.rs
@@ -616,20 +616,15 @@ impl HybridSearchEngine {
     /// # Arguments
     /// * `query` - Search query text
     /// * `vector_results` - Pre-computed vector search results (memory_id, similarity)
-    /// * `get_content` - Closure to fetch content for reranking
     ///
     /// # Returns
     /// Hybrid search results with component scores
-    pub fn search<F>(
+    pub fn search(
         &self,
         query: &str,
         vector_results: Vec<(MemoryId, f32)>,
-        get_content: F,
-    ) -> Result<Vec<HybridSearchResult>>
-    where
-        F: Fn(&MemoryId) -> Option<String>,
-    {
-        self.search_with_ic_weights(query, vector_results, get_content, None)
+    ) -> Result<Vec<HybridSearchResult>> {
+        self.search_with_ic_weights(query, vector_results, None)
     }
 
     /// Perform hybrid search with IC-weighted BM25 term boosting
@@ -640,23 +635,13 @@ impl HybridSearchEngine {
     /// - Verbs (relations): IC=0.7
     ///
     /// This improves retrieval by prioritizing semantically important query terms.
-    pub fn search_with_ic_weights<F>(
+    pub fn search_with_ic_weights(
         &self,
         query: &str,
         vector_results: Vec<(MemoryId, f32)>,
-        get_content: F,
         term_weights: Option<&HashMap<String, f32>>,
-    ) -> Result<Vec<HybridSearchResult>>
-    where
-        F: Fn(&MemoryId) -> Option<String>,
-    {
-        self.search_with_ic_weights_and_phrases(
-            query,
-            vector_results,
-            get_content,
-            term_weights,
-            None,
-        )
+    ) -> Result<Vec<HybridSearchResult>> {
+        self.search_with_ic_weights_and_phrases(query, vector_results, term_weights, None)
     }
 
     /// Perform hybrid search with IC-weighted BM25 term boosting AND phrase matching
@@ -665,22 +650,17 @@ impl HybridSearchEngine {
     /// Phrase boosts enable exact multi-word phrase matching:
     /// - "support group" matches the exact phrase, not just "support" OR "group"
     /// - Compound nouns get 2.0x boost, adjacent nouns get 1.5x boost
-    pub fn search_with_ic_weights_and_phrases<F>(
+    pub fn search_with_ic_weights_and_phrases(
         &self,
         query: &str,
         vector_results: Vec<(MemoryId, f32)>,
-        get_content: F,
         term_weights: Option<&HashMap<String, f32>>,
         phrase_boosts: Option<&[(String, f32)]>,
-    ) -> Result<Vec<HybridSearchResult>>
-    where
-        F: Fn(&MemoryId) -> Option<String>,
-    {
+    ) -> Result<Vec<HybridSearchResult>> {
         // Use default discriminativeness (no dynamic weight adjustment)
         self.search_with_dynamic_weights(
             query,
             vector_results,
-            get_content,
             term_weights,
             phrase_boosts,
             None,
@@ -700,22 +680,17 @@ impl HybridSearchEngine {
     /// - discriminativeness 0.0-0.4: use default weights (BM25=0.4, Vector=0.6)
     /// - discriminativeness 0.5-0.7: boost BM25 (BM25=0.55, Vector=0.45)
     /// - discriminativeness 0.8-1.0: strong BM25 (BM25=0.7, Vector=0.3)
-    pub fn search_with_dynamic_weights<F>(
+    pub fn search_with_dynamic_weights(
         &self,
         query: &str,
         vector_results: Vec<(MemoryId, f32)>,
-        get_content: F,
         term_weights: Option<&HashMap<String, f32>>,
         phrase_boosts: Option<&[(String, f32)]>,
         keyword_discriminativeness: Option<f32>,
-    ) -> Result<Vec<HybridSearchResult>>
-    where
-        F: Fn(&MemoryId) -> Option<String>,
-    {
+    ) -> Result<Vec<HybridSearchResult>> {
         self.search_with_dynamic_weights_pool(
             query,
             vector_results,
-            get_content,
             term_weights,
             phrase_boosts,
             keyword_discriminativeness,
@@ -732,19 +707,15 @@ impl HybridSearchEngine {
     /// markers near the focal entity have a chance to enter the candidate set.
     /// Pure post-fusion reranking cannot rescue passages that were never
     /// retrieved — see arXiv 2603.17580 ("Negation is Not Semantic").
-    pub fn search_with_dynamic_weights_pool<F>(
+    pub fn search_with_dynamic_weights_pool(
         &self,
         query: &str,
         vector_results: Vec<(MemoryId, f32)>,
-        _get_content: F,
         term_weights: Option<&HashMap<String, f32>>,
         phrase_boosts: Option<&[(String, f32)]>,
         keyword_discriminativeness: Option<f32>,
         bm25_pool_override: Option<usize>,
-    ) -> Result<Vec<HybridSearchResult>>
-    where
-        F: Fn(&MemoryId) -> Option<String>,
-    {
+    ) -> Result<Vec<HybridSearchResult>> {
         // 1. BM25 search with IC-weighted term boosting AND phrase matching
         let bm25_pool = bm25_pool_override.unwrap_or(self.config.candidate_count);
         let bm25_results = self.bm25_index.search_with_term_and_phrase_weights(

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -2231,6 +2231,9 @@ impl MemorySystem {
             Vec<(MemoryId, f32)>,
             std::collections::HashMap<MemoryId, f32>,
         ) = {
+            // Content lookup used by the prospective-signals boost (Layer 4.7) below.
+            // No longer threaded into the hybrid search chain — the search wrappers
+            // do their own reranking from the BM25 index without needing memory bodies.
             let get_content = |id: &MemoryId| -> Option<String> {
                 self.working_memory
                     .read()
@@ -2304,7 +2307,6 @@ impl MemorySystem {
                 .search_with_dynamic_weights_pool(
                     bm25_query_text,
                     vector_results.clone(),
-                    get_content,
                     term_weights,
                     phrases,
                     disc_opt,

--- a/src/memory/query_parser.rs
+++ b/src/memory/query_parser.rs
@@ -2564,9 +2564,7 @@ pub fn is_polar_question(query_text: &str) -> bool {
     if first_word.is_empty() {
         return false;
     }
-    crate::constants::POLAR_QUESTION_LEADERS
-        .iter()
-        .any(|leader| *leader == first_word.as_str())
+    crate::constants::POLAR_QUESTION_LEADERS.contains(&first_word.as_str())
 }
 
 /// Template-based decontextualization of a polar question into its negated
@@ -2576,7 +2574,7 @@ pub fn is_polar_question(query_text: &str) -> bool {
 ///   - "Are we using HNSW?" → "we are not using HNSW"
 ///   - "Do we call OpenAI's embedding API?" → "we do not call OpenAI's embedding API"
 ///   - "Did learning history records also move to postcard?"
-///        → "learning history records did not also move to postcard"
+///     → "learning history records did not also move to postcard"
 ///   - "Is GitHub auto-merge enabled?" → "GitHub auto-merge is not enabled"
 ///
 /// Returns `None` when:
@@ -2596,10 +2594,7 @@ pub fn polar_to_negated_form(query_text: &str) -> Option<String> {
         return None;
     }
     let leader_lc = words[0].to_lowercase();
-    if !crate::constants::POLAR_QUESTION_LEADERS
-        .iter()
-        .any(|l| *l == leader_lc.as_str())
-    {
+    if !crate::constants::POLAR_QUESTION_LEADERS.contains(&leader_lc.as_str()) {
         return None;
     }
     // Skip if the original already contains an overt negation token — the

--- a/src/memory/replay.rs
+++ b/src/memory/replay.rs
@@ -911,7 +911,7 @@ mod tests {
 
         // Simulate interference history for a "survivor" memory
         // (high interference but maintained high activation)
-        let _similar_memories = vec![(
+        let _similar_memories = [(
             "survivor-mem".to_string(),
             0.90,
             0.85, // High importance maintained despite interference

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -4539,15 +4539,13 @@ mod tests {
         use crate::constants::{ASSISTANT_RESPONSE_TAG_PENALTY, AUTO_CAPTURED_TAG_PENALTY};
 
         // Individual penalties should be in (0.8, 1.0) — meaningful but not devastating
-        assert!(
+        const _: () = assert!(
             AUTO_CAPTURED_TAG_PENALTY > 0.80 && AUTO_CAPTURED_TAG_PENALTY < 1.0,
-            "AUTO_CAPTURED_TAG_PENALTY should be in (0.80, 1.0), got {}",
-            AUTO_CAPTURED_TAG_PENALTY
+            "AUTO_CAPTURED_TAG_PENALTY should be in (0.80, 1.0)"
         );
-        assert!(
+        const _: () = assert!(
             ASSISTANT_RESPONSE_TAG_PENALTY > 0.80 && ASSISTANT_RESPONSE_TAG_PENALTY < 1.0,
-            "ASSISTANT_RESPONSE_TAG_PENALTY should be in (0.80, 1.0), got {}",
-            ASSISTANT_RESPONSE_TAG_PENALTY
+            "ASSISTANT_RESPONSE_TAG_PENALTY should be in (0.80, 1.0)"
         );
 
         // Combined penalty (both tags) should still be >= 0.5 — no cliff

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -385,6 +385,7 @@ mod tests {
     // ── security_headers ──
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn security_headers_present_in_dev_mode() {
         let _guard = ENV_LOCK.lock().unwrap();
         use axum::body::Body;
@@ -425,6 +426,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn security_headers_hsts_in_production() {
         let _guard = ENV_LOCK.lock().unwrap();
         use axum::body::Body;

--- a/src/recall_harness/metrics.rs
+++ b/src/recall_harness/metrics.rs
@@ -338,7 +338,7 @@ mod tests {
         //    = 0.6422...
         let id = ids();
         // Use 10 distinct ids; reuse the 5-id helper by building extras.
-        let extra: Vec<Uuid> = (6..=10).map(|n| Uuid::from_u128(n)).collect();
+        let extra: Vec<Uuid> = (6..=10).map(Uuid::from_u128).collect();
         let r = id[0];
         let n = id[1];
         let r2 = id[2];

--- a/src/token_estimation.rs
+++ b/src/token_estimation.rs
@@ -142,7 +142,7 @@ fn main() {
         let tokens = estimate_tokens(cjk);
         let char_count = cjk.chars().count();
         // Should be in CJK mode: ~1.5 tokens per character
-        let expected = (char_count * 3 + 1) / 2;
+        let expected = (char_count * 3).div_ceil(2);
         assert_eq!(
             tokens, expected,
             "CJK: got {tokens}, expected {expected} (chars={char_count})"

--- a/tests/adaptive_memory_tests.rs
+++ b/tests/adaptive_memory_tests.rs
@@ -28,12 +28,14 @@ use shodh_memory::memory::{
 };
 
 /// Create fallback NER instance for testing
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
 }
 
 /// Create experience with NER-extracted entities
+#[allow(dead_code)]
 fn create_experience_with_ner(
     content: &str,
     exp_type: ExperienceType,
@@ -89,6 +91,7 @@ fn create_error_experience(content: &str, entities: Vec<&str>) -> Experience {
     create_experience(content, ExperienceType::Error, entities)
 }
 
+#[allow(dead_code)]
 fn create_conversation_experience(content: &str, entities: Vec<&str>) -> Experience {
     create_experience(content, ExperienceType::Conversation, entities)
 }
@@ -160,7 +163,7 @@ fn test_retrieval_outcome_default() {
 
 #[test]
 fn test_tracked_retrieval_creation() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp1 = create_learning_experience(
         "Rust ownership prevents memory leaks",
@@ -191,7 +194,7 @@ fn test_tracked_retrieval_creation() {
 
 #[test]
 fn test_tracked_retrieval_memory_ids() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp = create_learning_experience("Test content", vec!["test"]);
     let id = system.remember(exp, None).expect("Failed to record");
@@ -210,7 +213,7 @@ fn test_tracked_retrieval_memory_ids() {
 
 #[test]
 fn test_reinforce_helpful_outcome() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp1 =
         create_learning_experience("API endpoint for user authentication", vec!["api", "auth"]);
@@ -237,7 +240,7 @@ fn test_reinforce_helpful_outcome() {
 
 #[test]
 fn test_reinforce_misleading_outcome() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp = create_learning_experience("Misleading information", vec!["test"]);
     let id = system.remember(exp, None).expect("Failed");
@@ -255,7 +258,7 @@ fn test_reinforce_misleading_outcome() {
     // Apply multiple misleading reinforcements to ensure measurable decay
     for _ in 0..5 {
         let stats = system
-            .reinforce_recall(&[id.clone()], RetrievalOutcome::Misleading)
+            .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Misleading)
             .expect("Failed");
         assert_eq!(stats.memories_processed, 1);
         assert_eq!(stats.importance_decays, 1);
@@ -282,7 +285,7 @@ fn test_reinforce_misleading_outcome() {
 
 #[test]
 fn test_reinforce_neutral_outcome() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp1 = create_learning_experience("First neutral memory", vec!["neutral"]);
     let exp2 = create_learning_experience("Second neutral memory", vec!["neutral"]);
@@ -314,7 +317,7 @@ fn test_reinforce_empty_list() {
 
 #[test]
 fn test_reinforce_tracked_convenience() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp = create_learning_experience("Tracked memory test", vec!["tracked"]);
     system.remember(exp, None).expect("Failed");
@@ -335,7 +338,7 @@ fn test_reinforce_tracked_convenience() {
 
 #[test]
 fn test_importance_boost_cumulative() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp = create_learning_experience("Memory that gets boosted multiple times", vec!["boost"]);
     let id = system.remember(exp, None).expect("Failed");
@@ -344,7 +347,7 @@ fn test_importance_boost_cumulative() {
     let mut total_boosts = 0;
     for _ in 0..10 {
         let stats = system
-            .reinforce_recall(&[id.clone()], RetrievalOutcome::Helpful)
+            .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Helpful)
             .expect("Failed");
         assert_eq!(stats.importance_boosts, 1);
         total_boosts += stats.importance_boosts;
@@ -356,7 +359,7 @@ fn test_importance_boost_cumulative() {
 
 #[test]
 fn test_importance_decay_floor() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp = create_learning_experience("Memory that gets decayed to minimum", vec!["decay"]);
     let id = system.remember(exp, None).expect("Failed");
@@ -365,7 +368,7 @@ fn test_importance_decay_floor() {
     let mut total_decays = 0;
     for _ in 0..20 {
         let stats = system
-            .reinforce_recall(&[id.clone()], RetrievalOutcome::Misleading)
+            .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Misleading)
             .expect("Failed");
         assert_eq!(stats.importance_decays, 1);
         total_decays += 1;
@@ -377,7 +380,7 @@ fn test_importance_decay_floor() {
 
 #[test]
 fn test_coactivation_strengthens_graph() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp1 = create_learning_experience("Database connection pooling", vec!["database"]);
     let exp2 = create_learning_experience("Query optimization techniques", vec!["database"]);
@@ -907,7 +910,7 @@ fn test_prefetch_reason_default() {
 
 #[test]
 fn test_adaptive_memory_workflow() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let experiences = vec![
         create_learning_experience(
@@ -947,8 +950,11 @@ fn test_adaptive_memory_workflow() {
         .expect("Failed");
     assert!(stats.memories_processed > 0);
 
-    let graph_stats = system.graph_stats();
-    assert!(graph_stats.node_count > 0 || graph_stats.edge_count >= 0);
+    // Graph stats are produced as a side-effect of reinforce_recall; the
+    // original `node_count > 0 || edge_count >= 0` check was tautological
+    // because both counts are unsigned. The stats access alone validates the
+    // call path without imposing a brittle invariant.
+    let _graph_stats = system.graph_stats();
 
     let prefetch = AnticipatoryPrefetch::new();
     let ctx = PrefetchContext {
@@ -962,7 +968,7 @@ fn test_adaptive_memory_workflow() {
 
 #[test]
 fn test_graph_maintenance() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp1 = create_learning_experience("First memory", vec!["test"]);
     let exp2 = create_learning_experience("Second memory", vec!["test"]);
@@ -976,8 +982,9 @@ fn test_graph_maintenance() {
 
     system.graph_maintenance();
 
-    let stats = system.graph_stats();
-    assert!(stats.node_count >= 0);
+    // `stats.node_count >= 0` is tautological (usize); the stats call itself
+    // exercises the graph_stats path which is what we want to validate here.
+    let _stats = system.graph_stats();
 }
 
 #[test]
@@ -1007,7 +1014,7 @@ fn test_reinforcement_stats_structure() {
 
 #[test]
 fn test_high_volume_reinforcement() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let mut ids = Vec::new();
     for i in 0..50 {
@@ -1026,7 +1033,7 @@ fn test_high_volume_reinforcement() {
 
 #[test]
 fn test_rapid_feedback_cycles() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     for i in 0..20 {
         let exp = create_learning_experience(&format!("Cycle {i}"), vec!["cycle"]);

--- a/tests/brutal_stress_tests.rs
+++ b/tests/brutal_stress_tests.rs
@@ -290,8 +290,12 @@ fn test_brutal_multiple_restart_cycles() {
 
         // Verify all previous memories exist
         for (i, id) in all_ids.iter().enumerate() {
-            let memory = system.get_memory(id).unwrap_or_else(|_| panic!("Cycle {}: Memory {} should exist from previous cycle",
-                cycle, i));
+            let memory = system.get_memory(id).unwrap_or_else(|_| {
+                panic!(
+                    "Cycle {}: Memory {} should exist from previous cycle",
+                    cycle, i
+                )
+            });
             assert!(
                 memory.experience.content.contains("Restart cycle"),
                 "Cycle {}: Memory {} content should be preserved",

--- a/tests/brutal_stress_tests.rs
+++ b/tests/brutal_stress_tests.rs
@@ -26,12 +26,14 @@ use shodh_memory::memory::{
 // ============================================================================
 
 /// Create fallback NER for testing (rule-based, no ONNX required)
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
 }
 
 /// Create experience with NER entity extraction
+#[allow(dead_code)]
 fn create_experience_with_ner(content: &str, ner: &NeuralNer) -> Experience {
     let entities = ner.extract(content).unwrap_or_default();
     let entity_names: Vec<String> = entities.iter().map(|e| e.text.clone()).collect();
@@ -288,10 +290,8 @@ fn test_brutal_multiple_restart_cycles() {
 
         // Verify all previous memories exist
         for (i, id) in all_ids.iter().enumerate() {
-            let memory = system.get_memory(id).expect(&format!(
-                "Cycle {}: Memory {} should exist from previous cycle",
-                cycle, i
-            ));
+            let memory = system.get_memory(id).unwrap_or_else(|_| panic!("Cycle {}: Memory {} should exist from previous cycle",
+                cycle, i));
             assert!(
                 memory.experience.content.contains("Restart cycle"),
                 "Cycle {}: Memory {} content should be preserved",
@@ -324,7 +324,7 @@ fn test_brutal_multiple_restart_cycles() {
     for (i, id) in all_ids.iter().enumerate() {
         system
             .get_memory(id)
-            .expect(&format!("Final: Memory {} should exist", i));
+            .unwrap_or_else(|_| panic!("Final: Memory {} should exist", i));
     }
     assert_eq!(all_ids.len(), 50, "Should have all 50 memories");
 }
@@ -355,7 +355,7 @@ fn test_brutal_partial_write_recovery() {
         // Boost importance multiple times to ensure detectable change
         for _ in 0..5 {
             system
-                .reinforce_recall(&[memory_id.clone()], RetrievalOutcome::Helpful)
+                .reinforce_recall(std::slice::from_ref(&memory_id), RetrievalOutcome::Helpful)
                 .expect("Failed");
         }
         boosted_importance = system.get_memory(&memory_id).unwrap().importance();
@@ -424,7 +424,7 @@ fn test_brutal_exceed_working_memory() {
     for (i, id) in all_ids.iter().enumerate() {
         system
             .get_memory(id)
-            .expect(&format!("Memory {} should exist in storage", i));
+            .unwrap_or_else(|_| panic!("Memory {} should exist in storage", i));
     }
 }
 
@@ -500,7 +500,7 @@ fn test_brutal_importance_boundary_cycling() {
         // Boost to max
         for _ in 0..50 {
             system
-                .reinforce_recall(&[id.clone()], RetrievalOutcome::Helpful)
+                .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Helpful)
                 .expect("Failed");
         }
         let high = system.get_memory(&id).expect("Failed").importance();
@@ -514,7 +514,7 @@ fn test_brutal_importance_boundary_cycling() {
         // Decay to min
         for _ in 0..100 {
             system
-                .reinforce_recall(&[id.clone()], RetrievalOutcome::Misleading)
+                .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Misleading)
                 .expect("Failed");
         }
         let low = system.get_memory(&id).expect("Failed").importance();
@@ -538,7 +538,7 @@ fn test_brutal_importance_bounds_invariant() {
     // Extreme boosts
     for _ in 0..1000 {
         system
-            .reinforce_recall(&[id.clone()], RetrievalOutcome::Helpful)
+            .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Helpful)
             .expect("Failed");
     }
     let importance = system.get_memory(&id).expect("Failed").importance();
@@ -556,7 +556,7 @@ fn test_brutal_importance_bounds_invariant() {
     // Extreme decays
     for _ in 0..1000 {
         system
-            .reinforce_recall(&[id.clone()], RetrievalOutcome::Misleading)
+            .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Misleading)
             .expect("Failed");
     }
     let importance = system.get_memory(&id).expect("Failed").importance();
@@ -653,12 +653,10 @@ fn test_brutal_graph_maintenance_cycles() {
         system.graph_maintenance();
     }
 
-    // Verify graph still works
-    let stats = system.graph_stats();
-    assert!(
-        stats.node_count > 0 || stats.edge_count >= 0,
-        "Graph should be intact"
-    );
+    // Verify graph still works — the stats call itself is what we want to
+    // exercise; `node_count > 0 || edge_count >= 0` was tautological (both
+    // counts are unsigned).
+    let _stats = system.graph_stats();
 }
 
 // ============================================================================
@@ -1000,7 +998,7 @@ fn test_brutal_lock_order_safety() {
         for id in &ids {
             system
                 .get_memory(id)
-                .expect(&format!("Memory missing in cycle {}", cycle));
+                .unwrap_or_else(|_| panic!("Memory missing in cycle {}", cycle));
         }
 
         // Perform mixed operations
@@ -1087,7 +1085,7 @@ fn test_brutal_reinforcement_race() {
                     d.fetch_add(1, Ordering::Relaxed);
                     RetrievalOutcome::Misleading
                 };
-                let _ = sys.reinforce_recall(&[id.clone()], outcome);
+                let _ = sys.reinforce_recall(std::slice::from_ref(&id), outcome);
             }
         });
         handles.push(handle);
@@ -1102,7 +1100,7 @@ fn test_brutal_reinforcement_race() {
     let importance = memory.importance();
 
     assert!(
-        importance >= 0.0 && importance <= 1.0,
+        (0.0..=1.0).contains(&importance),
         "Importance {} out of bounds after {} boosts and {} decays",
         importance,
         boosts.load(Ordering::Relaxed),
@@ -1270,9 +1268,9 @@ fn test_brutal_graph_consistency() {
         handle.join().expect("Thread panicked");
     }
 
-    // Verify graph is still valid
-    let stats = system.graph_stats();
-    assert!(stats.node_count >= 0, "Graph should have valid node count");
+    // Verify graph is still valid — the stats call itself validates the path;
+    // `node_count >= 0` was tautological (usize).
+    let _stats = system.graph_stats();
 }
 
 /// Test rapid creation and deletion simulation (via importance decay)
@@ -1291,7 +1289,7 @@ fn test_brutal_lifecycle_churn() {
     for _ in 0..100 {
         for id in &ids {
             system
-                .reinforce_recall(&[id.clone()], RetrievalOutcome::Misleading)
+                .reinforce_recall(std::slice::from_ref(id), RetrievalOutcome::Misleading)
                 .expect("Decay failed");
         }
     }
@@ -1300,7 +1298,7 @@ fn test_brutal_lifecycle_churn() {
     for (i, id) in ids.iter().enumerate() {
         let memory = system
             .get_memory(id)
-            .expect(&format!("Memory {} should exist", i));
+            .unwrap_or_else(|_| panic!("Memory {} should exist", i));
         // Importance should be at or near minimum (0.0)
         assert!(
             memory.importance() <= 0.1,

--- a/tests/bug_regression_tests.rs
+++ b/tests/bug_regression_tests.rs
@@ -21,12 +21,14 @@ use shodh_memory::memory::{MemoryConfig, MemorySystem};
 // ============================================================================
 
 /// Create fallback NER for testing (rule-based, no ONNX required)
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
 }
 
 /// Create experience with NER entity extraction
+#[allow(dead_code)]
 fn create_experience_with_ner(content: &str, ner: &NeuralNer) -> Experience {
     let entities = ner.extract(content).unwrap_or_default();
     let entity_names: Vec<String> = entities.iter().map(|e| e.text.clone()).collect();
@@ -283,7 +285,7 @@ fn test_bug007_combined_search_scales_linearly() {
         ..Default::default()
     };
 
-    let results = system.recall(&query).expect("Failed to retrieve");
+    let _results = system.recall(&query).expect("Failed to retrieve");
     let duration = start.elapsed();
 
     // Combined search should complete in < 500ms for 50 memories
@@ -337,7 +339,7 @@ fn test_bug009_geohash_empty_string() {
 
     // The actual behavior is to return valid coordinates within bounds
     assert!(
-        lat >= -90.0 && lat <= 90.0 && lon >= -180.0 && lon <= 180.0,
+        (-90.0..=90.0).contains(&lat) && (-180.0..=180.0).contains(&lon),
         "BUG-009: Empty geohash should decode to valid coordinates, got ({}, {})",
         lat,
         lon
@@ -368,7 +370,7 @@ fn test_bug010_radius_nan_handled() {
 
     // NaN should produce valid precision (default to small precision)
     assert!(
-        precision >= 1 && precision <= 12,
+        (1..=12).contains(&precision),
         "BUG-010 REGRESSION: NaN radius produced invalid precision {}",
         precision
     );
@@ -380,7 +382,7 @@ fn test_bug010_radius_infinity_handled() {
 
     // Infinity should produce valid precision (low precision for large area)
     assert!(
-        precision >= 1 && precision <= 12,
+        (1..=12).contains(&precision),
         "BUG-010 REGRESSION: Infinity radius produced invalid precision {}",
         precision
     );
@@ -392,7 +394,7 @@ fn test_bug010_radius_negative_handled() {
 
     // Negative should produce valid precision
     assert!(
-        precision >= 1 && precision <= 12,
+        (1..=12).contains(&precision),
         "BUG-010 REGRESSION: Negative radius produced invalid precision {}",
         precision
     );
@@ -404,7 +406,7 @@ fn test_bug010_radius_zero_handled() {
 
     // Zero should produce valid precision (high precision for small area)
     assert!(
-        precision >= 1 && precision <= 12,
+        (1..=12).contains(&precision),
         "BUG-010 REGRESSION: Zero radius produced invalid precision {}",
         precision
     );
@@ -417,7 +419,7 @@ fn test_bug010_radius_huge_handled() {
 
     // Huge radius should produce valid low precision
     assert!(
-        precision >= 1 && precision <= 12,
+        (1..=12).contains(&precision),
         "BUG-010 REGRESSION: Huge radius produced invalid precision {}",
         precision
     );
@@ -436,10 +438,10 @@ fn test_bug010_radius_normal_values() {
         (1000000.0, 2), // 1000km
     ];
 
-    for (radius, expected_min_precision) in test_cases {
+    for (radius, _expected_min_precision) in test_cases {
         let precision = geohash_precision_for_radius(radius);
         assert!(
-            precision >= 1 && precision <= 12,
+            (1..=12).contains(&precision),
             "Radius {} produced invalid precision {}",
             radius,
             precision
@@ -658,7 +660,7 @@ fn test_geo_filter_retrieval() {
 
     // Should find SF downtown and nearby, but not Oakland or LA
     assert!(
-        results.len() >= 1 && results.len() <= 3,
+        !results.is_empty() && results.len() <= 3,
         "Geo filter should return 1-3 results within 1km, got {}",
         results.len()
     );

--- a/tests/chunking_retrieval_tests.rs
+++ b/tests/chunking_retrieval_tests.rs
@@ -174,7 +174,7 @@ fn test_search_returns_full_memory_not_chunk() {
 
     let experience = create_long_memory_with_markers();
     let original_content = experience.content.clone();
-    let stored = system.remember(experience, None).expect("Failed to store");
+    let _stored = system.remember(experience, None).expect("Failed to store");
 
     // Search for end content
     let query = Query {

--- a/tests/cognitive_memory_tests.rs
+++ b/tests/cognitive_memory_tests.rs
@@ -9,16 +9,18 @@
 //! - NER integration for entity extraction
 
 use shodh_memory::embeddings::ner::{NerConfig, NeuralNer};
-use shodh_memory::memory::{EntityRef, Experience, ExperienceType, Memory, MemoryId, MemoryTier};
+use shodh_memory::memory::{Experience, ExperienceType, Memory, MemoryId, MemoryTier};
 use shodh_memory::uuid::Uuid;
 
 /// Create fallback NER instance for testing
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
 }
 
 /// Create experience with NER-extracted entities
+#[allow(dead_code)]
 fn create_experience_with_ner(
     content: &str,
     exp_type: ExperienceType,
@@ -503,7 +505,7 @@ fn test_importance_getter() {
 
 #[test]
 fn test_importance_update() {
-    let mut memory = Memory::new(
+    let memory = Memory::new(
         MemoryId(Uuid::new_v4()),
         Experience::default(),
         0.5,
@@ -519,7 +521,7 @@ fn test_importance_update() {
 
 #[test]
 fn test_importance_clamped() {
-    let mut memory = Memory::new(
+    let memory = Memory::new(
         MemoryId(Uuid::new_v4()),
         Experience::default(),
         0.5,
@@ -544,7 +546,7 @@ fn test_importance_clamped() {
 
 #[test]
 fn test_boost_importance() {
-    let mut memory = Memory::new(
+    let memory = Memory::new(
         MemoryId(Uuid::new_v4()),
         Experience::default(),
         0.5,
@@ -597,7 +599,7 @@ fn test_access_count_initial() {
 
 #[test]
 fn test_record_access() {
-    let mut memory = Memory::new(
+    let memory = Memory::new(
         MemoryId(Uuid::new_v4()),
         Experience::default(),
         0.5,
@@ -616,7 +618,7 @@ fn test_record_access() {
 
 #[test]
 fn test_record_access_many() {
-    let mut memory = Memory::new(
+    let memory = Memory::new(
         MemoryId(Uuid::new_v4()),
         Experience::default(),
         0.5,
@@ -716,7 +718,7 @@ fn test_bincode_roundtrip_with_tier() {
 
 #[test]
 fn test_bincode_roundtrip_with_activation() {
-    let mut memory = Memory::new(
+    let memory = Memory::new(
         MemoryId(Uuid::new_v4()),
         Experience::default(),
         0.5,
@@ -974,7 +976,7 @@ fn test_max_importance() {
 
 #[test]
 fn test_zero_activation() {
-    let mut memory = Memory::new(
+    let memory = Memory::new(
         MemoryId(Uuid::new_v4()),
         Experience::default(),
         0.5,

--- a/tests/consolidation_tests.rs
+++ b/tests/consolidation_tests.rs
@@ -18,12 +18,14 @@ use shodh_memory::uuid::Uuid;
 use tempfile::TempDir;
 
 /// Create fallback NER for testing (rule-based, no ONNX required)
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
 }
 
 /// Create experience with NER entity extraction
+#[allow(dead_code)]
 fn create_experience_with_ner(content: &str, ner: &NeuralNer) -> Experience {
     let entities = ner.extract(content).unwrap_or_default();
     let entity_names: Vec<String> = entities.iter().map(|e| e.text.clone()).collect();
@@ -367,7 +369,7 @@ fn test_low_importance_eligible_for_forget() {
 
 #[test]
 fn test_importance_affects_retention() {
-    let (mut system, _temp) = setup_memory_system();
+    let (system, _temp) = setup_memory_system();
 
     // Record high importance memory
     let high_id = system
@@ -404,7 +406,7 @@ fn test_importance_affects_retention() {
 
 #[test]
 fn test_working_memory_capacity() {
-    let (mut system, _temp) = setup_auto_compress_system();
+    let (system, _temp) = setup_auto_compress_system();
 
     // Record more memories than working memory capacity
     for i in 0..20 {
@@ -420,7 +422,7 @@ fn test_working_memory_capacity() {
 
 #[test]
 fn test_session_memory_used() {
-    let (mut system, _temp) = setup_auto_compress_system();
+    let (system, _temp) = setup_auto_compress_system();
 
     // Fill up working memory
     for i in 0..15 {
@@ -887,7 +889,7 @@ fn test_concurrent_tier_reads() {
 // =============================================================================
 
 use chrono::{Duration, TimeZone, Utc};
-use shodh_memory::memory::{ConsolidationEvent, Query};
+use shodh_memory::memory::Query;
 
 /// Helper to get a "beginning of time" DateTime for all-time queries
 fn epoch() -> chrono::DateTime<chrono::Utc> {

--- a/tests/file_memory_tests.rs
+++ b/tests/file_memory_tests.rs
@@ -171,7 +171,7 @@ type Handler interface {
     .unwrap();
 
     // Create a binary file (should be skipped)
-    fs::write(temp_dir.path().join("image.png"), &[0x89, 0x50, 0x4E, 0x47]).unwrap();
+    fs::write(temp_dir.path().join("image.png"), [0x89, 0x50, 0x4E, 0x47]).unwrap();
 
     // Create a large file (should be skipped with default config)
     let large_content = "x".repeat(600_000); // 600KB

--- a/tests/graph_memory_tests.rs
+++ b/tests/graph_memory_tests.rs
@@ -19,12 +19,14 @@ use std::collections::HashMap;
 use tempfile::TempDir;
 
 /// Create fallback NER instance for testing
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
 }
 
 /// Convert NER entity type to GraphMemory EntityLabel
+#[allow(dead_code)]
 fn ner_type_to_label(ner_type: &NerEntityType) -> EntityLabel {
     match ner_type {
         NerEntityType::Person => EntityLabel::Person,
@@ -35,6 +37,7 @@ fn ner_type_to_label(ner_type: &NerEntityType) -> EntityLabel {
 }
 
 /// Create entity from NER extraction
+#[allow(dead_code)]
 fn create_entity_from_ner(ner: &NeuralNer, text: &str) -> Vec<EntityNode> {
     let extracted = ner.extract(text).unwrap_or_default();
     extracted
@@ -1160,7 +1163,7 @@ fn test_decay_synapse_persists() {
 
     // Create edge with old activation timestamp
     let thirty_days_ago = Utc::now() - Duration::days(30);
-    let mut edge = create_relationship_with_plasticity(
+    let edge = create_relationship_with_plasticity(
         id1,
         id2,
         RelationType::Knows,
@@ -1178,7 +1181,7 @@ fn test_decay_synapse_persists() {
     let should_prune = graph.decay_synapse(&edge_id).expect("Failed");
 
     // Verify decay was applied
-    let decayed_edge = graph
+    let _decayed_edge = graph
         .get_relationship(&edge_id)
         .expect("Failed")
         .expect("Edge should exist");

--- a/tests/handler_pipeline_tests.rs
+++ b/tests/handler_pipeline_tests.rs
@@ -89,6 +89,7 @@ fn authed_post(uri: &str, body: Value) -> Request<Body> {
         .unwrap()
 }
 
+#[allow(dead_code)]
 fn authed_put(uri: &str, body: Value) -> Request<Body> {
     let bytes = serde_json::to_vec(&body).unwrap();
     Request::builder()
@@ -109,6 +110,7 @@ fn authed_delete(uri: &str) -> Request<Body> {
         .unwrap()
 }
 
+#[allow(dead_code)]
 fn authed_patch(uri: &str, body: Value) -> Request<Body> {
     let bytes = serde_json::to_vec(&body).unwrap();
     Request::builder()

--- a/tests/hebbian_learning_tests.rs
+++ b/tests/hebbian_learning_tests.rs
@@ -17,6 +17,7 @@ use shodh_memory::memory::{
 use tempfile::TempDir;
 
 /// Create fallback NER instance for testing
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
@@ -58,6 +59,7 @@ fn create_experience(content: &str) -> Experience {
 }
 
 /// Create experience with NER-extracted entities
+#[allow(dead_code)]
 fn create_experience_with_ner(content: &str, ner: &NeuralNer) -> Experience {
     let entities = ner.extract(content).unwrap_or_default();
     let entity_names: Vec<String> = entities.iter().map(|e| e.text.clone()).collect();
@@ -75,7 +77,7 @@ fn create_experience_with_ner(content: &str, ner: &NeuralNer) -> Experience {
 
 #[test]
 fn test_retrieve_returns_memories() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Record some memories
     memory
@@ -101,7 +103,7 @@ fn test_retrieve_returns_memories() {
 
 #[test]
 fn test_retrieve_multiple_related() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Record related memories
     for i in 0..10 {
@@ -129,7 +131,7 @@ fn test_retrieve_multiple_related() {
 
 #[test]
 fn test_reinforce_helpful_boosts_importance() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Record memory
     let id = memory
@@ -164,7 +166,7 @@ fn test_reinforce_helpful_boosts_importance() {
 
 #[test]
 fn test_reinforce_misleading_decays_importance() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Record memory with high importance
     let id = memory
@@ -203,7 +205,7 @@ fn test_reinforce_misleading_decays_importance() {
 
 #[test]
 fn test_reinforce_neutral_no_change() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Record memory
     let id = memory
@@ -234,7 +236,7 @@ fn test_reinforce_neutral_no_change() {
 
 #[test]
 fn test_co_retrieval_strengthens_association() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Record related memories
     let id1 = memory
@@ -264,7 +266,7 @@ fn test_co_retrieval_strengthens_association() {
 
 #[test]
 fn test_repeated_co_retrieval_increases_strength() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Record related memories
     let id1 = memory
@@ -298,7 +300,7 @@ fn test_repeated_co_retrieval_increases_strength() {
 
 #[test]
 fn test_single_memory_no_associations() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     let id = memory
         .remember(create_experience("Single isolated memory"), None)
@@ -318,7 +320,7 @@ fn test_single_memory_no_associations() {
 
 #[test]
 fn test_many_co_retrieved_associations() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Record many related memories
     let mut ids = Vec::new();
@@ -351,7 +353,7 @@ fn test_many_co_retrieved_associations() {
 
 #[test]
 fn test_reinforcement_stats_counts() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Record memories
     let id1 = memory
@@ -374,7 +376,7 @@ fn test_reinforcement_stats_counts() {
 
 #[test]
 fn test_reinforcement_empty_ids() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     let ids: Vec<shodh_memory::memory::MemoryId> = vec![];
     let stats = memory
@@ -389,7 +391,7 @@ fn test_reinforcement_empty_ids() {
 
 #[test]
 fn test_reinforcement_invalid_ids() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Create random IDs that don't exist
     let ids = vec![
@@ -414,7 +416,7 @@ fn test_reinforcement_invalid_ids() {
 
 #[test]
 fn test_importance_boost_formula() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Create memory with known importance
     let id = memory
@@ -433,7 +435,7 @@ fn test_importance_boost_formula() {
 
     // Reinforce as helpful
     memory
-        .reinforce_recall(&[id.clone()], RetrievalOutcome::Helpful)
+        .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Helpful)
         .unwrap();
 
     let after = memory.get_memory(&id).unwrap();
@@ -453,7 +455,7 @@ fn test_importance_boost_formula() {
 
 #[test]
 fn test_importance_decay_formula() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Create memory with high importance
     let id = memory
@@ -473,7 +475,7 @@ fn test_importance_decay_formula() {
 
     // Reinforce as misleading
     memory
-        .reinforce_recall(&[id.clone()], RetrievalOutcome::Misleading)
+        .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Misleading)
         .unwrap();
 
     let after = memory.get_memory(&id).unwrap();
@@ -497,7 +499,7 @@ fn test_importance_decay_formula() {
 
 #[test]
 fn test_ltp_after_multiple_reinforcements() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     let id1 = memory
         .remember(create_experience("Pattern A observation"), None)
@@ -557,7 +559,7 @@ fn test_ltp_after_multiple_reinforcements() {
 
 #[test]
 fn test_retrieve_then_reinforce_cycle() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Record memories
     for i in 0..20 {
@@ -592,7 +594,7 @@ fn test_retrieve_then_reinforce_cycle() {
 
 #[test]
 fn test_reinforced_memories_rank_higher() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Record several memories about the same topic
     let id_target = memory
@@ -614,7 +616,7 @@ fn test_reinforced_memories_rank_higher() {
     // Reinforce the target memory multiple times
     for _ in 0..5 {
         memory
-            .reinforce_recall(&[id_target.clone()], RetrievalOutcome::Helpful)
+            .reinforce_recall(std::slice::from_ref(&id_target), RetrievalOutcome::Helpful)
             .unwrap();
     }
 
@@ -641,7 +643,7 @@ fn test_reinforced_memories_rank_higher() {
 
 #[test]
 fn test_reinforce_same_memory_twice() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     let id = memory
         .remember(create_experience("Duplicate test"), None)
@@ -659,7 +661,7 @@ fn test_reinforce_same_memory_twice() {
 
 #[test]
 fn test_alternating_feedback() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     let id = memory
         .remember(create_experience("Alternating feedback test"), None)
@@ -667,16 +669,16 @@ fn test_alternating_feedback() {
 
     // Alternate helpful and misleading
     memory
-        .reinforce_recall(&[id.clone()], RetrievalOutcome::Helpful)
+        .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Helpful)
         .unwrap();
     memory
-        .reinforce_recall(&[id.clone()], RetrievalOutcome::Misleading)
+        .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Misleading)
         .unwrap();
     memory
-        .reinforce_recall(&[id.clone()], RetrievalOutcome::Helpful)
+        .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Helpful)
         .unwrap();
     memory
-        .reinforce_recall(&[id.clone()], RetrievalOutcome::Misleading)
+        .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Misleading)
         .unwrap();
 
     // Memory should still exist and be valid - get_memory returns Result<Memory>, success means it exists
@@ -689,7 +691,7 @@ fn test_alternating_feedback() {
 
 #[test]
 fn test_high_volume_reinforcement() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Record many memories
     let mut ids = Vec::new();
@@ -751,7 +753,7 @@ fn test_hebbian_graph_persists_across_restart() {
 
     // Phase 1: Create memories and form associations
     {
-        let mut memory = create_system_with_graph(config.clone());
+        let memory = create_system_with_graph(config.clone());
 
         id1 = memory
             .remember(create_experience("Hebbian persistence test memory A"), None)
@@ -810,7 +812,7 @@ fn test_hebbian_edge_strength_persists() {
 
     // Phase 1: Create strong associations
     {
-        let mut memory = create_system_with_graph(config.clone());
+        let memory = create_system_with_graph(config.clone());
 
         id1 = memory
             .remember(create_experience("Edge strength test A"), None)
@@ -855,7 +857,7 @@ fn test_hebbian_edge_strength_persists() {
 
 #[test]
 fn test_coactivation_during_retrieve_forms_edges() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Record memories
     let id1 = memory
@@ -907,7 +909,7 @@ fn test_ltp_persists_across_restart() {
 
     // Phase 1: Create LTP by many co-activations
     {
-        let mut memory = create_system_with_graph(config.clone());
+        let memory = create_system_with_graph(config.clone());
 
         id1 = memory
             .remember(create_experience("LTP persistence test A"), None)
@@ -948,7 +950,7 @@ fn test_ltp_persists_across_restart() {
 
 #[test]
 fn test_graph_stats_accuracy() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Record several memories
     let mut ids = Vec::new();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -19,12 +19,14 @@ use shodh_memory::{
 };
 
 /// Create fallback NER instance for testing
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
 }
 
 /// Create experience with NER-extracted entities
+#[allow(dead_code)]
 fn create_experience_with_ner(
     content: &str,
     exp_type: ExperienceType,

--- a/tests/integration_webhook_tests.rs
+++ b/tests/integration_webhook_tests.rs
@@ -11,11 +11,11 @@
 use shodh_memory::integrations::{
     github::{
         GitHubBranch, GitHubIssue, GitHubLabel, GitHubMilestone, GitHubPullRequest,
-        GitHubRepository, GitHubUser, GitHubWebhook, GitHubWebhookPayload,
+        GitHubRepository, GitHubUser, GitHubWebhook,
     },
     linear::{
         LinearCycle, LinearIssueData, LinearLabel, LinearProject, LinearState, LinearTeam,
-        LinearUser, LinearWebhook, LinearWebhookPayload,
+        LinearUser, LinearWebhook,
     },
 };
 

--- a/tests/memory_persistence_tests.rs
+++ b/tests/memory_persistence_tests.rs
@@ -452,7 +452,8 @@ fn test_concurrent_reinforcement() {
     let booster = thread::spawn(move || {
         for _ in 0..20 {
             let sys = system_clone.lock();
-            let _ = sys.reinforce_recall(std::slice::from_ref(&id_clone), RetrievalOutcome::Helpful);
+            let _ =
+                sys.reinforce_recall(std::slice::from_ref(&id_clone), RetrievalOutcome::Helpful);
             drop(sys);
             thread::sleep(Duration::from_millis(5));
         }

--- a/tests/memory_persistence_tests.rs
+++ b/tests/memory_persistence_tests.rs
@@ -23,12 +23,14 @@ use shodh_memory::memory::{
 };
 
 /// Create fallback NER instance for testing
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
 }
 
 /// Create experience with NER-extracted entities
+#[allow(dead_code)]
 fn create_experience_with_ner(content: &str, ner: &NeuralNer) -> Experience {
     let entities = ner.extract(content).unwrap_or_default();
     let entity_names: Vec<String> = entities.iter().map(|e| e.text.clone()).collect();
@@ -133,7 +135,7 @@ fn test_importance_changes_survive_restart() {
         // Apply multiple helpful reinforcements
         for _ in 0..10 {
             system
-                .reinforce_recall(&[memory_id.clone()], RetrievalOutcome::Helpful)
+                .reinforce_recall(std::slice::from_ref(&memory_id), RetrievalOutcome::Helpful)
                 .expect("Failed to reinforce");
         }
 
@@ -196,7 +198,7 @@ fn test_access_count_survives_restart() {
         // Access multiple times through reinforcement
         for _ in 0..5 {
             system
-                .reinforce_recall(&[memory_id.clone()], RetrievalOutcome::Neutral)
+                .reinforce_recall(std::slice::from_ref(&memory_id), RetrievalOutcome::Neutral)
                 .expect("Failed to reinforce");
         }
     }
@@ -264,7 +266,7 @@ fn test_multiple_memories_survive_restart() {
 
 #[test]
 fn test_cache_coherency_importance_visible_immediately() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp = create_experience("Cache coherency test memory", vec!["cache"]);
     let id = system.remember(exp, None).expect("Failed to record");
@@ -280,7 +282,7 @@ fn test_cache_coherency_importance_visible_immediately() {
 
     // Boost importance
     system
-        .reinforce_recall(&[id.clone()], RetrievalOutcome::Helpful)
+        .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Helpful)
         .expect("Failed to reinforce");
 
     // Verify change is immediately visible through same query
@@ -297,7 +299,7 @@ fn test_cache_coherency_importance_visible_immediately() {
 
 #[test]
 fn test_cache_coherency_multiple_retrievals() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp = create_experience("Multi-retrieval coherency test", vec!["multi"]);
     let id = system.remember(exp, None).expect("Failed to record");
@@ -318,7 +320,7 @@ fn test_cache_coherency_multiple_retrievals() {
             .importance();
 
         system
-            .reinforce_recall(&[id.clone()], RetrievalOutcome::Helpful)
+            .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Helpful)
             .expect("Failed");
 
         let after = system
@@ -340,7 +342,7 @@ fn test_cache_coherency_multiple_retrievals() {
 
 #[test]
 fn test_cache_coherency_decay_visible_immediately() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp = create_experience("Decay visibility test", vec!["decay"]);
     let id = system.remember(exp, None).expect("Failed to record");
@@ -360,7 +362,7 @@ fn test_cache_coherency_decay_visible_immediately() {
 
     // Apply decay
     system
-        .reinforce_recall(&[id.clone()], RetrievalOutcome::Misleading)
+        .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Misleading)
         .expect("Failed");
 
     let after_decay = system
@@ -392,7 +394,7 @@ fn test_concurrent_record_and_retrieve() {
     // Spawn thread that records memories
     let writer = thread::spawn(move || {
         for i in 0..10 {
-            let mut sys = system_clone.lock();
+            let sys = system_clone.lock();
             let exp = create_experience(
                 &format!("Concurrent write test memory {}", i),
                 vec!["concurrent"],
@@ -449,8 +451,8 @@ fn test_concurrent_reinforcement() {
     // Spawn thread that boosts
     let booster = thread::spawn(move || {
         for _ in 0..20 {
-            let mut sys = system_clone.lock();
-            let _ = sys.reinforce_recall(&[id_clone.clone()], RetrievalOutcome::Helpful);
+            let sys = system_clone.lock();
+            let _ = sys.reinforce_recall(std::slice::from_ref(&id_clone), RetrievalOutcome::Helpful);
             drop(sys);
             thread::sleep(Duration::from_millis(5));
         }
@@ -458,8 +460,8 @@ fn test_concurrent_reinforcement() {
 
     // Main thread also reinforces
     for _ in 0..20 {
-        let mut sys = system.lock();
-        let _ = sys.reinforce_recall(&[id.clone()], RetrievalOutcome::Helpful);
+        let sys = system.lock();
+        let _ = sys.reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Helpful);
         drop(sys);
         thread::sleep(Duration::from_millis(5));
     }
@@ -505,7 +507,7 @@ fn test_reinforce_nonexistent_memory() {
 
 #[test]
 fn test_reinforce_mixed_existing_nonexistent() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp = create_experience("Real memory for mixed test", vec!["mixed"]);
     let real_id = system.remember(exp, None).expect("Failed to record");
@@ -523,7 +525,7 @@ fn test_reinforce_mixed_existing_nonexistent() {
 
 #[test]
 fn test_importance_bounds_at_maximum() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp = create_experience("Max importance test", vec!["max"]);
     let id = system.remember(exp, None).expect("Failed to record");
@@ -531,7 +533,7 @@ fn test_importance_bounds_at_maximum() {
     // Boost many times to try to exceed 1.0
     for _ in 0..100 {
         system
-            .reinforce_recall(&[id.clone()], RetrievalOutcome::Helpful)
+            .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Helpful)
             .expect("Failed");
     }
 
@@ -556,7 +558,7 @@ fn test_importance_bounds_at_maximum() {
 
 #[test]
 fn test_importance_bounds_at_minimum() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp = create_experience("Min importance test", vec!["min"]);
     let id = system.remember(exp, None).expect("Failed to record");
@@ -564,7 +566,7 @@ fn test_importance_bounds_at_minimum() {
     // Decay many times to try to go below floor
     for _ in 0..100 {
         system
-            .reinforce_recall(&[id.clone()], RetrievalOutcome::Misleading)
+            .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Misleading)
             .expect("Failed");
     }
 
@@ -584,7 +586,7 @@ fn test_importance_bounds_at_minimum() {
 
 #[test]
 fn test_alternating_boost_and_decay() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp = create_experience("Alternating reinforcement test", vec!["alternating"]);
     let id = system.remember(exp, None).expect("Failed to record");
@@ -609,11 +611,11 @@ fn test_alternating_boost_and_decay() {
     for i in 0..10 {
         if i % 2 == 0 {
             system
-                .reinforce_recall(&[id.clone()], RetrievalOutcome::Helpful)
+                .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Helpful)
                 .expect("Failed");
         } else {
             system
-                .reinforce_recall(&[id.clone()], RetrievalOutcome::Misleading)
+                .reinforce_recall(std::slice::from_ref(&id), RetrievalOutcome::Misleading)
                 .expect("Failed");
         }
         importances.push(
@@ -652,7 +654,7 @@ fn test_empty_reinforcement_list() {
 
 #[test]
 fn test_large_batch_reinforcement() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let mut ids = Vec::new();
     for i in 0..50 {
@@ -687,7 +689,7 @@ fn test_large_batch_reinforcement() {
 
 #[test]
 fn test_memory_in_working_tier_after_record() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let exp = create_experience("Working tier test memory", vec!["tier"]);
     let _id = system.remember(exp, None).expect("Failed to record");
@@ -708,7 +710,7 @@ fn test_memory_in_working_tier_after_record() {
 
 #[test]
 fn test_high_volume_record_and_retrieve() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     // Record many memories
     for i in 0..100 {
@@ -754,7 +756,7 @@ fn test_high_volume_record_and_retrieve() {
 
 #[test]
 fn test_rapid_record_retrieve_cycle() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     let mut recorded_ids = Vec::new();
 
@@ -769,7 +771,7 @@ fn test_rapid_record_retrieve_cycle() {
     for (i, id) in recorded_ids.iter().enumerate() {
         let memory = system
             .get_memory(id)
-            .expect(&format!("Should find memory {} by ID", i));
+            .unwrap_or_else(|_| panic!("Should find memory {} by ID", i));
         assert!(
             memory.experience.content.contains("Rapid cycle memory"),
             "Memory {} content should be correct",
@@ -795,7 +797,7 @@ fn test_rapid_record_retrieve_cycle() {
 
 #[test]
 fn test_stress_reinforcement_cycles() {
-    let (mut system, _temp_dir) = create_test_system();
+    let (system, _temp_dir) = create_test_system();
 
     // Create memories
     let mut ids = Vec::new();

--- a/tests/memory_tiering_tests.rs
+++ b/tests/memory_tiering_tests.rs
@@ -13,16 +13,17 @@ use shodh_memory::embeddings::ner::{NerConfig, NeuralNer};
 use shodh_memory::memory::{
     Experience, ExperienceType, MemoryConfig, MemorySystem, Query, RetrievalMode,
 };
-use std::path::PathBuf;
 use tempfile::TempDir;
 
 /// Create fallback NER instance for testing
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
 }
 
 /// Create experience with NER-extracted entities
+#[allow(dead_code)]
 fn create_experience_with_ner(
     content: &str,
     exp_type: ExperienceType,
@@ -70,16 +71,16 @@ fn create_experience(content: &str, exp_type: ExperienceType) -> Experience {
 
 #[test]
 fn test_working_memory_stores_recent() {
-    let (mut memory_system, _temp_dir) = setup_memory_system(10, 50);
+    let (memory_system, _temp_dir) = setup_memory_system(10, 50);
 
     // Record some experiences
-    let id1 = memory_system
+    let _id1 = memory_system
         .remember(
             create_experience("First memory", ExperienceType::Observation),
             None,
         )
         .expect("Failed to record");
-    let id2 = memory_system
+    let _id2 = memory_system
         .remember(
             create_experience("Second memory", ExperienceType::Observation),
             None,
@@ -100,7 +101,7 @@ fn test_working_memory_stores_recent() {
 
 #[test]
 fn test_working_memory_lru_eviction() {
-    let (mut memory_system, _temp_dir) = setup_memory_system(5, 50); // Very small working memory
+    let (memory_system, _temp_dir) = setup_memory_system(5, 50); // Very small working memory
 
     // Record more than capacity
     for i in 0..10 {
@@ -126,7 +127,7 @@ fn test_working_memory_lru_eviction() {
 
 #[test]
 fn test_session_memory_promotion() {
-    let (mut memory_system, _temp_dir) = setup_memory_system(3, 50);
+    let (memory_system, _temp_dir) = setup_memory_system(3, 50);
 
     // Record high-importance memories (should go to session)
     let high_importance = Experience {
@@ -154,7 +155,7 @@ fn test_session_memory_promotion() {
 
 #[test]
 fn test_low_importance_stays_working() {
-    let (mut memory_system, _temp_dir) = setup_memory_system(10, 50);
+    let (memory_system, _temp_dir) = setup_memory_system(10, 50);
 
     // Record low-importance memory
     let low_importance = Experience {
@@ -239,7 +240,7 @@ fn test_longterm_persistence() {
             importance_threshold: 0.3,
         };
 
-        let mut memory_system = MemorySystem::new(config, None).expect("Failed to create");
+        let memory_system = MemorySystem::new(config, None).expect("Failed to create");
 
         // Record important memory that should be persisted
         memory_system
@@ -349,7 +350,7 @@ fn test_longterm_persistence() {
 
 #[test]
 fn test_multi_tier_retrieval() {
-    let (mut memory_system, _temp_dir) = setup_memory_system(5, 50);
+    let (memory_system, _temp_dir) = setup_memory_system(5, 50);
 
     // Fill working memory to trigger promotions
     for i in 0..15 {
@@ -384,7 +385,7 @@ fn test_multi_tier_retrieval() {
 
 #[test]
 fn test_importance_affects_tiering() {
-    let (mut memory_system, _temp_dir) = setup_memory_system(3, 50);
+    let (memory_system, _temp_dir) = setup_memory_system(3, 50);
 
     // High importance memory
     let high = Experience {
@@ -425,7 +426,7 @@ fn test_importance_affects_tiering() {
 
 #[test]
 fn test_forget_low_importance() {
-    let (mut memory_system, _temp_dir) = setup_memory_system(10, 50);
+    let (memory_system, _temp_dir) = setup_memory_system(10, 50);
 
     // Record mix of importance levels
     for i in 0..10 {
@@ -440,24 +441,20 @@ fn test_forget_low_importance() {
             .expect("Failed to record");
     }
 
-    let stats_before = memory_system.stats();
+    let _stats_before = memory_system.stats();
 
     // Forget low importance
-    let forgotten = memory_system
+    let _forgotten = memory_system
         .forget(shodh_memory::memory::ForgetCriteria::LowImportance(0.5))
         .expect("Failed to forget");
 
-    // Some memories should be forgotten
-    // Note: actual count depends on importance calculation
-    assert!(
-        forgotten >= 0,
-        "Forget operation should complete successfully"
-    );
+    // Forget operation should complete successfully — `expect` above already
+    // asserts that. Actual count depends on importance calculation.
 }
 
 #[test]
 fn test_forget_by_pattern() {
-    let (mut memory_system, _temp_dir) = setup_memory_system(10, 50);
+    let (memory_system, _temp_dir) = setup_memory_system(10, 50);
 
     // Record memories with distinct patterns
     memory_system
@@ -508,7 +505,7 @@ fn test_forget_by_pattern() {
 
 #[test]
 fn test_similarity_retrieval() {
-    let (mut memory_system, _temp_dir) = setup_memory_system(10, 50);
+    let (memory_system, _temp_dir) = setup_memory_system(10, 50);
 
     // Record semantically similar memories
     memory_system
@@ -550,7 +547,7 @@ fn test_similarity_retrieval() {
 
 #[test]
 fn test_hybrid_retrieval() {
-    let (mut memory_system, _temp_dir) = setup_memory_system(10, 50);
+    let (memory_system, _temp_dir) = setup_memory_system(10, 50);
 
     // Record memories
     memory_system
@@ -595,7 +592,7 @@ fn test_hybrid_retrieval() {
 
 #[test]
 fn test_geo_filter_retrieval() {
-    let (mut memory_system, _temp_dir) = setup_memory_system(10, 50);
+    let (memory_system, _temp_dir) = setup_memory_system(10, 50);
 
     // Record memories with geo coordinates
     let geo_memory = Experience {
@@ -638,7 +635,7 @@ fn test_geo_filter_retrieval() {
 
 #[test]
 fn test_mission_filter_retrieval() {
-    let (mut memory_system, _temp_dir) = setup_memory_system(10, 50);
+    let (memory_system, _temp_dir) = setup_memory_system(10, 50);
 
     // Record memories with mission IDs
     let mission_a = Experience {
@@ -706,7 +703,7 @@ fn test_mission_filter_retrieval() {
 
 #[test]
 fn test_high_volume_recording() {
-    let (mut memory_system, _temp_dir) = setup_memory_system(50, 100);
+    let (memory_system, _temp_dir) = setup_memory_system(50, 100);
 
     // Record 100 memories quickly
     for i in 0..100 {
@@ -730,7 +727,7 @@ fn test_high_volume_recording() {
 
 #[test]
 fn test_concurrent_access_pattern() {
-    let (mut memory_system, _temp_dir) = setup_memory_system(20, 50);
+    let (memory_system, _temp_dir) = setup_memory_system(20, 50);
 
     // Simulate read-write pattern
     for i in 0..20 {

--- a/tests/ner_tests.rs
+++ b/tests/ner_tests.rs
@@ -369,7 +369,7 @@ mod edge_cases {
         let ner = create_test_ner();
 
         // Test lowercase - should not be found (not capitalized)
-        let entities_lower = ner.extract("microsoft google apple").unwrap();
+        let _entities_lower = ner.extract("microsoft google apple").unwrap();
         // Lowercase words typically won't be detected as entities
 
         // Test proper case - should be found

--- a/tests/pipeline_integration_tests.rs
+++ b/tests/pipeline_integration_tests.rs
@@ -722,7 +722,7 @@ mod mode_tests {
         )
         .await;
         assert_eq!(status, StatusCode::OK);
-        assert!(body["memories"].as_array().unwrap().len() > 0);
+        assert!(!body["memories"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -761,8 +761,8 @@ mod mode_tests {
         assert_eq!(status1, StatusCode::OK);
         assert_eq!(status2, StatusCode::OK);
         // Both should return results (same underlying mode)
-        assert!(body1["memories"].as_array().unwrap().len() > 0);
-        assert!(body2["memories"].as_array().unwrap().len() > 0);
+        assert!(!body1["memories"].as_array().unwrap().is_empty());
+        assert!(!body2["memories"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/tests/query_filter_tests.rs
+++ b/tests/query_filter_tests.rs
@@ -4,8 +4,6 @@
 //! Includes NER integration for entity extraction.
 
 use chrono::{Duration, Utc};
-use std::collections::HashMap;
-use std::sync::Arc;
 
 use shodh_memory::embeddings::ner::{NerConfig, NeuralNer};
 use shodh_memory::memory::types::{
@@ -14,12 +12,14 @@ use shodh_memory::memory::types::{
 use shodh_memory::uuid::Uuid;
 
 /// Create fallback NER instance for testing
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
 }
 
 /// Create experience with NER-extracted entities
+#[allow(dead_code)]
 fn create_experience_with_ner(content: &str, ner: &NeuralNer) -> Experience {
     let entities = ner.extract(content).unwrap_or_default();
     let entity_names: Vec<String> = entities.iter().map(|e| e.text.clone()).collect();
@@ -925,8 +925,8 @@ fn test_reward_edge_modulation_constant() {
     use shodh_memory::constants::REWARD_EDGE_MODULATION;
 
     // Verify the constant is in a sane range
-    assert!(REWARD_EDGE_MODULATION > 0.0);
-    assert!(REWARD_EDGE_MODULATION <= 1.0);
+    const _: () = assert!(REWARD_EDGE_MODULATION > 0.0);
+    const _: () = assert!(REWARD_EDGE_MODULATION <= 1.0);
 
     // Verify modulation math: base_strength * (1.0 + reward * modulation)
     let base = 0.5_f32;
@@ -939,7 +939,7 @@ fn test_reward_edge_modulation_constant() {
     );
 
     // Negative reward should decrease strength
-    let negative = base * (1.0 + (-1.0) * REWARD_EDGE_MODULATION);
+    let negative = base * (1.0 + -REWARD_EDGE_MODULATION);
     assert!(
         negative < base,
         "Negative reward should decrease edge strength"

--- a/tests/salience_tests.rs
+++ b/tests/salience_tests.rs
@@ -400,7 +400,7 @@ fn test_entities_ranked_by_salience() {
         .expect("Failed to add low entity");
 
     let high_entity = create_entity("High_Importance", Some(EntityLabel::Person), true, 0.8);
-    let high_id = graph
+    let _high_id = graph
         .add_entity(high_entity)
         .expect("Failed to add high entity");
 

--- a/tests/spreading_activation_tests.rs
+++ b/tests/spreading_activation_tests.rs
@@ -17,12 +17,14 @@ use shodh_memory::uuid::Uuid;
 use tempfile::TempDir;
 
 /// Create fallback NER instance for testing
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
 }
 
 /// Create experience with NER-extracted entities
+#[allow(dead_code)]
 fn create_experience_with_ner(content: &str, ner: &NeuralNer) -> Experience {
     let entities = ner.extract(content).unwrap_or_default();
     let entity_names: Vec<String> = entities.iter().map(|e| e.text.clone()).collect();
@@ -334,7 +336,7 @@ fn test_activation_never_zero() {
 
 #[test]
 fn test_connected_memories_coactivate() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     let id1 = memory
         .remember(create_experience("Memory A"), None)
@@ -361,7 +363,7 @@ fn test_connected_memories_coactivate() {
 
 #[test]
 fn test_chain_activation_propagates() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Create a chain: A -> B -> C
     let id_a = memory
@@ -396,7 +398,7 @@ fn test_chain_activation_propagates() {
 
 #[test]
 fn test_disconnected_memories_independent() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Create two unconnected memories
     let _id1 = memory
@@ -420,7 +422,7 @@ fn test_disconnected_memories_independent() {
 
 #[test]
 fn test_hub_memory_activates_many() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Create hub and spokes
     let hub = memory
@@ -449,7 +451,7 @@ fn test_hub_memory_activates_many() {
     };
 
     let results = memory.recall(&query).unwrap();
-    assert!(results.len() >= 1);
+    assert!(!results.is_empty());
 }
 
 // =============================================================================
@@ -827,7 +829,7 @@ fn test_medium_decay_rate() {
 
 #[test]
 fn test_triangle_activation() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Create triangle: A-B, B-C, C-A
     let id_a = memory
@@ -863,7 +865,7 @@ fn test_triangle_activation() {
 
 #[test]
 fn test_star_activation() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Create star: center connected to 5 leaves
     let center = memory
@@ -892,7 +894,7 @@ fn test_star_activation() {
 
 #[test]
 fn test_bipartite_activation() {
-    let (mut memory, _temp) = setup_memory_system();
+    let (memory, _temp) = setup_memory_system();
 
     // Create bipartite: group A connected to group B
     let mut group_a = Vec::new();
@@ -959,7 +961,7 @@ fn test_activation_update_performance() {
 
     // Just verify it completed with valid activation
     let activation = memory.activation();
-    assert!(activation >= 0.0 && activation <= 1.0);
+    assert!((0.0..=1.0).contains(&activation));
 }
 
 #[test]

--- a/tests/storage_edge_case_tests.rs
+++ b/tests/storage_edge_case_tests.rs
@@ -17,12 +17,14 @@ use shodh_memory::memory::{MemoryConfig, MemorySystem};
 // ============================================================================
 
 /// Create fallback NER for testing (rule-based, no ONNX required)
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
 }
 
 /// Create experience with NER entity extraction
+#[allow(dead_code)]
 fn create_experience_with_ner(content: &str, ner: &NeuralNer) -> Experience {
     let entities = ner.extract(content).unwrap_or_default();
     let entity_names: Vec<String> = entities.iter().map(|e| e.text.clone()).collect();
@@ -122,7 +124,7 @@ fn test_unicode_content() {
         ..Default::default()
     };
 
-    let memory_id = system
+    let _memory_id = system
         .remember(exp, None)
         .expect("Failed to record unicode content");
 
@@ -236,7 +238,7 @@ fn test_unicode_entity_names() {
         ..Default::default()
     };
 
-    let results = system.recall(&query).expect("Failed to retrieve");
+    let _results = system.recall(&query).expect("Failed to retrieve");
     // May or may not find results depending on tag indexing
 }
 

--- a/tests/timing_sla_tests.rs
+++ b/tests/timing_sla_tests.rs
@@ -6,7 +6,7 @@
 //! Run with: cargo test --test timing_sla_tests -- --test-threads=1
 //! Note: Run single-threaded for accurate timing measurements.
 
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use tempfile::TempDir;
 
 use shodh_memory::embeddings::ner::{NerConfig, NeuralNer};
@@ -24,6 +24,7 @@ const RECORD_P99_MS: u128 = 3000; // 3s P99 for record (debug mode, first record
 const RETRIEVE_P50_MS: u128 = 200; // 200ms P50 for retrieve (debug mode)
 const RETRIEVE_P99_MS: u128 = 1000; // 1s P99 for retrieve (debug mode)
 const BATCH_100_MAX_MS: u128 = 60000; // 60s max for 100 records (debug mode)
+#[allow(dead_code)]
 const INDEX_OP_MAX_MS: u128 = 10; // 10ms max for single index op (debug mode)
 const STATS_MAX_MS: u128 = 50; // 50ms max for stats (debug mode)
 
@@ -32,12 +33,14 @@ const STATS_MAX_MS: u128 = 50; // 50ms max for stats (debug mode)
 // ============================================================================
 
 /// Create fallback NER for testing (rule-based, no ONNX required)
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
 }
 
 /// Create experience with NER entity extraction
+#[allow(dead_code)]
 fn create_experience_with_ner(content: &str, ner: &NeuralNer) -> Experience {
     let entities = ner.extract(content).unwrap_or_default();
     let entity_names: Vec<String> = entities.iter().map(|e| e.text.clone()).collect();
@@ -91,6 +94,7 @@ fn create_rich_experience(i: usize) -> Experience {
 }
 
 /// Create rich experience with NER entity extraction
+#[allow(dead_code)]
 fn create_rich_experience_with_ner(i: usize, ner: &NeuralNer) -> Experience {
     let content = format!(
         "CEO Satya Nadella at Microsoft headquarters in Seattle discussed {} \
@@ -119,9 +123,10 @@ fn percentile(sorted_durations: &[u128], p: f64) -> u128 {
 }
 
 /// Collect timing samples for an operation
+#[allow(dead_code)]
 fn benchmark_operation<F>(op: F, iterations: usize) -> Vec<u128>
 where
-    F: Fn() -> (),
+    F: Fn(),
 {
     let mut durations = Vec::with_capacity(iterations);
     for _ in 0..iterations {
@@ -482,7 +487,7 @@ fn test_sla_flush_latency() {
 #[test]
 fn test_sla_concurrent_access_latency() {
     use std::sync::Arc;
-    use std::thread;
+    
 
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let config = create_test_config(&temp_dir);

--- a/tests/timing_sla_tests.rs
+++ b/tests/timing_sla_tests.rs
@@ -487,7 +487,6 @@ fn test_sla_flush_latency() {
 #[test]
 fn test_sla_concurrent_access_latency() {
     use std::sync::Arc;
-    
 
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let config = create_test_config(&temp_dir);

--- a/tests/universe_tests.rs
+++ b/tests/universe_tests.rs
@@ -17,12 +17,14 @@ use std::collections::HashMap;
 use tempfile::TempDir;
 
 /// Create fallback NER for testing (rule-based, no ONNX required)
+#[allow(dead_code)]
 fn setup_fallback_ner() -> NeuralNer {
     let config = NerConfig::default();
     NeuralNer::new_fallback(config)
 }
 
 /// Convert NER entity type to EntityLabel
+#[allow(dead_code)]
 fn ner_type_to_label(ner_type: &str) -> EntityLabel {
     match ner_type {
         "PER" => EntityLabel::Person,
@@ -33,6 +35,7 @@ fn ner_type_to_label(ner_type: &str) -> EntityLabel {
 }
 
 /// Create entity from NER extraction result
+#[allow(dead_code)]
 fn create_entity_from_ner(
     name: &str,
     ner_type: &str,
@@ -203,7 +206,7 @@ fn test_high_salience_near_center() {
 
     // Add high salience entity (proper noun with high initial salience)
     let high_entity = create_entity("CentralStar", Some(EntityLabel::Person), true, 0.9);
-    let high_salience_id = graph
+    let _high_salience_id = graph
         .add_entity(high_entity)
         .expect("Failed to add high salience entity");
 
@@ -328,7 +331,7 @@ fn test_star_size_based_on_salience() {
 
     // High salience star
     let high_entity = create_entity("BigStar", Some(EntityLabel::Person), true, 0.9);
-    let high_id = graph.add_entity(high_entity).expect("Failed");
+    let _high_id = graph.add_entity(high_entity).expect("Failed");
 
     for _ in 0..30 {
         let boost = create_entity("BigStar", Some(EntityLabel::Person), true, 0.9);
@@ -593,7 +596,7 @@ fn test_star_metadata() {
     let (graph, _temp_dir) = setup_graph_memory();
 
     let entity = create_entity("MetadataStar", Some(EntityLabel::Person), true, 0.6);
-    let entity_id = graph.add_entity(entity).expect("Failed");
+    let _entity_id = graph.add_entity(entity).expect("Failed");
 
     // Add some mentions
     for _ in 0..5 {


### PR DESCRIPTION
## Summary

Clean sweep of clippy 1.94 errors and warnings across both production lib and test code so all three gates pass with `-D warnings`:

- `cargo check --lib`
- `cargo clippy --lib -- -D warnings`
- `cargo clippy --tests --lib -- -D warnings`

Originally cut as a small pre-blocker for MCAP Phase 1 commit-1 DoD; expanded by request to cover the full test surface.

## What changed (35 files, +283/-278)

### Production lib — behavior-neutral refactors

- **`src/memory/hybrid_search.rs`** — Removed dead `get_content: F` closure parameter threaded through 5 wrapper layers (`search`, `search_with_ic_weights`, `search_with_ic_weights_and_phrases`, `search_with_dynamic_weights`, `search_with_dynamic_weights_pool`). The bottom layer ignored it (`_get_content`); the parameter served no purpose downstream. Fixes `clippy::too_many_arguments` (8/7).
- **`src/memory/mod.rs`** — Removed the `get_content,` arg from the lone external caller. Kept the closure declaration itself because it is still consumed by the prospective-signals boost (Layer 4.7) at line 2590 — added a comment narrowing its documented purpose.
- **`src/memory/query_parser.rs`** — `.iter().any(|x| *x == s.as_str())` → `.contains(&s.as_str())` (`POLAR_QUESTION_LEADERS` is `&[&str]`). Fixed doc-list 8-space continuation → 4-space.
- **`src/embeddings/chunking.rs`** — `x >= 5 && x <= 15` → `(5..=15).contains(&x)`.
- **`src/recall_harness/metrics.rs`** — Redundant closure `|n| Uuid::from_u128(n)` → `Uuid::from_u128`.
- **`src/token_estimation.rs`** — `(x * 3 + 1) / 2` → `(x * 3).div_ceil(2)`.

### Test code — cfg(test) modules inside src/

- **`src/auth.rs`** (8 `#[tokio::test]` fns) and **`src/middleware.rs`** (2 fns) — Added `#[allow(clippy::await_holding_lock)]` narrowly per test function. The `ENV_LOCK: Mutex<()>` is held across `.await` by design — it serializes tests that mutate process-global env vars (`SHODH_API_KEYS`, `SHODH_ENV`). Releasing earlier or swapping to `tokio::sync::Mutex` would reintroduce the cross-test env race the lock exists to prevent.
- **`src/handlers/state.rs`, `src/memory/graph_retrieval.rs`, `src/memory/types.rs`** — Converted `assert!(CONSTANT > 0.6, ...)` style runtime assertions on `const` values to `const _: () = assert!(...)`. These now fail at **compile time** instead of test time — strictly stronger. Tradeoff: runtime `{}` format args dropped (compile-time errors already point to the exact line and constant, no `format!` allowed in const-eval).
- **`src/handlers/test_helpers.rs`** — Added `impl Default for TestHarness { fn default() -> Self { Self::new() } }`.
- **`src/memory/replay.rs`** — `vec![(...)]` → `[(...)]` for one-shot literal.
- **`src/memory/graph_retrieval.rs`** — Same `useless_vec` cleanup at 5 sites.

### Test code — tests/ (15 files)

- **Dead-code allows** (`#[allow(dead_code)]`) added narrowly per-function to shared NER/setup helpers that are copy-pasted across test files (`setup_fallback_ner`, `create_experience_with_ner`, `create_entity_from_ner`, `ner_type_to_label`, `create_rich_experience_with_ner`, `create_conversation_experience`, `benchmark_operation`, `authed_put`, `authed_patch`, `INDEX_OP_MAX_MS`). Each test binary instantiates only the helpers it actually invokes, but the modules share a common copy-pasted block; deletion would force a per-file diff against the others. `#[allow]` is the honest fix.
- **`&[x.clone()]` → `std::slice::from_ref(&x)`** across `tests/brutal_stress_tests.rs`, `tests/memory_persistence_tests.rs`, `tests/hebbian_learning_tests.rs`, `tests/adaptive_memory_tests.rs` — eliminates redundant allocation in tests that pass a single-element slice.
- **Tautological `assert!(x >= 0)` on `usize`/`u32`/`u64` deleted** in `tests/brutal_stress_tests.rs`, `tests/memory_tiering_tests.rs`, `tests/adaptive_memory_tests.rs`, `tests/query_filter_tests.rs`. Where the surrounding call was a side-effect probe (e.g., `graph_stats()`), the call was preserved with an explanatory comment so the lint signal isn't silenced at the cost of the actual test intent.
- **`importance >= 0.0 && importance <= 1.0` → `(0.0..=1.0).contains(&importance)`** for legitimate float bounds checks (these are NOT tautological).
- **`format!` inside `.expect()` → `.unwrap_or_else(|_| panic!(...))`** in `tests/brutal_stress_tests.rs` and `tests/memory_persistence_tests.rs` — avoids eager allocation of the panic string on the hot success path.
- **`assert!(... > 0.0)` on imported constants → `const _: () = assert!(...)`** in `tests/query_filter_tests.rs`.

## Adversarial notes

- **Lesson from mid-fix bug:** my first pass at the `get_content` dead-parameter removal also deleted the closure construction in `memory/mod.rs`, breaking compilation because the closure is still consumed downstream by the prospective-signals layer. The parameter was dead in the search chain; the closure itself was not. Re-verified with `cargo check` before claiming the fix was complete. Pattern to watch: dead parameters at one level can mask still-live consumers elsewhere in the outer scope.
- **`await_holding_lock` allows are narrowly scoped per `#[tokio::test]` fn**, never module-wide. If you grep them out later, audit each — they exist because env-var serialization needs the lock across the request future. Removing the lock without a different serialization mechanism will reintroduce flaky test failures under `cargo test --jobs > 1`.
- **`const _: () = assert!(...)` over runtime `assert!`** chosen because the asserted value IS a `const`. Compile-time failure is strictly stronger than test-time failure and runs even with `#[ignore]`. Cost: lost runtime `{}` interpolation, but the failing constant's name and line are visible in the compiler error anyway.
- **Tautological asserts on unsigned types were deleted, not silenced.** `assert!(usize_val >= 0)` carries zero information. Where a message was potentially load-bearing for debugging the surrounding behavior, the side-effect call was preserved with a comment explaining why the original assertion was vacuous. No behavioral change.
- **Float `>= 0.0` bounds checks were preserved** (and modernized to range-contains where idiomatic). Only unsigned `>= 0` checks were deleted.
- **No `#[allow(...)]` was added at module/crate scope.** All allows are narrowly per-function or per-item.
- **Not in scope:** functional changes, dependency bumps, test additions, behavior changes. This PR is pure hygiene against clippy 1.94's expanded lint set.

## Test plan

- [ ] `cargo check --lib` passes
- [ ] `cargo clippy --lib -- -D warnings` passes
- [ ] `cargo clippy --tests --lib -- -D warnings` passes
- [ ] CI green
- [ ] (manual spot-check) at least one test from `tests/brutal_stress_tests.rs` runs successfully under `cargo test --test brutal_stress_tests` — confirms tautological assertion deletions didn't accidentally remove a load-bearing side effect

## Follow-up

This unblocks `feat/mcap-ingest` (MCAP Phase 1) whose commit-1 DoD requires `cargo clippy --features mcap --lib -- -D warnings` to be clean.
