### PR TITLE
feat(recall): per-case diagnostics — see which query is weak, not just the category mean

### DIFF
--- a/.github/workflows/recall.yml
+++ b/.github/workflows/recall.yml
@@ -95,6 +95,7 @@ jobs:
             --suite smoke \
             --repeats 5 \
             --output current.json \
+            --per-case-output per-case.json \
             --baseline tests/recall/baseline.json \
             --tolerance "${TOLERANCE}" \
             --storage ./recall-storage 2>&1 | tee recall-eval.log
@@ -127,6 +128,7 @@ jobs:
           name: recall-eval-report
           path: |
             current.json
+            per-case.json
             recall-eval.log
             recall-diff.md
           if-no-files-found: warn

--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -20,7 +20,9 @@ use clap::{Parser, ValueEnum};
 
 use shodh_memory::memory::types::LayerMode;
 use shodh_memory::recall_harness::report::{compare_to_baseline, Report};
-use shodh_memory::recall_harness::runner::{run_smoke_suite, RunInputs};
+use shodh_memory::recall_harness::runner::{
+    run_smoke_suite_with_ranks, ReportWithRanks, RunInputs,
+};
 
 /// Exit codes — kept stable so CI scripts can branch on them.
 const EXIT_PASS: i32 = 0;
@@ -105,6 +107,13 @@ struct Args {
     #[arg(long)]
     baseline: Option<PathBuf>,
 
+    /// Optional path to write per-case diagnostics (JSON array) for the gated
+    /// layer: each case's ndcg/recall/mrr plus the relevant items it dropped
+    /// from the top-k. Diagnostic side output — not the gated report, not the
+    /// baseline. Use it to see *which* query is weak, not just a category mean.
+    #[arg(long)]
+    per_case_output: Option<PathBuf>,
+
     /// Allowed regression in percent of baseline. Default: 2.0%.
     #[arg(long, default_value_t = 2.0)]
     tolerance: f64,
@@ -175,7 +184,28 @@ fn run(args: &Args) -> Result<i32> {
         age_days: args.age_days,
     };
 
-    let mut report = run_smoke_suite(&inputs).context("running smoke suite")?;
+    let ReportWithRanks {
+        mut report,
+        per_case,
+        ..
+    } = run_smoke_suite_with_ranks(&inputs).context("running smoke suite")?;
+
+    // Per-case diagnostics are written before the baseline comparison so they
+    // are always captured, even on a regressing run that exits non-zero.
+    if let Some(per_case_path) = &args.per_case_output {
+        let json = serde_json::to_vec_pretty(&per_case)
+            .context("serialising per-case diagnostics to JSON")?;
+        std::fs::write(per_case_path, &json).with_context(|| {
+            format!(
+                "writing per-case diagnostics to {}",
+                per_case_path.display()
+            )
+        })?;
+        eprintln!(
+            "recall-eval: per-case diagnostics written to {}",
+            per_case_path.display()
+        );
+    }
 
     if let Some(baseline_path) = &args.baseline {
         let baseline_bytes = std::fs::read(baseline_path)

--- a/src/recall_harness/report.rs
+++ b/src/recall_harness/report.rs
@@ -50,6 +50,28 @@ fn default_repeats() -> usize {
     1
 }
 
+/// Per-case diagnostics for the highest (gated) layer.
+///
+/// Not part of [`Report`] / `baseline.json` — those stay aggregate-only so the
+/// committed baseline is small and diffable. This is emitted to a side artifact
+/// (`recall-eval --per-case-output`) so a human can answer "which query is weak
+/// and which relevant items did it drop?" instead of only seeing a category
+/// average move. `missed` lists the relevant `corpus_item_id`s that fell
+/// outside the top-`k`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PerCaseRecord {
+    pub case_id: String,
+    pub category: String,
+    pub query: String,
+    pub ndcg_at_k: f64,
+    pub recall_at_k: f64,
+    pub mrr: f64,
+    pub p_at_1: f64,
+    pub relevant_total: usize,
+    pub relevant_found: usize,
+    pub missed: Vec<String>,
+}
+
 /// Aggregate metrics for one pipeline layer across all cases.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct LayerReport {

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -8,7 +8,7 @@
 //!
 //! See issue #266 for the runner's CLI and acceptance criteria.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -23,8 +23,8 @@ use super::fixtures::{
 };
 use super::metrics::Metrics;
 use super::report::{
-    aggregate_category, aggregate_layer, median, CategoryReport, Failure, LayerReport, Report,
-    SMOKE_K,
+    aggregate_category, aggregate_layer, median, CategoryReport, Failure, LayerReport,
+    PerCaseRecord, Report, SMOKE_K,
 };
 
 /// Embedder identifier emitted in the report. Matches the model wired into
