### PR TITLE
fix(graph): serialization compat hardening (KG audit Tier 0)

### DIFF
--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -5737,8 +5737,7 @@ impl GraphMemory {
         for (entity_id, selectivity) in &entity_selectivity {
             let key = entity_id.as_bytes();
             if let Ok(Some(value)) = self.db.get_cf(self.entities_cf(), key) {
-                if let Ok((mut entity, _)) = decode_entity_node(&value)
-                {
+                if let Ok((mut entity, _)) = decode_entity_node(&value) {
                     entity.selectivity = Some(*selectivity);
                     if let Ok(encoded) = crate::serialization::encode(&entity) {
                         entity_batch.put_cf(self.entities_cf(), key, encoded);
@@ -5919,8 +5918,7 @@ impl GraphMemory {
 
         for (i, result) in results.into_iter().enumerate() {
             if let Ok(Some(value)) = result {
-                if let Ok((mut entity, _)) = decode_entity_node(&value)
-                {
+                if let Ok((mut entity, _)) = decode_entity_node(&value) {
                     let old_salience = entity.salience;
                     entity.salience = (entity.salience + boost).clamp(0.05, 1.0);
 

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -828,12 +828,13 @@ fn merge_provenance(trail: &mut Vec<ProvenanceRecord>, record: ProvenanceRecord)
     }
 }
 
-/// Postcard encoding of the default value(s) for `RelationshipEdge` fields added
-/// AFTER the `provenance` field was introduced — currently just the single
-/// trailing `provenance: Vec<ProvenanceRecord>` (an empty Vec is the varint
-/// length `0`). Used to decode pre-provenance edges that were serialized before
-/// this field existed (postcard has no `#[serde(default)]` EOF tolerance).
-const EDGE_PROVENANCE_DEFAULT_SUFFIX: &[u8] = &[0x00];
+/// Postcard defaults for every trailing `RelationshipEdge` field added after the
+/// postcard cutover (#192), in field order: `endpoint_selectivity: Option` (None
+/// = `0x00`), `forman_curvature: Option` (None = `0x00`), `provenance: Vec` (empty
+/// = varint `0x00`). `try_decode_compat` appends these one at a time, so a record
+/// missing any suffix of these fields decodes (postcard has no `#[serde(default)]`
+/// EOF tolerance). Keep in sync with any new trailing field.
+const EDGE_PROVENANCE_DEFAULT_SUFFIX: &[u8] = &[0x00, 0x00, 0x00];
 
 /// Decode a stored `RelationshipEdge`, tolerating legacy records written before
 /// the `provenance` field existed. See [`crate::serialization::try_decode_compat`].
@@ -845,6 +846,17 @@ fn decode_relationship_edge(data: &[u8]) -> Result<(RelationshipEdge, bool)> {
         data,
         EDGE_PROVENANCE_DEFAULT_SUFFIX,
     )
+}
+
+/// Postcard defaults for trailing `EntityNode` fields added after the postcard
+/// cutover (#192): `selectivity: Option` (None = `0x00`). Keep in sync with any
+/// new trailing field.
+const ENTITY_NODE_DEFAULT_SUFFIX: &[u8] = &[0x00];
+
+/// Decode a stored `EntityNode`, tolerating legacy records written before trailing
+/// fields (e.g. `selectivity`) existed. See [`crate::serialization::try_decode_compat`].
+fn decode_entity_node(data: &[u8]) -> Result<(EntityNode, bool)> {
+    crate::serialization::try_decode_compat::<EntityNode>(data, ENTITY_NODE_DEFAULT_SUFFIX)
 }
 
 fn default_last_activated() -> DateTime<Utc> {
@@ -2312,7 +2324,7 @@ impl GraphMemory {
             let entity_iter = db.iterator_cf(entities_cf, rocksdb::IteratorMode::Start);
             let mut migrated_count = 0;
             for (_, value) in entity_iter.flatten() {
-                if let Ok((entity, _)) = crate::serialization::try_decode::<EntityNode>(&value) {
+                if let Ok((entity, _)) = decode_entity_node(&value) {
                     // Store in name_index CF: name -> UUID bytes
                     db.put_cf(
                         name_index_cf,
@@ -2455,7 +2467,7 @@ impl GraphMemory {
         for uuid in name_index.values() {
             let key = uuid.as_bytes();
             if let Ok(Some(value)) = db.get_cf(entities_cf, key) {
-                if let Ok((entity, _)) = crate::serialization::try_decode::<EntityNode>(&value) {
+                if let Ok((entity, _)) = decode_entity_node(&value) {
                     if let Some(emb) = entity.name_embedding {
                         cache.push((*uuid, emb));
                         if cache.len() >= ENTITY_EMBEDDING_CACHE_MAX {
@@ -2674,7 +2686,7 @@ impl GraphMemory {
         let key = uuid.as_bytes();
         match self.db.get_cf(self.entities_cf(), key)? {
             Some(value) => {
-                let (entity, _) = crate::serialization::try_decode::<EntityNode>(&value)?;
+                let (entity, _) = decode_entity_node(&value)?;
                 Ok(Some(entity))
             }
             None => Ok(None),
@@ -4386,7 +4398,7 @@ impl GraphMemory {
             }
 
             let (_, value) = result?;
-            let (entity, _) = crate::serialization::try_decode::<EntityNode>(&value)?;
+            let (entity, _) = decode_entity_node(&value)?;
 
             let entity_matches = self.match_pattern(&entity.uuid, pattern, min_strength)?;
             for m in entity_matches {
@@ -5725,7 +5737,7 @@ impl GraphMemory {
         for (entity_id, selectivity) in &entity_selectivity {
             let key = entity_id.as_bytes();
             if let Ok(Some(value)) = self.db.get_cf(self.entities_cf(), key) {
-                if let Ok((mut entity, _)) = crate::serialization::try_decode::<EntityNode>(&value)
+                if let Ok((mut entity, _)) = decode_entity_node(&value)
                 {
                     entity.selectivity = Some(*selectivity);
                     if let Ok(encoded) = crate::serialization::encode(&entity) {
@@ -5907,7 +5919,7 @@ impl GraphMemory {
 
         for (i, result) in results.into_iter().enumerate() {
             if let Ok(Some(value)) = result {
-                if let Ok((mut entity, _)) = crate::serialization::try_decode::<EntityNode>(&value)
+                if let Ok((mut entity, _)) = decode_entity_node(&value)
                 {
                     let old_salience = entity.salience;
                     entity.salience = (entity.salience + boost).clamp(0.05, 1.0);
@@ -5956,7 +5968,7 @@ impl GraphMemory {
             self.db
                 .iterator_cf_opt(self.entities_cf(), read_opts, rocksdb::IteratorMode::Start);
         for (_, value) in iter.flatten() {
-            if let Ok((entity, _)) = crate::serialization::try_decode::<EntityNode>(&value) {
+            if let Ok((entity, _)) = decode_entity_node(&value) {
                 entities.push(entity);
             }
         }

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -732,15 +732,23 @@ where
         return Ok(());
     }
 
-    // Decode with legacy bincode fallback
-    let (val, _needs_migration): (T, bool) =
-        serialization::try_decode(value).with_context(|| {
-            format!(
-                "decoding record (key len={}, value len={})",
+    // Decode with legacy bincode fallback. A record that can't be decoded — e.g. a
+    // pre-postcard bincode record missing fields added after the cutover, which
+    // bincode cannot default — is SKIPPED and reported, never fatal: one bad record
+    // must not abort the whole column-family migration. (Such records are already
+    // unreadable by the server's compat decoder, so skipping loses nothing new.)
+    let (val, _needs_migration): (T, bool) = match serialization::try_decode(value) {
+        Ok(decoded) => decoded,
+        Err(e) => {
+            eprintln!(
+                "  skip: undecodable record (key len={}, value len={}): {e}",
                 key.len(),
                 value.len()
-            )
-        })?;
+            );
+            *skipped += 1;
+            return Ok(());
+        }
+    };
 
     if !dry_run {
         let new_value = serialization::encode(&val)?;

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -162,15 +162,29 @@ pub fn try_decode_compat<T: DeserializeOwned>(
         match postcard::from_bytes::<T>(payload) {
             Ok(val) => return Ok((val, false)),
             Err(postcard::Error::DeserializeUnexpectedEnd) if !default_suffix.is_empty() => {
-                // Older record missing trailing field(s): supply their postcard
-                // defaults and retry. needs_migration = true so the caller can
-                // rewrite it in the current schema.
+                // Older record missing one or more trailing fields. A record can be
+                // short by SEVERAL fields (each schema revision adds one), so supply
+                // the field defaults ONE AT A TIME and retry until it decodes or the
+                // defaults run out — appending all of them at once would trip
+                // postcard's trailing-bytes check for a record missing only some.
+                // needs_migration = true so the caller rewrites it in current schema.
                 let mut extended = Vec::with_capacity(payload.len() + default_suffix.len());
                 extended.extend_from_slice(payload);
-                extended.extend_from_slice(default_suffix);
-                let val = postcard::from_bytes::<T>(&extended)
-                    .map_err(|e| anyhow::anyhow!("postcard decode (compat retry): {e}"))?;
-                return Ok((val, true));
+                for &b in default_suffix {
+                    extended.push(b);
+                    match postcard::from_bytes::<T>(&extended) {
+                        Ok(val) => return Ok((val, true)),
+                        Err(postcard::Error::DeserializeUnexpectedEnd) => continue,
+                        Err(e) => {
+                            return Err(anyhow::anyhow!("postcard decode (compat retry): {e}"))
+                        }
+                    }
+                }
+                return Err(anyhow::anyhow!(
+                    "postcard decode (compat): record still truncated after appending \
+                     {} default field(s)",
+                    default_suffix.len()
+                ));
             }
             Err(e) => return Err(anyhow::anyhow!("postcard decode (tagged): {e}")),
         }


### PR DESCRIPTION
Tier-0 (silent data-loss) fixes from the comprehensive KG audit. All backward-compat hardening — **no behavior change for current-schema data**.

1. **`try_decode_compat` loop-appends defaults** — was a single 1-byte retry, so a postcard record missing >1 trailing field (the endpoint_selectivity/forman_curvature/provenance window) silently failed to decode → dropped edge. Now appends field defaults one at a time until it decodes. Edge suffix widened to `[0x00,0x00,0x00]`.
2. **EntityNode compat decode** — 7 bare `try_decode::<EntityNode>` sites → `decode_entity_node`; legacy entities missing the post-cutover `selectivity` field no longer silently fail to load.
3. **Migration continue-on-error** — one undecodable legacy bincode record no longer aborts the entire graph CF migration; it's skipped + reported.

Audit tasks T0 #1–3. Reviewed against the code (verified, not agent-assumed).