### PR TITLE
feat(lineage): anchor auto-detected pivot branches into the edge graph

### DIFF
--- a/src/memory/lineage.rs
+++ b/src/memory/lineage.rs
@@ -167,6 +167,16 @@ impl LineageEdge {
         }
     }
 
+    /// Tag this edge as belonging to a specific lineage branch.
+    ///
+    /// `None` keeps the edge on the main branch. Used when a pivot signal opens
+    /// a new branch so the edges the pivot memory originates are attributed to
+    /// that branch instead of silently staying on `main`.
+    pub fn with_branch(mut self, branch_id: Option<String>) -> Self {
+        self.branch_id = branch_id;
+        self
+    }
+
     /// Confirm an inferred edge
     pub fn confirm(&mut self) {
         self.source = LineageSource::Confirmed;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -7734,6 +7734,43 @@ impl MemorySystem {
     ) -> Result<Vec<LineageEdge>> {
         let mut inferred_edges = Vec::new();
 
+        // Detect a project-pivot signal up front. When present we open a branch
+        // here, so the branch id is available to (a) tag the edges this memory
+        // originates and (b) anchor a BranchedFrom edge into the edge graph —
+        // otherwise branches were created as orphan metadata records that nothing
+        // referenced and every edge stayed silently on `main`.
+        let branch_id: Option<String> =
+            if lineage::LineageGraph::detect_branch_signal(&new_memory.experience.content) {
+                self.lineage_graph.ensure_main_branch(user_id)?;
+                let branch_name = format!("pivot-{}", chrono::Utc::now().format("%Y%m%d-%H%M%S"));
+                match self.lineage_graph.create_branch(
+                    user_id,
+                    &branch_name,
+                    "main",
+                    new_memory.id.clone(),
+                    Some(&format!(
+                        "Auto-detected pivot: {}",
+                        crate::memory::char_truncate(&new_memory.experience.content, 80)
+                    )),
+                ) {
+                    Ok(branch) => {
+                        tracing::info!(
+                            user_id = %user_id,
+                            branch = %branch.name,
+                            memory_id = %new_memory.id.0,
+                            "Auto-created lineage branch from pivot signal"
+                        );
+                        Some(branch.id)
+                    }
+                    Err(e) => {
+                        tracing::debug!("Auto-branch creation failed (non-fatal): {}", e);
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
         for candidate in candidate_memories {
             // Backward pass: candidate → new_memory (what caused this memory?)
             if let Some((relation, confidence)) =
@@ -7793,12 +7830,15 @@ impl MemorySystem {
                         self.lineage_graph.store_edge(user_id, &updated)?;
                     }
                     None => {
+                        // Edges originating from the pivot memory belong to the
+                        // branch it opened (None → main otherwise).
                         let edge = LineageEdge::inferred(
                             new_memory.id.clone(),
                             candidate.id.clone(),
                             relation,
                             confidence,
-                        );
+                        )
+                        .with_branch(branch_id.clone());
                         self.lineage_graph.store_edge(user_id, &edge)?;
                         inferred_edges.push(edge);
                     }
@@ -7807,36 +7847,27 @@ impl MemorySystem {
             }
         }
 
-        // Check for branch signal in memory content
-        if lineage::LineageGraph::detect_branch_signal(&new_memory.experience.content) {
-            self.lineage_graph.ensure_main_branch(user_id)?;
-            // Auto-create branch for the pivot
-            let branch_name = format!("pivot-{}", chrono::Utc::now().format("%Y%m%d-%H%M%S"));
-            match self.lineage_graph.create_branch(
-                user_id,
-                &branch_name,
-                "main",
-                new_memory.id.clone(),
-                Some(&format!(
-                    "Auto-detected pivot: {}",
-                    &new_memory
-                        .experience
-                        .content
-                        .chars()
-                        .take(80)
-                        .collect::<String>()
-                )),
-            ) {
-                Ok(branch) => {
-                    tracing::info!(
-                        user_id = %user_id,
-                        branch = %branch.name,
-                        memory_id = %new_memory.id.0,
-                        "Auto-created lineage branch from pivot signal"
-                    );
-                }
-                Err(e) => {
-                    tracing::debug!("Auto-branch creation failed (non-fatal): {}", e);
+        // If this memory opened a branch, anchor it into the edge graph with a
+        // BranchedFrom edge to the most recent prior candidate — the work it
+        // pivoted away from. Without this the branch is unreachable by trace()
+        // and find_root_cause().
+        if let Some(ref bid) = branch_id {
+            if let Some(origin) = candidate_memories
+                .iter()
+                .filter(|c| c.id != new_memory.id && c.created_at <= new_memory.created_at)
+                .max_by_key(|c| c.created_at)
+            {
+                let existing = self.lineage_graph.get_edges_from(user_id, &new_memory.id)?;
+                if !existing.iter().any(|e| e.to == origin.id) {
+                    let edge = LineageEdge::inferred(
+                        new_memory.id.clone(),
+                        origin.id.clone(),
+                        lineage::CausalRelation::BranchedFrom,
+                        crate::constants::LINEAGE_CONFIDENCE_BRANCHED_FROM,
+                    )
+                    .with_branch(Some(bid.clone()));
+                    self.lineage_graph.store_edge(user_id, &edge)?;
+                    inferred_edges.push(edge);
                 }
             }
         }

--- a/tests/lineage_branch_tests.rs
+++ b/tests/lineage_branch_tests.rs
@@ -1,0 +1,122 @@
+//! Branch-subsystem wiring tests.
+//!
+//! A project-pivot signal must do more than create an orphan branch metadata
+//! record: it must (a) open a branch and (b) anchor it into the edge graph with
+//! a `BranchedFrom` edge tagged by the new `branch_id`, so the branch is
+//! reachable via `trace()` / `find_root_cause()`. Before the wiring fix the
+//! branch was created but no edge referenced it and every edge stayed on `main`.
+
+use chrono::{DateTime, Duration, Utc};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use shodh_memory::memory::lineage::CausalRelation;
+use shodh_memory::memory::types::{Experience, ExperienceType};
+use shodh_memory::memory::{Memory, MemoryConfig, MemoryId, MemorySystem};
+
+fn create_test_system() -> (MemorySystem, TempDir) {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let config = MemoryConfig {
+        storage_path: temp_dir.path().to_path_buf(),
+        working_memory_size: 100,
+        session_memory_size_mb: 50,
+        max_heap_per_user_mb: 500,
+        auto_compress: false,
+        compression_age_days: 7,
+        importance_threshold: 0.3,
+    };
+    let system = MemorySystem::new(config, None).expect("memory system");
+    (system, temp_dir)
+}
+
+fn mem(content: &str, created_at: DateTime<Utc>) -> Memory {
+    let exp = Experience {
+        experience_type: ExperienceType::Decision,
+        content: content.to_string(),
+        ..Default::default()
+    };
+    Memory::new(
+        MemoryId(Uuid::new_v4()),
+        exp,
+        0.7,
+        None,
+        None,
+        None,
+        Some(created_at),
+    )
+}
+
+#[test]
+fn pivot_signal_opens_branch_and_anchors_branchedfrom_edge() {
+    let (system, _tmp) = create_test_system();
+    let user = "branch-user";
+    let now = Utc::now();
+    let prior = mem(
+        "Working on the Vamana index integration for vector search.",
+        now - Duration::days(1),
+    );
+    let pivot = mem(
+        "We need to abandon this and pivot to a different strategy entirely.",
+        now,
+    );
+
+    let edges = system
+        .infer_lineage_for_memory(user, &pivot, std::slice::from_ref(&prior))
+        .expect("infer lineage");
+
+    // (a) A pivot branch was created (in addition to main).
+    let branches = system
+        .lineage_graph()
+        .list_branches(user)
+        .expect("branches");
+    let pivot_branch = branches
+        .iter()
+        .find(|b| b.id != "main")
+        .unwrap_or_else(|| panic!("expected a pivot branch, got {branches:?}"));
+    let bid = pivot_branch.id.clone();
+
+    // (b) A BranchedFrom edge connects the pivot memory to the prior work and
+    //     carries the new branch id.
+    let branched = edges
+        .iter()
+        .find(|e| e.relation == CausalRelation::BranchedFrom)
+        .unwrap_or_else(|| panic!("expected a BranchedFrom edge, got {edges:?}"));
+    assert_eq!(branched.from, pivot.id);
+    assert_eq!(branched.to, prior.id);
+    assert_eq!(branched.branch_id.as_deref(), Some(bid.as_str()));
+
+    // The edge is persisted (not merely returned).
+    let stored = system
+        .lineage_graph()
+        .get_edges_from(user, &pivot.id)
+        .expect("edges from");
+    assert!(stored
+        .iter()
+        .any(|e| e.relation == CausalRelation::BranchedFrom && e.branch_id.is_some()));
+}
+
+#[test]
+fn no_pivot_signal_creates_no_branch() {
+    let (system, _tmp) = create_test_system();
+    let user = "no-pivot-user";
+    let now = Utc::now();
+    let a = mem(
+        "Implemented the SPANN search dimension guard.",
+        now - Duration::days(1),
+    );
+    let b = mem("Added a unit test for the SPANN guard.", now);
+
+    let _ = system
+        .infer_lineage_for_memory(user, &b, std::slice::from_ref(&a))
+        .expect("infer lineage");
+
+    // No pivot language → no auto branch (only main may exist, if anything).
+    let branches = system
+        .lineage_graph()
+        .list_branches(user)
+        .expect("branches");
+    assert!(
+        branches.iter().all(|br| br.id == "main"),
+        "unexpected non-main branch: {branches:?}"
+    );
+}


### PR DESCRIPTION
@
## Problem

A project-pivot signal (`detect_branch_signal`) already auto-created a `LineageBranch` record — but the branch was an **orphan**:

- `branch_id` was **never set to `Some`** anywhere in the codebase (verified by grep). Every inferred edge stayed on `main`.
- No edge referenced the branch, so `trace()` / `find_root_cause()` could never traverse it, and "what is on this branch?" had no answer.

The subsystem (struct, store, `create_branch`, `BranchedFrom` relation, `branch_id` field, REST endpoints) existed but was half-wired.

## Fix

In `infer_lineage_for_memory`:

1. **Detect the pivot up front** (was detected at the very end, *after* all edges had already been stored on `main`) so the new `branch_id` is available while edges are built.
2. **Tag originated edges**: edges where the pivot memory is the source now carry the new `branch_id` (new `LineageEdge::with_branch(Option<String>)` builder).
3. **Anchor the branch**: create a `BranchedFrom` edge from the pivot memory → the most recent prior candidate (the work it pivoted away from) at `LINEAGE_CONFIDENCE_BRANCHED_FROM` (0.9), tagged with the branch id — so the branch is reachable in the traversable graph.
4. Pivot-description preview switched to `char_truncate` (char-safe vs the old `.chars().take(80)`).

## Tests

`tests/lineage_branch_tests.rs` (deterministic — calls `infer_lineage_for_memory` directly, no HTTP/background timing):
- `pivot_signal_opens_branch_and_anchors_branchedfrom_edge`: a pivot opens a branch and persists a branch-tagged `BranchedFrom` edge from the pivot memory to the prior memory.
- `no_pivot_signal_creates_no_branch`: ordinary content creates no auto branch.

## Scope

`src/memory/lineage.rs` (builder), `src/memory/mod.rs` (wiring), new test file. No storage-format or API changes — `branch_id` was already a persisted field that simply was never populated.
@