### PR TITLE
fix(storage): migrate_legacy was a silent no-op

### DIFF
--- a/src/memory/storage.rs
+++ b/src/memory/storage.rs
@@ -2929,15 +2929,28 @@ impl MemoryStorage {
                 continue;
             }
 
-            // Try current format first (quick check) — postcard or bincode
-            let is_current = deserialize_memory(&value).is_ok();
-
-            if is_current {
+            // "Current" for this migration means SHO v2 (postcard) — the format
+            // every write path now produces. The old `deserialize_memory(..).is_ok()`
+            // check was wrong: deserialize_memory returns Ok for legacy records
+            // too (that is its whole purpose), so EVERY decodable record looked
+            // "current" and nothing was ever migrated. The `needs_migration`
+            // bool is also not a reliable discriminator here — its fallback path
+            // reports raw bincode 2.x as "current" (false) even though that data
+            // still needs converting to postcard. So gate on the SHO envelope
+            // version directly.
+            let is_current_postcard = matches!(
+                crate::serialization::unwrap_sho(&value),
+                Some((crate::serialization::SHO_VERSION_POSTCARD, _))
+            );
+            if is_current_postcard {
                 already_current += 1;
                 continue;
             }
 
-            // Not current format - try with fallback
+            // Anything else (SHO v1 bincode, raw bincode/msgpack) is legacy:
+            // decode via the full fallback chain and queue it for re-encode to
+            // postcard. A decode failure is counted as `failed`, never silently
+            // skipped.
             match deserialize_memory(&value) {
                 Ok((memory, _)) => {
                     to_migrate.push((key.to_vec(), memory));
@@ -3769,6 +3782,61 @@ mod tests {
         assert!(!is_legacy);
         // Current format is not a fallback — metric should NOT increment
         assert_eq!(after, before);
+    }
+
+    #[test]
+    fn test_migrate_legacy_converts_raw_bincode_and_is_idempotent() {
+        // Regression: migrate_legacy() decided "already current" via
+        // `deserialize_memory(..).is_ok()`, but that returns Ok for legacy
+        // records too (its whole purpose), so EVERY decodable record looked
+        // current and `migrated` was always 0 — a silent no-op. Verify a
+        // genuinely-legacy record (raw bincode 2.x, no SHO envelope) is migrated
+        // to postcard and that a second pass is idempotent.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = MemoryStorage::new(dir.path(), None).expect("storage");
+
+        let id = MemoryId(uuid::Uuid::new_v4());
+        let memory = sample_memory(id.clone(), "legacy raw bincode record");
+        // Raw bincode 2.x with NO SHO envelope — the pre-migration on-disk
+        // shape. (encode_sho would emit current postcard and defeat the test.)
+        let legacy_bytes =
+            bincode::serde::encode_to_vec(&memory, bincode::config::standard()).expect("encode");
+        assert!(
+            crate::serialization::unwrap_sho(&legacy_bytes).is_none(),
+            "fixture must NOT carry an SHO header"
+        );
+        storage
+            .db
+            .put(id.0.as_bytes(), &legacy_bytes)
+            .expect("seed legacy record");
+
+        // First pass must actually migrate the legacy record (was 0 before fix).
+        let (migrated, _already, failed) = storage.migrate_legacy().expect("migrate");
+        assert_eq!(migrated, 1, "the legacy record must be migrated to postcard");
+        assert_eq!(failed, 0, "no decode/write failures");
+
+        // The on-disk record is now SHO v2 postcard.
+        let raw = storage
+            .db
+            .get(id.0.as_bytes())
+            .expect("get")
+            .expect("record present");
+        assert!(
+            matches!(
+                crate::serialization::unwrap_sho(&raw),
+                Some((crate::serialization::SHO_VERSION_POSTCARD, _))
+            ),
+            "record must be rewritten as SHO v2 postcard"
+        );
+
+        // Second pass is a no-op: the record is already current.
+        let (migrated2, already_current2, failed2) = storage.migrate_legacy().expect("migrate2");
+        assert_eq!(migrated2, 0, "second pass migrates nothing");
+        assert!(
+            already_current2 >= 1,
+            "the now-postcard record must count as already current"
+        );
+        assert_eq!(failed2, 0);
     }
 
     #[test]

--- a/src/memory/storage.rs
+++ b/src/memory/storage.rs
@@ -3812,7 +3812,10 @@ mod tests {
 
         // First pass must actually migrate the legacy record (was 0 before fix).
         let (migrated, _already, failed) = storage.migrate_legacy().expect("migrate");
-        assert_eq!(migrated, 1, "the legacy record must be migrated to postcard");
+        assert_eq!(
+            migrated, 1,
+            "the legacy record must be migrated to postcard"
+        );
         assert_eq!(failed, 0, "no decode/write failures");
 
         // The on-disk record is now SHO v2 postcard.


### PR DESCRIPTION
## Problem

`MemoryStorage::migrate_legacy()` (exposed at `POST /api/storage/migrate`) reported success while migrating **zero** records.

It decided "already current" with:

```rust
let is_current = deserialize_memory(&value).is_ok();
if is_current { already_current += 1; continue; }
```

But `deserialize_memory` returns `Ok` for *legacy* records too — decode-with-fallback is its whole job. So every decodable record hit the `is_current` branch and was counted `already_current`; the `to_migrate` push lived in a second, unreachable match arm. `migrated` was therefore always `0`. Operators got a green "migration complete" while on-disk data stayed in the legacy format.

## Fix

Gate "current" on the **SHO envelope version** directly (`SHO v2` = postcard), which is the actual definition of "migrated" for this path:

```rust
let is_current_postcard = matches!(
    crate::serialization::unwrap_sho(&value),
    Some((crate::serialization::SHO_VERSION_POSTCARD, _))
);
```

The `needs_migration` bool from `deserialize_memory` is **not** a correct discriminator here — its fallback path reports raw bincode 2.x as "current" (`false`) even though that data still needs converting to postcard. Checking the envelope version migrates that class too. Also removes the redundant double-decode.

## Test

New `test_migrate_legacy_converts_raw_bincode_and_is_idempotent`: seeds a raw bincode 2.x record (no SHO header), asserts `migrate_legacy` rewrites it to SHO v2 postcard (`migrated == 1`), and that a second pass is idempotent (`migrated == 0`, counted `already_current`).

## Origin

Found in a multi-agent audit of the repo; verified against current `main`. Severity: high (silent data-migration integrity failure — operators believe data was upgraded when it wasn't).