### PR TITLE
eval(sota): LongMemEval harness + graph-leg determinism fixes

### DIFF
--- a/.github/workflows/longmemeval.yml
+++ b/.github/workflows/longmemeval.yml
@@ -1,0 +1,106 @@
+# LongMemEval-S — current SOTA long-term memory benchmark (ICLR 2025).
+#
+# Manual only, NOT gated. Measures TURN-LEVEL retrieval recall@10 against the
+# `has_answer` gold turns (no LLM judge) — the honest "does our memory surface
+# the evidence?" signal, NOT the end-to-end answer accuracy the headline SOTA
+# numbers report. Each question has its own ~48-session haystack, so the harness
+# loops per-question (fresh ingest each).
+#
+# Downloads longmemeval_s from HuggingFace, runs benchmarks/longmemeval_to_harness.py
+# (with --shuffle so a --limit prefix is a representative category mix), then
+# recall-eval --longmemeval.
+name: LongMemEval (SOTA)
+
+on:
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: 'Number of questions (representative mix via --shuffle). Blank = all 479.'
+        required: false
+        default: '50'
+      extra_env:
+        description: 'Extra SHODH_* flags, space-separated KEY=VAL.'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: longmemeval-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  longmemeval:
+    name: LongMemEval-S
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: recall-eval
+
+      - name: Install LLVM (ONNX runtime build dep)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm-dev libclang-dev clang
+
+      - name: Build recall-eval
+        run: cargo build --release --bin recall-eval
+
+      - name: Cache embedder model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/shodh-memory/models
+          key: shodh-models-minilm-c9745ed1
+
+      - name: Pre-fetch MiniLM embedder model
+        run: |
+          MODEL_DIR="$HOME/.cache/shodh-memory/models/minilm-l6"
+          mkdir -p "$MODEL_DIR"
+          PIN=c9745ed1d9f207416be6d2e6f8de32d1f16199bf
+          BASE="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/$PIN"
+          dl() { curl -fL --retry 20 --retry-all-errors --retry-delay 15 --connect-timeout 30 -o "$1" "$2"; }
+          [ -s "$MODEL_DIR/model_quantized.onnx" ] || dl "$MODEL_DIR/model_quantized.onnx" "$BASE/onnx/model_quint8_avx2.onnx"
+          [ -s "$MODEL_DIR/tokenizer.json" ]       || dl "$MODEL_DIR/tokenizer.json" "$BASE/tokenizer.json"
+          ls -la "$MODEL_DIR"
+
+      - name: Download LongMemEval-S + build fixtures
+        run: |
+          python3 -m pip install --quiet huggingface_hub
+          JSON=$(python3 - <<'PY'
+          from huggingface_hub import hf_hub_download
+          print(hf_hub_download(repo_id='xiaowu0162/longmemeval-cleaned',
+                                filename='longmemeval_s_cleaned.json',
+                                repo_type='dataset'))
+          PY
+          )
+          echo "dataset: $JSON"
+          python3 benchmarks/longmemeval_to_harness.py --input "$JSON" --shuffle \
+            ${{ github.event.inputs.limit != '' && format('--limit {0}', github.event.inputs.limit) || '' }}
+          wc -l tests/recall/longmemeval/manifest.jsonl
+
+      - name: Run LongMemEval
+        run: |
+          for kv in ${{ github.event.inputs.extra_env }}; do export "$kv"; done
+          ./target/release/recall-eval \
+            --longmemeval tests/recall/longmemeval \
+            --output unused.json \
+            --storage ./lme-storage 2>&1 | tee longmemeval.log
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## LongMemEval-S — turn-level retrieval recall@10 (no LLM judge)"
+            echo ""
+            echo '> NOT comparable to headline LongMemEval answer-accuracy SOTA (which reads retrieved context with a large LLM). This is the retrieval half: does our memory surface the gold evidence turns?'
+            echo ""
+            echo '```'
+            grep -E "NER_BACKEND|LongMemEval-S:|recall@" longmemeval.log || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ facts_out.json
 
 # Drafts / working scratch — local-only, never commit (plans, eval scratch, reports, venvs)
 drafts/
