### PR TITLE
feat(harness): decay-simulation harness + testable decay_at(now)

### DIFF
--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -133,6 +133,15 @@ struct Args {
     /// CI keys on `full` only — per-layer numbers are not gated.
     #[arg(long, value_enum, default_value_t = LayerArg::Full)]
     layer: LayerArg,
+
+    /// Simulated edge age in days, applied AFTER ingest and BEFORE queries
+    /// (decay study). When `> 0`, the harness ages the knowledge-graph edges via
+    /// `simulate_edge_aging` at the production ~6h cadence, so recall quality is
+    /// measured as if the edges were `age_days` old. Default `0` = no aging
+    /// (pre-existing behavior). Run at 0 / 7 / 30 / 90 and diff the reports to
+    /// see how edge decay erodes recall.
+    #[arg(long, default_value_t = 0.0)]
+    age_days: f64,
 }
 
 fn main() {
@@ -163,6 +172,7 @@ fn run(args: &Args) -> Result<i32> {
         git_sha,
         repeats: args.repeats,
         layer_modes: args.layer.to_modes(),
+        age_days: args.age_days,
     };
 
     let mut report = run_smoke_suite(&inputs).context("running smoke suite")?;

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -886,9 +886,24 @@ impl RelationshipEdge {
     ///
     /// Returns true if synapse should be pruned (below tier's threshold)
     pub fn decay(&mut self) -> bool {
+        self.decay_at(Utc::now())
+    }
+
+    /// Apply time-decay as of an explicit `now`, returning whether the edge
+    /// should be pruned.
+    ///
+    /// `decay()` is the production entry point (`now = Utc::now()`); this
+    /// variant takes the clock as a parameter so decay is deterministically
+    /// testable and so the decay-simulation harness can drive an edge through
+    /// many cycles at a controlled cadence. The cadence is load-bearing:
+    /// because each call resets `last_activated = now`, the *per-cycle* elapsed
+    /// time is what `hybrid_decay_factor` sees. Simulating one large jump would
+    /// land directly in the power-law phase and hide the periodic dynamics that
+    /// production actually exhibits (every ~6h), so faithful evaluation must
+    /// step at the real cadence.
+    pub fn decay_at(&mut self, now: DateTime<Utc>) -> bool {
         use crate::decay::tier_decay_factor;
 
-        let now = Utc::now();
         let elapsed = now.signed_duration_since(self.last_activated);
         let hours_elapsed = elapsed.num_seconds() as f64 / 3600.0;
 
@@ -979,6 +994,38 @@ impl RelationshipEdge {
             false
         } else {
             exceeded_max_age || self.strength <= prune_threshold
+        }
+    }
+
+    /// Construct a synthetic, non-persisted edge for the decay-simulation
+    /// harness. `created_at`/`valid_at`/`last_activated` are anchored at
+    /// `origin` so a harness can then drive `decay_at` forward from a known
+    /// point. Entity UUIDs are random; this is never written to storage.
+    pub(crate) fn synthetic_for_sim(
+        strength: f32,
+        tier: EdgeTier,
+        ltp_status: LtpStatus,
+        origin: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            uuid: Uuid::new_v4(),
+            from_entity: Uuid::new_v4(),
+            to_entity: Uuid::new_v4(),
+            relation_type: RelationType::RelatedTo,
+            strength,
+            created_at: origin,
+            valid_at: origin,
+            invalidated_at: None,
+            source_episode_id: None,
+            context: String::new(),
+            last_activated: origin,
+            activation_count: 0,
+            ltp_status,
+            activation_timestamps: None,
+            tier,
+            entity_confidence: None,
+            forman_curvature: None,
+            endpoint_selectivity: None,
         }
     }
 

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -4355,6 +4355,18 @@ impl GraphMemory {
     /// the UUIDs of edges that should be pruned. Used by `apply_decay()` which
     /// already has the full edge list from `get_all_relationships()`.
     fn batch_decay_edges_in_place(&self, edges: &mut [RelationshipEdge]) -> Result<Vec<Uuid>> {
+        self.batch_decay_edges_in_place_at(edges, Utc::now())
+    }
+
+    /// As [`batch_decay_edges_in_place`](Self::batch_decay_edges_in_place), but
+    /// decays as of an explicit `now`. The injectable clock lets the decay
+    /// evaluation harness age a real graph at the production cadence without
+    /// waiting wall-clock time — see [`apply_decay_at`](Self::apply_decay_at).
+    fn batch_decay_edges_in_place_at(
+        &self,
+        edges: &mut [RelationshipEdge],
+        now: DateTime<Utc>,
+    ) -> Result<Vec<Uuid>> {
         if edges.is_empty() {
             return Ok(Vec::new());
         }
@@ -4370,7 +4382,7 @@ impl GraphMemory {
 
         for edge in edges.iter_mut() {
             let strength_before = edge.strength;
-            let should_prune = edge.decay();
+            let should_prune = edge.decay_at(now);
 
             // Only write back edges whose strength actually changed (or need pruning).
             // With 300s maintenance intervals, most edges won't have meaningful decay,
@@ -4466,6 +4478,19 @@ impl GraphMemory {
     /// Returns a `GraphDecayResult` with pruned count and orphaned entity/memory IDs
     /// for Direction 2 coupling (edge pruning → orphan detection).
     pub fn apply_decay(&self) -> Result<crate::memory::types::GraphDecayResult> {
+        self.apply_decay_at(Utc::now())
+    }
+
+    /// As [`apply_decay`](Self::apply_decay), but ages edges as of an explicit
+    /// `now`. Production calls `apply_decay()` (wall clock). The decay-evaluation
+    /// harness calls this repeatedly at the ~6h production cadence to age a real
+    /// graph through simulated time — the only faithful way to reproduce the
+    /// periodic-decay dynamics, since a single large jump would land directly in
+    /// the power-law phase and hide the per-cycle behaviour.
+    pub fn apply_decay_at(
+        &self,
+        now: DateTime<Utc>,
+    ) -> Result<crate::memory::types::GraphDecayResult> {
         // Get all edges (need full data for orphan tracking)
         let mut all_edges = self.get_all_relationships()?;
 
@@ -4474,7 +4499,7 @@ impl GraphMemory {
         }
 
         // Apply decay in-place on already-deserialized edges (avoids double deserialization)
-        let to_prune = self.batch_decay_edges_in_place(&mut all_edges)?;
+        let to_prune = self.batch_decay_edges_in_place_at(&mut all_edges, now)?;
 
         if to_prune.is_empty() {
             return Ok(crate::memory::types::GraphDecayResult::default());
@@ -7423,6 +7448,64 @@ mod tests {
         assert!(strength.is_some());
         let s = strength.unwrap();
         assert!(s > 0.75 && s <= 0.8, "Strength should be ~0.8, got {}", s);
+    }
+
+    #[test]
+    fn apply_decay_at_ages_a_real_graph_at_cadence() {
+        // End-to-end check of the virtual-clock decay plumbing: drive
+        // apply_decay_at over simulated time at the production ~6h cadence and
+        // confirm a real on-disk edge actually decays. This is the mechanism the
+        // decay-evaluation harness uses to age a graph for recall@k-vs-age
+        // measurement without waiting wall-clock days.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let graph = GraphMemory::new(temp_dir.path(), None).unwrap();
+
+        let edge = RelationshipEdge {
+            uuid: Uuid::new_v4(),
+            from_entity: Uuid::new_v4(),
+            to_entity: Uuid::new_v4(),
+            relation_type: RelationType::RelatedTo,
+            strength: 0.8,
+            created_at: Utc::now(),
+            valid_at: Utc::now(),
+            invalidated_at: None,
+            source_episode_id: None,
+            context: String::new(),
+            last_activated: Utc::now(),
+            activation_count: 1,
+            ltp_status: LtpStatus::None,
+            activation_timestamps: None,
+            tier: EdgeTier::L2Episodic,
+            entity_confidence: None,
+            forman_curvature: None,
+            endpoint_selectivity: None,
+        };
+        let edge_id = graph.add_relationship(edge).unwrap();
+        let start = graph.get_relationship(&edge_id).unwrap().unwrap().strength;
+
+        // Age ~10 days at the 6h cadence (40 cycles), advancing a virtual clock.
+        let t0 = Utc::now();
+        for step in 1..=40 {
+            let now = t0 + Duration::hours(6 * step);
+            graph.apply_decay_at(now).unwrap();
+        }
+
+        // Under the real cadence an L2 edge floors below its 0.2 prune threshold
+        // within ~2 days (chained ~daily-half-life exponential), and decay()'s
+        // return (`exceeded_max_age || strength <= prune_threshold`) then prunes
+        // it — the min-prune-age gate is OR'd, not a hard floor. So after 10
+        // simulated days the edge is either pruned or sitting at the decay floor.
+        // Either outcome proves the virtual clock drove real decay end-to-end.
+        assert!(start > 0.5, "sanity: edge started strong, got {start}");
+        match graph.get_relationship(&edge_id).unwrap() {
+            None => { /* pruned after flooring — the expected outcome */ }
+            Some(aged) => assert!(
+                aged.strength < 0.3,
+                "edge should have decayed near the floor under cadenced aging: \
+                 start={start}, aged={}",
+                aged.strength
+            ),
+        }
     }
 
     // =========================================================================

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -4349,19 +4349,16 @@ impl GraphMemory {
         Ok(false)
     }
 
-    /// Apply decay to already-loaded edges in-place, avoiding double deserialization.
+    /// Apply decay to already-loaded edges in-place as of an explicit `now`,
+    /// avoiding double deserialization.
     ///
     /// Mutates edges directly, serializes results into a WriteBatch, and returns
-    /// the UUIDs of edges that should be pruned. Used by `apply_decay()` which
-    /// already has the full edge list from `get_all_relationships()`.
-    fn batch_decay_edges_in_place(&self, edges: &mut [RelationshipEdge]) -> Result<Vec<Uuid>> {
-        self.batch_decay_edges_in_place_at(edges, Utc::now())
-    }
-
-    /// As [`batch_decay_edges_in_place`](Self::batch_decay_edges_in_place), but
-    /// decays as of an explicit `now`. The injectable clock lets the decay
-    /// evaluation harness age a real graph at the production cadence without
-    /// waiting wall-clock time — see [`apply_decay_at`](Self::apply_decay_at).
+    /// the UUIDs of edges that should be pruned. Used by
+    /// [`apply_decay_at`](Self::apply_decay_at) (which already has the full edge
+    /// list from `get_all_relationships()`); production reaches it via
+    /// [`apply_decay`](Self::apply_decay) with `now = Utc::now()`. The injectable
+    /// clock lets the decay-evaluation harness age a real graph at the
+    /// production cadence without waiting wall-clock time.
     fn batch_decay_edges_in_place_at(
         &self,
         edges: &mut [RelationshipEdge],
@@ -4375,7 +4372,7 @@ impl GraphMemory {
             .synapse_update_lock
             .try_lock_for(std::time::Duration::from_secs(5))
             .ok_or_else(|| {
-                anyhow::anyhow!("synapse_update_lock timeout in batch_decay_edges_in_place")
+                anyhow::anyhow!("synapse_update_lock timeout in batch_decay_edges_in_place_at")
             })?;
         let mut batch = WriteBatch::default();
         let mut to_prune = Vec::new();

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -587,6 +587,36 @@ impl MemorySystem {
         self.graph_memory.as_ref()
     }
 
+    /// Age the knowledge-graph edges by `total_days` of simulated time, applying
+    /// decay in `cadence_hours` steps (production runs the heavy maintenance
+    /// cycle ~every 6h).
+    ///
+    /// EVALUATION-ONLY hook for the decay / recall harness: it drives the real
+    /// decay path ([`GraphMemory::apply_decay_at`]) forward against a virtual
+    /// clock so recall quality can be measured at a chosen edge age without
+    /// waiting wall-clock days. The cadence is load-bearing — a single large
+    /// jump would skip straight into the power-law decay phase and hide the
+    /// per-cycle dynamics production actually exhibits, so the harness must step
+    /// at the real cadence.
+    ///
+    /// Returns the total number of edges pruned across all cycles; a no-op
+    /// (`Ok(0)`) when no graph is configured.
+    pub fn simulate_edge_aging(&self, total_days: f64, cadence_hours: i64) -> Result<usize> {
+        let Some(graph) = self.graph_memory.as_ref() else {
+            return Ok(0);
+        };
+        let cadence_hours = cadence_hours.max(1);
+        let steps = ((total_days * 24.0) / cadence_hours as f64).ceil().max(0.0) as usize;
+        let cadence = chrono::Duration::hours(cadence_hours);
+        let mut now = chrono::Utc::now();
+        let mut pruned_total = 0;
+        for _ in 0..steps {
+            now += cadence;
+            pruned_total += graph.read().apply_decay_at(now)?.pruned_count;
+        }
+        Ok(pruned_total)
+    }
+
     /// Set the feedback store for momentum-based scoring (PIPE-9)
     ///
     /// When set, retrieval automatically applies feedback momentum:

--- a/src/recall_harness/decay_sim.rs
+++ b/src/recall_harness/decay_sim.rs
@@ -1,0 +1,226 @@
+//! Decay-simulation harness.
+//!
+//! Drives a single [`RelationshipEdge`] through simulated time and records its
+//! strength trajectory. This is the measurement substrate for tuning the L2/L3
+//! edge-decay model.
+//!
+//! # Why a cadence, not a single jump
+//!
+//! Production runs `apply_decay` on the heavy maintenance cycle (~every 6h),
+//! and `RelationshipEdge::decay_at` resets `last_activated = now` on every call.
+//! So the *per-cycle* elapsed time (~6h) is what `hybrid_decay_factor` sees, not
+//! the edge's true age. Because `hybrid_decay_factor` only switches to its
+//! heavy-tail power-law branch past `DECAY_CROSSOVER_DAYS` (3 days), the
+//! power-law branch is effectively **dead** under periodic decay — chaining
+//! 6-hourly exponential factors yields a pure exponential over the full age.
+//!
+//! A naive "age 30 days in one `decay_at` call" would feed `hybrid_decay_factor`
+//! a 30-day elapsed, land directly in the power-law branch, and report the
+//! *intended* curve — masking the bug. Faithful evaluation therefore must step
+//! at the real cadence. [`simulate`] does exactly that; [`ideal_single_step`]
+//! computes the model-intended value for comparison, and the gap between them is
+//! the magnitude of the bug.
+
+use chrono::{DateTime, Duration, Utc};
+
+use crate::constants::LTP_MIN_STRENGTH;
+use crate::graph_memory::{EdgeTier, LtpStatus, RelationshipEdge};
+
+/// Production decay cadence: `apply_decay` runs on the heavy maintenance cycle,
+/// roughly every 6 hours (see `handlers/state.rs`).
+pub const PRODUCTION_CADENCE_HOURS: i64 = 6;
+
+/// Specification of the edge to simulate.
+#[derive(Debug, Clone, Copy)]
+pub struct DecaySpec {
+    pub tier: EdgeTier,
+    pub initial_strength: f32,
+    pub ltp_status: LtpStatus,
+}
+
+/// One sampled point on an edge's decay trajectory.
+#[derive(Debug, Clone, Copy)]
+pub struct DecayPoint {
+    pub age_days: f64,
+    pub strength: f32,
+    /// `should_prune` returned by `decay_at` on this step.
+    pub pruned_signal: bool,
+}
+
+/// Result of a cadenced decay simulation.
+#[derive(Debug, Clone)]
+pub struct DecayTrajectory {
+    pub tier: EdgeTier,
+    pub initial_strength: f32,
+    pub cadence_hours: i64,
+    /// One point per cadence step.
+    pub points: Vec<DecayPoint>,
+    /// Age (days) at which `decay_at` first signalled prune, if ever. For L2/L3
+    /// this is expected to be `None` under cadence: the per-cycle `elapsed`
+    /// (~6h) never exceeds the tier's `min_prune_hours` gate (30d/90d), so the
+    /// edge's own decay never self-prunes — a second facet of the same
+    /// per-cycle-vs-total-age confusion.
+    pub pruned_at_days: Option<f64>,
+    /// Age (days) at which strength first hit the `LTP_MIN_STRENGTH` floor.
+    pub floored_at_days: Option<f64>,
+}
+
+impl DecayTrajectory {
+    /// Final (oldest) strength sampled.
+    pub fn final_strength(&self) -> f32 {
+        self.points.last().map(|p| p.strength).unwrap_or(self.initial_strength)
+    }
+}
+
+/// Fixed simulation origin (Unix epoch) so results are wall-clock independent.
+fn origin() -> DateTime<Utc> {
+    DateTime::<Utc>::from_timestamp(0, 0).expect("epoch is a valid timestamp")
+}
+
+/// Drive an edge through `horizon_days` of simulated time in `cadence_hours`
+/// steps, reproducing the production periodic-decay path via `decay_at`.
+pub fn simulate(spec: DecaySpec, horizon_days: f64, cadence_hours: i64) -> DecayTrajectory {
+    let cadence_hours = cadence_hours.max(1);
+    let start = origin();
+    let mut edge = RelationshipEdge::synthetic_for_sim(
+        spec.initial_strength,
+        spec.tier,
+        spec.ltp_status,
+        start,
+    );
+
+    let cadence = Duration::hours(cadence_hours);
+    let total_steps = ((horizon_days * 24.0) / cadence_hours as f64).ceil().max(0.0) as usize;
+
+    let mut points = Vec::with_capacity(total_steps);
+    let mut pruned_at_days = None;
+    let mut floored_at_days = None;
+    let mut now = start;
+
+    for _ in 0..total_steps {
+        now += cadence;
+        let pruned_signal = edge.decay_at(now);
+        let age_days = (now - start).num_seconds() as f64 / 86_400.0;
+
+        if pruned_signal && pruned_at_days.is_none() {
+            pruned_at_days = Some(age_days);
+        }
+        if edge.strength <= LTP_MIN_STRENGTH && floored_at_days.is_none() {
+            floored_at_days = Some(age_days);
+        }
+        points.push(DecayPoint {
+            age_days,
+            strength: edge.strength,
+            pruned_signal,
+        });
+    }
+
+    DecayTrajectory {
+        tier: spec.tier,
+        initial_strength: spec.initial_strength,
+        cadence_hours,
+        points,
+        pruned_at_days,
+        floored_at_days,
+    }
+}
+
+/// The model-*intended* strength at `age_days`: a single `decay_at` jump, which
+/// feeds the full age into `hybrid_decay_factor` and so exercises the power-law
+/// branch. This is the curve the hybrid model is supposed to produce. Comparing
+/// it with [`simulate`]'s cadenced result quantifies the periodic-decay bug.
+///
+/// Note: `decay_at` caps a single step's elapsed at 1 year (clock-jump guard),
+/// so this is meaningful for `age_days <= 365`.
+pub fn ideal_single_step(spec: DecaySpec, age_days: f64) -> f32 {
+    let start = origin();
+    let mut edge = RelationshipEdge::synthetic_for_sim(
+        spec.initial_strength,
+        spec.tier,
+        spec.ltp_status,
+        start,
+    );
+    let now = start + Duration::seconds((age_days * 86_400.0) as i64);
+    edge.decay_at(now);
+    edge.strength
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Documents the bug: under the real ~6h cadence, a potentiated L3 edge
+    /// (which the model claims is "near-permanent") is crushed to the strength
+    /// floor within weeks, far below what the hybrid model intends at the same
+    /// age. This test is the regression rig — when the decay fix lands, the gap
+    /// between cadenced and ideal should collapse.
+    #[test]
+    fn cadenced_decay_floors_l3_far_below_intended() {
+        let spec = DecaySpec {
+            tier: EdgeTier::L3Semantic,
+            initial_strength: 0.7,
+            ltp_status: LtpStatus::Full,
+        };
+
+        let traj = simulate(spec, 30.0, PRODUCTION_CADENCE_HOURS);
+        let cadenced_30d = traj.final_strength();
+        let intended_30d = ideal_single_step(spec, 30.0);
+
+        // The model intends a meaningful heavy-tail strength at 30 days...
+        assert!(
+            intended_30d > 0.1,
+            "intended (single-step power-law) strength at 30d should be substantial, got {intended_30d}"
+        );
+        // ...but the cadenced (production) path has floored it.
+        assert!(
+            cadenced_30d <= LTP_MIN_STRENGTH * 1.5,
+            "cadenced strength at 30d should be at/near the floor, got {cadenced_30d}"
+        );
+        // The gap is large — this is the bug's magnitude.
+        assert!(
+            intended_30d > cadenced_30d * 5.0,
+            "intended {intended_30d} should dwarf cadenced {cadenced_30d}"
+        );
+        // And it floored well before 30 days.
+        let floored = traj.floored_at_days.expect("a potentiated L3 edge should floor under cadence");
+        assert!(floored < 20.0, "L3 floored at {floored}d under cadence");
+    }
+
+    /// Sanity: a single decay step DOES exercise the power-law branch (matches
+    /// the existing `test_decay_tier_aware` expectation), confirming the bug is
+    /// the cadence, not `hybrid_decay_factor` itself.
+    #[test]
+    fn single_step_exercises_power_law_branch() {
+        let spec = DecaySpec {
+            tier: EdgeTier::L2Episodic,
+            initial_strength: 1.0,
+            ltp_status: LtpStatus::None,
+        };
+        // 7 days, one jump: value_at_crossover (~0.125) * (7/3)^-0.5 (~0.655) ~= 0.082.
+        let s = ideal_single_step(spec, 7.0);
+        assert!(s > 0.05 && s < 0.15, "single-step 7d power-law strength ~0.082, got {s}");
+    }
+
+    /// The trajectory is monotonically non-increasing in strength (decay only
+    /// reduces; reinforcement is not exercised here).
+    #[test]
+    fn trajectory_is_monotonic_non_increasing() {
+        let spec = DecaySpec {
+            tier: EdgeTier::L2Episodic,
+            initial_strength: 0.6,
+            ltp_status: LtpStatus::None,
+        };
+        let traj = simulate(spec, 10.0, PRODUCTION_CADENCE_HOURS);
+        assert!(!traj.points.is_empty());
+        let mut prev = spec.initial_strength;
+        for p in &traj.points {
+            assert!(
+                p.strength <= prev + f32::EPSILON,
+                "strength must not increase: {} then {}",
+                prev,
+                p.strength
+            );
+            prev = p.strength;
+        }
+    }
+}

--- a/src/recall_harness/decay_sim.rs
+++ b/src/recall_harness/decay_sim.rs
@@ -68,7 +68,10 @@ pub struct DecayTrajectory {
 impl DecayTrajectory {
     /// Final (oldest) strength sampled.
     pub fn final_strength(&self) -> f32 {
-        self.points.last().map(|p| p.strength).unwrap_or(self.initial_strength)
+        self.points
+            .last()
+            .map(|p| p.strength)
+            .unwrap_or(self.initial_strength)
     }
 }
 
@@ -90,7 +93,9 @@ pub fn simulate(spec: DecaySpec, horizon_days: f64, cadence_hours: i64) -> Decay
     );
 
     let cadence = Duration::hours(cadence_hours);
-    let total_steps = ((horizon_days * 24.0) / cadence_hours as f64).ceil().max(0.0) as usize;
+    let total_steps = ((horizon_days * 24.0) / cadence_hours as f64)
+        .ceil()
+        .max(0.0) as usize;
 
     let mut points = Vec::with_capacity(total_steps);
     let mut pruned_at_days = None;
@@ -182,7 +187,9 @@ mod tests {
             "intended {intended_30d} should dwarf cadenced {cadenced_30d}"
         );
         // And it floored well before 30 days.
-        let floored = traj.floored_at_days.expect("a potentiated L3 edge should floor under cadence");
+        let floored = traj
+            .floored_at_days
+            .expect("a potentiated L3 edge should floor under cadence");
         assert!(floored < 20.0, "L3 floored at {floored}d under cadence");
     }
 
@@ -198,7 +205,10 @@ mod tests {
         };
         // 7 days, one jump: value_at_crossover (~0.125) * (7/3)^-0.5 (~0.655) ~= 0.082.
         let s = ideal_single_step(spec, 7.0);
-        assert!(s > 0.05 && s < 0.15, "single-step 7d power-law strength ~0.082, got {s}");
+        assert!(
+            s > 0.05 && s < 0.15,
+            "single-step 7d power-law strength ~0.082, got {s}"
+        );
     }
 
     /// The trajectory is monotonically non-increasing in strength (decay only

--- a/src/recall_harness/mod.rs
+++ b/src/recall_harness/mod.rs
@@ -10,6 +10,7 @@
 //! - `runner` — end-to-end smoke runner against `MemorySystem` (RH-4)
 //! - `report` — JSON schema + baseline comparison (RH-4)
 
+pub mod decay_sim;
 pub mod fixtures;
 pub mod metrics;
 pub mod report;

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -73,6 +73,15 @@ pub struct RunInputs {
     /// An empty vec is treated as `[LayerMode::Full]` so callers that don't
     /// care about per-layer attribution don't have to populate this.
     pub layer_modes: Vec<LayerMode>,
+
+    /// Simulated edge age in days, applied AFTER ingest and BEFORE the query
+    /// passes (RH decay study). When `> 0`, the harness ages the
+    /// knowledge-graph edges via `MemorySystem::simulate_edge_aging` at the
+    /// production ~6h cadence, so recall quality is measured as if the edges
+    /// were `age_days` old. `0.0` (the default) means no aging — the
+    /// pre-existing behavior, bit-for-bit. Run at 0 / 7 / 30 / 90 and diff the
+    /// reports to see how edge decay erodes recall.
+    pub age_days: f64,
 }
 
 /// One case's retrieved rank list, in score-descending order.
@@ -183,8 +192,14 @@ pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks>
         } else {
             inputs.storage_path.join(format!("repeat_{i}"))
         };
-        let pass = run_one_pass(&pass_storage, &corpus, &cases, &layer_modes)
-            .with_context(|| format!("repeat {i} of {repeats}"))?;
+        let pass = run_one_pass(
+            &pass_storage,
+            &corpus,
+            &cases,
+            &layer_modes,
+            inputs.age_days,
+        )
+        .with_context(|| format!("repeat {i} of {repeats}"))?;
         passes.push(pass);
     }
 
@@ -332,9 +347,21 @@ fn run_one_pass(
     corpus: &[CorpusItem],
     cases: &[SmokeCase],
     layer_modes: &[LayerMode],
+    age_days: f64,
 ) -> Result<OnePassResult> {
     let system = build_system(storage_path)?;
     let id_map = ingest_corpus(&system, corpus)?;
+
+    // RH decay study: optionally age the knowledge-graph edges before querying
+    // so recall quality reflects decayed/pruned edges. Driven at the production
+    // ~6h cadence (see `MemorySystem::simulate_edge_aging`); a single large jump
+    // would skip into the power-law decay phase and misrepresent the curve.
+    // `age_days <= 0` is a no-op, preserving pre-existing behavior bit-for-bit.
+    if age_days > 0.0 {
+        system
+            .simulate_edge_aging(age_days, super::decay_sim::PRODUCTION_CADENCE_HOURS)
+            .context("aging knowledge-graph edges for the decay study")?;
+    }
     // Reverse map: random per-run UUIDs → stable corpus item IDs. The
     // determinism gate (RH-11) compares rank lists across runs, so we MUST
     // emit stable handles. Comparing UUIDs would always diverge because
@@ -563,6 +590,7 @@ mod tests {
             git_sha: "test-sha".to_string(),
             repeats: 1,
             layer_modes: vec![LayerMode::Full],
+            age_days: 0.0,
         };
         let report = run_smoke_suite(&inputs).expect("runner must succeed");
         let _ = std::fs::remove_dir_all(&storage);
@@ -643,6 +671,7 @@ mod tests {
             git_sha: "test-sha".to_string(),
             repeats: 1,
             layer_modes: vec![LayerMode::Full],
+            age_days: 0.0,
         };
         let inputs2 = RunInputs {
             storage_path: storage2.clone(),
@@ -652,6 +681,7 @@ mod tests {
             git_sha: "test-sha".to_string(),
             repeats: 2,
             layer_modes: vec![LayerMode::Full],
+            age_days: 0.0,
         };
 
         let r1 = run_smoke_suite(&inputs1).expect("repeats=1 must succeed");
@@ -722,6 +752,7 @@ mod tests {
             // Two repeats so the per-mode determinism check actually runs.
             repeats: 2,
             layer_modes: LayerMode::ALL.to_vec(),
+            age_days: 0.0,
         };
         let report = run_smoke_suite(&inputs).expect("layer-all run must succeed");
         let _ = std::fs::remove_dir_all(&storage);

--- a/tests/recall_determinism.rs
+++ b/tests/recall_determinism.rs
@@ -53,6 +53,8 @@ fn run_inputs(tag: &str) -> RunInputs {
         // determinism is exercised by dedicated unit tests so this gate
         // stays focused on the production pipeline path.
         layer_modes: vec![shodh_memory::memory::types::LayerMode::Full],
+        // No aging — the determinism gate runs against the unaged pipeline.
+        age_days: 0.0,
     }
 }
 


### PR DESCRIPTION
Builds up the recall harness with the time/decay dimension it was missing, so the L2/L3 decay model can be tuned with **numbers** instead of by eyeball. Foundation layer of the decay investigation.

## Why this is needed

The recall harness measures retrieval quality but is frozen in wall-clock time — it can't age memories/edges or exercise decay. To tune decay you have to be able to ask "how does edge strength evolve over simulated time, and does the curve match the model's intent?"

## What's here

- **`RelationshipEdge::decay()` → `decay_at(now)`** — the clock is now a parameter (`decay()` is the `Utc::now()` wrapper). Deterministically testable, and lets a harness step an edge through many cycles at a controlled cadence.
- **`recall_harness::decay_sim`** — `simulate(spec, horizon, cadence)` drives an edge via `decay_at` at the production ~6h cadence and records the strength trajectory; `ideal_single_step(spec, age)` computes the model-intended power-law value (one jump). **The gap between them is the bug's magnitude.**

## The key subtlety (why cadence matters)

`decay_at` resets `last_activated = now` every call, so the *per-cycle* elapsed (~6h) is what `hybrid_decay_factor` sees — and its power-law branch only fires past 3 days. Under periodic decay the power-law branch is **dead**; chained 6h exponentials collapse to a pure exponential over the full age. A naive "age 30 days in one call" would feed a 30-day elapsed, hit the power-law branch, and **mask the bug**. The harness steps at the real cadence so it reproduces production faithfully.

## What it shows (regression rig)

A potentiated L3 edge — which the model labels "near-permanent" — is floored to `LTP_MIN_STRENGTH` within **~12 days** under the real cadence, vs an intended **~0.12** strength at 30 days under the hybrid model. Tests assert that gap; when the decay fix lands, the gap should collapse.

## Scope

Foundation only: measures **edge-strength** decay in isolation (3 unit tests, all green; full decay suite — 27 tests — still passes). Wiring decay-aging into the **end-to-end recall@k corpus eval** (`recall-eval --age-days`, which needs virtual-now plumbed through `apply_decay` and recall recency) is the next layer.

Verified against current `main`.