### PR TITLE
fix(benches): repair API-drift so all benchmarks compile

### DIFF
--- a/benches/associative_retrieval_benchmarks.rs
+++ b/benches/associative_retrieval_benchmarks.rs
@@ -40,6 +40,7 @@ fn create_entity(name: &str, label: EntityLabel, salience: f32) -> EntityNode {
         name_embedding: None,
         salience,
         is_proper_noun: true,
+        selectivity: None,
     }
 }
 
@@ -67,6 +68,8 @@ fn create_relationship(
         tier: Default::default(),
         activation_timestamps: None,
         entity_confidence: None,
+        forman_curvature: None,
+        endpoint_selectivity: None,
     }
 }
 

--- a/benches/graph_benchmarks.rs
+++ b/benches/graph_benchmarks.rs
@@ -54,6 +54,7 @@ fn create_entity(
         name_embedding: None,
         salience,
         is_proper_noun: is_proper,
+        selectivity: None,
     }
 }
 
@@ -82,6 +83,8 @@ fn create_relationship(
         tier: Default::default(),
         activation_timestamps: None,
         entity_confidence: None,
+        forman_curvature: None,
+        endpoint_selectivity: None,
     }
 }
 

--- a/benches/relevance_benchmarks.rs
+++ b/benches/relevance_benchmarks.rs
@@ -138,6 +138,7 @@ fn bench_full_pipeline(c: &mut Criterion) {
                     &memory_system,
                     None,
                     &config,
+                    None,
                 )
             });
         });
@@ -169,6 +170,7 @@ fn bench_latency_verification(c: &mut Criterion) {
                 &memory_system,
                 None,
                 &config,
+                None,
             )
         });
     });
@@ -188,7 +190,7 @@ fn bench_latency_verification(c: &mut Criterion) {
 
     for (name, context) in contexts.iter() {
         group.bench_function(*name, |b| {
-            b.iter(|| engine.surface_relevant(context, &memory_system, None, &config));
+            b.iter(|| engine.surface_relevant(context, &memory_system, None, &config, None));
         });
     }
 
@@ -226,6 +228,7 @@ fn bench_config_variations(c: &mut Criterion) {
                         &memory_system,
                         None,
                         &config,
+                        None,
                     )
                 });
             },
@@ -252,6 +255,7 @@ fn bench_config_variations(c: &mut Criterion) {
                     &memory_system,
                     None,
                     &config,
+                    None,
                 )
             });
         });
@@ -291,6 +295,7 @@ fn bench_threshold_impact(c: &mut Criterion) {
                         &memory_system,
                         None,
                         &config,
+                        None,
                     )
                 });
             },

--- a/benches/streaming_benchmarks.rs
+++ b/benches/streaming_benchmarks.rs
@@ -142,6 +142,10 @@ fn create_handshake(mode: StreamMode) -> StreamHandshake {
                 "decision".to_string(),
                 "discovery".to_string(),
             ],
+            // Fill any fields added to ExtractionConfig since this bench was
+            // written (e.g. the context-injection knobs) so the literal stays
+            // compilable as the config evolves.
+            ..ExtractionConfig::default()
         },
         session_id: None,
         metadata: HashMap::new(),
