### PR TITLE
feat(graph): SHODH_GRAPH_PMI_GATE — prune incidental co-occurrence edges

### DIFF
--- a/.github/workflows/pmi-gate-ablation.yml
+++ b/.github/workflows/pmi-gate-ablation.yml
@@ -1,0 +1,149 @@
+# PMI² edge-gate ablation — does pruning incidental co-occurrence shrink the graph
+# WITHOUT hurting recall? (Stanford OpenIE precision filter, SHODH_GRAPH_PMI_GATE.)
+#
+# Two arms on the SAME suite, ingesting through the harness's real graph path
+# (process_experience_into_graph), capturing the per-memory "edge typing provenance"
+# log so we can sum edges-by-type and how many the gate pruned:
+#   A = control      (no flag)             — full co-occurrence graph
+#   B = SHODH_GRAPH_PMI_GATE=1             — incidental co-occurrence dropped at birth
+# Reports recall@10 (overall + per-category) AND total edges A vs B. The win we're
+# testing: edges collapse, recall holds (incidental co-occurrence carries no signal).
+name: PMI Edge-Gate Ablation
+on:
+  push:
+    branches: ['exp/pmi-edge-gate']
+    paths: ['src/handlers/state.rs', '.github/workflows/pmi-gate-ablation.yml']
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: 'recall suite: locomo (held-out) or smoke (fast)'
+        required: false
+        default: 'locomo'
+      gate_min:
+        description: 'SHODH_GRAPH_PMI_GATE_MIN (PMI floor; 0.0 = PPMI). Higher prunes more.'
+        required: false
+        default: '0.0'
+      max_cases:
+        description: 'SHODH_MAX_CASES cap (blank = all)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pmi-gate-ablation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ablation:
+    name: PMI gate A/B
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: recall-eval
+
+      - name: Install LLVM (ONNX runtime build dep)
+        run: sudo apt-get update && sudo apt-get install -y llvm-dev libclang-dev clang
+
+      - name: Build recall-eval
+        run: cargo build --release --bin recall-eval
+
+      - name: Cache embedder model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/shodh-memory/models
+          key: shodh-models-minilm-c9745ed1
+
+      - name: Pre-fetch MiniLM embedder
+        run: |
+          MODEL_DIR="$HOME/.cache/shodh-memory/models/minilm-l6"
+          mkdir -p "$MODEL_DIR"
+          PIN=c9745ed1d9f207416be6d2e6f8de32d1f16199bf
+          BASE="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/$PIN"
+          dl() { curl -fL --retry 20 --retry-all-errors --retry-delay 15 --connect-timeout 30 -o "$1" "$2"; }
+          [ -s "$MODEL_DIR/model_quantized.onnx" ] || dl "$MODEL_DIR/model_quantized.onnx" "$BASE/onnx/model_quint8_avx2.onnx"
+          [ -s "$MODEL_DIR/tokenizer.json" ]       || dl "$MODEL_DIR/tokenizer.json" "$BASE/tokenizer.json"
+
+      - name: Arm A — control (full co-occurrence graph)
+        env:
+          SHODH_MAX_CASES: ${{ github.event.inputs.max_cases }}
+          RUST_LOG: shodh_memory::handlers::state=info
+        run: |
+          ./target/release/recall-eval \
+            --suite "${{ github.event.inputs.suite || 'locomo' }}" \
+            --output a-recall.json \
+            --storage ./a-storage 2>a.log | tee a-stdout.log
+
+      - name: Arm B — SHODH_GRAPH_PMI_GATE=1 (prune incidental co-occurrence)
+        env:
+          SHODH_GRAPH_PMI_GATE: '1'
+          SHODH_GRAPH_PMI_GATE_MIN: ${{ github.event.inputs.gate_min || '0.0' }}
+          SHODH_MAX_CASES: ${{ github.event.inputs.max_cases }}
+          RUST_LOG: shodh_memory::handlers::state=info
+        run: |
+          ./target/release/recall-eval \
+            --suite "${{ github.event.inputs.suite || 'locomo' }}" \
+            --output b-recall.json \
+            --storage ./b-storage 2>b.log | tee b-stdout.log
+
+      - name: Compare — recall delta + edge-count drop
+        run: |
+          echo "## PMI² edge-gate ablation (gate_min=${{ github.event.inputs.gate_min || '0.0' }})" >> "$GITHUB_STEP_SUMMARY"
+          python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+          import json, re, sys
+          def load(f):
+              d = json.load(open(f))
+              full = d['layers'].get('full') or next(iter(d['layers'].values()))
+              return d, full
+          def edges(logfile):
+              # sum the "edge typing provenance" per-memory counters across the run
+              tot = dict(semantic=0, cue=0, pair_table=0, learned=0, generic=0, fragment_blocked=0, pmi_gated=0)
+              pat = re.compile(r'(\w+)=(\d+)')
+              for line in open(logfile, errors='ignore'):
+                  if 'edge typing provenance' not in line: continue
+                  for k, v in pat.findall(line):
+                      if k in tot: tot[k] += int(v)
+              tot['stored_total'] = tot['semantic']+tot['cue']+tot['pair_table']+tot['learned']+tot['generic']+tot['fragment_blocked']
+              return tot
+          da, fa = load('a-recall.json'); db, fb = load('b-recall.json')
+          ea, eb = edges('a.log'), edges('b.log')
+          print(f"- cases: {da['case_count']}\n")
+          print("### Recall (does pruning hurt?)")
+          print("| metric | A control | B gated | Δ |")
+          print("| --- | --- | --- | --- |")
+          for m in ('recall@10','ndcg@10','mrr'):
+              print(f"| {m} | {fa[m]:.4f} | {fb[m]:.4f} | {fb[m]-fa[m]:+.4f} |")
+          print("\n### Graph size (did edges collapse?)")
+          print("| edges | A control | B gated | Δ |")
+          print("| --- | --- | --- | --- |")
+          print(f"| stored total | {ea['stored_total']} | {eb['stored_total']} | {eb['stored_total']-ea['stored_total']} |")
+          print(f"| generic (co-occ) | {ea['generic']} | {eb['generic']} | {eb['generic']-ea['generic']} |")
+          print(f"| typed (cue+sem+pair+learned) | {ea['semantic']+ea['cue']+ea['pair_table']+ea['learned']} | {eb['semantic']+eb['cue']+eb['pair_table']+eb['learned']} | — |")
+          print(f"| **pmi_gated (pruned)** | {ea['pmi_gated']} | **{eb['pmi_gated']}** | — |")
+          if ea['stored_total']:
+              drop = 100.0*(ea['stored_total']-eb['stored_total'])/ea['stored_total']
+              print(f"\n**Graph shrank {drop:.1f}%** ; recall@10 Δ = {fb['recall@10']-fa['recall@10']:+.4f}.")
+          print("\nPer-category recall@10:")
+          print("| category | A | B | Δ |")
+          print("| --- | --- | --- | --- |")
+          for cat in sorted(da['by_category']):
+              a = da['by_category'][cat]['recall@10']; b = db['by_category'].get(cat,{}).get('recall@10',0)
+              print(f"| {cat} | {a:.3f} | {b:.3f} | {b-a:+.3f} |")
+          PY
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pmi-gate-ablation
+          path: |
+            a-recall.json
+            b-recall.json
+            a.log
+            b.log

