### PR TITLE
fix(retrieval): harden against panics on adversarial / non-ASCII input

### DIFF
--- a/src/memory/hybrid_search.rs
+++ b/src/memory/hybrid_search.rs
@@ -802,7 +802,9 @@ impl HybridSearchEngine {
                 bm25_weight,
                 vector_weight,
                 keyword_discriminativeness,
-                &query[..query.len().min(50)]
+                // Char-safe preview: `&query[..50]` would panic if byte 50 lands
+                // inside a multi-byte UTF-8 codepoint (CJK/emoji/accented input).
+                super::char_truncate(query, 50)
             );
         }
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -299,6 +299,47 @@ fn tokenize_words(text: &str) -> HashSet<&str> {
         .collect()
 }
 
+/// Char-safe prefix of `s` containing at most `max_chars` characters.
+///
+/// Unlike `&s[..n]`, this never panics on a multi-byte UTF-8 boundary, so it is
+/// safe for previews / log lines / display truncation of arbitrary user text
+/// (CJK, emoji, accented input). Returns the whole string when it is already
+/// `<= max_chars` characters; the caller can detect truncation by comparing
+/// `result.len()` to `s.len()`.
+pub(crate) fn char_truncate(s: &str, max_chars: usize) -> &str {
+    match s.char_indices().nth(max_chars) {
+        Some((idx, _)) => &s[..idx],
+        None => s,
+    }
+}
+
+#[cfg(test)]
+mod char_truncate_tests {
+    use super::char_truncate;
+
+    #[test]
+    fn never_splits_multibyte_utf8() {
+        // <= max_chars → returned unchanged
+        assert_eq!(char_truncate("hello", 10), "hello");
+        assert_eq!(char_truncate("abcde", 5), "abcde");
+        assert_eq!(char_truncate("", 5), "");
+        // plain ASCII truncation
+        assert_eq!(char_truncate("hello", 3), "hel");
+        assert_eq!(char_truncate("anything", 0), "");
+        // CJK: 3 bytes/char — `&s[..2]` would panic mid-codepoint.
+        let cjk = "你好世界"; // 4 chars, 12 bytes
+        assert_eq!(char_truncate(cjk, 2), "你好");
+        assert_eq!(char_truncate(cjk, 4), cjk);
+        assert_eq!(char_truncate(cjk, 99), cjk);
+        // Emoji: 4 bytes/char.
+        let emoji = "😀😁😂";
+        assert_eq!(char_truncate(emoji, 1), "😀");
+        assert_eq!(char_truncate(emoji, 3), emoji);
+        // The result is always a prefix shorter-or-equal in bytes.
+        assert!(char_truncate(cjk, 2).len() < cjk.len());
+    }
+}
+
 impl MemorySystem {
     /// Create a new memory system.
     ///

--- a/src/memory/query_parser.rs
+++ b/src/memory/query_parser.rs
@@ -552,17 +552,32 @@ fn extract_relative_dates(
 
     // "N days/weeks/months ago"
     for cap in AGO_RE.captures_iter(text) {
+        // AGO_RE captures `(\d+)`. A digit string too long for i64 fails to parse
+        // and harmlessly falls back to 1. The real hazard is a value that DOES
+        // parse but is large enough to overflow the day/Duration arithmetic:
+        // `n * 365` overflows i64, and `chrono::Duration::days(..)` / date
+        // subtraction PANIC on out-of-range values. A crafted query such as
+        // "90000000000 years ago" would therefore crash the retrieval thread.
+        // Convert to a day offset with checked arithmetic and skip anything
+        // absurd or out of range instead of panicking.
         let n: i64 = cap[1].parse().unwrap_or(1);
         let unit = cap[2].to_lowercase();
-        let date = match unit.as_str() {
-            "day" => today - chrono::Duration::days(n),
-            "week" => today - chrono::Duration::weeks(n),
-            "month" => {
-                // Approximate: 30 days per month
-                today - chrono::Duration::days(n * 30)
-            }
-            "year" => today - chrono::Duration::days(n * 365),
+        let days_offset: i64 = match unit.as_str() {
+            "day" => n,
+            "week" => n.checked_mul(7).unwrap_or(i64::MAX),
+            "month" => n.checked_mul(30).unwrap_or(i64::MAX), // ~30 days/month
+            "year" => n.checked_mul(365).unwrap_or(i64::MAX),
             _ => continue,
+        };
+        // ~10,000 years. Beyond this a relative date is noise, not a real query,
+        // and the value would overflow chrono's Duration/date range.
+        const MAX_RELATIVE_DAYS: i64 = 3_650_000;
+        if !(0..=MAX_RELATIVE_DAYS).contains(&days_offset) {
+            continue;
+        }
+        let date = match today.checked_sub_signed(chrono::Duration::days(days_offset)) {
+            Some(d) => d,
+            None => continue, // resulting date is out of the representable range
         };
         let pos = cap.get(0).map(|m| m.start()).unwrap_or(0);
         results.push((date, cap[0].to_string(), pos, TemporalRefType::Relative));
@@ -4299,6 +4314,45 @@ mod polar_negation_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extract_relative_dates_does_not_overflow_on_absurd_values() {
+        // Regression: a crafted "N years/months ago" with a huge N used to
+        // overflow `n * 365` and panic chrono's Duration/date math, crashing the
+        // retrieval thread. These must be skipped, never panic.
+        let now = Utc::now();
+        for q in [
+            "90000000000 years ago",         // n*365 is large but fits i64
+            "9999999999 months ago",         // n*30 large
+            "99999999999999999999 days ago", // 20 digits: parse fails → falls back to 1
+            "0 days ago",                    // boundary
+        ] {
+            // The assertion is simply that this returns without panicking.
+            let _ = extract_relative_dates(q, &now);
+        }
+
+        // A realistic relative date is still extracted correctly.
+        let refs = extract_relative_dates("3 days ago", &now);
+        assert!(
+            refs.iter()
+                .any(|(_, label, _, _)| label.contains("3 days ago")),
+            "a normal '3 days ago' must still be extracted, got {refs:?}"
+        );
+        assert_eq!(
+            refs.iter()
+                .find(|(_, l, _, _)| l.contains("3 days ago"))
+                .map(|(d, _, _, _)| *d),
+            Some(now.date_naive() - chrono::Duration::days(3)),
+            "the extracted date must be exactly 3 days before today"
+        );
+
+        // The absurd "90000000000 years ago" is out of the sane range and skipped.
+        let absurd = extract_relative_dates("90000000000 years ago", &now);
+        assert!(
+            absurd.iter().all(|(_, l, _, _)| !l.contains("90000000000")),
+            "an absurd relative date should be skipped, got {absurd:?}"
+        );
+    }
 
     #[test]
     fn test_noun_detection() {

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -1567,10 +1567,15 @@ impl MemoryTreeNode {
             "├── "
         };
 
-        // Truncate content for display
+        // Truncate content for display on a CHAR boundary, not a byte index:
+        // `&content[..57]` panics when byte 57 falls inside a multi-byte UTF-8
+        // codepoint (e.g. CJK/emoji content), and the `len() > 60` byte guard
+        // did not prevent that. `char_truncate` returns the whole string when it
+        // is already short, so an unchanged length means no ellipsis is needed.
         let content = &self.memory.experience.content;
-        let display_content = if content.len() > 60 {
-            format!("{}...", &content[..57])
+        let preview = crate::memory::char_truncate(content, 57);
+        let display_content = if preview.len() < content.len() {
+            format!("{preview}...")
         } else {
             content.clone()
         };


### PR DESCRIPTION
Three real panic paths (one from the audit, two from a follow-up sweep):

1. **chrono overflow** — `query_parser::extract_relative_dates`: a crafted "N years/months ago" with a huge N overflowed `n * 365` and panicked chrono's Duration/date math, **crashing the retrieval thread**. Now uses checked arithmetic, bounds the offset to ~10k years, and skips out-of-range refs via `checked_sub_signed`.
2. **UTF-8 byte-slice (BM25 debug preview)** — `hybrid_search.rs`: `&query[..50]` panics if byte 50 splits a multi-byte codepoint (CJK/emoji).
3. **UTF-8 byte-slice (lineage-tree display)** — `types.rs`: `&content[..57]` — **not in the original audit**, found by the sweep; its `len() > 60` byte guard didn't prevent the char-boundary panic.

Both slices now use a new shared `char_truncate(s, max_chars)` helper (`memory/mod.rs`) that cuts on a char boundary. Tests: `char_truncate` (ASCII/CJK/emoji/boundaries) + a chrono-overflow regression test. `cargo check --all-targets` clean.