### PR TITLE
fix(graph): causal intent + AssociatedWith penalty exclusion (KG audit T2)

### DIFF
--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -276,6 +276,7 @@ fn spread_single_direction(
                             RelationType::CoOccurs
                                 | RelationType::RelatedTo
                                 | RelationType::CoRetrieved
+                                | RelationType::AssociatedWith
                         )
                         && !intent.relation_types.contains(&edge.relation_type)
                     {
@@ -558,7 +559,10 @@ fn ppr_edge_weight(
         if !intent.relation_types.is_empty()
             && !matches!(
                 edge.relation_type,
-                RelationType::CoOccurs | RelationType::RelatedTo | RelationType::CoRetrieved
+                RelationType::CoOccurs
+                    | RelationType::RelatedTo
+                    | RelationType::CoRetrieved
+                    | RelationType::AssociatedWith
             )
             && !intent.relation_types.contains(&edge.relation_type)
         {

--- a/src/memory/query_parser.rs
+++ b/src/memory/query_parser.rs
@@ -4024,7 +4024,13 @@ fn verb_stem_to_relation_types(stem: &str) -> Vec<RelationType> {
         }
 
         // Causal relationships
-        "caus" | "result" | "lead" => vec![RelationType::Causes, RelationType::ResultsIn],
+        // Triggers is the type the cue extractor assigns to the most common causal
+        // phrasings ("caused", "led to", "because of", "due to") — it MUST be in the
+        // causal intent set or the ontology penalty (0.4x) suppresses exactly those
+        // edges on causal queries.
+        "caus" | "result" | "lead" => {
+            vec![RelationType::Causes, RelationType::ResultsIn, RelationType::Triggers]
+        }
 
         // Ownership / structural
         "own" | "belong" | "possess" => vec![RelationType::OwnedBy, RelationType::PartOf],

--- a/src/memory/query_parser.rs
+++ b/src/memory/query_parser.rs
@@ -4029,7 +4029,11 @@ fn verb_stem_to_relation_types(stem: &str) -> Vec<RelationType> {
         // causal intent set or the ontology penalty (0.4x) suppresses exactly those
         // edges on causal queries.
         "caus" | "result" | "lead" => {
-            vec![RelationType::Causes, RelationType::ResultsIn, RelationType::Triggers]
+            vec![
+                RelationType::Causes,
+                RelationType::ResultsIn,
+                RelationType::Triggers,
+            ]
         }
 
         // Ownership / structural


### PR DESCRIPTION
From the comprehensive KG audit (task #10).

**⚠️ Recall-affecting** — changes causal-query ranking on the graph path. Please let the Recall Harness (runs on this PR) confirm no regression before merging.

1. **Triggers → causal intent set** — the cue extractor types the most common causal phrasings (`caused`/`led to`/`because of`/`due to`) as `Triggers`, but the causal query intent whitelisted only `[Causes, ResultsIn]` → causal queries applied the 0.4× `ONTOLOGICAL_RELATION_PENALTY` to exactly the causal edges they should surface. Invisible unless you A/B the spreading path.
2. **AssociatedWith → never-penalized exclusion** at both penalty sites — it's documented generic-never-penalized (graph_memory.rs:1562) but was missing from the exclusion `matches!` lists, so it got penalized 0.4× on mismatched-intent queries.