### PR TITLE
feat(graph): PPR as the default spreading activation (+0.012 recall@10, no category tradeoff)

### DIFF
--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -1015,13 +1015,22 @@ pub fn spreading_activation_retrieve_with_stats(
     let graph_start = Instant::now();
     let mut traversed_edges: Vec<Uuid>;
 
-    // SHODH_PPR: replace the hand-rolled BFS spread with Personalized PageRank — the
-    // convergent, mass-conserving form of spreading activation (PPR). The seed
+    // SHODH_PPR: Personalized PageRank replaces the hand-rolled BFS spread — the
+    // convergent, mass-conserving form of spreading activation. The seed
     // activation_map becomes the restart vector; PPR's stationary distribution becomes the
     // new activation_map consumed by the shared episode-scoring path below.
+    //
+    // DEFAULT ON since runs 27252898191 + 27255557316 (reproduced to 4 decimals):
+    // recall@10 ALL 0.6853→0.6976 with single_hop +0.018 AND temporal +0.014 —
+    // the first graph-side lever WITHOUT the structural category tradeoff
+    // (multi_hop -0.006 the only cost; p@1/MRR also up; funnel graph present%
+    // 51→76). PPR subsumes the BFS spread's patches in one principled mechanism:
+    // no per-hop threshold pruning (the 2-3 hop activation collapse), restart
+    // mass replaces ad-hoc hop decay, and column normalization handles hubs.
+    // SHODH_PPR=0 restores the legacy BFS spread (escape hatch).
     let ppr_enabled = std::env::var("SHODH_PPR")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
+        .map(|v| !(v == "0" || v.eq_ignore_ascii_case("false")))
+        .unwrap_or(true);
 
     if ppr_enabled {
         let pred_w = std::env::var("SHODH_GRAPH_PREDICATE_WEIGHTS")


### PR DESCRIPTION
## What

`SHODH_PPR` flips default-on: Personalized PageRank replaces the hand-rolled BFS spread as the graph leg's activation mechanism. `SHODH_PPR=0` is the escape hatch back to the legacy spread.

## Why (measured, reproduced)

Two independent runs, PPR arm identical to 4 decimals:

| metric | base (FLAT, post-#321/#322) | PPR | Δ |
|---|---|---|---|
| recall@10 ALL | 0.6853 | **0.6976** | **+0.0123** |
| single_hop | 0.7515 | **0.7699** | +0.0184 |
| temporal | 0.7958 | **0.8099** | +0.0141 |
| multi_hop | 0.4379 | 0.4318 | −0.0061 |
| open_domain | 0.2833 | 0.2833 | 0 |
| p@1 ALL | 0.4767 | 0.4833 | +0.0066 |
| MRR ALL | 0.5733 | 0.5794 | +0.0061 |
| funnel graph present% | 51.0 | 76.3 | +25.3 |

Runs: [27252898191](https://github.com/varun29ankuS/shodh-memory/actions/runs/27252898191) (graph-leg sweep — PPR best of 6 arms), [27255557316](https://github.com/varun29ankuS/shodh-memory/actions/runs/27255557316) (confirm + PPR×traverse probe; PPR+traverse is worse than PPR alone — rejected).

Every prior graph-side knob traded one category against another (the structural tradeoff that killed vec-trust, vec-abs, peakedness, traverse-as-default). PPR is the first that lifts ALL with single_hop and temporal both up — because it fixes the spread's mechanics rather than re-weighting its output: no per-hop threshold pruning (the documented 2-3 hop activation collapse), restart mass instead of compounding ad-hoc decay, column normalization instead of degree heuristics. Under FLAT fusion the leg's activation magnitude survives into the final score, which is why this matters now and didn't under RRF (pre-FLAT measurement called PPR 'second-order' — the regime changed).

## New baseline

After merge, the canonical recall@10 reference moves **0.6853 → 0.6976**. In-flight A/Bs measured against 0.6853 remain internally valid (their own base arms) but their absolute numbers predate this default.