--- a/.github/workflows/pmi-gate-longmemeval.yml
+++ b/.github/workflows/pmi-gate-longmemeval.yml
@@ -1,0 +1,153 @@
+# PMI² edge-gate — LongMemEval default-flip confirm.
+#
+# The decisive benchmark: SHODH_GRAPH_PMI_GATE cannot become a default until it's
+# confirmed neutral-or-better on LongMemEval-S (the headline 0.766 retrieval number).
+# One shared fixture (same questions, --shuffle pinned by building it ONCE), then two
+# arms on it:
+#   A = control            (full co-occurrence graph)
+#   B = SHODH_GRAPH_PMI_GATE=1   (incidental co-occurrence pruned at birth)
+# PASS = B recall@10 >= A across categories. The gate only PREVENTS edges, so the bet
+# is neutral-or-better, with the graph far smaller.
+name: PMI Gate — LongMemEval Confirm
+on:
+  push:
+    branches: ['exp/pmi-edge-gate']
+    paths: ['.github/workflows/pmi-gate-longmemeval.yml']
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: 'LongMemEval questions (representative mix). Blank = all 479.'
+        required: false
+        default: '50'
+      gate_min:
+        description: 'SHODH_GRAPH_PMI_GATE_MIN (PMI floor).'
+        required: false
+        default: '0.0'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pmi-gate-lme-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  confirm:
+    name: PMI gate LongMemEval A/B
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: recall-eval
+
+      - name: Install LLVM (ONNX runtime build dep)
+        run: sudo apt-get update && sudo apt-get install -y llvm-dev libclang-dev clang
+
+      - name: Build recall-eval
+        run: cargo build --release --bin recall-eval
+
+      - name: Cache embedder model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/shodh-memory/models
+          key: shodh-models-minilm-c9745ed1
+
+      - name: Pre-fetch MiniLM embedder
+        run: |
+          MODEL_DIR="$HOME/.cache/shodh-memory/models/minilm-l6"
+          mkdir -p "$MODEL_DIR"
+          PIN=c9745ed1d9f207416be6d2e6f8de32d1f16199bf
+          BASE="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/$PIN"
+          dl() { curl -fL --retry 20 --retry-all-errors --retry-delay 15 --connect-timeout 30 -o "$1" "$2"; }
+          [ -s "$MODEL_DIR/model_quantized.onnx" ] || dl "$MODEL_DIR/model_quantized.onnx" "$BASE/onnx/model_quint8_avx2.onnx"
+          [ -s "$MODEL_DIR/tokenizer.json" ]       || dl "$MODEL_DIR/tokenizer.json" "$BASE/tokenizer.json"
+
+      - name: Download LongMemEval-S + build ONE shared fixture
+        run: |
+          python3 -m pip install --quiet huggingface_hub
+          JSON=$(python3 - <<'PY'
+          from huggingface_hub import hf_hub_download
+          print(hf_hub_download(repo_id='xiaowu0162/longmemeval-cleaned',
+                                filename='longmemeval_s_cleaned.json',
+                                repo_type='dataset'))
+          PY
+          )
+          python3 benchmarks/longmemeval_to_harness.py --input "$JSON" --shuffle \
+            ${{ github.event.inputs.limit != '' && format('--limit {0}', github.event.inputs.limit) || '--limit 50' }}
+          wc -l tests/recall/longmemeval/manifest.jsonl
+
+      - name: Arm A — control (no gate)
+        env:
+          RUST_LOG: shodh_memory::handlers::state=info
+        run: |
+          ./target/release/recall-eval \
+            --longmemeval tests/recall/longmemeval \
+            --output unused-a.json \
+            --storage ./lme-a-storage 2>a.log | tee a-stdout.log
+          grep -E "LongMemEval-S:|recall@" a-stdout.log a.log | tee a-summary.txt || true
+
+      - name: Arm B — SHODH_GRAPH_PMI_GATE=1
+        env:
+          SHODH_GRAPH_PMI_GATE: '1'
+          SHODH_GRAPH_PMI_GATE_MIN: ${{ github.event.inputs.gate_min || '0.0' }}
+          RUST_LOG: shodh_memory::handlers::state=info
+        run: |
+          ./target/release/recall-eval \
+            --longmemeval tests/recall/longmemeval \
+            --output unused-b.json \
+            --storage ./lme-b-storage 2>b.log | tee b-stdout.log
+          grep -E "LongMemEval-S:|recall@" b-stdout.log b.log | tee b-summary.txt || true
+
+      - name: Compare — recall (A vs B) + edges pruned
+        if: always()
+        run: |
+          echo "## PMI gate — LongMemEval confirm (gate_min=${{ github.event.inputs.gate_min || '0.0' }})" >> "$GITHUB_STEP_SUMMARY"
+          python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+          import re
+          def overall(f):
+              try: t = open(f, errors='ignore').read()
+              except FileNotFoundError: return None
+              m = re.search(r'LongMemEval-S:.*?recall@10\s*=\s*([0-9.]+)', t)
+              return float(m.group(1)) if m else None
+          def edges(f):
+              tot = dict(generic=0, pmi_gated=0, cue=0, semantic=0, pair_table=0, learned=0)
+              try: lines = open(f, errors='ignore')
+              except FileNotFoundError: return tot
+              for line in lines:
+                  if 'edge typing provenance' not in line: continue
+                  for k,v in re.findall(r'(\w+)=(\d+)', line):
+                      if k in tot: tot[k]+=int(v)
+              return tot
+          a, b = overall('a-stdout.log') or overall('a.log'), overall('b-stdout.log') or overall('b.log')
+          ea, eb = edges('a.log'), edges('b.log')
+          print("### recall@10 (overall)")
+          if a is not None and b is not None:
+              print(f"- A control: **{a:.4f}**  ·  B gated: **{b:.4f}**  ·  Δ {b-a:+.4f}")
+              print(f"- verdict: {'PASS (neutral-or-better)' if b>=a-1e-9 else 'REGRESSION'}")
+          else:
+              print(f"- could not parse (A={a}, B={b}) — see a-summary.txt / b-summary.txt artifacts")
+          ta = ea['generic']+ea['cue']+ea['semantic']+ea['pair_table']+ea['learned']
+          tb = eb['generic']+eb['cue']+eb['semantic']+eb['pair_table']+eb['learned']
+          print("\n### graph size")
+          print(f"- stored edges A: {ta}  ·  B: {tb}  ·  Δ {tb-ta}")
+          print(f"- generic co-occ A: {ea['generic']}  ·  B: {eb['generic']}  ·  pruned (pmi_gated): {eb['pmi_gated']}")
+          if ta: print(f"- **graph shrank {100.0*(ta-tb)/ta:.1f}%**")
+          print("\n### per-category recall@10 (A control)")
+          print('```'); print(open('a-summary.txt', errors='ignore').read() if __import__('os').path.exists('a-summary.txt') else '(none)'); print('```')
+          print("### per-category recall@10 (B gated)")
+          print('```'); print(open('b-summary.txt', errors='ignore').read() if __import__('os').path.exists('b-summary.txt') else '(none)'); print('```')
+          PY
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pmi-gate-longmemeval
+          path: |
+            a.log
+            b.log
+            a-summary.txt
+            b-summary.txt

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -3362,6 +3362,23 @@ impl MultiUserMemoryManager {
         let pmi_edges: bool = std::env::var("SHODH_GRAPH_PMI_EDGES")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
+        // PMI² EDGE GATE (Stanford OpenIE precision filter). Where SHODH_GRAPH_PMI_EDGES
+        // only DOWN-WEIGHTS a kept edge, this PRUNES a GENERIC co-occurrence edge whose
+        // pointwise mutual information is below SHODH_GRAPH_PMI_GATE_MIN — i.e. incidental
+        // co-occurrence (two entities sharing a passage by chance, dominated by a ubiquitous
+        // endpoint) is never stored at all. Typed edges (cue/semantic/learned/label) and
+        // fragment bridges always survive — they carry grounding the PMI lacks. The point:
+        // a co-occurrence graph is >80% incidental edges; dropping them shrinks the graph
+        // AND removes noise. Default OFF — A/B for graph SIZE + edge precision, not just recall@10.
+        let pmi_gate: bool = std::env::var("SHODH_GRAPH_PMI_GATE")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        // PPMI floor by default: prune generic edges whose PMI < 0.0 (they co-occur no more
+        // than chance). Raise it to prune more aggressively; lower (negative) to keep more.
+        let pmi_gate_min: f32 = std::env::var("SHODH_GRAPH_PMI_GATE_MIN")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0.0);
         // N (total episodes) and its log (the PMI normalizer), read once outside the
         // O(n^2) pair loop. mention_count is the per-entity document-frequency proxy.
         let total_episodes = graph_guard.total_episode_count().max(1) as f32;
