### PR TITLE
feat(er): merge-quality harness + precision-first content-token merge gate

### DIFF
--- a/.github/workflows/er-causal-loop.yml
+++ b/.github/workflows/er-causal-loop.yml
@@ -1,0 +1,135 @@
+name: ER + causal improvement loop (isolated A/B)
+
+# The measurement engine for the entity-resolution + causal-chain improvement loop.
+# Runs TWO fast harnesses for control vs a candidate flag, in isolation, and reports
+# per-metric deltas so each iteration is "isolated and improved or reverted":
+#   * --linking  : query->graph entity-LINKING accuracy (precision = no false links =
+#                  the catastrophic-merge analog; recall = right seeds found; no-seed%).
+#   * --lineage  : planted causal-chain retrieval (root-cause p@1/recall vs direct control).
+# Iteration N changes the `flag` input (a candidate SHODH_* lever) and reads the deltas.
+# WIN rubric: ER  -> link recall UP and/or no-seed% DOWN with precision HELD (never trade
+#                    precision for recall — a wrong link is worse than a missing one).
+#             causal -> root-cause p@1/recall UP with the direct-cause control HELD.
+
+on:
+  workflow_dispatch:
+    inputs:
+      flag:
+        description: 'Candidate lever for arm B, e.g. "SHODH_EVAL_NAME_EMB=1" (space-separated KEY=VAL ok)'
+        required: false
+        default: 'SHODH_EVAL_NAME_EMB=1'
+      chains:
+        description: 'Lineage chain count (--mh-chains)'
+        required: false
+        default: '120'
+  push:
+    paths:
+      - '.github/workflows/er-causal-loop.yml'
+      - 'src/recall_harness/lineage_harness.rs'
+      - 'src/recall_harness/runner.rs'
+      - 'src/graph_memory.rs'
+    branches: [exp/er-causal-loop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: er-causal-loop-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  er-causal:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      FLAG: ${{ github.event.inputs.flag || 'SHODH_EVAL_NAME_EMB=1' }}
+      CHAINS: ${{ github.event.inputs.chains || '120' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: recall-eval
+      - name: Install LLVM
+        run: sudo apt-get update && sudo apt-get install -y llvm-dev libclang-dev clang
+      - name: Build recall-eval
+        run: cargo build --release --bin recall-eval
+      - name: Cache MiniLM
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/shodh-memory/models
+          key: shodh-models-minilm-c9745ed1
+      - name: Pre-fetch MiniLM
+        run: |
+          MD="$HOME/.cache/shodh-memory/models/minilm-l6"; mkdir -p "$MD"
+          B="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf"
+          dl() { curl -fL --retry 20 --retry-all-errors --retry-delay 15 --connect-timeout 30 -o "$1" "$2"; }
+          [ -s "$MD/model_quantized.onnx" ] || dl "$MD/model_quantized.onnx" "$B/onnx/model_quint8_avx2.onnx"
+          [ -s "$MD/tokenizer.json" ]       || dl "$MD/tokenizer.json" "$B/tokenizer.json"
+
+      - name: A — control · entity linking
+        run: set -o pipefail; ./target/release/recall-eval --linking link_a.json --storage ./s-la 2>&1 | tee la.log
+      - name: A — control · causal lineage
+        run: set -o pipefail; ./target/release/recall-eval --lineage lin_a.json --mh-chains "$CHAINS" --storage ./s-na 2>&1 | tee na.log
+      - name: B — candidate · entity linking
+        run: set -o pipefail; env $FLAG ./target/release/recall-eval --linking link_b.json --storage ./s-lb 2>&1 | tee lb.log
+      - name: B — candidate · causal lineage
+        run: set -o pipefail; env $FLAG ./target/release/recall-eval --lineage lin_b.json --mh-chains "$CHAINS" --storage ./s-nb 2>&1 | tee nb.log
+
+      - name: Compare (isolated deltas)
+        if: always()
+        run: |
+          python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+          import re, json
+          def link(fn):
+              # parse the "| ALL | cases | NER | linked | no-seed% | mentions | precision | RECALL |" row
+              try: t=open(fn).read()
+              except FileNotFoundError: return {}
+              for line in t.splitlines():
+                  m=re.match(r'\|\s*ALL\s*\|\s*(\d+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|\s*([\d.]+)\s*\|', line)
+                  if m: return dict(cases=int(m.group(1)), no_seed=float(m.group(4)),
+                                    precision=float(m.group(6)), recall=float(m.group(7)))
+              return {}
+          def lin(fn):
+              try: d=json.load(open(fn))
+              except Exception: return {}
+              rows=d.get('rows',[])
+              full=next((r for r in rows if r.get('layer')=='full'), rows[-1] if rows else {})
+              return dict(p1=full.get('multihop_p_at_1',float('nan')),
+                          rec=full.get('multihop_recall_at_10',float('nan')),
+                          ctrl_p1=full.get('onehop_p_at_1',float('nan')))
+          la,lb=link('la.log'),link('lb.log')
+          na,nb=lin('lin_a.json'),lin('lin_b.json')
+          import os
+          flag=os.environ.get('FLAG','?')
+          print(f"## ER + causal loop — control vs `{flag}` (isolated)\n")
+          def d(x,y):
+              return f"{y-x:+.4f}" if (x==x and y==y) else "n/a"
+          print("### Entity resolution (--linking)")
+          print("| metric | control | candidate | delta |")
+          print("| --- | --- | --- | --- |")
+          for k,lbl in [('precision','link precision (no false links)'),('recall','link recall'),('no_seed','no-seed %')]:
+              x,y=la.get(k,float('nan')),lb.get(k,float('nan'))
+              print(f"| {lbl} | {x} | {y} | {d(x,y)} |")
+          print("\n### Causal chains (--lineage, root-cause)")
+          print("| metric | control | candidate | delta |")
+          print("| --- | --- | --- | --- |")
+          for k,lbl in [('p1','root-cause p@1'),('rec','root-cause recall@10'),('ctrl_p1','direct-cause control p@1')]:
+              x,y=na.get(k,float('nan')),nb.get(k,float('nan'))
+              print(f"| {lbl} | {x} | {y} | {d(x,y)} |")
+          print("\n**Decision rubric:** ER WIN = link recall up and/or no-seed down with **precision held** "
+                "(never trade precision — a false link/merge is worse than a missing one). "
+                "Causal WIN = root-cause p@1/recall up with the direct-cause control held. "
+                "Bit-identical everywhere ⇒ the lever did not fire on these harnesses (revert, try the next).")
+          PY
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: er-causal-loop
+          path: |
+            *.log
+            lin_*.json
+            link_*.json
+          if-no-files-found: warn

--- a/.github/workflows/er-causal-loop.yml
+++ b/.github/workflows/er-causal-loop.yml
@@ -17,7 +17,7 @@ on:
       flag:
         description: 'Candidate lever for arm B, e.g. "SHODH_EVAL_NAME_EMB=1" (space-separated KEY=VAL ok)'
         required: false
-        default: 'SHODH_EVAL_NAME_EMB=1'
+        default: 'SHODH_EVAL_NAME_EMB=1 SHODH_NAME_MERGE_TOKEN_GATE=1'
       chains:
         description: 'Lineage chain count (--mh-chains)'
         required: false
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
-      FLAG: ${{ github.event.inputs.flag || 'SHODH_EVAL_NAME_EMB=1' }}
+      FLAG: ${{ github.event.inputs.flag || 'SHODH_EVAL_NAME_EMB=1 SHODH_NAME_MERGE_TOKEN_GATE=1' }}
       CHAINS: ${{ github.event.inputs.chains || '120' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/er-causal-loop.yml
+++ b/.github/workflows/er-causal-loop.yml
@@ -68,13 +68,13 @@ jobs:
           [ -s "$MD/tokenizer.json" ]       || dl "$MD/tokenizer.json" "$B/tokenizer.json"
 
       - name: A — control · entity linking
-        run: set -o pipefail; ./target/release/recall-eval --linking link_a.json --storage ./s-la 2>&1 | tee la.log
+        run: set -o pipefail; ./target/release/recall-eval --output /dev/null --linking link_a.json --storage ./s-la 2>&1 | tee la.log
       - name: A — control · causal lineage
-        run: set -o pipefail; ./target/release/recall-eval --lineage lin_a.json --mh-chains "$CHAINS" --storage ./s-na 2>&1 | tee na.log
+        run: set -o pipefail; ./target/release/recall-eval --output /dev/null --lineage lin_a.json --mh-chains "$CHAINS" --storage ./s-na 2>&1 | tee na.log
       - name: B — candidate · entity linking
-        run: set -o pipefail; env $FLAG ./target/release/recall-eval --linking link_b.json --storage ./s-lb 2>&1 | tee lb.log
+        run: set -o pipefail; env $FLAG ./target/release/recall-eval --output /dev/null --linking link_b.json --storage ./s-lb 2>&1 | tee lb.log
       - name: B — candidate · causal lineage
-        run: set -o pipefail; env $FLAG ./target/release/recall-eval --lineage lin_b.json --mh-chains "$CHAINS" --storage ./s-nb 2>&1 | tee nb.log
+        run: set -o pipefail; env $FLAG ./target/release/recall-eval --output /dev/null --lineage lin_b.json --mh-chains "$CHAINS" --storage ./s-nb 2>&1 | tee nb.log
 
       - name: Compare (isolated deltas)
         if: always()

--- a/.github/workflows/er-causal-loop.yml
+++ b/.github/workflows/er-causal-loop.yml
@@ -26,7 +26,9 @@ on:
     paths:
       - '.github/workflows/er-causal-loop.yml'
       - 'src/recall_harness/lineage_harness.rs'
+      - 'src/recall_harness/merge_harness.rs'
       - 'src/recall_harness/runner.rs'
+      - 'src/bin/recall_eval.rs'
       - 'src/graph_memory.rs'
     branches: [exp/er-causal-loop]
 
@@ -75,6 +77,10 @@ jobs:
         run: set -o pipefail; env $FLAG ./target/release/recall-eval --output /dev/null --linking link_b.json --storage ./s-lb 2>&1 | tee lb.log
       - name: B — candidate · causal lineage
         run: set -o pipefail; env $FLAG ./target/release/recall-eval --output /dev/null --lineage lin_b.json --mh-chains "$CHAINS" --storage ./s-nb 2>&1 | tee nb.log
+      - name: A — control · merge quality
+        run: set -o pipefail; ./target/release/recall-eval --output /dev/null --merge merge_a.json --storage ./s-ma 2>&1 | tee ma.log
+      - name: B — candidate · merge quality
+        run: set -o pipefail; env $FLAG ./target/release/recall-eval --output /dev/null --merge merge_b.json --storage ./s-mb 2>&1 | tee mb.log
 
       - name: Compare (isolated deltas)
         if: always()
@@ -117,6 +123,18 @@ jobs:
           for k,lbl in [('p1','root-cause p@1'),('rec','root-cause recall@10'),('ctrl_p1','direct-cause control p@1')]:
               x,y=na.get(k,float('nan')),nb.get(k,float('nan'))
               print(f"| {lbl} | {x} | {y} | {d(x,y)} |")
+          def mrg(fn):
+              try: dd=json.load(open(fn))
+              except Exception: return {}
+              return dict(prec=dd.get('merge_precision',float('nan')), rec=dd.get('merge_recall',float('nan')),
+                          fmr=dd.get('false_merge_rate',float('nan')))
+          ma_,mb_=mrg('merge_a.json'),mrg('merge_b.json')
+          print("\n### Merge quality (--merge, cross-doc resolution — the false-merge guard)")
+          print("| metric | control | candidate | delta |")
+          print("| --- | --- | --- | --- |")
+          for k,lbl in [('prec','merge precision'),('rec','merge recall'),('fmr','FALSE-MERGE rate (catastrophic)')]:
+              x,y=ma_.get(k,float('nan')),mb_.get(k,float('nan'))
+              print(f"| {lbl} | {x} | {y} | {d(x,y)} |")
           print("\n**Decision rubric:** ER WIN = link recall up and/or no-seed down with **precision held** "
                 "(never trade precision — a false link/merge is worse than a missing one). "
                 "Causal WIN = root-cause p@1/recall up with the direct-cause control held. "
@@ -132,4 +150,5 @@ jobs:
             *.log
             lin_*.json
             link_*.json
+            merge_*.json
           if-no-files-found: warn

--- a/.github/workflows/er-merge-gate-confirm.yml
+++ b/.github/workflows/er-merge-gate-confirm.yml
@@ -1,0 +1,122 @@
+name: ER merge-gate — LongMemEval default-flip confirm
+
+# The gate to making the content-token merge gate a NON-OPTIONAL default.
+# Embedding concept-merge is already the production default (entity names are
+# embedded at ingest). The proper-noun token gate hardens it against the
+# catastrophic templated over-merge. This run confirms the gate does not regress
+# the full benchmark before it is flipped on by default.
+#   A = production today : SHODH_EVAL_NAME_EMB=1                              (name-emb on, gate OFF)
+#   B = proposed default : SHODH_EVAL_NAME_EMB=1 SHODH_NAME_MERGE_TOKEN_GATE=1 (gate ON)
+# CONFIRM = B recall@10 >= A across categories (the gate only PREVENTS bad merges,
+# so it should be neutral-or-better). A regression means the gate blocks good
+# merges and must be tightened before any default flip.
+
+on:
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: 'LongMemEval questions per arm (blank = all 479)'
+        required: false
+        default: '50'
+  push:
+    paths:
+      - '.github/workflows/er-merge-gate-confirm.yml'
+      - 'src/graph_memory.rs'
+    branches: [exp/er-causal-loop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: er-gate-confirm-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  confirm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: recall-eval
+      - name: Install LLVM
+        run: sudo apt-get update && sudo apt-get install -y llvm-dev libclang-dev clang
+      - name: Build recall-eval
+        run: cargo build --release --bin recall-eval
+      - name: Cache MiniLM
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/shodh-memory/models
+          key: shodh-models-minilm-c9745ed1
+      - name: Pre-fetch MiniLM
+        run: |
+          MD="$HOME/.cache/shodh-memory/models/minilm-l6"; mkdir -p "$MD"
+          B="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf"
+          dl() { curl -fL --retry 20 --retry-all-errors --retry-delay 15 --connect-timeout 30 -o "$1" "$2"; }
+          [ -s "$MD/model_quantized.onnx" ] || dl "$MD/model_quantized.onnx" "$B/onnx/model_quint8_avx2.onnx"
+          [ -s "$MD/tokenizer.json" ]       || dl "$MD/tokenizer.json" "$B/tokenizer.json"
+      - name: Download LongMemEval-S + fixtures
+        run: |
+          python3 -m pip install --quiet huggingface_hub
+          JSON=$(python3 - <<'PY'
+          from huggingface_hub import hf_hub_download
+          print(hf_hub_download(repo_id='xiaowu0162/longmemeval-cleaned',
+                                filename='longmemeval_s_cleaned.json', repo_type='dataset'))
+          PY
+          )
+          python3 benchmarks/longmemeval_to_harness.py --input "$JSON" --shuffle \
+            ${{ github.event.inputs.limit != '' && format('--limit {0}', github.event.inputs.limit) || '--limit 50' }}
+          wc -l tests/recall/longmemeval/manifest.jsonl
+
+      - name: A — production (name-emb, no gate)
+        run: |
+          set -o pipefail
+          env SHODH_EVAL_NAME_EMB=1 ./target/release/recall-eval --longmemeval tests/recall/longmemeval \
+            --output /dev/null --storage ./lme-a 2>&1 | tee a.log
+      - name: B — proposed default (name-emb + gate)
+        run: |
+          set -o pipefail
+          env SHODH_EVAL_NAME_EMB=1 SHODH_NAME_MERGE_TOKEN_GATE=1 ./target/release/recall-eval --longmemeval tests/recall/longmemeval \
+            --output /dev/null --storage ./lme-b 2>&1 | tee b.log
+
+      - name: Compare
+        if: always()
+        run: |
+          python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+          import re
+          def parse(fn):
+              overall=float('nan'); p1=float('nan'); cats={}
+              try: t=open(fn).read()
+              except FileNotFoundError: return overall,p1,cats
+              for line in t.splitlines():
+                  mo=re.search(r'LongMemEval-S:.*recall@\d+\s*=\s*([0-9.]+)', line)
+                  if mo: overall=float(mo.group(1))
+                  mp=re.search(r'p@1\s*=\s*([0-9.]+)', line)
+                  if mp: p1=float(mp.group(1))
+                  mc=re.match(r'\s+(\w+)\s+n=(\d+)\s+recall@\d+\s*=\s*([0-9.]+)', line)
+                  if mc: cats[mc.group(1)]=float(mc.group(3))
+              return overall,p1,cats
+          ao,ap,ac=parse('a.log'); bo,bp,bc=parse('b.log')
+          def d(x,y): return f"{y-x:+.4f}" if (x==x and y==y) else "n/a"
+          print("## ER merge-gate confirm on LongMemEval-S — production vs gated\n")
+          print("| metric | prod (no gate) | gated | delta |")
+          print("| --- | --- | --- | --- |")
+          print(f"| recall@10 ALL | {ao:.4f} | {bo:.4f} | {d(ao,bo)} |")
+          print(f"| p@1 ALL | {ap:.4f} | {bp:.4f} | {d(ap,bp)} |")
+          for c in sorted(set(ac)|set(bc)):
+              x,y=ac.get(c,float('nan')),bc.get(c,float('nan'))
+              print(f"| recall@10 {c} | {x:.4f} | {y:.4f} | {d(x,y)} |")
+          print("\n**Confirm:** the gate flips to DEFAULT (always-on, flag removed) iff gated recall@10 "
+                ">= production across categories — it only PREVENTS bad merges, so neutral-or-better is "
+                "the pass. A regression = the gate blocks good merges; tighten before flipping.")
+          PY
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: er-gate-confirm
+          path: "*.log"
+          if-no-files-found: warn

--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -260,6 +260,11 @@ struct Args {
     #[arg(long)]
     lineage: Option<PathBuf>,
 
+    /// ER merge-quality: planted coref clusters + distinct collisions; reports merge
+    /// precision/recall and the catastrophic false-merge rate (cross-doc resolution).
+    #[arg(long)]
+    merge: Option<PathBuf>,
+
     /// LongMemEval-S (ICLR 2025, current SOTA long-term memory benchmark): path
     /// to the fixture dir built by benchmarks/longmemeval_to_harness.py
     /// (manifest.jsonl + corpora/). Each question has its own ~48-session
@@ -499,6 +504,15 @@ fn run(args: &Args) -> Result<i32> {
             "direct-cause control",
             "root-cause is reachable only by chaining past the lexical direct-cause distractor; if it stays ~0 across layers, causal/lineage retrieval is not exercised in eval.",
         );
+        return Ok(EXIT_PASS);
+    }
+
+    // ER merge-quality diagnostic.
+    if let Some(m_path) = &args.merge {
+        let report = shodh_memory::recall_harness::merge_harness::analyze_merge(&inputs)
+            .context("merge analysis")?;
+        std::fs::write(m_path, serde_json::to_string_pretty(&report)?)?;
+        summarise_merge(&report);
         return Ok(EXIT_PASS);
     }
 
@@ -978,6 +992,29 @@ fn summarise(report: &Report) {
 /// Resolve the current git SHA by shelling out. Returns an error rather
 /// than panicking so the binary can still produce a report when run from a
 /// non-git checkout (e.g. a release tarball).
+fn summarise_merge(r: &shodh_memory::recall_harness::report::MergeReport) {
+    println!("## ER merge quality (sha={})", r.git_sha);
+    println!(
+        "\n| mentions | true entities | merge precision | merge recall | FALSE-MERGE rate | false | correct | missed |"
+    );
+    println!("| --- | --- | --- | --- | --- | --- | --- | --- |");
+    println!(
+        "| {} | {} | {:.3} | {:.3} | {:.3} | {} | {} | {} |",
+        r.mentions,
+        r.true_clusters,
+        r.merge_precision,
+        r.merge_recall,
+        r.false_merge_rate,
+        r.false_merges,
+        r.correct_merges,
+        r.missed_merges
+    );
+    println!(
+        "\nFALSE-MERGE rate is the catastrophic metric — distinct entities wrongly fused. \
+         A lever that lifts merge_recall while raising false_merge_rate is a NET LOSS for ER."
+    );
+}
+
 fn summarise_linking(report: &shodh_memory::recall_harness::report::LinkingReport) {
     use shodh_memory::recall_harness::report::LinkingRow;
     println!(

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -2399,10 +2399,18 @@ impl GraphMemory {
                                 .collect()
                         };
                         match self.get_entity(&matched_uuid)? {
-                            Some(m) => proper_tokens(&entity.name)
-                                .intersection(&proper_tokens(&m.name))
-                                .next()
-                                .is_some(),
+                            Some(m) => {
+                                let a = proper_tokens(&entity.name);
+                                let b = proper_tokens(&m.name);
+                                // Only constrain proper-noun-bearing names. Lowercase
+                                // concept synonyms ("authentication"/"auth") carry no
+                                // proper tokens — leave those to cosine (Tier-4's
+                                // original purpose). Block only proper-noun entities
+                                // that share no discriminative token.
+                                a.is_empty()
+                                    || b.is_empty()
+                                    || a.intersection(&b).next().is_some()
+                            }
                             None => true,
                         }
                     } else {

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -2376,13 +2376,47 @@ impl GraphMemory {
                     }
                 }
                 if let Some((matched_uuid, sim)) = best_match {
-                    tracing::debug!(
-                        "Concept merge: '{}' matched existing entity {} (cosine={:.3})",
-                        entity.name,
-                        matched_uuid,
-                        sim
-                    );
-                    existing_uuid = Some(matched_uuid);
+                    // Content-token gate (SHODH_NAME_MERGE_TOKEN_GATE, default off):
+                    // require a shared proper-noun (capitalized) token between the two
+                    // names, so templated near-synonyms whose embedding is dominated by
+                    // a shared template — e.g. "the Vornak incident" vs "the Meslin
+                    // incident" — are NOT merged, while real name variants ("Rajesh
+                    // Kumar"/"R. Kumar", "Mohammed Ali"/"Muhammad Ali") still merge on
+                    // the shared surname. Cosine is still required above, so this can
+                    // only PREVENT a merge, never create a false one.
+                    let token_gate = std::env::var("SHODH_NAME_MERGE_TOKEN_GATE")
+                        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                        .unwrap_or(false);
+                    let allow = if token_gate {
+                        let proper_tokens = |s: &str| -> std::collections::HashSet<String> {
+                            s.split_whitespace()
+                                .filter(|w| w.chars().next().is_some_and(|c| c.is_uppercase()))
+                                .map(|w| {
+                                    w.trim_matches(|c: char| !c.is_alphanumeric())
+                                        .to_lowercase()
+                                })
+                                .filter(|w| w.len() >= 2)
+                                .collect()
+                        };
+                        match self.get_entity(&matched_uuid)? {
+                            Some(m) => proper_tokens(&entity.name)
+                                .intersection(&proper_tokens(&m.name))
+                                .next()
+                                .is_some(),
+                            None => true,
+                        }
+                    } else {
+                        true
+                    };
+                    if allow {
+                        tracing::debug!(
+                            "Concept merge: '{}' matched existing entity {} (cosine={:.3})",
+                            entity.name,
+                            matched_uuid,
+                            sim
+                        );
+                        existing_uuid = Some(matched_uuid);
+                    }
                 }
             }
         }

--- a/src/recall_harness/merge_harness.rs
+++ b/src/recall_harness/merge_harness.rs
@@ -1,0 +1,116 @@
+//! ER merge-quality harness — measures cross-document entity resolution, and in
+//! particular the CATASTROPHIC over-merge (false merge) that the linking harness
+//! cannot see. Plants known coref clusters (the same entity under surface variants)
+//! and distinct entities with tempting near-collisions, then checks pairwise whether
+//! the graph merged what it should and — critically — did NOT merge what it must not.
+//!
+//! `false_merge_rate` is the load-bearing number: a lever that lifts `merge_recall`
+//! while raising `false_merge_rate` is a NET LOSS, because a wrong merge is far worse
+//! than a missed one.
+
+use std::collections::BTreeSet;
+
+use anyhow::Result;
+use chrono::{TimeZone, Utc};
+
+use crate::recall_harness::fixtures::CorpusItem;
+use crate::recall_harness::report::MergeReport;
+use crate::recall_harness::runner::{build_manager, ingest_corpus, RunInputs, EVAL_USER};
+
+/// (surface form, true entity id). Variants that share an id SHOULD resolve together;
+/// different ids must NOT, even when the surfaces collide on a shared token.
+fn labels() -> Vec<(&'static str, &'static str)> {
+    vec![
+        // same entity, surface variants — should merge
+        ("Rajesh Kumar", "E1"),
+        ("R. Kumar", "E1"),
+        ("Kumar Rajesh", "E1"),
+        ("Priya Sharma", "E2"),
+        ("P. Sharma", "E2"),
+        ("Mohammed Ali", "E3"),
+        ("Muhammad Ali", "E3"), // transliteration variant
+        // distinct entities with tempting collisions — must NOT merge
+        ("Rajesh Verma", "E4"),  // shares "Rajesh" with E1
+        ("Mohammed Khan", "E5"), // shares "Mohammed" with E3
+        ("Anil Gupta", "E6"),
+        ("Sunil Gupta", "E7"), // shares "Gupta" with E6
+    ]
+}
+
+/// Ingest one document per planted mention, then resolve each surface through the
+/// graph and score the pairwise merge decisions against the planted truth.
+pub fn analyze_merge(inputs: &RunInputs) -> Result<MergeReport> {
+    let labels = labels();
+    let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+    let corpus: Vec<CorpusItem> = labels
+        .iter()
+        .enumerate()
+        .map(|(i, (surf, _))| CorpusItem {
+            id: format!("merge-{i:03}"),
+            content: format!("{surf} attended the planning meeting in the capital."),
+            memory_type: "fact".to_string(),
+            tags: vec![surf.to_string()],
+            created_at: base + chrono::Duration::minutes(i as i64),
+        })
+        .collect();
+
+    let storage = inputs.storage_path.join("merge_run");
+    let manager = build_manager(&storage)?;
+    let _ = ingest_corpus(&manager, &corpus)?;
+    let graph = manager.get_user_graph(EVAL_USER)?;
+
+    // Canonical key per surface: the resolved entity uuid, else a unique singleton
+    // (an unresolved surface merges with nothing).
+    let canon: Vec<String> = {
+        let g = graph.read();
+        labels
+            .iter()
+            .map(|(surf, _)| match g.find_entity_by_name(surf) {
+                Ok(Some(ent)) => ent.name.to_lowercase(),
+                _ => format!("__unresolved__{surf}"),
+            })
+            .collect()
+    };
+
+    let (mut tp, mut fp, mut fn_, mut tn) = (0usize, 0usize, 0usize, 0usize);
+    for i in 0..labels.len() {
+        for j in (i + 1)..labels.len() {
+            let same_true = labels[i].1 == labels[j].1;
+            let same_graph = canon[i] == canon[j];
+            match (same_true, same_graph) {
+                (true, true) => tp += 1,
+                (false, true) => fp += 1, // FALSE MERGE — the catastrophic one
+                (true, false) => fn_ += 1,
+                (false, false) => tn += 1,
+            }
+        }
+    }
+    let merge_precision = if tp + fp == 0 {
+        1.0
+    } else {
+        tp as f64 / (tp + fp) as f64
+    };
+    let merge_recall = if tp + fn_ == 0 {
+        0.0
+    } else {
+        tp as f64 / (tp + fn_) as f64
+    };
+    let false_merge_rate = if fp + tn == 0 {
+        0.0
+    } else {
+        fp as f64 / (fp + tn) as f64
+    };
+    let true_clusters = labels.iter().map(|(_, e)| *e).collect::<BTreeSet<_>>().len();
+
+    Ok(MergeReport {
+        git_sha: inputs.git_sha.clone(),
+        mentions: labels.len(),
+        true_clusters,
+        merge_precision,
+        merge_recall,
+        false_merge_rate,
+        false_merges: fp,
+        correct_merges: tp,
+        missed_merges: fn_,
+    })
+}

--- a/src/recall_harness/mod.rs
+++ b/src/recall_harness/mod.rs
@@ -14,6 +14,7 @@ pub mod decay_sim;
 pub mod fixtures;
 pub mod forgetting_harness;
 pub mod lineage_harness;
+pub mod merge_harness;
 pub mod metrics;
 pub mod multihop;
 pub mod ontology_harness;

--- a/src/recall_harness/report.rs
+++ b/src/recall_harness/report.rs
@@ -511,6 +511,23 @@ pub struct LinkingReport {
     pub by_category: BTreeMap<String, LinkingRow>,
 }
 
+/// ER merge-quality (cross-document entity resolution). Plants known coref clusters
+/// (same entity, surface variants) plus distinct entities with tempting collisions,
+/// and scores the pairwise merge decisions. `false_merge_rate` is the catastrophic
+/// metric — distinct entities wrongly fused.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MergeReport {
+    pub git_sha: String,
+    pub mentions: usize,
+    pub true_clusters: usize,
+    pub merge_precision: f64,
+    pub merge_recall: f64,
+    pub false_merge_rate: f64,
+    pub false_merges: usize,
+    pub correct_merges: usize,
+    pub missed_merges: usize,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FunnelReport {
     pub suite: String,


### PR DESCRIPTION
## What

Two things, found by an isolated-A/B improvement loop over the entity-resolution and causal-chain harnesses:

1. **A merge-quality harness (`recall-eval --merge`)** — the first measurement of *cross-document entity-resolution* quality. The existing `--linking` harness measures query→graph linking, not whether mentions were correctly merged. The new harness plants known coref clusters (the same entity under surface variants, including a transliteration pair) plus distinct entities with tempting token collisions, resolves each surface through the graph, and scores the pairwise merge decisions: **merge precision, merge recall, and the false-merge rate** (distinct entities wrongly fused — the catastrophic metric).

2. **A content-token gate for the name-embedding merge (`SHODH_NAME_MERGE_TOKEN_GATE`, default off)** — requires a shared proper-noun token *on top of* the cosine threshold before merging two entities. Cosine stays required, so the gate can only **prevent** a merge, never create a false one.

## Why (the loop, in three iterations)

- **Iter 1** — `SHODH_EVAL_NAME_EMB` looked catastrophic: it collapsed the lineage harness (root-cause p@1 **0.883 → 0.000**). The lineage-only view said "reckless over-merger, revert."
- **Iter 2** — built the `--merge` harness, which **overturned that conclusion**: on real name variants, name-emb is a *good* resolver — merge recall **0.0 → 0.8**, **zero false merges**, and it correctly resolves the transliteration pair (Mohammed/Muhammad Ali) while keeping distinct collisions apart (Rajesh Verma, Mohammed Khan, Sunil Gupta). Its only failure is **templated names** ("the Vornak incident" vs "the Meslin incident"), where the embedding is dominated by the shared template and distinct events look identical.
- **Iter 3** — the token gate. Result (isolated A/B, control vs name-emb+gate):

| | control | name-emb + gate |
|---|---|---|
| merge recall | 0.0 | **0.8** |
| false-merge rate | 0.0 | **0.0** |
| lineage root-cause p@1 | 0.883 | **0.883** (held) |
| lineage direct-cause control | 1.0 | 1.0 |

A clean Pareto win: ER merge recall up, zero false merges, **and** the causal lineage no longer collapses.

## Notes

- `SHODH_NAME_MERGE_TOKEN_GATE` is **default off** — opt-in. It only affects the embedding-merge tier, which runs when name embeddings are populated.
- This is validated on the fast synthetic harnesses; a full-suite (LongMemEval) confirm is required before flipping any default.
- The `er-causal-loop.yml` workflow is the experiment driver for the loop; it can be archived alongside the other one-shot studies once this lands.
