### PR TITLE
feat(fusion): make calibrated-max (FLAT) the default fusion (+0.0665 recall@10)

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -2957,7 +2957,7 @@ impl MemorySystem {
             // instead of being RRF-buried by BM25's lexical crowd in the hybrid pre-fusion
             // (funnel-located: the entire multi_hop loss is vector 7.4 → hybrid 28.4). Implies
             // the calibrated graph leg. hybrid_w is split; vector trusted more by default.
-            let flat_fusion = std::env::var("SHODH_FUSION_FLAT")
+            let explicit_flat = std::env::var("SHODH_FUSION_FLAT")
                 .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                 .unwrap_or(false);
             // Consensus weight for the MIN leg in the max-fusion (a candidate present in BOTH
@@ -3017,6 +3017,20 @@ impl MemorySystem {
             let fw_graph = env_w("SHODH_FW_GRAPH", 0.3);
             let fw_vec = env_w("SHODH_FW_VEC", 0.6);
             let fw_bm25 = env_w("SHODH_FW_BM25", 0.4);
+
+            // SHODH_FUSION_FLAT (calibrated-max) is now the DEFAULT fusion: measured
+            // +0.0665 recall@10 ALL (RRF 0.6188 → 0.6853), funnel fusion mean-rank 14.3→8.25,
+            // top10 68.7→76.0 (runs 27216648530 + 27218456694, reproduced identically). The
+            // per-candidate MAX of the calibrated vector/BM25 legs (+ small consensus on the
+            // min) and the calibrated graph leg keep a single-leg-strong gold from being
+            // RRF-buried by the lexical crowd. It is on UNLESS another explicit fusion mode
+            // (V2 / ACT-R / SUM) is requested, or SHODH_FUSION_RRF selects the legacy
+            // rank-reciprocal fusion (escape hatch). Explicit SHODH_FUSION_FLAT still forces it.
+            let rrf_escape = std::env::var("SHODH_FUSION_RRF")
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false);
+            let flat_fusion = explicit_flat
+                || (!rrf_escape && !v2_fusion && !actr_fusion && !sum_fusion);
 
             // Graph leg.
             for (r, (id, activation, h)) in graph_results.iter().enumerate() {


### PR DESCRIPTION
## Make calibrated-max (FLAT) the default fusion — +0.0665 recall@10

The LoCoMo eval baseline ran the **legacy RRF** (rank-reciprocal) fusion, which discards leg-score **magnitude** — so a single-leg-strong gold gets buried under the lexical crowd. A diagnostic investigation (4 A/Bs) located the bottleneck precisely: **gold is 96.3% present at fusion but mean-rank 14.3** (only 68.7% in top-10). The fix was a fusion mode that *already existed in the code but had never been enabled in eval*: `SHODH_FUSION_FLAT` (per-candidate **MAX** of the calibrated vector/BM25 legs + a small consensus bonus, plus the calibrated graph leg).

### Measured (300 cases / 1500 corpus, reproduced **identically** across two runs)
| category | RRF | FLAT | Δ |
|---|---|---|---|
| **ALL** | 0.6188 | **0.6853** | **+0.0665** |
| single_hop | 0.6963 | 0.7515 | +0.055 |
| multi_hop | 0.3329 | 0.4379 | **+0.105** |
| temporal | 0.7136 | 0.7958 | +0.082 |
| open_domain | 0.3000 | 0.2833 | −0.017 |

**Funnel (mechanism):** fusion `top10%` 68.7→**76.0**, `mean_rank` **14.30→8.25** — FLAT pulls the present-but-buried gold into the top-10.

### Change
`flat_fusion` is now the default **unless**:
- an explicit `SHODH_FUSION_V2` / `SHODH_ACTR_FUSION` / `SHODH_FUSION_SUM` mode is chosen (these still take precedence), or
- `SHODH_FUSION_RRF=1` selects the legacy rank-reciprocal fusion (escape hatch).

Explicit `SHODH_FUSION_FLAT=1` still forces it. No other default behavior changes.

### Audit (6-point, all green)
- **effect** +0.0665 ≫ ±0.003 noise floor
- **measurement** reproduced byte-identical (0.6853) across two runs → deterministic
- **mechanism** funnel confirms rank 14.3→8.25
- **skepticism** large per-category margins
- **failure-mode** open_domain −0.017 is the only regression, bounded; `flat_consensus=0.15` gives +0.0795 ALL but pushes open_domain to −0.039 → kept the safer default 0.3 (open_domain dip flagged for follow-up)
- **cross-check** recall + funnel agree

`cargo check` clean; **735 lib tests pass**.

Targets `exp/ner-gliner-ablation`.