@@ -110,6 +110,9 @@ pub struct CaseRankList {
 pub struct ReportWithRanks {
     pub report: Report,
     pub ranks: Vec<CaseRankList>,
+    /// Per-case diagnostics for the highest (gated) layer, aligned with the
+    /// fixture case order. Side output only — never folded into `report`.
+    pub per_case: Vec<PerCaseRecord>,
 }
 
 /// Run the smoke suite end-to-end and return a populated [`Report`].
@@ -300,6 +303,16 @@ pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks>
         failures,
     };
 
+    // Per-case diagnostics for the highest (gated) mode, taken from the same
+    // repeat-0 pass the aggregates use and aligned with `cases` by index.
+    let per_case = {
+        let mp = passes[0]
+            .per_mode
+            .get(&highest_mode)
+            .expect("repeat 0 must have highest mode");
+        build_per_case_records(&cases, &mp.per_case, &mp.ranks)
+    };
+
     // The public ranks output is the repeat-0 rank list for the highest
     // mode — that matches existing RH-11 test expectations (which assume
     // a single mode). Cross-repeat divergence is already surfaced via
@@ -313,7 +326,56 @@ pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks>
         .expect("repeat 0 must have highest mode")
         .ranks;
 
-    Ok(ReportWithRanks { report, ranks })
+    Ok(ReportWithRanks {
+        report,
+        ranks,
+        per_case,
+    })
+}
+
+/// Build per-case diagnostics from one mode's aligned outputs.
+///
+/// `metrics[i]`, `ranks[i]`, and `cases[i]` must describe the same query (the
+/// runner guarantees this by pushing all three in lockstep over `cases`).
+/// `missed` is the set of relevant `corpus_item_id`s absent from the top-`k`
+/// retrieved list, which is what makes a weak case actionable.
+fn build_per_case_records(
+    cases: &[SmokeCase],
+    metrics: &[Metrics],
+    ranks: &[CaseRankList],
+) -> Vec<PerCaseRecord> {
+    cases
+        .iter()
+        .enumerate()
+        .map(|(i, case)| {
+            let m = &metrics[i];
+            let topk: HashSet<&str> = ranks[i]
+                .retrieved
+                .iter()
+                .take(SMOKE_K)
+                .map(|s| s.as_str())
+                .collect();
+            let missed: Vec<String> = case
+                .relevant
+                .iter()
+                .map(|r| r.corpus_item_id.clone())
+                .filter(|id| !topk.contains(id.as_str()))
+                .collect();
+            let relevant_total = case.relevant.len();
+            PerCaseRecord {
+                case_id: case.id.clone(),
+                category: category_name(case.category).to_string(),
+                query: case.query.clone(),
+                ndcg_at_k: m.ndcg_at_k,
+                recall_at_k: m.recall_at_k,
+                mrr: m.mrr,
+                p_at_1: m.p_at_1,
+                relevant_total,
+                relevant_found: relevant_total - missed.len(),
+                missed,
+            }
+        })
+        .collect()
 }
 
 /// Per-case results for one `LayerMode` within a single ingest+query pass.
