### PR TITLE
fix(recall): retrieval competition demotes suppressed memories instead of deleting them

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2140,6 +2140,20 @@ pub const COMPETITION_SURVIVAL_FLOOR: f32 = 0.1;
 /// record the full amount.
 pub const COMPETITION_SURVIVOR_DAMAGE_RATIO: f32 = 0.3;
 
+/// Retrieval-competition score multiplier applied to a "suppressed" memory.
+///
+/// Retrieval competition used to DELETE suppressed memories from the result
+/// set. Per-layer recall diagnostics showed this erased correct hits: 8 of the
+/// 108 smoke cases survived the entire pipeline through `+facts` and then
+/// vanished at `full`, because the suppression proxy is score-proximity (not
+/// content similarity) — a distinct, relevant memory whose score merely sat
+/// close to the top got removed. Suppressed memories are now DEMOTED by this
+/// factor and kept, so the final sort can still surface them. Kept mild (0.9)
+/// because suppressed memories are by definition high-scoring (ratio > 0.9 of
+/// the winner) and usually relevant — for multi-hop chains the co-tagged
+/// siblings are exactly these close-score "competitors".
+pub const COMPETITION_SUPPRESSED_DEMOTION: f32 = 0.9;
+
 /// Connectivity factor divisor for replay candidate prioritization
 ///
 /// Higher connectivity = more important for consolidation.

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -3396,19 +3396,32 @@ impl MemorySystem {
                 self.record_consolidation_event(event.clone());
             }
 
-            // Re-order memories based on competition results (winners first)
+            // DEMOTE suppressed memories — never remove them. Deleting suppressed
+            // results erased correct hits: the suppression proxy is score
+            // proximity, not content similarity, so a distinct relevant memory
+            // whose score sat close to the top was removed (per-layer recall
+            // diagnostics: 8 cases survived through `+facts` then vanished at
+            // `full`). Apply a mild multiplicative penalty and let the final
+            // sort+truncate decide; a suppressed-but-relevant memory can still
+            // surface. The winner/suppressed split below still gates coactivation.
             if !competition_result.suppressed.is_empty() {
-                let winner_set: std::collections::HashSet<_> = competition_result
-                    .winners
+                let suppressed_set: std::collections::HashSet<&str> = competition_result
+                    .suppressed
                     .iter()
-                    .map(|(id, _)| id.clone())
+                    .map(|s| s.as_str())
                     .collect();
-
-                // Keep only winners, maintain their relative order
-                memories.retain(|m| winner_set.contains(&m.id.0.to_string()));
+                for m in memories.iter_mut() {
+                    if suppressed_set.contains(m.id.0.to_string().as_str()) {
+                        let demoted = m.score.unwrap_or(0.0)
+                            * crate::constants::COMPETITION_SUPPRESSED_DEMOTION;
+                        let mut cloned: Memory = m.as_ref().clone();
+                        cloned.set_score(demoted);
+                        *m = Arc::new(cloned);
+                    }
+                }
 
                 tracing::debug!(
-                    "Retrieval competition: {} memories suppressed",
+                    "Retrieval competition: {} memories demoted (kept, not removed)",
                     competition_result.suppressed.len()
                 );
             }


### PR DESCRIPTION
@
## The finding (per-layer diagnostics, #308)

The single biggest recall sink: **8 of 108 smoke cases had recall 1.0 through the *entire* pipeline** (`vamana_only → +spreading → +bm25 → +rerank → +facts`) and then **dropped at `full`** — two of them (smoke-048 Axum router, smoke-071 Cowan) to **0.0**.

Cause: retrieval competition (SHO-106) called `memories.retain(winners)`, **deleting** the "suppressed" set from the results. Two reasons that erases correct hits:
- The suppression proxy is **score proximity, not content similarity** (the similarity arg is fed the score itself, then ignored). A distinct, relevant memory whose score merely sat near the top got removed.
- For **multi-hop chains**, the co-tagged siblings naturally have near-equal scores → competition deleted exactly the chain items we want.

(The competition didnt even apply the winner score-reductions it computes — its *only* retrieval effect was this deletion.)

## Fix

**Demote, never delete.** Suppressed memories get a mild multiplicative penalty (`COMPETITION_SUPPRESSED_DEMOTION = 0.9`) and stay in the pool; the existing final sort+truncate decides. A suppressed-but-relevant hit can now surface. The winner/suppressed split is untouched for the coactivation gate and interference records (learning behaviour unchanged).

## Verification

This is a ranking change → proven on the harness, not asserted:
- PR recall run shows per-category deltas vs baseline (expect recall@10 / multi_hop / entity up, no net regression — the gate fails on >2% regression).
- Im also firing `gh workflow run recall.yml -f layer=all -f repeats=1` to confirm the 8 cases (esp. smoke-048/071) now survive `full`.

Baseline regen will follow once the win is confirmed (the current baseline encodes the buggy deletion).
@