### PR TITLE
feat(embeddings): swap to gte-small int8 + auto re-embed on open

### DIFF
--- a/.github/workflows/locomo-recall.yml
+++ b/.github/workflows/locomo-recall.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Install LLVM (ONNX runtime build dep)
         run: |
           sudo apt-get update
-          sudo apt-get install -y llvm-dev libclang-dev clang
+          sudo apt-get install -y llvm-dev libclang-dev clang time
 
       - name: Set up e5-small-v2 embedder
         if: ${{ github.event.inputs.embedder == 'e5' }}
@@ -274,13 +274,19 @@ jobs:
           SHODH_GRAPH_EXPAND_MIN_STRENGTH: ${{ github.event.inputs.graph_expand_min_strength }}
         run: |
           for kv in ${{ github.event.inputs.extra_env }}; do export "$kv"; done
-          ./target/release/recall-eval \
+          /usr/bin/time -v -o locomo-time.log ./target/release/recall-eval \
             --suite locomo \
             --layer "${{ github.event.inputs.layer }}" \
             --repeats "${{ github.event.inputs.repeats }}" \
             --output locomo-recall.json \
             --per-case-output locomo-per-case.json \
             --storage ./locomo-storage 2>&1 | tee locomo-recall.log
+          # Resource footprint (deployment sizing): peak RSS of the full recall engine
+          MAXRSS_KB=$(grep -i "Maximum resident set size" locomo-time.log | grep -oE '[0-9]+' | head -1 || echo 0)
+          WALL=$(grep -i "Elapsed (wall clock)" locomo-time.log | sed 's/.*: //' || echo "?")
+          echo "## Resource usage (deployment sizing)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Peak RSS: $((MAXRSS_KB / 1024)) MB** — full engine: RocksDB + Vamana/SPANN index + gte-small embedder + NER + graph" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Wall clock: ${WALL}  (embedder=gte-small int8)" >> "$GITHUB_STEP_SUMMARY"
           echo "## LoCoMo held-out recall@k" >> "$GITHUB_STEP_SUMMARY"
           python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
           import json
@@ -339,6 +345,7 @@ jobs:
             locomo-recall.json
             locomo-per-case.json
             locomo-recall.log
+            locomo-time.log
             locomo-reachability.json
             locomo-reachability.log
             learning-curve.json

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -30,19 +30,19 @@ jobs:
 
       - name: Download models and ONNX Runtime
         run: |
-          mkdir -p bundled/lib bundled/models/minilm-l6 bundled/models/bert-tiny-ner
+          mkdir -p bundled/lib bundled/models/gte-small bundled/models/bert-tiny-ner
           # Pinned to immutable HuggingFace commit hashes
-          curl -fSL -o bundled/models/minilm-l6/model_quantized.onnx \
-            "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf/onnx/model_quint8_avx2.onnx"
-          curl -fSL -o bundled/models/minilm-l6/tokenizer.json \
-            "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf/tokenizer.json"
+          curl -fSL -o bundled/models/gte-small/model_quantized.onnx \
+            "https://huggingface.co/Xenova/gte-small/resolve/5927d1727bb12db490052a1b33265ad78058de08/onnx/model_quantized.onnx"
+          curl -fSL -o bundled/models/gte-small/tokenizer.json \
+            "https://huggingface.co/Xenova/gte-small/resolve/5927d1727bb12db490052a1b33265ad78058de08/tokenizer.json"
           curl -fSL -o bundled/models/bert-tiny-ner/model.onnx \
             "https://huggingface.co/onnx-community/TinyBERT-finetuned-NER-ONNX/resolve/9b03777d9832105fbe419f258127fb2ec3eb09d7/onnx/model_quantized.onnx"
           curl -fSL -o bundled/models/bert-tiny-ner/tokenizer.json \
             "https://huggingface.co/onnx-community/TinyBERT-finetuned-NER-ONNX/resolve/9b03777d9832105fbe419f258127fb2ec3eb09d7/tokenizer.json"
           # SHA-256 verification
-          echo "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21  bundled/models/minilm-l6/model_quantized.onnx" | sha256sum -c -
-          echo "be50c3628f2bf5bb5e3a7f17b1f74611b2561a3a27eeab05e5aa30f411572037  bundled/models/minilm-l6/tokenizer.json" | sha256sum -c -
+          echo "18dec105109b6004369799ca4761fb8fb413c64172c02147bcfac186b5c5f6cb  bundled/models/gte-small/model_quantized.onnx" | sha256sum -c -
+          echo "da0e79933b9ed51798a3ae27893d3c5fa4a201126cef75586296df9b4d2c62a0  bundled/models/gte-small/tokenizer.json" | sha256sum -c -
           echo "ba4a1a00cf1600cae8e7cf3fda4650c825811719065b51041256392edd3647b8  bundled/models/bert-tiny-ner/model.onnx" | sha256sum -c -
           echo "d241a60d5e8f04cc1b2b3e9ef7a4921b27bf526d9f6050ab90f9267a1f9e5c66  bundled/models/bert-tiny-ner/tokenizer.json" | sha256sum -c -
           # ONNX Runtime