@@ -572,6 +634,83 @@ mod tests {
     fn unique_storage_dir(label: &str) -> PathBuf {
         let id = Uuid::new_v4().simple().to_string();
         std::env::temp_dir().join(format!("shodh-recall-{label}-{id}"))
+    }
+
+    #[test]
+    fn per_case_records_flag_missed_relevant_items() {
+        let cases = vec![
+            SmokeCase {
+                id: "smoke-001".into(),
+                category: SmokeCategory::MultiHop,
+                query: "chain query".into(),
+                fixture_corpus_id: "shodh-smoke".into(),
+                relevant: vec![
+                    fixtures::RelevanceJudgement {
+                        corpus_item_id: "ssm-001".into(),
+                        grade: 3,
+                    },
+                    fixtures::RelevanceJudgement {
+                        corpus_item_id: "ssm-002".into(),
+                        grade: 1,
+                    },
+                ],
+            },
+            SmokeCase {
+                id: "smoke-002".into(),
+                category: SmokeCategory::Entity,
+                query: "entity query".into(),
+                fixture_corpus_id: "shodh-smoke".into(),
+                relevant: vec![fixtures::RelevanceJudgement {
+                    corpus_item_id: "ssm-010".into(),
+                    grade: 3,
+                }],
+            },
+        ];
+        let metrics = vec![
+            Metrics {
+                recall_at_k: 0.5,
+                ndcg_at_k: 0.6,
+                mrr: 1.0,
+                p_at_1: 1.0,
+                ..Default::default()
+            },
+            Metrics {
+                recall_at_k: 1.0,
+                ndcg_at_k: 1.0,
+                mrr: 1.0,
+                p_at_1: 1.0,
+                ..Default::default()
+            },
+        ];
+        let ranks = vec![
+            // Case 1 retrieved ssm-001 (found) but dropped ssm-002 (missed).
+            CaseRankList {
+                case_id: "smoke-001".into(),
+                retrieved: vec!["ssm-001".into(), "ssm-099".into()],
+            },
+            // Case 2 retrieved its only relevant item.
+            CaseRankList {
+                case_id: "smoke-002".into(),
+                retrieved: vec!["ssm-010".into()],
+            },
+        ];
+
+        let recs = build_per_case_records(&cases, &metrics, &ranks);
+        assert_eq!(recs.len(), 2);
+
+        let r0 = &recs[0];
+        assert_eq!(r0.case_id, "smoke-001");
+        assert_eq!(r0.category, "multi_hop");
+        assert_eq!(r0.relevant_total, 2);
+        assert_eq!(r0.relevant_found, 1);
+        assert_eq!(r0.missed, vec!["ssm-002".to_string()]);
+        assert_eq!(r0.recall_at_k, 0.5);
+        assert_eq!(r0.ndcg_at_k, 0.6);
+
+        let r1 = &recs[1];
+        assert_eq!(r1.category, "entity");
+        assert_eq!(r1.relevant_found, 1);
+        assert!(r1.missed.is_empty());
     }
 
     /// Smoke test the full runner end-to-end against the canonical fixtures.


### PR DESCRIPTION
@
## Why

The baseline gives us category means (multi_hop **0.77**, entity 0.87) but the committed `Report`/`baseline.json` store **only aggregates**. So we can see a category is weak but not *which* of its 18 queries miss, or *which* relevant chain-items they drop. Every targeted recall improvement (multi_hop, the deferred ranking tasks, decay) would otherwise be guesswork.

This is the observability a world-class eval needs, and it directly addresses the logged gap "no per-stage retrieval diagnostics."

## What

`PerCaseRecord` for the gated (`full`) layer, per query:
- `case_id`, `category`, `query`
- `ndcg@k`, `recall@k`, `mrr`, `p@1`
- `relevant_total`, `relevant_found`
- **`missed`** — the relevant `corpus_item_id`s that fell outside top-k (the actionable bit)

Emitted to a **side artifact** via `recall-eval --per-case-output per-case.json`, uploaded by `recall.yml`. Example of what it unlocks: *"multi_hop smoke-094 recall 0.50 — dropped ssm-042, ssm-043"* → go look at why those two arent chaining in.

## Deliberately scoped

- **Not** folded into `Report`/`baseline.json` — those stay aggregate-only so the committed baseline is small and diffable, and the gate is unchanged.
- **Pure-additive: zero ranking change.** The gated report, the baseline comparison, and exit codes are untouched.

## Tests

Build logic extracted to `build_per_case_records` and unit-tested without the model: missed-item computation, found-count, category mapping, metric propagation (`per_case_records_flag_missed_relevant_items`). Compiles clean; fmt clean.

## Next

Once merged, the recall run emits `per-case.json` → I can pull it and see exactly which multi_hop queries are weak, turning the next improvement from a guess into a target.
@