### PR TITLE
fix(streaming): remote-triggerable WebSocket deadlock in Event/Sensor arms

### DIFF
--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -831,6 +831,15 @@ impl StreamingMemoryExtractor {
                 severity,
                 data,
             } => {
+                // Release the outer write guard before re-acquiring below.
+                // `tokio::sync::RwLock` is NOT reentrant, so holding the
+                // `sessions.write()` taken at the top of this method while this
+                // arm calls `sessions.read()`/`sessions.write()` again
+                // self-deadlocks (the Content/Flush/Close arms drop it for the
+                // same reason). `session.touch()` above already recorded
+                // activity; the buffer write below re-locks and re-fetches.
+                drop(sessions);
+
                 // Check if this event type triggers immediate extraction
                 let is_trigger = {
                     let sessions = self.sessions.read().await;
@@ -886,6 +895,11 @@ impl StreamingMemoryExtractor {
                 timestamp,
                 units,
             } => {
+                // Release the outer write guard before re-acquiring below — the
+                // non-reentrant RwLock would otherwise self-deadlock (see the
+                // Event arm). `session.touch()` above already recorded activity.
+                drop(sessions);
+
                 // Format sensor reading as content
                 let mut parts: Vec<String> = Vec::new();
                 for (key, value) in &values {


### PR DESCRIPTION
## What

`StreamingMemoryExtractor::process_message` acquires `self.sessions.write().await` at the top and holds it across the whole `match`. Two arms then re-acquire the same lock:

- **Event** arm: `self.sessions.read().await` (trigger check) and `self.sessions.write().await` (buffer)
- **Sensor** arm: `self.sessions.write().await` (buffer)

`tokio::sync::RwLock` is **not reentrant**, so the second acquire blocks forever on the guard the same task already holds → deadlock. The `Content`/`Flush`/`Close` arms already `drop(sessions)` before re-locking; `Event`/`Sensor` did not.

## Why it's critical

Reachable from the **public `/api/stream` WebSocket** — `handlers/webhooks.rs` parses arbitrary client JSON into a `StreamMessage` and calls `process_message`. A single `Event` or `Sensor` frame wedges the shared session map for the whole process. Remote DoS on the **default build** (not behind any feature flag).

## Fix

`drop(sessions)` at the start of the Event and Sensor arms before they re-lock. `session` (the `&mut` from `get_mut`) is last used by the `touch()` call above the match, so the borrow is already dead on these paths and the drop is sound — same pattern the Content/Flush/Close arms use.

## Follow-up (not in this PR)

A regression test (`tokio::time::timeout` around `process_message` with a non-trigger `Event` message, asserting it returns rather than hangs) is the right guard, but the test module currently has no `StreamingMemoryExtractor` + `MemorySystem` construction helper, so it needs RocksDB fixture scaffolding. Tracked separately.

Found during the codebase audit; verified by reading the lock discipline across all six match arms.