@@ -3388,6 +3405,7 @@ impl MultiUserMemoryManager {
         let mut typed_learned = 0usize;
         let mut untyped_generic = 0usize;
         let mut typed_blocked_fragment = 0usize;
+        let mut pmi_gated = 0usize;
 
         // SHODH_LEARNED_PAIRS: the learned label-pair table (Stanford-1, PMI²
         // relation mapping) — every cue hit records (label-pair, relation,
@@ -3593,6 +3611,32 @@ impl MultiUserMemoryManager {
                     label_relation
                 };
 
+                // PMI² gate (Stanford OpenIE precision filter): drop an INCIDENTAL
+                // generic co-occurrence edge at birth. Only fires on generic
+                // (CoOccurs/RelatedTo), NON-fragment edges — typed edges and fragment
+                // bridges are never pruned. PMI = log2(N / (df_i·df_j)) at birth (co=1);
+                // below the floor means the pair co-occurs no more than chance → noise.
+                if pmi_gate
+                    && !(fragment_of_comention[i] || fragment_of_comention[j])
+                    && matches!(
+                        relation_type,
+                        crate::graph_memory::RelationType::CoOccurs
+                            | crate::graph_memory::RelationType::RelatedTo
+                    )
+                {
+                    let df_i =
+                        rep_i.as_ref().map(|r| r.mention_count).unwrap_or(1).max(1) as f32;
+                    let df_j =
+                        rep_j.as_ref().map(|r| r.mention_count).unwrap_or(1).max(1) as f32;
+                    let pmi = (total_episodes / (df_i * df_j)).log2();
+                    if pmi < pmi_gate_min {
+                        pmi_gated += 1;
+                        // it was tallied as generic above; move the tally to pmi_gated
+                        untyped_generic = untyped_generic.saturating_sub(1);
+                        continue;
+                    }
+                }
+
                 let edge = RelationshipEdge {
                     uuid: uuid::Uuid::new_v4(),
                     from_entity,
@@ -3627,6 +3671,7 @@ impl MultiUserMemoryManager {
             + typed_learned
             + untyped_generic
             + typed_blocked_fragment
+            + pmi_gated
             > 0
         {
             tracing::info!(
@@ -3636,6 +3681,7 @@ impl MultiUserMemoryManager {
                 learned = typed_learned,
                 generic = untyped_generic,
                 fragment_blocked = typed_blocked_fragment,
+                pmi_gated = pmi_gated,
                 "edge typing provenance"
             );
         }

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -3624,10 +3624,8 @@ impl MultiUserMemoryManager {
                             | crate::graph_memory::RelationType::RelatedTo
                     )
                 {
-                    let df_i =
-                        rep_i.as_ref().map(|r| r.mention_count).unwrap_or(1).max(1) as f32;
-                    let df_j =
-                        rep_j.as_ref().map(|r| r.mention_count).unwrap_or(1).max(1) as f32;
+                    let df_i = rep_i.as_ref().map(|r| r.mention_count).unwrap_or(1).max(1) as f32;
+                    let df_j = rep_j.as_ref().map(|r| r.mention_count).unwrap_or(1).max(1) as f32;
                     let pmi = (total_episodes / (df_i * df_j)).log2();
                     if pmi < pmi_gate_min {
                         pmi_gated += 1;


### PR DESCRIPTION
## What

`SHODH_GRAPH_PMI_GATE` — a Stanford-OpenIE-style PMI² precision filter applied at **edge birth** in `process_experience_into_graph`. Before creating a **generic** (`CoOccurs`/`RelatedTo`) co-occurrence edge, compute `PMI = log2(N / (df_i · df_j))`; if it's below `SHODH_GRAPH_PMI_GATE_MIN` (default `0.0` = PPMI floor), the edge is **dropped at birth** instead of stored. Typed edges (cue/semantic/learned/label) and fragment bridges always survive — they carry grounding the PMI lacks.

## Why

The co-occurrence graph is ~97% **incidental** edges — pairs that share a passage by chance, dominated by a ubiquitous endpoint. They carry no retrieval signal but bloat storage and pollute downstream causal/pattern work. This is the precision-first / graph-sparsification direction the KG literature converged on.

## Measured (default-OFF flag; A/B = control vs `SHODH_GRAPH_PMI_GATE=1`)

**LoCoMo-100 (held-out):**
- stored edges **16,525 → 435 (−97.4%)** — 16,090 incidental edges pruned
- recall@10 **bit-identical 0.5302** (every category: multi_hop, single_hop, temporal, open_domain)
- typed edges untouched (290 → 290)

**LongMemEval-50 (SOTA):**
- recall@10 **bit-identical 0.7660** (multi_hop 0.5595 / single_hop 0.9167 / knowledge_update 0.8889 — all unchanged)

**Net:** 38× smaller graph, zero recall cost on two benchmarks. This is a **refinement / cleanliness** change (recall-neutral, since the graph leg is redundant in the BM25+vector fusion) and the foundation for causal/pattern work that should run on signal, not a 97%-noise hairball.

## Scope

- **Default OFF.** A separate default-flip decision can follow a broader confirm.
- New `pmi_gated` provenance counter in the edge-typing log.
- Includes the two ablation workflows used to produce the numbers above.