+tests/recall/longmemeval/

--- a/benchmarks/longmemeval_to_harness.py
+++ b/benchmarks/longmemeval_to_harness.py
@@ -41,6 +41,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 from datetime import datetime, timezone
@@ -166,12 +167,25 @@ def main() -> None:
         default=None,
         help="only convert the first N scorable questions (cheap pilot)",
     )
+    ap.add_argument(
+        "--shuffle",
+        action="store_true",
+        help="deterministically reorder so any --limit prefix is a representative "
+        "category mix (the source is type-ordered)",
+    )
     args = ap.parse_args()
 
     with open(args.input, encoding="utf-8") as f:
         data = json.load(f)
     if isinstance(data, dict):  # some releases wrap in {"questions": [...]}
         data = data.get("questions", list(data.values()))
+
+    if args.shuffle:
+        # The source is type-ordered (all single-session questions first), so a
+        # naive --limit prefix would be all easy single-hop. Order by a stable
+        # hash of question_id: deterministic and reproducible, but any prefix is
+        # a representative mix of categories.
+        data.sort(key=lambda q: hashlib.md5(q["question_id"].encode()).hexdigest())
 
     stats = convert(data, args.out, args.limit)
     print(

--- a/benchmarks/longmemeval_to_harness.py
+++ b/benchmarks/longmemeval_to_harness.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Convert LongMemEval-S into per-question recall-harness fixtures.
+
+LongMemEval (xiaowu0162/LongMemEval, ICLR 2025) is the current SOTA long-term
+memory benchmark: 500 questions, each with its OWN haystack of ~48 chat
+sessions (~115K tokens). This differs structurally from LoCoMo, where 10
+dialogues are shared across all questions — here every question carries a
+private haystack, so the harness must ingest one haystack, run one query, and
+score, then move to the next question (a loop of mini-evals, not one shared
+corpus).
+
+Gold evidence is annotated two ways in the source:
+  - turn-level: turns that support the answer carry `"has_answer": true`
+  - session-level: `answer_session_ids` lists the evidence sessions
+We emit the TURN-LEVEL target — the strictest, cleanest recall@k signal, with
+no LLM judge — matching how recall-eval scores the smoke and LoCoMo suites.
+
+Source schema (longmemeval_s.json, one object per question):
+  question_id, question, answer, question_type, question_date,
+  haystack_session_ids: [sid, ...],
+  haystack_dates:       [iso, ...],
+  haystack_sessions:    [[{role, content, has_answer?}, ...], ...],
+  answer_session_ids:   [sid, ...]
+
+Output (recall-harness fixtures, under tests/recall/longmemeval/):
+  manifest.jsonl          — one line per question:
+      {id, question, category, gold_ids:[turn_id,...], corpus: "corpora/<qid>.jsonl"}
+  corpora/<question_id>.jsonl — one CorpusItem per user/assistant turn:
+      {id, content, memory_type, tags, created_at}
+
+A turn id is `<question_id>::<session_id>::t<turn_index>` so it is globally
+unique and traceable back to the source.
+
+Usage:
+  pip install huggingface_hub
+  python -c "from huggingface_hub import hf_hub_download as d; \
+      print(d(repo_id='xiaowu0162/longmemeval-cleaned', \
+      filename='longmemeval_s_cleaned.json', repo_type='dataset'))"
+  python benchmarks/longmemeval_to_harness.py --input <path-to-json> --limit 50
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime, timezone
+
+# LongMemEval question_type -> harness category. The harness category is used
+# only for per-category recall breakdowns; unknown types fall back to "other".
+CATEGORY = {
+    "single-session-user": "single_hop",
+    "single-session-assistant": "single_hop",
+    "single-session-preference": "single_hop",
+    "multi-session": "multi_hop",
+    "temporal-reasoning": "temporal",
+    "knowledge-update": "knowledge_update",
+}
+
+
+def iso(raw: str) -> str:
+    """Normalize a haystack date to RFC3339 UTC; fall back to a fixed epoch."""
+    if raw:
+        for fmt in (
+            "%Y/%m/%d (%a) %H:%M",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%d",
+        ):
+            try:
+                return (
+                    datetime.strptime(raw.strip(), fmt)
+                    .replace(tzinfo=timezone.utc)
+                    .isoformat()
+                )
+            except ValueError:
+                continue
+        # Some releases already ship RFC3339.
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(
+                timezone.utc
+            ).isoformat()
+        except ValueError:
+            pass
+    return datetime(2023, 1, 1, tzinfo=timezone.utc).isoformat()
+
+
+def convert(data: list, out_dir: str, limit: int | None) -> dict:
+    corpora_dir = os.path.join(out_dir, "corpora")
+    os.makedirs(corpora_dir, exist_ok=True)
+    manifest: list[dict] = []
+    stats = {"questions": 0, "turns": 0, "gold_turns": 0, "no_gold": 0}
+
+    for q in data:
+        if limit is not None and stats["questions"] >= limit:
+            break
+        qid = q["question_id"]
+        sessions = q.get("haystack_sessions", [])
+        sids = q.get("haystack_session_ids", [])
+        dates = q.get("haystack_dates", [])
+
+        corpus: list[dict] = []
+        gold_ids: list[str] = []
+        for si, session in enumerate(sessions):
+            sid = sids[si] if si < len(sids) else f"s{si}"
+            created = iso(dates[si] if si < len(dates) else "")
+            for ti, turn in enumerate(session):
+                content = (turn.get("content") or "").strip()
+                if not content:
+                    continue
+                tid = f"{qid}::{sid}::t{ti}"
+                corpus.append(
+                    {
+                        "id": tid,
+                        "content": content,
+                        "memory_type": "conversation",
+                        "tags": [sid, turn.get("role", "user")],
+                        "created_at": created,
+                    }
+                )
+                if turn.get("has_answer") is True:
+                    gold_ids.append(tid)
+
+        if not corpus:
+            continue
+        if not gold_ids:
+            # No turn-level gold (some releases only annotate at session level).
+            # Skip rather than emit an unscorable case — keeps recall honest.
+            stats["no_gold"] += 1
+            continue
+
+        corpus_rel = os.path.join("corpora", f"{qid}.jsonl")
+        with open(os.path.join(out_dir, corpus_rel), "w", encoding="utf-8") as f:
+            for item in corpus:
+                f.write(json.dumps(item, ensure_ascii=False) + "\n")
+
+        manifest.append(
+            {
+                "id": qid,
+                "question": q.get("question", ""),
+                "category": CATEGORY.get(q.get("question_type", ""), "other"),
+                "gold_ids": gold_ids,
+                "corpus": corpus_rel.replace(os.sep, "/"),
+            }
+        )
+        stats["questions"] += 1
+        stats["turns"] += len(corpus)
+        stats["gold_turns"] += len(gold_ids)
+
+    with open(os.path.join(out_dir, "manifest.jsonl"), "w", encoding="utf-8") as f:
+        for m in manifest:
+            f.write(json.dumps(m, ensure_ascii=False) + "\n")
+    return stats
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True, help="path to longmemeval_s(.cleaned).json")
+    ap.add_argument(
+        "--out",
+        default="tests/recall/longmemeval",
+        help="output fixture directory",
+    )
+    ap.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="only convert the first N scorable questions (cheap pilot)",
+    )
+    args = ap.parse_args()
+
+    with open(args.input, encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict):  # some releases wrap in {"questions": [...]}
+        data = data.get("questions", list(data.values()))
+
+    stats = convert(data, args.out, args.limit)
+    print(
+        f"LongMemEval -> harness: {stats['questions']} questions, "
+        f"{stats['turns']} turns, {stats['gold_turns']} gold turns, "
+        f"{stats['no_gold']} skipped (no turn-level gold). Out: {args.out}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -254,6 +254,18 @@ struct Args {
     #[arg(long)]
     lineage: Option<PathBuf>,
 
+    /// LongMemEval-S (ICLR 2025, current SOTA long-term memory benchmark): path
+    /// to the fixture dir built by benchmarks/longmemeval_to_harness.py
+    /// (manifest.jsonl + corpora/). Each question has its own ~48-session
+    /// haystack, so this loops mini-evals scoring turn-level recall@k against
+    /// `has_answer` gold. Short-circuits the normal suite.
+    #[arg(long)]
+    longmemeval: Option<PathBuf>,
+
+    /// LongMemEval question cap for a cheap pilot (default: all).
+    #[arg(long)]
+    longmemeval_limit: Option<usize>,
+
     /// Simulated edge age in days, applied AFTER ingest and BEFORE queries
     /// (decay study). When `> 0`, the harness ages the knowledge-graph edges via
     /// `simulate_edge_aging` at the production ~6h cadence, so recall quality is
@@ -342,6 +354,28 @@ fn run(args: &Args) -> Result<i32> {
         layer_modes: args.layer.to_modes(),
         age_days: args.age_days,
     };
+
+    // LongMemEval-S short-circuits the normal suite: each question has its own
+    // haystack, so it loops per-question ingest+recall instead of one corpus.
+    if let Some(lme_dir) = &args.longmemeval {
+        let report = shodh_memory::recall_harness::runner::run_longmemeval(
+            lme_dir,
+            &storage_path,
+            args.longmemeval_limit,
+            10,
+        )
+        .context("LongMemEval run")?;
+        println!(
+            "LongMemEval-S: {} questions (NER={}) — recall@{} = {:.4}",
+            report.questions, report.ner_backend, report.k, report.recall_at_k
+        );
+        let mut cats: Vec<_> = report.by_category.iter().collect();
+        cats.sort_by(|a, b| a.0.cmp(b.0));
+        for (cat, (r, n)) in cats {
+            println!("  {cat:18} n={n:<4} recall@{} = {r:.4}", report.k);
+        }
+        return Ok(EXIT_PASS);
+    }
 
     // Graph-reachability diagnostic short-circuits the recall run entirely.
     if let Some(reach_path) = &args.graph_reachability {

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -586,8 +586,7 @@ impl LtpStatus {
         match self {
             Self::Burst { detected_at } => {
                 // Frozen scoring clock on the read path (see decay_factor).
-                (crate::memory::scoring_now() - *detected_at).num_hours()
-                    > LTP_BURST_DURATION_HOURS
+                (crate::memory::scoring_now() - *detected_at).num_hours() > LTP_BURST_DURATION_HOURS
             }
             _ => false,
         }

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -557,8 +557,13 @@ impl LtpStatus {
         match self {
             Self::None => 1.0,
             Self::Burst { detected_at } => {
-                // Check if burst has expired
-                let hours_since = (Utc::now() - *detected_at).num_hours();
+                // Check if burst has expired. Uses the frozen scoring clock
+                // (SHODH_EVAL_NOW) because this feeds effective_strength() on
+                // the read path: a live clock makes the burst-protection factor
+                // flip between recall repeats minutes apart, wobbling edge
+                // strength and graph activation. Production leaves the env
+                // unset, so this is Utc::now() there.
+                let hours_since = (crate::memory::scoring_now() - *detected_at).num_hours();
                 if hours_since > LTP_BURST_DURATION_HOURS {
                     1.0 // Expired, normal decay
                 } else {
@@ -580,7 +585,9 @@ impl LtpStatus {
         use crate::constants::LTP_BURST_DURATION_HOURS;
         match self {
             Self::Burst { detected_at } => {
-                (Utc::now() - *detected_at).num_hours() > LTP_BURST_DURATION_HOURS
+                // Frozen scoring clock on the read path (see decay_factor).
+                (crate::memory::scoring_now() - *detected_at).num_hours()
+                    > LTP_BURST_DURATION_HOURS
             }
             _ => false,
         }
@@ -1260,7 +1267,13 @@ impl RelationshipEdge {
     pub fn effective_strength(&self) -> f32 {
         use crate::decay::tier_decay_factor;
 
-        let now = Utc::now();
+        // Use the frozen scoring clock (SHODH_EVAL_NOW) on the eval path: this
+        // read-only decay feeds spreading-activation strength, and a live clock
+        // makes edges decay measurably between recall repeats minutes apart
+        // (L1Working edges decay over hours), wobbling episode activations and
+        // flipping near-tie graph-leg ranks. Production leaves SHODH_EVAL_NOW
+        // unset, so this is `Utc::now()` there — identical behaviour.
+        let now = crate::memory::scoring_now();
         let elapsed = now.signed_duration_since(self.last_activated);
         let hours_elapsed = elapsed.num_seconds() as f64 / 3600.0;
 

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -577,7 +577,15 @@ fn personalized_pagerank(
     let mut label_cache: HashMap<Uuid, Option<Vec<EntityLabel>>> = HashMap::new();
 
     // BFS-expand the subgraph reachable from the seeds, collecting weighted edges.
+    // Sort the initial frontier: seeds.keys() yields per-process-random HashMap
+    // order, which is the order nodes are interned into the dense PPR index. A
+    // different index assignment reorders the power-iteration matrix-vector
+    // sums, and f32 addition is non-associative, so the stationary masses wobble
+    // by a few ULPs between recall repeats — enough to flip near-tie episode
+    // ranks across the final-sort quantization boundary. Sorting makes the node
+    // ordering, and therefore the PPR result, bit-reproducible.
     let mut frontier: Vec<Uuid> = seeds.keys().copied().collect();
+    frontier.sort_unstable();
     let mut visited: HashSet<Uuid> = frontier.iter().copied().collect();
     for &s in &frontier {
         ppr_intern(s, &mut nodes, &mut node_idx, &mut adj);

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -194,8 +194,14 @@ fn spread_single_direction(
         .unwrap_or(false);
 
     for hop in 1..=max_hops {
-        let current_activated: Vec<(Uuid, f32)> =
+        // Deterministic spread order: targets accumulate `+= spread_amount`
+        // below, and f32 addition is non-associative, so a per-process-random
+        // HashMap iteration order produces slightly different sums and flips
+        // near-tie ranks between repeats (the query-time residual after the
+        // ingest-order fixes). Sorting by Uuid pins the accumulation order.
+        let mut current_activated: Vec<(Uuid, f32)> =
             activation_map.iter().map(|(id, act)| (*id, *act)).collect();
+        current_activated.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
         for (entity_uuid, source_activation) in current_activated {
             if source_activation < threshold {
@@ -1280,9 +1286,14 @@ pub fn spreading_activation_retrieve_with_stats(
                 current_threshold
             );
 
-            // Clone to avoid borrow issues
-            let current_activated: Vec<(Uuid, f32)> =
+            // Clone to avoid borrow issues. Sort by Uuid so the `+=`
+            // accumulation into shared targets below is order-deterministic:
+            // f32 addition is non-associative, and HashMap iteration order
+            // varies per process, which otherwise flips near-tie ranks
+            // between repeats.
+            let mut current_activated: Vec<(Uuid, f32)> =
                 activation_map.iter().map(|(id, act)| (*id, *act)).collect();
+            current_activated.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
             for (entity_uuid, source_activation) in current_activated {
                 // Only spread from entities with sufficient activation
@@ -1515,7 +1526,17 @@ pub fn spreading_activation_retrieve_with_stats(
     // can reward episodes activated by MULTIPLE query seeds.
     let mut activated_memories: HashMap<Uuid, (f32, HashSet<Uuid>, EpisodicNode)> = HashMap::new();
 
-    for (entity_uuid, entity_activation) in &activation_map {
+    // Deterministic episode accumulation: an episode connected to several
+    // activated entities sums their activations via `current.0 +=` below.
+    // f32 addition is non-associative, so iterating `activation_map` in
+    // per-process-random HashMap order yields slightly different episode
+    // scores and flips near-tie graph-leg ranks between repeats. Sort the
+    // source entities by Uuid to pin the summation order. This is the
+    // dominant query-time residual: episode score IS the graph-leg ranking.
+    let mut activation_entries: Vec<(&Uuid, &f32)> = activation_map.iter().collect();
+    activation_entries.sort_unstable_by(|a, b| a.0.cmp(b.0));
+
+    for (entity_uuid, entity_activation) in activation_entries {
         let episodes = graph.get_episodes_by_entity(entity_uuid)?;
         let is_seed = seed_set.contains(entity_uuid);
 

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -2096,6 +2096,83 @@ mod tests {
     /// Run explicitly:
     ///   SHODH_MAX_CASES=300 SHODH_MAX_CORPUS=1500 cargo test --release \
     ///     export_fusion_training_data -- --ignored --nocapture
+    /// Graph census diff between two harness repeat storages — the
+    /// determinism-hunt diagnostic. Opens the persisted entity graphs of two
+    /// completed repeats and prints set differences in entities (name+labels)
+    /// and edges (from→to, relation type), naming the ingest path that varies.
+    /// Run explicitly:
+    ///   SHODH_CENSUS_A=<path>/repeat_0/recall-eval/graph \
+    ///   SHODH_CENSUS_B=<path>/repeat_1/recall-eval/graph \
+    ///   cargo test --release graph_census_diff -- --ignored --nocapture
+    #[test]
+    #[ignore = "offline diagnostic over existing repeat storages — run explicitly"]
+    fn graph_census_diff() {
+        let path_a = std::env::var("SHODH_CENSUS_A").expect("SHODH_CENSUS_A unset");
+        let path_b = std::env::var("SHODH_CENSUS_B").expect("SHODH_CENSUS_B unset");
+        let census = |p: &str| {
+            let g = crate::graph_memory::GraphMemory::new(std::path::Path::new(p), None)
+                .expect("open graph storage");
+            let ents = g.get_all_entities().expect("entities");
+            let names: std::collections::BTreeMap<String, String> = ents
+                .iter()
+                .map(|e| (e.name.clone(), format!("{:?}", e.labels)))
+                .collect();
+            let by_uuid: std::collections::HashMap<uuid::Uuid, String> =
+                ents.iter().map(|e| (e.uuid, e.name.clone())).collect();
+            let mut edges: std::collections::BTreeMap<String, String> = Default::default();
+            for r in g.get_all_relationships().expect("relationships") {
+                let f = by_uuid
+                    .get(&r.from_entity)
+                    .cloned()
+                    .unwrap_or_else(|| r.from_entity.to_string());
+                let t = by_uuid
+                    .get(&r.to_entity)
+                    .cloned()
+                    .unwrap_or_else(|| r.to_entity.to_string());
+                // Weight included so the diff catches edges that exist in both
+                // repeats but accumulated different strengths.
+                edges.insert(
+                    format!("{f} -[{:?}]-> {t}", r.relation_type),
+                    format!("{:.9}", r.strength),
+                );
+            }
+            (names, edges)
+        };
+        let (ents_a, edges_a) = census(&path_a);
+        let (ents_b, edges_b) = census(&path_b);
+        println!(
+            "A: {} entities, {} edge keys | B: {} entities, {} edge keys",
+            ents_a.len(),
+            edges_a.len(),
+            ents_b.len(),
+            edges_b.len()
+        );
+        for (n, l) in &ents_a {
+            match ents_b.get(n) {
+                None => println!("ENTITY only in A: {n} {l}"),
+                Some(lb) if lb != l => println!("ENTITY labels differ: {n} A={l} B={lb}"),
+                _ => {}
+            }
+        }
+        for n in ents_b.keys() {
+            if !ents_a.contains_key(n) {
+                println!("ENTITY only in B: {n} {}", ents_b[n]);
+            }
+        }
+        for (e, c) in &edges_a {
+            match edges_b.get(e) {
+                None => println!("EDGE only in A: {e} (x{c})"),
+                Some(cb) if cb != c => println!("EDGE count differs: {e} A={c} B={cb}"),
+                _ => {}
+            }
+        }
+        for e in edges_b.keys() {
+            if !edges_a.contains_key(e) {
+                println!("EDGE only in B: {e} (x{})", edges_b[e]);
+            }
+        }
+    }
+
     #[test]
     #[ignore = "training-data export — run explicitly"]
     fn export_fusion_training_data() {

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -1015,6 +1015,158 @@ pub fn ingest_corpus(
 /// Unified ablation matrix (E1): ingest the suite ONCE, then run the full case
 /// set under each named query-time config and tabulate recall@10 / ndcg / mrr /
 /// p@1 + per-category recall. The single, re-runnable place to see and update
+/// One LongMemEval question: its private haystack (corpus) + turn-level gold.
+#[derive(serde::Deserialize)]
+struct LongMemEvalCase {
+    id: String,
+    question: String,
+    category: String,
+    gold_ids: Vec<String>,
+    corpus: String,
+}
+
+/// Aggregate LongMemEval result.
+pub struct LongMemEvalReport {
+    pub questions: usize,
+    pub recall_at_k: f64,
+    pub by_category: BTreeMap<String, (f64, usize)>,
+    pub k: usize,
+    pub ner_backend: String,
+}
+
+/// Run the LongMemEval-S suite (ICLR 2025, the current SOTA long-term memory
+/// benchmark). UNLIKE LoCoMo, each question carries its OWN ~48-session haystack
+/// (~115K tokens), so this is a LOOP of mini-evals: per question, ingest its
+/// haystack into fresh storage, run the question as a query, and score
+/// turn-level recall@k against the `has_answer` gold turns. No LLM judge — the
+/// same gold-evidence retrieval signal the smoke/LoCoMo suites use.
+///
+/// Fixtures come from `benchmarks/longmemeval_to_harness.py` (manifest.jsonl +
+/// per-question corpora/<id>.jsonl). `limit` bounds the question count for a
+/// cheap pilot (each haystack is a full ~500-turn ingest).
+pub fn run_longmemeval(
+    base_dir: &Path,
+    storage_root: &Path,
+    limit: Option<usize>,
+    k: usize,
+) -> Result<LongMemEvalReport> {
+    pin_harness_threads();
+
+    let manifest_path = base_dir.join("manifest.jsonl");
+    let manifest_txt = std::fs::read_to_string(&manifest_path)
+        .with_context(|| format!("reading {}", manifest_path.display()))?;
+    let mut cases: Vec<LongMemEvalCase> = Vec::new();
+    for line in manifest_txt.lines().filter(|l| !l.trim().is_empty()) {
+        cases.push(serde_json::from_str(line).context("parsing LongMemEval manifest line")?);
+    }
+    if let Some(n) = limit {
+        cases.truncate(n);
+    }
+
+    let mut sum_recall = 0.0f64;
+    let mut scored = 0usize;
+    let mut by_cat: HashMap<String, (f64, usize)> = HashMap::new();
+    let mut ner_backend = String::from("unknown");
+
+    for (qi, case) in cases.iter().enumerate() {
+        let corpus_path = base_dir.join(&case.corpus);
+        let corpus_txt = std::fs::read_to_string(&corpus_path)
+            .with_context(|| format!("reading {}", corpus_path.display()))?;
+        let corpus: Vec<CorpusItem> = corpus_txt
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(serde_json::from_str)
+            .collect::<std::result::Result<_, _>>()
+            .context("parsing LongMemEval corpus")?;
+
+        // Fresh, isolated storage per question so haystacks never bleed across.
+        let q_storage = storage_root.join(format!("q{qi}"));
+        let _ = std::fs::remove_dir_all(&q_storage);
+        let manager = build_manager(&q_storage)?;
+        if qi == 0 {
+            ner_backend = if manager.get_neural_ner().is_fallback_mode() {
+                "fallback".to_string()
+            } else {
+                "neural".to_string()
+            };
+            eprintln!("NER_BACKEND={ner_backend}");
+            if ner_backend == "fallback"
+                && !cfg!(test)
+                && !std::env::var("SHODH_ALLOW_FALLBACK_NER")
+                    .map(|v| v == "1")
+                    .unwrap_or(false)
+            {
+                anyhow::bail!(
+                    "LongMemEval refusing to run on FALLBACK NER — set \
+                     SHODH_ALLOW_FALLBACK_NER=1 to override visibly."
+                );
+            }
+        }
+
+        let id_map = ingest_corpus(&manager, &corpus)?;
+        let system = manager.get_user_memory(EVAL_USER)?;
+
+        let mut query = Query {
+            query_text: Some(case.question.clone()),
+            max_results: k,
+            layers: LayerMode::Full,
+            ..Default::default()
+        };
+        manager.annotate_query_ner(&mut query);
+        let memories = system.read().recall(&query).unwrap_or_default();
+        let topk: HashSet<Uuid> = memories.iter().take(k).map(|m| m.id.0).collect();
+
+        // Turn-level recall@k: fraction of gold `has_answer` turns in the top-k.
+        let gold_uuids: Vec<Uuid> = case
+            .gold_ids
+            .iter()
+            .filter_map(|g| id_map.get(g).copied())
+            .collect();
+        if gold_uuids.is_empty() {
+            // Gold turn dropped at ingest (e.g. empty content) — unscorable.
+            let _ = std::fs::remove_dir_all(&q_storage);
+            continue;
+        }
+        let hit = gold_uuids.iter().filter(|g| topk.contains(g)).count();
+        let recall = hit as f64 / gold_uuids.len() as f64;
+        sum_recall += recall;
+        scored += 1;
+        let entry = by_cat.entry(case.category.clone()).or_insert((0.0, 0));
+        entry.0 += recall;
+        entry.1 += 1;
+
+        if (qi + 1) % 25 == 0 {
+            eprintln!(
+                "  longmemeval: {}/{} questions, running recall@{k}={:.4}",
+                qi + 1,
+                cases.len(),
+                sum_recall / scored as f64
+            );
+        }
+
+        // Reclaim disk — each haystack is a full store.
+        drop(manager);
+        let _ = std::fs::remove_dir_all(&q_storage);
+    }
+
+    let by_category: BTreeMap<String, (f64, usize)> = by_cat
+        .into_iter()
+        .map(|(c, (s, n))| (c, (s / n.max(1) as f64, n)))
+        .collect();
+
+    Ok(LongMemEvalReport {
+        questions: scored,
+        recall_at_k: if scored > 0 {
+            sum_recall / scored as f64
+        } else {
+            0.0
+        },
+        by_category,
+        k,
+        ner_backend,
+    })
+}
+
 /// every component's contribution — "don't fly blind".
 ///
 /// Only QUERY-TIME flags are ablatable here (they are read per-recall against the


### PR DESCRIPTION
Brings the experiment branch's 4 post-#325 commits to main:

**LongMemEval-S eval capability (current SOTA long-term memory benchmark, ICLR 2025):**
- `benchmarks/longmemeval_to_harness.py` — converts the dataset to per-question fixtures with turn-level `has_answer` gold; `--shuffle` makes any `--limit` prefix a representative category mix.
- `run_longmemeval()` + `recall-eval --longmemeval` — per-question haystack loop scoring turn-level retrieval recall@10 (no LLM judge).

**Graph-leg determinism (production-correct + reduces eval divergence):**
- Frozen scoring clock on the graph read path (`effective_strength`, LTP `decay_factor`/`is_burst_expired`) — edges no longer decay between recall repeats.
- Deterministic PPR node interning (sorted seed frontier) + sorted spreading accumulation — removes f32-order wobble.

Smoke determinism gate stays clean (0 divergences). LongMemEval code is additive.