@@ -402,8 +406,9 @@ fn bench_message_processing(c: &mut Criterion) {
     // Content message processing
     group.bench_function("process_content_message", |b| {
         let extractor = StreamingMemoryExtractor::new(Arc::clone(&ner));
-        let session_id =
-            rt.block_on(extractor.create_session(create_handshake(StreamMode::Conversation)));
+        let session_id = rt
+            .block_on(extractor.create_session(create_handshake(StreamMode::Conversation)))
+            .expect("bench: create_session");
 
         b.iter(|| {
             let msg = create_content_message(CONVERSATION_MESSAGES[0]);
@@ -414,7 +419,9 @@ fn bench_message_processing(c: &mut Criterion) {
     // Event message processing
     group.bench_function("process_event_message", |b| {
         let extractor = StreamingMemoryExtractor::new(Arc::clone(&ner));
-        let session_id = rt.block_on(extractor.create_session(create_handshake(StreamMode::Event)));
+        let session_id = rt
+            .block_on(extractor.create_session(create_handshake(StreamMode::Event)))
+            .expect("bench: create_session");
 
         b.iter(|| {
             let (severity, event, desc) = EVENT_MESSAGES[0];
@@ -426,8 +433,9 @@ fn bench_message_processing(c: &mut Criterion) {
     // Sensor message processing
     group.bench_function("process_sensor_message", |b| {
         let extractor = StreamingMemoryExtractor::new(Arc::clone(&ner));
-        let session_id =
-            rt.block_on(extractor.create_session(create_handshake(StreamMode::Sensor)));
+        let session_id = rt
+            .block_on(extractor.create_session(create_handshake(StreamMode::Sensor)))
+            .expect("bench: create_session");
 
         b.iter(|| {
             let (sensor_id, value, unit) = SENSOR_READINGS[0];
@@ -439,8 +447,9 @@ fn bench_message_processing(c: &mut Criterion) {
     // Ping message (baseline)
     group.bench_function("process_ping", |b| {
         let extractor = StreamingMemoryExtractor::new(Arc::clone(&ner));
-        let session_id =
-            rt.block_on(extractor.create_session(create_handshake(StreamMode::Conversation)));
+        let session_id = rt
+            .block_on(extractor.create_session(create_handshake(StreamMode::Conversation)))
+            .expect("bench: create_session");
 
         b.iter(|| {
             rt.block_on(extractor.process_message(
@@ -480,7 +489,8 @@ fn bench_batch_throughput(c: &mut Criterion) {
                 let memory_arc = Arc::new(parking_lot::RwLock::new(memory_system));
                 let extractor = StreamingMemoryExtractor::new(Arc::clone(&ner));
                 let session_id = rt
-                    .block_on(extractor.create_session(create_handshake(StreamMode::Conversation)));
+                    .block_on(extractor.create_session(create_handshake(StreamMode::Conversation)))
+                    .expect("bench: create_session");
 
                 // Pre-generate messages
                 let messages: Vec<StreamMessage> = (0..size)
@@ -612,7 +622,8 @@ fn bench_full_extraction_pipeline(c: &mut Criterion) {
                     // Create session
                     let session_id = extractor
                         .create_session(create_handshake(StreamMode::Conversation))
-                        .await;
+                        .await
+                        .expect("bench: create_session");
 
                     // Buffer messages
                     for msg in CONVERSATION_MESSAGES {
@@ -648,7 +659,8 @@ fn bench_full_extraction_pipeline(c: &mut Criterion) {
                 rt.block_on(async {
                     let session_id = extractor
                         .create_session(create_handshake(StreamMode::Event))
-                        .await;
+                        .await
+                        .expect("bench: create_session");
 
                     // Buffer some events
                     for (severity, event, desc) in &EVENT_MESSAGES[..5] {
@@ -705,8 +717,9 @@ fn bench_streaming_summary(c: &mut Criterion) {
 
         // Session creation
         let start = Instant::now();
-        let session_id =
-            rt.block_on(extractor.create_session(create_handshake(StreamMode::Conversation)));
+        let session_id = rt
+            .block_on(extractor.create_session(create_handshake(StreamMode::Conversation)))
+            .expect("bench: create_session");
         session_times.push(start.elapsed());
 
         // Message buffering


### PR DESCRIPTION
CI never compiles benches (`cargo build` skips them), so API changes silently broke them over time. Four benches had rotted:

- **streaming_benchmarks**: `ExtractionConfig` gained fields → `..ExtractionConfig::default()`; `create_session` now returns `Result` → unwrap at each call site.
- **graph_benchmarks**, **associative_retrieval_benchmarks**: `EntityNode.selectivity`, `RelationshipEdge.{forman_curvature,endpoint_selectivity}` added → `: None`.
- **relevance_benchmarks**: `surface_relevant` gained a 5th param (`Option<&RwLock<FeedbackStore>>`) → pass `None`.

`cargo check --all-targets` is now clean (all 12 benches + tests + bins).

**Follow-up recommended:** add a `cargo check --benches` (or `--all-targets`) step to CI so benches can't silently rot again — that's the root cause of this drift.