### PR TITLE
perf(retrieval): cache entity label-match in Layer 4.9 ontological rerank

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -2823,24 +2823,33 @@ impl MemorySystem {
                 if let Some(graph) = self.graph_memory.as_ref() {
                     let g = graph.read();
                     let mut boosted_count = 0usize;
+                    // Cache the per-entity label-match decision across candidates.
+                    // expected_labels is constant for this call, and a hot entity
+                    // appears in many candidates' entity_refs, so without a cache
+                    // get_entity (a store read) is repeated for the same uuid on
+                    // every candidate that references it.
+                    let mut label_match_cache: std::collections::HashMap<Uuid, bool> =
+                        std::collections::HashMap::new();
                     for (_mem_id, fused_score) in res.iter_mut().take(rerank_budget) {
                         if let Ok(Some(episode)) = g.get_episode(&_mem_id.0) {
                             let type_matches = episode
                                 .entity_refs
                                 .iter()
                                 .filter(|uuid| {
-                                    g.get_entity(uuid)
-                                        .ok()
-                                        .flatten()
-                                        .map(|e| {
-                                            e.labels.iter().any(|l| {
-                                                onto_intent
-                                                    .expected_labels
-                                                    .iter()
-                                                    .any(|exp| l.matches_with_hierarchy(exp))
+                                    *label_match_cache.entry(**uuid).or_insert_with(|| {
+                                        g.get_entity(uuid)
+                                            .ok()
+                                            .flatten()
+                                            .map(|e| {
+                                                e.labels.iter().any(|l| {
+                                                    onto_intent
+                                                        .expected_labels
+                                                        .iter()
+                                                        .any(|exp| l.matches_with_hierarchy(exp))
+                                                })
                                             })
-                                        })
-                                        .unwrap_or(false)
+                                            .unwrap_or(false)
+                                    })
                                 })
                                 .count();
                             if type_matches > 0 {


### PR DESCRIPTION
@
## Problem

Layer 4.9 ontological rerank scored up to `rerank_budget` candidates. For each, it iterated the episodes `entity_refs` and called `g.get_entity(uuid)` (a graph-store read) to test the entitys labels against `onto_intent.expected_labels`.

`expected_labels` is **constant** for the call, and hot entities appear in many candidates `entity_refs`, so the same uuid was re-fetched once per referencing candidate — redundant store reads scaling with candidate count × entity fan-in.

## Fix

Cache the per-entity match decision in a `HashMap<Uuid, bool>` for the duration of the rerank (`entry(**uuid).or_insert_with(...)`). Each entity is read at most once.

**Output is identical** — the cached bool is exactly the label-match result the uncached path computed; ranking and boost are unchanged.

## Scope

`src/memory/mod.rs`, the Layer 4.9 block. Pairs with #300 (consistent labels) — this makes the read-side cheaper now that more entities carry meaningful labels.
@