@@ -50,7 +50,7 @@ jobs:
           tar -xzf onnxruntime.tgz
           cp onnxruntime-linux-x64-1.23.2/lib/libonnxruntime.so.1.23.2 bundled/lib/libonnxruntime.so
           echo "=== Downloaded files ==="
-          ls -la bundled/models/minilm-l6/ bundled/models/bert-tiny-ner/ bundled/lib/
+          ls -la bundled/models/gte-small/ bundled/models/bert-tiny-ner/ bundled/lib/
           du -sh bundled/
         shell: bash
 
@@ -132,19 +132,19 @@ jobs:
 
       - name: Download models and ONNX Runtime
         run: |
-          mkdir -p bundled/lib bundled/models/minilm-l6 bundled/models/bert-tiny-ner
+          mkdir -p bundled/lib bundled/models/gte-small bundled/models/bert-tiny-ner
           # Pinned to immutable HuggingFace commit hashes
-          curl -fSL -o bundled/models/minilm-l6/model_quantized.onnx \
-            "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf/onnx/model_quint8_avx2.onnx"
-          curl -fSL -o bundled/models/minilm-l6/tokenizer.json \
-            "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf/tokenizer.json"
+          curl -fSL -o bundled/models/gte-small/model_quantized.onnx \
+            "https://huggingface.co/Xenova/gte-small/resolve/5927d1727bb12db490052a1b33265ad78058de08/onnx/model_quantized.onnx"
+          curl -fSL -o bundled/models/gte-small/tokenizer.json \
+            "https://huggingface.co/Xenova/gte-small/resolve/5927d1727bb12db490052a1b33265ad78058de08/tokenizer.json"
           curl -fSL -o bundled/models/bert-tiny-ner/model.onnx \
             "https://huggingface.co/onnx-community/TinyBERT-finetuned-NER-ONNX/resolve/9b03777d9832105fbe419f258127fb2ec3eb09d7/onnx/model_quantized.onnx"
           curl -fSL -o bundled/models/bert-tiny-ner/tokenizer.json \
             "https://huggingface.co/onnx-community/TinyBERT-finetuned-NER-ONNX/resolve/9b03777d9832105fbe419f258127fb2ec3eb09d7/tokenizer.json"
           # SHA-256 verification (shasum on macOS)
-          echo "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21  bundled/models/minilm-l6/model_quantized.onnx" | shasum -a 256 -c -
-          echo "be50c3628f2bf5bb5e3a7f17b1f74611b2561a3a27eeab05e5aa30f411572037  bundled/models/minilm-l6/tokenizer.json" | shasum -a 256 -c -
+          echo "18dec105109b6004369799ca4761fb8fb413c64172c02147bcfac186b5c5f6cb  bundled/models/gte-small/model_quantized.onnx" | shasum -a 256 -c -
+          echo "da0e79933b9ed51798a3ae27893d3c5fa4a201126cef75586296df9b4d2c62a0  bundled/models/gte-small/tokenizer.json" | shasum -a 256 -c -
           echo "ba4a1a00cf1600cae8e7cf3fda4650c825811719065b51041256392edd3647b8  bundled/models/bert-tiny-ner/model.onnx" | shasum -a 256 -c -
           echo "d241a60d5e8f04cc1b2b3e9ef7a4921b27bf526d9f6050ab90f9267a1f9e5c66  bundled/models/bert-tiny-ner/tokenizer.json" | shasum -a 256 -c -
           # ONNX Runtime
@@ -152,7 +152,7 @@ jobs:
           tar -xzf onnxruntime.tgz
           cp onnxruntime-osx-arm64-1.23.2/lib/libonnxruntime.1.23.2.dylib bundled/lib/libonnxruntime.dylib
           echo "=== Downloaded files ==="
-          ls -la bundled/lib/ bundled/models/minilm-l6/ bundled/models/bert-tiny-ner/
+          ls -la bundled/lib/ bundled/models/gte-small/ bundled/models/bert-tiny-ner/
           du -sh bundled/
 
       - name: Install maturin
@@ -230,19 +230,19 @@ jobs:
 
       - name: Download models and ONNX Runtime
         run: |
-          mkdir -p bundled/lib bundled/models/minilm-l6 bundled/models/bert-tiny-ner
+          mkdir -p bundled/lib bundled/models/gte-small bundled/models/bert-tiny-ner
           # Pinned to immutable HuggingFace commit hashes
