### PR TITLE
perf(retrieval): hoist linguistic_boost out of the Full-mode sort comparator

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -3268,11 +3268,20 @@ impl MemorySystem {
         // Linguistic analysis: additive boost (5% of IC weight), not a full re-sort
         // RH-8 gate: linguistic re-sort only runs in `Full` mode.
         if layer_full && !query_analysis.focal_entities.is_empty() {
+            // Precompute the boosted score once per memory. Computing
+            // linguistic_boost inside the comparator re-scanned each memory's
+            // content O(n log n) times (twice per comparison); now it is O(n).
+            let boosted: std::collections::HashMap<MemoryId, f32> = memories
+                .iter()
+                .map(|m| {
+                    let key = m.score.unwrap_or(0.0)
+                        + Self::linguistic_boost(&m.experience.content, &query_analysis) * 0.05;
+                    (m.id.clone(), key)
+                })
+                .collect();
             memories.sort_by(|a, b| {
-                let score_a = a.score.unwrap_or(0.0)
-                    + Self::linguistic_boost(&a.experience.content, &query_analysis) * 0.05;
-                let score_b = b.score.unwrap_or(0.0)
-                    + Self::linguistic_boost(&b.experience.content, &query_analysis) * 0.05;
+                let score_a = boosted.get(&a.id).copied().unwrap_or(0.0);
+                let score_b = boosted.get(&b.id).copied().unwrap_or(0.0);
                 // Score desc → recency desc → MemoryId asc for stable rank order.
                 score_b
                     .total_cmp(&score_a)


### PR DESCRIPTION
@
## Problem

The Full-mode linguistic re-sort (in the recall pipeline) called `linguistic_boost` — a full scan of a memorys content — **inside the sort comparator**:

```rust
memories.sort_by(|a, b| {
    let score_a = a.score.unwrap_or(0.0) + Self::linguistic_boost(&a.experience.content, &qa) * 0.05;
    let score_b = b.score.unwrap_or(0.0) + Self::linguistic_boost(&b.experience.content, &qa) * 0.05;
    ...
});
```

`sort_by` invokes the comparator `O(n log n)` times, twice per call → each memorys boost is recomputed ~`2 log n` times.

## Fix

Precompute the boosted score once per memory (`O(n)`) into a `HashMap<MemoryId, f32>`; the comparator does an `O(1)` lookup.

**Ordering is unchanged** — identical key (`base + linguistic_boost*0.05`) and identical `score-desc → recency-desc → id-asc` tie-break. Pure compute reduction; full retrieval/pipeline test suite validates equivalence.

## Scope

`src/memory/mod.rs`, one block.
@