### PR TITLE
fix(audit): salvage correctness batch onto current main (LTP decay, NER span, fact-graph wiring, cache LRU, predicate-weights)

### DIFF
--- a/src/embeddings/minilm.rs
+++ b/src/embeddings/minilm.rs
@@ -1059,6 +1059,32 @@ impl Embedder for MiniLMEmbedder {
             return Ok(vec![empty_embedding; texts.len()]);
         }
 
+        // Apply the document/passage instruction prefix to every non-empty text
+        // before any encode path — this mirrors the single-text encode() →
+        // encode_prefixed(text, &self.doc_prefix) contract. For symmetric models
+        // (MiniLM/bge/mxbai) doc_prefix is empty, so we keep the original slice and
+        // this is a byte-identical no-op. For asymmetric models (e5/nomic) it places
+        // documents on the same manifold as prefixed queries; without it, batch
+        // ingest embedded documents on the wrong manifold. Empty inputs stay empty.
+        let prefixed: Vec<String>;
+        let prefixed_refs: Vec<&str>;
+        let texts: &[&str] = if self.doc_prefix.is_empty() {
+            texts
+        } else {
+            prefixed = texts
+                .iter()
+                .map(|t| {
+                    if t.is_empty() {
+                        String::new()
+                    } else {
+                        format!("{}{}", self.doc_prefix, t)
+                    }
+                })
+                .collect();
+            prefixed_refs = prefixed.iter().map(|s| s.as_str()).collect();
+            &prefixed_refs
+        };
+
         // Use simplified mode if in that mode
         if self.simplified_mode {
             let start = std::time::Instant::now();

--- a/src/embeddings/ner.rs
+++ b/src/embeddings/ner.rs
@@ -988,7 +988,11 @@ impl NeuralNer {
                             .is_some_and(|slice| slice.eq_ignore_ascii_case(&e.name))
                     })
                     .map(|(pos, _)| (pos, pos + name_len))
-                    .unwrap_or((0, name_len.min(text.len())));
+                    // Not found in the source text (e.g. the extractor normalised the
+                    // surface form): emit a zero-width span at offset 0 to signal
+                    // "position unknown" rather than fabricating a (0, name_len) span
+                    // that falsely claims the first name_len bytes are this entity.
+                    .unwrap_or((0, 0));
 
                 NerEntity {
                     text: e.name,
@@ -999,6 +1003,10 @@ impl NeuralNer {
                 }
             })
             .collect();
