### PR TITLE
feat(recall): per-LAYER per-case diagnostics (pinpoint the dropping stage)

### DIFF
--- a/.github/workflows/recall.yml
+++ b/.github/workflows/recall.yml
@@ -31,6 +31,14 @@ on:
         description: 'Allowed regression in percent of baseline'
         required: false
         default: '2.0'
+      layer:
+        description: 'Layer attribution: full (gated) or all (per-stage diagnosis)'
+        required: false
+        default: 'full'
+      repeats:
+        description: 'Ingest+query repeats (use 1 for a fast diagnosis run)'
+        required: false
+        default: '5'
 
 permissions:
   contents: read
@@ -43,6 +51,10 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   TOLERANCE: ${{ github.event.inputs.tolerance || '2.0' }}
+  # PR runs are always the gated `full`/5; only a manual dispatch can widen to
+  # per-stage diagnosis (`all`) or a fast single repeat.
+  LAYER: ${{ github.event.inputs.layer || 'full' }}
+  REPEATS: ${{ github.event.inputs.repeats || '5' }}
 
 jobs:
   smoke:
@@ -93,7 +105,8 @@ jobs:
           # across passes is hard-failed as `infrastructure`.
           ./target/release/recall-eval \
             --suite smoke \
-            --repeats 5 \
+            --layer "${LAYER}" \
+            --repeats "${REPEATS}" \
             --output current.json \
             --per-case-output per-case.json \
             --baseline tests/recall/baseline.json \

--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -186,14 +186,16 @@ fn run(args: &Args) -> Result<i32> {
 
     let ReportWithRanks {
         mut report,
-        per_case,
+        per_case_by_layer,
         ..
     } = run_smoke_suite_with_ranks(&inputs).context("running smoke suite")?;
 
     // Per-case diagnostics are written before the baseline comparison so they
-    // are always captured, even on a regressing run that exits non-zero.
+    // are always captured, even on a regressing run that exits non-zero. The
+    // payload is keyed by layer (`"full"`, … `--layer all` gives every stage)
+    // so a missed item can be traced to the stage that dropped it.
     if let Some(per_case_path) = &args.per_case_output {
-        let json = serde_json::to_vec_pretty(&per_case)
+        let json = serde_json::to_vec_pretty(&per_case_by_layer)
             .context("serialising per-case diagnostics to JSON")?;
         std::fs::write(per_case_path, &json).with_context(|| {
             format!(

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -110,9 +110,13 @@ pub struct CaseRankList {
 pub struct ReportWithRanks {
     pub report: Report,
     pub ranks: Vec<CaseRankList>,
-    /// Per-case diagnostics for the highest (gated) layer, aligned with the
-    /// fixture case order. Side output only — never folded into `report`.
-    pub per_case: Vec<PerCaseRecord>,
+    /// Per-case diagnostics keyed by layer `report_key` (e.g. `"full"`,
+    /// `"vamana-only"`), each aligned with the fixture case order. With
+    /// `--layer all` this carries every mode, so a missed item can be traced
+    /// to the stage that dropped it (e.g. present in `vamana-only`, gone in
+    /// `full` ⇒ a later layer demoted it). Side output only — never folded
+    /// into `report`.
+    pub per_case_by_layer: BTreeMap<String, Vec<PerCaseRecord>>,
 }
 
 /// Run the smoke suite end-to-end and return a populated [`Report`].
@@ -303,15 +307,22 @@ pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks>
         failures,
     };
 
-    // Per-case diagnostics for the highest (gated) mode, taken from the same
-    // repeat-0 pass the aggregates use and aligned with `cases` by index.
-    let per_case = {
-        let mp = passes[0]
-            .per_mode
-            .get(&highest_mode)
-            .expect("repeat 0 must have highest mode");
-        build_per_case_records(&cases, &mp.per_case, &mp.ranks)
-    };
+    // Per-case diagnostics for every mode, from the same repeat-0 pass the
+    // aggregates use and aligned with `cases` by index. With `--layer all`
+    // this lets a missed item be traced to the stage that dropped it.
+    let per_case_by_layer: BTreeMap<String, Vec<PerCaseRecord>> = layer_modes
+        .iter()
+        .map(|mode| {
+            let mp = passes[0]
+                .per_mode
+                .get(mode)
+                .expect("repeat 0 must have mode");
+            (
+                mode.report_key().to_string(),
+                build_per_case_records(&cases, &mp.per_case, &mp.ranks),
+            )
+        })
+        .collect();
 
     // The public ranks output is the repeat-0 rank list for the highest
     // mode — that matches existing RH-11 test expectations (which assume
@@ -329,7 +340,7 @@ pub fn run_smoke_suite_with_ranks(inputs: &RunInputs) -> Result<ReportWithRanks>
     Ok(ReportWithRanks {
         report,
         ranks,
-        per_case,
+        per_case_by_layer,
     })
 }
 


### PR DESCRIPTION
@
## Why

#307 told us *which* query is weak, but not *which pipeline stage* lost the item — and that distinction has **opposite fixes**: a memory present in `vamana-only` but gone in `full` was *demoted by a later layer* (rerank/fusion bug); a memory absent in *every* layer is a *core retrieval/embedding gap*. We have a concrete mystery to crack: `smoke-033` "parking_lot" → recall=0 on a memory that says "All hot-path locking uses parking_lot."

## What

- `ReportWithRanks.per_case` → `per_case_by_layer` (`map<layer, [PerCaseRecord]>`). With `--layer all` the side artifact now carries every stages per-case results.
- `recall.yml`: `workflow_dispatch` gains `layer` (full|all) and `repeats` inputs. **PR runs are unchanged** — still gated `full`/5. Only a manual dispatch widens to per-stage diagnosis. `compare_to_baseline` only reads the `full` layer, so `--layer all` still gates correctly.

Pure-additive — no ranking, gate, or baseline change. Build helper remains unit-tested.

## Usage
`gh workflow run recall.yml --ref <branch> -f layer=all -f repeats=1` → download `per-case.json` → trace where each missed item drops out of the ladder.
@