### PR TITLE
fix(graph+vector): SPANN guards + relationship_count drift/underflow

### DIFF
--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -1511,7 +1511,7 @@ impl GraphMemory {
         let episodes_cf = db
             .cf_handle(CF_EPISODES)
             .ok_or_else(|| anyhow::anyhow!("CF '{}' not found after DB open", CF_EPISODES))?;
-        let relationship_count = Self::count_cf_entries(&db, relationships_cf);
+        let relationship_count = Self::count_relationship_edges(&db, relationships_cf);
         let episode_count = Self::count_cf_entries(&db, episodes_cf);
 
         // Load entity embedding cache for concept merging
@@ -1789,6 +1789,22 @@ impl GraphMemory {
     /// Count entries in a column family (one-time startup cost)
     fn count_cf_entries(db: &DB, cf: &ColumnFamily) -> usize {
         db.iterator_cf(cf, rocksdb::IteratorMode::Start).count()
+    }
+
+    /// Count only true relationship-edge records in the relationships CF.
+    ///
+    /// The relationships CF holds two kinds of keys: real edge records (16-byte
+    /// UUID key → encoded `RelationshipEdge`) and `mem_edge:<a>:<b>`
+    /// forward/reverse index keys (ASCII key → 16-byte edge UUID). The generic
+    /// `count_cf_entries` counts both, which over-states the edge count (~3x for
+    /// memory-pair edges). The startup seed for `relationship_count` must count
+    /// only the 16-byte-keyed edge records so it stays consistent with the
+    /// increments/decrements applied at runtime.
+    fn count_relationship_edges(db: &DB, cf: &ColumnFamily) -> usize {
+        db.iterator_cf(cf, rocksdb::IteratorMode::Start)
+            .filter_map(|r| r.ok())
+            .filter(|(key, _)| key.len() == 16)
+            .count()
     }
 
     /// Load entity embedding cache from persisted entities.
@@ -2717,7 +2733,15 @@ impl GraphMemory {
 
         // Delete from main storage
         self.db.delete_cf(self.relationships_cf(), key)?;
-        self.relationship_count.fetch_sub(1, Ordering::Relaxed);
+        // Saturating decrement: never wrap below 0. relationship_count is an
+        // accounting estimate that can legitimately drift (some creation paths
+        // historically omitted the increment), and a plain fetch_sub would wrap
+        // usize to ~1.8e19 once it hits 0.
+        let _ = self.relationship_count.fetch_update(
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+            |c| Some(c.saturating_sub(1)),
+        );
 
         // Remove from entity_edges index for BOTH entities
         // (add_relationship indexes both from_entity and to_entity)
@@ -3740,6 +3764,10 @@ impl GraphMemory {
             })?;
         let mut batch = WriteBatch::default();
         let mut strengthened = 0;
+        // Count of genuinely-new edges (the `else` branch below), tracked
+        // separately from `strengthened` (which also counts updates to existing
+        // edges) so relationship_count is incremented only for new records.
+        let mut new_edges = 0;
         let mut promotion_boosts = Vec::new();
 
         for (from_id_str, to_id_str, boost) in edge_boosts {
@@ -3845,12 +3873,22 @@ impl GraphMemory {
                     );
 
                     strengthened += 1;
+                    new_edges += 1;
                 }
             }
         }
 
         if strengthened > 0 {
             self.db.write(batch)?;
+
+            // Account for genuinely-new edges created above. Mirrors
+            // record_memory_coactivation; without this the counter drifts low
+            // while delete_relationship keeps decrementing, eventually
+            // (pre-saturation) underflowing it.
+            if new_edges > 0 {
+                self.relationship_count
+                    .fetch_add(new_edges, Ordering::Relaxed);
+            }
 
             // Index new replay edges in entity_edges CF so they're visible to
             // traversal and degree-cap enforcement (GQ-11 fix)

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -2737,11 +2737,11 @@ impl GraphMemory {
         // accounting estimate that can legitimately drift (some creation paths
         // historically omitted the increment), and a plain fetch_sub would wrap
         // usize to ~1.8e19 once it hits 0.
-        let _ = self.relationship_count.fetch_update(
-            Ordering::Relaxed,
-            Ordering::Relaxed,
-            |c| Some(c.saturating_sub(1)),
-        );
+        let _ = self
+            .relationship_count
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| {
+                Some(c.saturating_sub(1))
+            });
 
         // Remove from entity_edges index for BOTH entities
         // (add_relationship indexes both from_entity and to_entity)

--- a/src/vector_db/spann.rs
+++ b/src/vector_db/spann.rs
@@ -1205,7 +1205,9 @@ mod tests {
         };
 
         let mut index = SpannIndex::new(config);
-        let err = index.build(vectors).expect_err("build must reject use_pq=false");
+        let err = index
+            .build(vectors)
+            .expect_err("build must reject use_pq=false");
         assert!(
             err.to_string().contains("use_pq=true"),
             "error should explain PQ is required, got: {err}"

--- a/src/vector_db/spann.rs
+++ b/src/vector_db/spann.rs
@@ -365,6 +365,19 @@ impl SpannIndex {
             return Err(anyhow!("Cannot build index from empty vectors"));
         }
 
+        // SPANN posting entries store ONLY PQ codes, never the original vectors,
+        // so search() requires a PQ quantizer. A build with use_pq=false would
+        // succeed and persist, then fail every search — a silently dead index.
+        // Reject it up front. (Use the Vamana backend if exact, un-quantized
+        // vectors are required.)
+        if !self.config.use_pq {
+            return Err(anyhow!(
+                "SPANN requires PQ (use_pq=true): posting lists store only PQ \
+                 codes, not original vectors, so a non-PQ index cannot be \
+                 searched. Enable PQ or use the Vamana backend for exact vectors."
+            ));
+        }
+
         let n = vectors.len();
         let dim = vectors[0].len();
 
@@ -562,6 +575,20 @@ impl SpannIndex {
         let centroids = self.centroids.read();
         if centroids.is_empty() {
             return Ok(Vec::new());
+        }
+
+        // Guard against dimension mismatch. build() and ProductQuantizer::encode()
+        // both validate this, but search() did not — a short query reached
+        // pq::build_distance_table and panicked on an out-of-bounds subvector
+        // slice (and compute_distance would have silently truncated via zip).
+        // Fail with an error like the sibling methods instead of panicking the
+        // calling thread.
+        if query.len() != self.config.dimension {
+            return Err(anyhow!(
+                "Query dimension {} doesn't match index dimension {}",
+                query.len(),
+                self.config.dimension
+            ));
         }
 
         // Step 1: Find top-nprobes nearest partitions
@@ -1165,7 +1192,10 @@ mod tests {
     }
 
     #[test]
-    fn test_no_pq() {
+    fn test_build_rejects_use_pq_false() {
+        // SPANN cannot search a non-PQ index (posting entries hold only PQ
+        // codes). build() must reject use_pq=false up front rather than
+        // producing a successfully-built but permanently-unsearchable index.
         let vectors = generate_random_vectors(100, 384);
 
         let config = SpannConfig {
@@ -1175,8 +1205,32 @@ mod tests {
         };
 
         let mut index = SpannIndex::new(config);
-        index.build(vectors).unwrap();
+        let err = index.build(vectors).expect_err("build must reject use_pq=false");
+        assert!(
+            err.to_string().contains("use_pq=true"),
+            "error should explain PQ is required, got: {err}"
+        );
+    }
 
-        assert!(index.quantizer.read().is_none());
+    #[test]
+    fn test_search_rejects_dimension_mismatch() {
+        // A wrong-length query previously panicked inside PQ distance-table
+        // construction; it must now return an Err like build()/encode() do.
+        let vectors = generate_random_vectors(100, 384);
+        let config = SpannConfig {
+            dimension: 384,
+            ..Default::default()
+        };
+        let mut index = SpannIndex::new(config);
+        index.build(vectors).expect("build with PQ");
+
+        let bad_query = vec![0.1f32; 128]; // wrong dimension
+        let err = index
+            .search(&bad_query, 5)
+            .expect_err("search must reject a dimension-mismatched query");
+        assert!(
+            err.to_string().contains("dimension"),
+            "error should mention dimension, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
Two contained correctness fixes from the repo audit, grouped as one themed PR (graph + vector). Verified against current `main`; all SPANN (5) and graph_memory (61) lib tests pass.

## 1. SPANN robustness (`src/vector_db/spann.rs`)

**Panic on dimension mismatch.** `search()` never checked `query.len()` against `config.dimension`. With PQ enabled (the default), a short query reached `pq::build_distance_table` and **panicked** on an out-of-bounds subvector slice (and `compute_distance` would have silently truncated via `zip`). `build()` and `ProductQuantizer::encode()` already validate dimension; `search()` now returns an `Err` to match.

**Dead index when `use_pq=false`.** `build()` honored `use_pq=false` (no quantizer, `pq_codes=None`), but `search()` unconditionally bails when the quantizer is absent — so a non-PQ index built and persisted fine yet was **permanently un-searchable**, failure deferred to query time. SPANN posting entries store only PQ codes by design (Vamana is the exact-vector backend), so `build()` now rejects `use_pq=false` up front.

Tests: replaced `test_no_pq` (which built a dead index and never searched it) with `test_build_rejects_use_pq_false`; added `test_search_rejects_dimension_mismatch`.

## 2. `relationship_count` drift / underflow (`src/graph_memory.rs`)

`GraphStats.relationship_count` (via `get_stats`) was unreliable and could become an absurd wrapped value:

- `delete_relationship` did an unconditional `fetch_sub(1)` → once the counter hit 0, the next decrement wrapped `usize` to ~1.8e19. Now a **saturating** `fetch_update` floors at 0.
- `strengthen_memory_edges` (replay consolidation) created new edges via `batch.put_cf` but **never incremented** the counter → it drifted low. Now tracks `new_edges` separately from `strengthened` (which also counts updates to existing edges) and `fetch_add`s after the write, mirroring `record_memory_coactivation`.
- Startup seed used `count_cf_entries` over the whole relationships CF, which also counts the `mem_edge:` index keys in that CF (~3x over-count). New `count_relationship_edges` counts only 16-byte edge-record keys.

Severity: medium (monitoring-stat integrity; not persisted-data corruption).

## Deferred (separate PR)
The audit also found L2/L3 edge decay never reaches its power-law phase (the Wixted hybrid model) because `decay()` resets `last_activated` every cycle. That fix changes a **core marketed decay behavior** and needs a new persisted timestamp field + migration + reinforcement-path updates — too much to bundle here. Tracking separately.