-          curl -fSL -o bundled/models/minilm-l6/model_quantized.onnx \
-            "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf/onnx/model_quint8_avx2.onnx"
-          curl -fSL -o bundled/models/minilm-l6/tokenizer.json \
-            "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf/tokenizer.json"
+          curl -fSL -o bundled/models/gte-small/model_quantized.onnx \
+            "https://huggingface.co/Xenova/gte-small/resolve/5927d1727bb12db490052a1b33265ad78058de08/onnx/model_quantized.onnx"
+          curl -fSL -o bundled/models/gte-small/tokenizer.json \
+            "https://huggingface.co/Xenova/gte-small/resolve/5927d1727bb12db490052a1b33265ad78058de08/tokenizer.json"
           curl -fSL -o bundled/models/bert-tiny-ner/model.onnx \
             "https://huggingface.co/onnx-community/TinyBERT-finetuned-NER-ONNX/resolve/9b03777d9832105fbe419f258127fb2ec3eb09d7/onnx/model_quantized.onnx"
           curl -fSL -o bundled/models/bert-tiny-ner/tokenizer.json \
             "https://huggingface.co/onnx-community/TinyBERT-finetuned-NER-ONNX/resolve/9b03777d9832105fbe419f258127fb2ec3eb09d7/tokenizer.json"
           # SHA-256 verification (shasum on macOS)
-          echo "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21  bundled/models/minilm-l6/model_quantized.onnx" | shasum -a 256 -c -
-          echo "be50c3628f2bf5bb5e3a7f17b1f74611b2561a3a27eeab05e5aa30f411572037  bundled/models/minilm-l6/tokenizer.json" | shasum -a 256 -c -
+          echo "18dec105109b6004369799ca4761fb8fb413c64172c02147bcfac186b5c5f6cb  bundled/models/gte-small/model_quantized.onnx" | shasum -a 256 -c -
+          echo "da0e79933b9ed51798a3ae27893d3c5fa4a201126cef75586296df9b4d2c62a0  bundled/models/gte-small/tokenizer.json" | shasum -a 256 -c -
           echo "ba4a1a00cf1600cae8e7cf3fda4650c825811719065b51041256392edd3647b8  bundled/models/bert-tiny-ner/model.onnx" | shasum -a 256 -c -
           echo "d241a60d5e8f04cc1b2b3e9ef7a4921b27bf526d9f6050ab90f9267a1f9e5c66  bundled/models/bert-tiny-ner/tokenizer.json" | shasum -a 256 -c -
           # ONNX Runtime
@@ -250,7 +250,7 @@ jobs:
           tar -xzf onnxruntime.tgz
           cp onnxruntime-osx-x86_64-1.23.2/lib/libonnxruntime.1.23.2.dylib bundled/lib/libonnxruntime.dylib
           echo "=== Downloaded files ==="
-          ls -la bundled/lib/ bundled/models/minilm-l6/ bundled/models/bert-tiny-ner/
+          ls -la bundled/lib/ bundled/models/gte-small/ bundled/models/bert-tiny-ner/
           du -sh bundled/
 
       - name: Install maturin
@@ -327,17 +327,17 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path bundled/lib
-          New-Item -ItemType Directory -Force -Path bundled/models/minilm-l6
+          New-Item -ItemType Directory -Force -Path bundled/models/gte-small
           New-Item -ItemType Directory -Force -Path bundled/models/bert-tiny-ner
           # Pinned to immutable HuggingFace commit hashes
-          Invoke-WebRequest -Uri "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf/onnx/model_quint8_avx2.onnx" -OutFile "bundled/models/minilm-l6/model_quantized.onnx"
-          Invoke-WebRequest -Uri "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf/tokenizer.json" -OutFile "bundled/models/minilm-l6/tokenizer.json"
+          Invoke-WebRequest -Uri "https://huggingface.co/Xenova/gte-small/resolve/5927d1727bb12db490052a1b33265ad78058de08/onnx/model_quantized.onnx" -OutFile "bundled/models/gte-small/model_quantized.onnx"
+          Invoke-WebRequest -Uri "https://huggingface.co/Xenova/gte-small/resolve/5927d1727bb12db490052a1b33265ad78058de08/tokenizer.json" -OutFile "bundled/models/gte-small/tokenizer.json"
           Invoke-WebRequest -Uri "https://huggingface.co/onnx-community/TinyBERT-finetuned-NER-ONNX/resolve/9b03777d9832105fbe419f258127fb2ec3eb09d7/onnx/model_quantized.onnx" -OutFile "bundled/models/bert-tiny-ner/model.onnx"
           Invoke-WebRequest -Uri "https://huggingface.co/onnx-community/TinyBERT-finetuned-NER-ONNX/resolve/9b03777d9832105fbe419f258127fb2ec3eb09d7/tokenizer.json" -OutFile "bundled/models/bert-tiny-ner/tokenizer.json"
           # SHA-256 verification
           $expected = @{
-            "bundled/models/minilm-l6/model_quantized.onnx" = "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21"
-            "bundled/models/minilm-l6/tokenizer.json" = "be50c3628f2bf5bb5e3a7f17b1f74611b2561a3a27eeab05e5aa30f411572037"
+            "bundled/models/gte-small/model_quantized.onnx" = "18dec105109b6004369799ca4761fb8fb413c64172c02147bcfac186b5c5f6cb"
+            "bundled/models/gte-small/tokenizer.json" = "da0e79933b9ed51798a3ae27893d3c5fa4a201126cef75586296df9b4d2c62a0"
             "bundled/models/bert-tiny-ner/model.onnx" = "ba4a1a00cf1600cae8e7cf3fda4650c825811719065b51041256392edd3647b8"
             "bundled/models/bert-tiny-ner/tokenizer.json" = "d241a60d5e8f04cc1b2b3e9ef7a4921b27bf526d9f6050ab90f9267a1f9e5c66"
           }

