### PR TITLE
fix(scoring): disable the Layer-5 hebbian rank boost by default (+6.7pp p@1, recall unchanged)

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -2666,6 +2666,17 @@ impl MemorySystem {
             "linguistic",
             "competition",
         ];
+        // DEFAULT: the Layer-5 hebbian RANK BOOST is disabled. The L5 bisect (run
+        // 27251798933) measured it as a strict ordering saboteur: disabling only
+        // hebbian lifted p@1 ALL 0.4100→0.4767 (+6.7pp), single_hop +11pp,
+        // open_domain 2x, multi_hop up, temporal HELD, MRR +0.042 — with recall@10
+        // bit-identical (L5 is post-truncation). Mechanism: heb scores come from
+        // graph co-activation and edges strengthen on EVERY retrieval (not on
+        // outcome), so frequently co-retrieved hub memories climb within the
+        // top-10 and displace gold at rank 1 — retrieval-gated rich-get-richer.
+        // Hebbian LEARNING (edge strengthening, spreading activation) is untouched;
+        // only the L5 score multiplier is off. Setting SHODH_DISABLE_BOOSTS
+        // explicitly (even to "") replaces this default — the escape hatch.
         let disabled_boosts: std::collections::HashSet<String> =
             std::env::var("SHODH_DISABLE_BOOSTS")
                 .map(|v| {
@@ -2674,7 +2685,7 @@ impl MemorySystem {
                         .filter(|t| !t.is_empty())
                         .collect()
                 })
-                .unwrap_or_default();
+                .unwrap_or_else(|_| std::iter::once("hebbian".to_string()).collect());
         for tok in &disabled_boosts {
             if tok != "all" && !BOOST_FAMILIES.contains(&tok.as_str()) {
                 tracing::warn!("SHODH_DISABLE_BOOSTS: unknown boost family '{tok}' (ignored)");


### PR DESCRIPTION
## What

Default `SHODH_DISABLE_BOOSTS` to `hebbian` when the env var is unset: the Layer-5 hebbian **rank boost** is off by default. Hebbian **learning** (edge strengthening, spreading activation) is untouched. Setting `SHODH_DISABLE_BOOSTS` explicitly — including to an empty string — overrides the default.

## Why (measured)

L5 bisect, run [27251798933](https://github.com/varun29ankuS/shodh-memory/actions/runs/27251798933): leave-one-out over the 6 eval-active Layer-5 boost families, with a recall@10-identity guard (Layer 5 runs post-truncation, so recall@10 must not move — it didn't, in any of 8 arms).

Disabling **only** hebbian:

| metric | baseline | -hebbian |
|---|---|---|
| p@1 ALL | 0.4100 | **0.4767** (+6.7pp) |
| p@1 single_hop | 0.4110 | **0.5215** (+11pp) |
| p@1 temporal | 0.5352 | **0.5352** (held) |
| p@1 open_domain | 0.0667 | **0.1333** (2x) |
| p@1 multi_hop | 0.3333 | **0.3529** |
| MRR ALL | 0.5315 | **0.5733** |
| recall@10 ALL | 0.6853 | **0.6853** (bit-identical) |

Strictly Pareto: every category ≥ baseline. Beats disabling the whole L5 pack (which trades temporal p@1 −8.5pp through the linguistic family). Effect size is ~20× the observed run-to-run variance (0.3pp, stage-1 vs stage-2 cross-check).

## Mechanism

`heb` scores derive from graph co-activation, and edges strengthen on **every retrieval** (`batch_strengthen_synapses` on traversal) with no outcome gating. Frequently co-retrieved hub memories therefore accumulate boost and climb inside the top-10, displacing gold at rank 1 — retrieval-gated rich-get-richer. The correct form of this signal is outcome-gated (feedback momentum), which already exists as a separate factor and stays on.

## Context

Found via the post-fusion boost-stack ablation (stage 1: run 27249880829 — Layer 5 is structurally invisible to recall@10 but reorders the kept window; stage 2: this bisect). Kill-switch infrastructure landed in 18327a5.