### PR TITLE
fix(retrieval): stop double-counting the created_at temporal signal

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -3051,8 +3051,18 @@ impl MemorySystem {
                     }
 
                     // Tier 2: created_at proximity fallback for filtering queries
-                    // Most memories don't have temporal_refs, so use created_at as proxy
-                    if best_match == 0.0 && temporal_ctx.is_filtering_query {
+                    // Most memories don't have temporal_refs, so use created_at as proxy.
+                    //
+                    // Skip memories already boosted by the Layer 4.45 temporal
+                    // pre-filter: that set IS the created_at-in-range memories
+                    // (SearchCriteria::ByDate filters on created_at), so applying
+                    // this created_at proximity boost on top would reward the exact
+                    // same signal twice. Tier 1 (explicit temporal_refs) is a
+                    // distinct content signal and still applies to them above.
+                    if best_match == 0.0
+                        && temporal_ctx.is_filtering_query
+                        && !temporal_prefilter_ids.contains(&mem.id)
+                    {
                         if let Some((range_start, range_end)) = temporal_ctx.date_range {
                             let created_date = mem.created_at.date_naive();
                             let range_mid = range_start


### PR DESCRIPTION
@
## Problem

For a date-filtering query, a memory whose `created_at` falls in the parsed range was rewarded for that **same fact twice**:

- **Layer 4.45** multiplies the fused score of every memory in `temporal_prefilter_ids` — and that set is exactly the created_at-in-range memories (Layer 0.4 builds it via `SearchCriteria::ByDate`, which filters on `created_at`).
- **Layer 5 Tier-2** then adds a `created_at`-proximity `temporal_factor` for those same memories.

Tier-1 (explicit `temporal_refs` content-date match) is a *different* signal and is fine.

## Fix

Guard Tier-2 with `&& !temporal_prefilter_ids.contains(&mem.id)`. The created_at signal is now rewarded once. Still intact:
- Tier-1 explicit-refs boost applies to prefiltered memories (distinct signal).
- Tier-2 still applies to near-range / decay-tail memories the strict prefilter excludes, and in lower RH-8 modes where Layer 0.4 doesnt run (the set is empty).

## Validation

Contained one-condition change; compiles clean. Behavioral validation is left to CIs full pipeline suite. This nudges ranking (in-range memories no longer get the compounded boost in Full mode) — a follow-up recall-harness sweep (task #18/#16) is the right place to confirm the net recall effect, and the change is easy to tune or revert if the harness disagrees.

## Scope

`src/memory/mod.rs`, the Tier-2 condition.
@