--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,8 @@ python/shodh_memory/lib/*.dylib
 !python/shodh_memory/lib/__init__.py
 
 # Model files (downloaded during CI wheel builds)
-python/shodh_memory/models/minilm-l6/*.onnx
-python/shodh_memory/models/minilm-l6/*.json
+python/shodh_memory/models/gte-small/*.onnx
+python/shodh_memory/models/gte-small/*.json
 python/shodh_memory/models/bert-tiny-ner/*.onnx
 python/shodh_memory/models/bert-tiny-ner/*.json
 experiments/

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,20 +38,20 @@ RUN curl -L -o ort.tgz "https://github.com/microsoft/onnxruntime/releases/downlo
 ENV ORT_DYLIB_PATH=/usr/local/lib/libonnxruntime.so
 
 # Pre-download embedding models (cacheable independent of source code)
-# MiniLM-L6-v2 quantized (~23MB) + tokenizer (~700KB)
+# gte-small quantized int8 (~34MB) + tokenizer (~700KB)
 # NER TinyBERT quantized (~14.5MB) + tokenizer (~700KB)
 # Pinned to immutable HuggingFace commit hashes with SHA-256 verification
-RUN mkdir -p /models/minilm-l6 /models/bert-tiny-ner \
-    && curl -fSL -o /models/minilm-l6/model_quantized.onnx \
-       "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf/onnx/model_quint8_avx2.onnx" \
-    && curl -fSL -o /models/minilm-l6/tokenizer.json \
-       "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf/tokenizer.json" \
+RUN mkdir -p /models/gte-small /models/bert-tiny-ner \
+    && curl -fSL -o /models/gte-small/model_quantized.onnx \
+       "https://huggingface.co/Xenova/gte-small/resolve/5927d1727bb12db490052a1b33265ad78058de08/onnx/model_quantized.onnx" \
+    && curl -fSL -o /models/gte-small/tokenizer.json \
+       "https://huggingface.co/Xenova/gte-small/resolve/5927d1727bb12db490052a1b33265ad78058de08/tokenizer.json" \
     && curl -fSL -o /models/bert-tiny-ner/model.onnx \
        "https://huggingface.co/onnx-community/TinyBERT-finetuned-NER-ONNX/resolve/9b03777d9832105fbe419f258127fb2ec3eb09d7/onnx/model_quantized.onnx" \
     && curl -fSL -o /models/bert-tiny-ner/tokenizer.json \
        "https://huggingface.co/onnx-community/TinyBERT-finetuned-NER-ONNX/resolve/9b03777d9832105fbe419f258127fb2ec3eb09d7/tokenizer.json" \
-    && echo "b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21  /models/minilm-l6/model_quantized.onnx" | sha256sum -c - \
-    && echo "be50c3628f2bf5bb5e3a7f17b1f74611b2561a3a27eeab05e5aa30f411572037  /models/minilm-l6/tokenizer.json" | sha256sum -c - \
+    && echo "18dec105109b6004369799ca4761fb8fb413c64172c02147bcfac186b5c5f6cb  /models/gte-small/model_quantized.onnx" | sha256sum -c - \
+    && echo "da0e79933b9ed51798a3ae27893d3c5fa4a201126cef75586296df9b4d2c62a0  /models/gte-small/tokenizer.json" | sha256sum -c - \
     && echo "ba4a1a00cf1600cae8e7cf3fda4650c825811719065b51041256392edd3647b8  /models/bert-tiny-ner/model.onnx" | sha256sum -c - \
     && echo "d241a60d5e8f04cc1b2b3e9ef7a4921b27bf526d9f6050ab90f9267a1f9e5c66  /models/bert-tiny-ner/tokenizer.json" | sha256sum -c -
 
@@ -99,7 +99,7 @@ RUN ldconfig
 
 # Copy pre-downloaded models into the image (eliminates runtime downloads)
 # Directory structure matches what the downloader expects:
-#   minilm-l6/model_quantized.onnx + tokenizer.json  (embedding model)
+#   gte-small/model_quantized.onnx + tokenizer.json  (embedding model)
 #   bert-tiny-ner/model.onnx + tokenizer.json         (NER model)
 COPY --from=builder --chown=shodh:shodh /models /home/shodh/.cache/shodh-memory/models
 
@@ -124,7 +124,7 @@ ENV RUST_LOG=info \
     SHODH_PORT=3030 \
     SHODH_MEMORY_PATH=/data \
     ORT_DYLIB_PATH=/usr/local/lib/libonnxruntime.so \
-    SHODH_MODEL_PATH=/home/shodh/.cache/shodh-memory/models/minilm-l6 \
+    SHODH_MODEL_PATH=/home/shodh/.cache/shodh-memory/models/gte-small \
     SHODH_NER_MODEL_PATH=/home/shodh/.cache/shodh-memory/models/bert-tiny-ner \
     LD_LIBRARY_PATH=/usr/local/lib
 

--- a/benches/pipeline_benchmarks.rs
+++ b/benches/pipeline_benchmarks.rs
@@ -166,8 +166,8 @@ fn bench_pipeline_step1_ner(c: &mut Criterion) {
 
 fn bench_pipeline_step2_embedding(c: &mut Criterion) {
     eprintln!("\n╔══════════════════════════════════════════════════════════════╗");
-    eprintln!("║  STEP 2: EMBEDDING GENERATION - MiniLM-L6-v2                 ║");
-    eprintln!("║  Model: all-MiniLM-L6-v2 (~22MB ONNX, 384-dim vectors)       ║");
+    eprintln!("║  STEP 2: EMBEDDING GENERATION - gte-small                   ║");
+    eprintln!("║  Model: gte-small (~34MB int8 ONNX, 384-dim vectors)         ║");
     eprintln!("╚══════════════════════════════════════════════════════════════╝\n");
 
     let embedder = setup_embedder();

--- a/src/embeddings/downloader.rs
+++ b/src/embeddings/downloader.rs
@@ -22,14 +22,16 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-/// URLs for MiniLM model files (hosted on HuggingFace)
-/// Full model is 90MB, quantized is 23MB - we download quantized for edge devices
-/// Pinned to commit c9745ed1 to prevent checksum drift when HuggingFace updates models
+/// URLs for gte-small model files (hosted on HuggingFace)
+/// Full model is 133MB, quantized (int8) is 34MB - we download quantized for edge devices
+/// gte-small: 384-dim, 512-token window, mean-pool BERT arch — drop-in for MiniLM-L6,
+/// measured +0.12 recall@10 over MiniLM on the LoCoMo gold set (int8 == fp32 quality).
+/// Pinned to commit 5927d172 to prevent checksum drift when HuggingFace updates models
 const MODEL_ONNX_URL: &str =
-    "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf/onnx/model.onnx";
-const MODEL_QUANTIZED_URL: &str = "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf/onnx/model_quint8_avx2.onnx";
+    "https://huggingface.co/Xenova/gte-small/resolve/5927d1727bb12db490052a1b33265ad78058de08/onnx/model.onnx";
+const MODEL_QUANTIZED_URL: &str = "https://huggingface.co/Xenova/gte-small/resolve/5927d1727bb12db490052a1b33265ad78058de08/onnx/model_quantized.onnx";
 const TOKENIZER_URL: &str =
-    "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf/tokenizer.json";
+    "https://huggingface.co/Xenova/gte-small/resolve/5927d1727bb12db490052a1b33265ad78058de08/tokenizer.json";
 
 /// URLs for NER model files (TinyBERT-finetuned-NER, ~14.5MB quantized)
 /// Using a lightweight 4-layer TinyBERT model optimized for edge devices
@@ -45,20 +47,20 @@ const NER_TOKENIZER_URL: &str =
 struct ModelChecksums;
 
 impl ModelChecksums {
-    /// Quantized model checksum (model_quint8_avx2.onnx)
-    /// Pinned: sentence-transformers/all-MiniLM-L6-v2 @ c9745ed1
+    /// Quantized model checksum (onnx/model_quantized.onnx)
+    /// Pinned: Xenova/gte-small @ 5927d172
     const QUANTIZED_MODEL: Option<&'static str> =
-        Some("b941bf19f1f1283680f449fa6a7336bb5600bdcd5f84d10ddc5cd72218a0fd21");
+        Some("18dec105109b6004369799ca4761fb8fb413c64172c02147bcfac186b5c5f6cb");
 
-    /// Full model checksum (model.onnx)
-    /// Pinned: sentence-transformers/all-MiniLM-L6-v2 @ c9745ed1
+    /// Full model checksum (onnx/model.onnx)
+    /// Pinned: Xenova/gte-small @ 5927d172
     const FULL_MODEL: Option<&'static str> =
-        Some("6fd5d72fe4589f189f8ebc006442dbb529bb7ce38f8082112682524616046452");
+        Some("398a29991324e0b383afa13375d681ced3079c83e097fb1ebd9290d7498523b3");
 
     /// Tokenizer checksum (tokenizer.json)
-    /// Pinned: sentence-transformers/all-MiniLM-L6-v2 @ c9745ed1
+    /// Pinned: Xenova/gte-small @ 5927d172
     const TOKENIZER: Option<&'static str> =
-        Some("be50c3628f2bf5bb5e3a7f17b1f74611b2561a3a27eeab05e5aa30f411572037");
+        Some("da0e79933b9ed51798a3ae27893d3c5fa4a201126cef75586296df9b4d2c62a0");
 
     /// NER quantized model checksum (model_quantized.onnx)
     /// Pinned: onnx-community/TinyBERT-finetuned-NER-ONNX @ 9b03777d
@@ -97,9 +99,9 @@ pub fn get_cache_dir() -> PathBuf {
     PathBuf::from(".shodh-cache")
 }
 
-/// Get the models directory for embeddings (MiniLM)
+/// Get the models directory for embeddings (gte-small)
 pub fn get_models_dir() -> PathBuf {
-    get_cache_dir().join("models").join("minilm-l6")
+    get_cache_dir().join("models").join("gte-small")
 }
 
 /// Get the models directory for NER (bert-tiny-ner)
@@ -481,9 +483,9 @@ pub fn download_models_internal(
         return Ok(models_dir);
     }
 
-    tracing::info!("Downloading MiniLM-L6-v2 model to {:?}", models_dir);
+    tracing::info!("Downloading gte-small model to {:?}", models_dir);
 
-    // Download model (quantized ~23MB or full ~90MB)
+    // Download model (quantized int8 ~34MB or full ~133MB)
     let (model_url, model_filename, model_checksum) = if use_quantized {
         (
             MODEL_QUANTIZED_URL,
@@ -502,7 +504,7 @@ pub fn download_models_internal(
         } else {
             "HuggingFace (full)"
         },
-        if use_quantized { 23 } else { 90 }
+        if use_quantized { 34 } else { 133 }
     );
     download_file_with_checksum(
         model_url,
@@ -527,7 +529,7 @@ pub fn download_models_internal(
     )?;
 
     tracing::info!(
-        "MiniLM-L6-v2 model downloaded successfully to {:?}",
+        "gte-small model downloaded successfully to {:?}",
         models_dir
     );
     Ok(models_dir)
@@ -852,7 +854,7 @@ mod tests {
     #[test]
     fn test_models_dir() {
         let models_dir = get_models_dir();
-        assert!(models_dir.to_string_lossy().contains("minilm-l6"));
+        assert!(models_dir.to_string_lossy().contains("gte-small"));
     }
 
     /// Regression test for #250: a 14KB providers_shared stub masquerading as

--- a/src/embeddings/minilm.rs
+++ b/src/embeddings/minilm.rs
@@ -9,7 +9,7 @@
 //! - Simplified fallback for resource-constrained devices
 //!
 //! Configuration via environment variables:
-//! - SHODH_MODEL_PATH: Base path to model files (default: ./models/minilm-l6)
+//! - SHODH_MODEL_PATH: Base path to model files (default: ./models/gte-small)
 //! - SHODH_EMBED_TIMEOUT_MS: Embedding timeout in ms (default: 5000)
 //! - SHODH_LAZY_LOAD: Set to "false" to load model at startup (default: true)
 //! - SHODH_ONNX_THREADS: Number of ONNX threads (default: 1 on macOS ARM64, 2 elsewhere)
@@ -107,7 +107,7 @@ pub struct EmbeddingConfig {
     /// Path to tokenizer file
     pub tokenizer_path: PathBuf,
 
-    /// Maximum sequence length (MiniLM default: 256)
+    /// Maximum sequence length (gte-small window: 512)
     pub max_length: usize,
 
     /// Use quantized model for faster inference
@@ -128,10 +128,10 @@ impl EmbeddingConfig {
     ///
     /// Search order for model files:
     /// 1. SHODH_MODEL_PATH environment variable
-    /// 2. Bundled in Python package (SHODH_PACKAGE_DIR/models/minilm-l6)
-    /// 3. ./models/minilm-l6 (local)
-    /// 4. ../models/minilm-l6 (parent)
-    /// 5. ~/.cache/shodh-memory/models/minilm-l6 (auto-download location)
+    /// 2. Bundled in Python package (SHODH_PACKAGE_DIR/models/gte-small)
+    /// 3. ./models/gte-small (local)
+    /// 4. ../models/gte-small (parent)
+    /// 5. ~/.cache/shodh-memory/models/gte-small (auto-download location)
     pub fn from_env() -> Self {
         let base_path = std::env::var("SHODH_MODEL_PATH")
             .map(PathBuf::from)
@@ -141,12 +141,12 @@ impl EmbeddingConfig {
                     // Bundled in Python package (highest priority for pip install)
                     std::env::var("SHODH_PACKAGE_DIR")
                         .ok()
-                        .map(|p| PathBuf::from(p).join("models/minilm-l6")),
-                    Some(PathBuf::from("./models/minilm-l6")),
-                    Some(PathBuf::from("../models/minilm-l6")),
+                        .map(|p| PathBuf::from(p).join("models/gte-small")),
+                    Some(PathBuf::from("./models/gte-small")),
+                    Some(PathBuf::from("../models/gte-small")),
                     // Auto-download cache location
                     Some(super::downloader::get_models_dir()),
-                    dirs::data_dir().map(|p| p.join("shodh-memory/models/minilm-l6")),
+                    dirs::data_dir().map(|p| p.join("shodh-memory/models/gte-small")),
                 ];
 
                 candidates
@@ -176,7 +176,7 @@ impl EmbeddingConfig {
         Self {
             model_path: base_path.join(model_filename),
             tokenizer_path: base_path.join("tokenizer.json"),
-            max_length: 256,
+            max_length: 512,
             use_quantized,
             embed_timeout_ms,
         }
@@ -187,7 +187,7 @@ impl EmbeddingConfig {
         Self {
             model_path,
             tokenizer_path,
-            max_length: 256,
+            max_length: 512,
             use_quantized: true,
             embed_timeout_ms: 5000,
         }
@@ -1011,7 +1011,7 @@ mod tests {
         let config = EmbeddingConfig::default();
 
         // Check dimension
-        assert_eq!(config.max_length, 256);
+        assert_eq!(config.max_length, 512);
     }
 
     #[test]
@@ -1020,7 +1020,7 @@ mod tests {
         let config = EmbeddingConfig {
             model_path: PathBuf::from("dummy.onnx"),
             tokenizer_path: PathBuf::from("dummy.json"),
-            max_length: 256,
+            max_length: 512,
             use_quantized: true,
             embed_timeout_ms: 5000,
         };
@@ -1042,7 +1042,7 @@ mod tests {
         let config = EmbeddingConfig {
             model_path: PathBuf::from("dummy.onnx"),
             tokenizer_path: PathBuf::from("dummy.json"),
-            max_length: 256,
+            max_length: 512,
             use_quantized: true,
             embed_timeout_ms: 5000,
         };

--- a/src/embeddings/mod.rs
+++ b/src/embeddings/mod.rs
@@ -25,6 +25,13 @@ pub use chunking::{chunk_text, ChunkConfig, ChunkResult};
 
 use anyhow::Result;
 
+/// Identifier of the embedding model wired into this build. Persisted into each
+/// store the first time it is (re-)embedded; if a store opens with a different
+/// marker, an automatic re-embed migration runs (MiniLM-space != gte-space, so
+/// stale vectors would silently mismatch live queries). Bump this whenever the
+/// embedding model changes.
+pub const CURRENT_EMBEDDER_ID: &str = "gte-small";
+
 // Re-export downloader functions for convenience
 pub use downloader::{
     are_models_downloaded, are_ner_models_downloaded, download_ner_models, ensure_downloaded,

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -437,6 +437,78 @@ impl MemorySystem {
         )
         .context("Failed to initialize retrieval engine")?;
 
+        // EMBEDDER MIGRATION (auto re-embed on open): if this store's vectors were
+        // produced by a different embedder than the live one, re-embed every memory
+        // so stored vectors share the query embedding space. MiniLM-space and
+        // gte-space are not comparable, so a silent mismatch would degrade recall.
+        // The marker is stamped only after a full pass, so a crash mid-migration
+        // re-runs on next open; any per-memory failures fall through to the orphan
+        // recovery below, which re-indexes them with the live embedder.
+        {
+            let current = crate::embeddings::CURRENT_EMBEDDER_ID;
+            let stored_embedder = storage.get_embedder_id().unwrap_or(None);
+            let store_count = storage.get_stats().map(|s| s.total_count).unwrap_or(0);
+            let needs_re_embed = match &stored_embedder {
+                Some(id) => id != current,
+                None => store_count > 0, // legacy data w/o marker = pre-marker MiniLM store
+            };
+            if needs_re_embed {
+                tracing::warn!(
+                    from = ?stored_embedder,
+                    to = current,
+                    memories = store_count,
+                    "Embedder changed — re-embedding all memories (one-time migration on open)"
+                );
+                let start = std::time::Instant::now();
+                let ids = storage.get_all_ids().unwrap_or_default();
+                let total = ids.len();
+                let mut done = 0usize;
+                let mut failed = 0usize;
+                for id in &ids {
+                    let mut memory = match storage.get(id) {
+                        Ok(m) => m,
+                        Err(_) => {
+                            failed += 1;
+                            continue;
+                        }
+                    };
+                    if memory.is_forgotten() {
+                        continue;
+                    }
+                    // Drop the stale cached vector so reindex re-encodes with the live embedder.
+                    memory.experience.embeddings = None;
+                    if storage.store(&memory).is_err() {
+                        failed += 1;
+                        continue;
+                    }
+                    if retriever.reindex_memory(&memory).is_err() {
+                        failed += 1;
+                        continue;
+                    }
+                    done += 1;
+                    if done % 1000 == 0 {
+                        tracing::info!("re-embed progress: {}/{} ({} failed)", done, total, failed);
+                    }
+                }
+                if let Err(e) = retriever.save() {
+                    tracing::warn!(error = %e, "re-embed: failed to persist rebuilt index");
+                }
+                if let Err(e) = storage.set_embedder_id(current) {
+                    tracing::warn!(error = %e, "re-embed: failed to write embedder marker");
+                }
+                tracing::info!(
+                    "Re-embed migration complete: {} re-embedded, {} failed, {} total in {:.1}s",
+                    done,
+                    failed,
+                    total,
+                    start.elapsed().as_secs_f64()
+                );
+            } else if stored_embedder.is_none() {
+                // Fresh/empty store: stamp the live embedder so a future swap is detected.
+                let _ = storage.set_embedder_id(current);
+            }
+        }
+
         // STARTUP RECOVERY: Check for orphaned memories and auto-repair
         // This fixes memories that were stored but not indexed (crash, embedding failure, etc.)
         let storage_count = storage.get_stats().map(|s| s.total_count).unwrap_or(0);

--- a/src/memory/storage.rs
+++ b/src/memory/storage.rs
@@ -1417,6 +1417,26 @@ impl MemoryStorage {
         }
     }
 
+    /// Read the persisted embedder-id marker — the model that produced the
+    /// vectors currently stored in this database. `None` means the marker was
+    /// never written (a legacy store predating the marker, or a fresh store).
+    pub fn get_embedder_id(&self) -> Result<Option<String>> {
+        const KEY: &[u8] = b"metadata:embedder_id";
+        match self.db.get(KEY)? {
+            Some(bytes) => Ok(Some(String::from_utf8_lossy(&bytes).into_owned())),
+            None => Ok(None),
+        }
+    }
+
+    /// Persist the embedder-id marker. Written only after the store's vectors
+    /// have been (re-)embedded with `id`, so a crash mid-migration leaves the
+    /// marker stale and the migration re-runs on next open.
+    pub fn set_embedder_id(&self, id: &str) -> Result<()> {
+        const KEY: &[u8] = b"metadata:embedder_id";
+        self.db.put(KEY, id.as_bytes())?;
+        Ok(())
+    }
+
     /// Internal store implementation (two-phase commit with rollback)
     fn store_inner(&self, memory: &Memory) -> Result<()> {
         let key = memory.id.0.as_bytes();

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -34,7 +34,7 @@ use super::report::{
 
 /// Embedder identifier emitted in the report. Matches the model wired into
 /// `MemorySystem::new` today; bump when the embedder changes.
-pub const EMBEDDER_ID: &str = "minilm-l6-v2";
+pub const EMBEDDER_ID: &str = "gte-small";
 
 /// Inputs to [`run_smoke_suite`].
 #[derive(Debug, Clone)]

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -34,7 +34,7 @@ use super::report::{
 
 /// Embedder identifier emitted in the report. Matches the model wired into
 /// `MemorySystem::new` today; bump when the embedder changes.
-pub const EMBEDDER_ID: &str = "gte-small";
+pub const EMBEDDER_ID: &str = crate::embeddings::CURRENT_EMBEDDER_ID;
 
 /// Inputs to [`run_smoke_suite`].
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
Swaps the embedding model from MiniLM-L6-v2 to **gte-small** (int8 ONNX, 384-dim, mean-pool — a drop-in), and adds an **auto re-embed-on-open migration** so existing stores transparently move to the new embedding space.

## Why
Pure-embedder A/B on the LoCoMo gold set (1531 cases, per-conversation retrieval):

| category | MiniLM r@10 | gte-small r@10 | Δ |
| --- | --- | --- | --- |
| ALL | 0.455 | 0.578 | +0.123 |
| temporal | 0.494 | 0.665 | +0.171 |
| single_hop | 0.523 | 0.637 | +0.114 |
| multi_hop | 0.270 | 0.383 | +0.113 |

int8 == fp32 quality on our data; fp16 won't load on the CPU EP. RAM +27MB vs MiniLM (~57MB resident).

## Honest caveat — end-to-end
The raw embedder lift is large, but **end-to-end through the full pipeline it is currently only +0.0073 recall@10** (full: 0.5391 -> 0.5464). Fusion absorbs ~94% of the embedder signal — the vector leg is not the current bottleneck, fusion is. We merge the better substrate now; the fusion fix that lets it land is tracked separately.

## Changes
- **Embedder swap** (df2c9b3): downloader URLs + SHA-256 (Xenova/gte-small@5927d172), max_length 256->512, cache dir minilm-l6->gte-small, Dockerfile + pypi bundling (all platforms), harness EMBEDDER_ID, and per-ablation **Peak RSS** reporting in locomo-recall.yml.
- **Auto re-embed migration** (b515548): MemorySystem::new detects an embedder-marker mismatch (or legacy data without a marker) and re-embeds every memory + rebuilds the index + stamps the marker. Crash-safe (marker only after a full pass; failures fall through to orphan recovery), per-user-store automatic, fresh stores no-op.

## Validation
- cargo check green.
- Pure-embedder A/B (above), Python on our gold set.
- End-to-end CI: gte run 26999363230 vs minilm baseline 26994487006 (full pipeline, 1531 cases).

## Notes for deployment / merge
- First open of an **existing** store re-embeds all memories (one-time, progress-logged).
- Embedding dimension unchanged (384) — no vector-schema change.
- Engine Peak RSS ~764 MB.