+
+        // Dedup to match the neural/batch paths — the heuristic extractor can emit
+        // the same surface mention more than once (e.g. repeated occurrences).
+        let entities = self.deduplicate_entities(entities);
 
         Ok(entities)
     }

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -1176,7 +1176,10 @@ impl RelationshipEdge {
             EdgeTier::L2Episodic | EdgeTier::L3Semantic => {
                 // L2/L3: Wixted 2004 hybrid (exponential consolidation → power-law long-term)
                 let days = hours_elapsed / 24.0;
-                let is_potentiated = ltp_factor < 0.5; // Weekly or Full LTP
+                // Burst/Weekly/Full LTP all use the potentiated (slower) power-law.
+                // decay_factor() returns exactly 0.5 for Burst, so `<` would exclude it
+                // (off-by-one) and decay Burst edges at the non-potentiated rate.
+                let is_potentiated = ltp_factor <= 0.5;
                 let decay = crate::decay::hybrid_decay_factor(days, is_potentiated);
                 let prune_threshold = self.tier.prune_threshold();
                 // Min age before pruning: 30 days for L2, 90 days for L3
@@ -1286,7 +1289,8 @@ impl RelationshipEdge {
             EdgeTier::L2Episodic | EdgeTier::L3Semantic => {
                 // Wixted 2004 hybrid: exponential consolidation → power-law long-term
                 let days = hours_elapsed / 24.0;
-                let is_potentiated = ltp_factor < 0.5;
+                // Inclusive: Burst decay_factor() == 0.5 must take the potentiated path.
+                let is_potentiated = ltp_factor <= 0.5;
                 (
                     crate::decay::hybrid_decay_factor(days, is_potentiated),
                     false,
@@ -2474,23 +2478,27 @@ impl GraphMemory {
             stemmed_index.insert(stemmed_name.clone(), entity.uuid);
         }
 
-        // Update entity embedding cache for future concept merges
+        // Update entity embedding cache for future concept merges.
+        // Recency-of-mention ordering: the front is the least-recently-mentioned
+        // entry (the eviction victim), the back is the most recent. A re-mention
+        // counts as an access and moves the entry to the back, so the drain below
+        // removes genuinely cold entities rather than merely the earliest-added
+        // (which may still be hot). Only matters once the graph exceeds
+        // ENTITY_EMBEDDING_CACHE_MAX (10k) distinct embedded entities.
         if let Some(ref emb) = entity.name_embedding {
             let mut cache = self.entity_embedding_cache.write();
             if is_new_entity {
                 cache.push((entity.uuid, emb.clone()));
-                // Evict oldest entries when cache exceeds the configured maximum.
-                // Oldest entries (index 0) are typically the least recently mentioned
-                // since they were loaded at startup or added earliest.
                 if cache.len() > ENTITY_EMBEDDING_CACHE_MAX {
                     let excess = cache.len() - ENTITY_EMBEDDING_CACHE_MAX;
                     cache.drain(..excess);
                 }
-            } else {
-                // Update existing entry in cache (embedding may have changed)
-                if let Some(entry) = cache.iter_mut().find(|(uuid, _)| *uuid == entity.uuid) {
-                    entry.1 = emb.clone();
-                }
+            } else if let Some(pos) = cache.iter().position(|(uuid, _)| *uuid == entity.uuid) {
+                // Re-mention: refresh the (possibly changed) embedding and promote
+                // to the back as the most-recently-accessed entry.
+                let mut entry = cache.remove(pos);
+                entry.1 = emb.clone();
+                cache.push(entry);
             }
         }
 

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -1479,7 +1479,13 @@ pub fn spreading_activation_retrieve_with_stats(
     // activation for every entity within REACH_HOPS of a seed (NO threshold) and merge by
     // max, so fusion can rank the reachable gold instead of never seeing it.
     if reach_inject {
-        match reachable_inject(graph, &seed_activations, intent_ref, false) {
+        // Honor SHODH_GRAPH_PREDICATE_WEIGHTS here too — the other graph passes (PPR,
+        // spreading, traversal) all weight edges by predicate type when it's set;
+        // reachable injection used to hardcode `false`, silently dropping that signal.
+        let pred_w = std::env::var("SHODH_GRAPH_PREDICATE_WEIGHTS")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        match reachable_inject(graph, &seed_activations, intent_ref, pred_w) {
             Ok(reach) => {
                 let before = activation_map.len();
                 for (u, a) in reach {

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -9062,11 +9062,24 @@ impl MemorySystem {
                     },
                 );
             }
+
+            // Connect newly extracted facts to the knowledge graph — the
+            // timer-driven run_maintenance() path does this, but the on-demand
+            // distillation path used to leave facts orphaned (never wired into
+            // EntityNodes/edges), so graph-augmented recall couldn't reach them.
+            self.connect_facts_to_graph(&deduplicated_facts);
         }
 
-        // Advance watermark after successful extraction
+        // Advance watermark to the LAST memory's created_at, NOT now(): using now()
+        // would skip memories created during the (potentially slow) extraction cycle
+        // — they'd have created_at < now() and never be processed for facts. Mirrors
+        // run_maintenance().
         if !memories.is_empty() {
-            let new_watermark = chrono::Utc::now().timestamp_millis();
+            let new_watermark = memories
+                .iter()
+                .map(|m| m.created_at.timestamp_millis())
+                .max()
+                .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
             self.fact_extraction_watermark
                 .store(new_watermark, std::sync::atomic::Ordering::Relaxed);
             self.long_term_memory


### PR DESCRIPTION
Salvages 6 un-shipped correctness fixes from the stale #319 (which was 79 commits behind) onto current `main`. Cherry-picked via 3-way merge, each verified at its current-main location, squashed into one commit.

### Fixes
1. **minilm.rs** (`encode_batch`) — applies the doc/passage prefix before encoding. No-op for symmetric models (MiniLM, empty prefix); fixes asymmetric (e5/nomic) batch ingest landing documents on the wrong manifold.
2. **ner.rs** (`extract_fallback`) — when the surface form isn't found, emit a zero-width `(0,0)` span instead of fabricating `(0, name_len)`; dedup heuristic-path entities.
3. **graph_memory.rs** (RelationshipEdge decay, 2 sites) — LTP off-by-one `< 0.5` → `<= 0.5`: Burst LTP (`decay_factor() == 0.5`) was excluded from the potentiated path and decayed too fast.
4. **graph_memory.rs** (`add_entity`) — entity-embedding cache is now LRU-by-access (was FIFO-by-insert, which evicted hot entities).
5. **graph_retrieval.rs** (`reachable_inject` call) — honors `SHODH_GRAPH_PREDICATE_WEIGHTS` (was hardcoded `false`, inconsistent with the other graph passes).
6. **memory/mod.rs** (on-demand fact distillation) — wires extracted facts into the graph (they were orphaned vs the timer path) + advances the watermark to MAX `created_at` (was `now()`, which skipped memories created during a slow extraction cycle).

Build green; tests pass (graph_memory 71 / embeddings 52 / graph_retrieval 26 / memory 71). Replaces #319.
