### PR TITLE
fix(graph): ppr_edge_weight keys ontology penalty on true neighbour (KG audit #12)

### DIFF
--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -536,6 +536,10 @@ fn edge_dir_fix_enabled() -> bool {
 /// factor and column-normalisation subsume them.
 fn ppr_edge_weight(
     edge: &crate::graph_memory::RelationshipEdge,
+    // The TRUE traversal neighbour (the `edge_neighbor` result), NOT `edge.to_entity`.
+    // The entity-type penalty must key on the endpoint activation actually flows to,
+    // or it penalises the wrong node once SHODH_GRAPH_EDGE_DIR routes to `from_entity`.
+    neighbor: Uuid,
     intent: Option<&OntologicalIntent>,
     predicate_weights: bool,
     graph: &GraphMemory,
@@ -565,9 +569,9 @@ fn ppr_edge_weight(
             w *= ONTOLOGICAL_RELATION_PENALTY;
         }
         if !intent.expected_labels.is_empty() {
-            let labels = label_cache.entry(edge.to_entity).or_insert_with(|| {
+            let labels = label_cache.entry(neighbor).or_insert_with(|| {
                 graph
-                    .get_entity(&edge.to_entity)
+                    .get_entity(&neighbor)
                     .ok()
                     .flatten()
                     .map(|e| e.labels)
@@ -650,11 +654,11 @@ fn personalized_pagerank(
             let ui = ppr_intern(u, &mut nodes, &mut node_idx, &mut adj);
             let edges = graph.get_entity_relationships_limited(&u, Some(MAX_EDGES_PER_NODE))?;
             for edge in edges {
-                let w = ppr_edge_weight(&edge, intent, predicate_weights, graph, &mut label_cache);
+                let nb = edge_neighbor(&edge, &u, dir_fix);
+                let w = ppr_edge_weight(&edge, nb, intent, predicate_weights, graph, &mut label_cache);
                 if w <= 0.0 {
                     continue;
                 }
-                let nb = edge_neighbor(&edge, &u, dir_fix);
                 let ti = ppr_intern(nb, &mut nodes, &mut node_idx, &mut adj);
                 adj[ui].push((ti, w));
                 traversed.push(edge.uuid);
@@ -870,11 +874,11 @@ fn reachable_inject(
             }
             let edges = graph.get_entity_relationships_limited(&u, Some(MAX_EDGES_PER_NODE))?;
             for edge in edges {
-                let w = ppr_edge_weight(&edge, intent, predicate_weights, graph, &mut label_cache);
+                let nb = edge_neighbor(&edge, &u, dir_fix);
+                let w = ppr_edge_weight(&edge, nb, intent, predicate_weights, graph, &mut label_cache);
                 if w <= 0.0 {
                     continue;
                 }
-                let nb = edge_neighbor(&edge, &u, dir_fix);
                 let new_act = au * w * HOP_DECAY;
                 if new_act > best.get(&nb).copied().unwrap_or(0.0) {
                     best.insert(nb, new_act);
@@ -948,7 +952,7 @@ fn traverse_beam(
                 if p.visited.contains(&nb) {
                     continue;
                 }
-                let w = ppr_edge_weight(&edge, intent, predicate_weights, graph, &mut label_cache);
+                let w = ppr_edge_weight(&edge, nb, intent, predicate_weights, graph, &mut label_cache);
                 if w <= 0.0 {
                     continue;
                 }

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -569,13 +569,9 @@ fn ppr_edge_weight(
             w *= ONTOLOGICAL_RELATION_PENALTY;
         }
         if !intent.expected_labels.is_empty() {
-            let labels = label_cache.entry(neighbor).or_insert_with(|| {
-                graph
-                    .get_entity(&neighbor)
-                    .ok()
-                    .flatten()
-                    .map(|e| e.labels)
-            });
+            let labels = label_cache
+                .entry(neighbor)
+                .or_insert_with(|| graph.get_entity(&neighbor).ok().flatten().map(|e| e.labels));
             if let Some(labels) = labels {
                 let type_match = labels.iter().any(|l| {
                     intent
@@ -655,7 +651,14 @@ fn personalized_pagerank(
             let edges = graph.get_entity_relationships_limited(&u, Some(MAX_EDGES_PER_NODE))?;
             for edge in edges {
                 let nb = edge_neighbor(&edge, &u, dir_fix);
-                let w = ppr_edge_weight(&edge, nb, intent, predicate_weights, graph, &mut label_cache);
+                let w = ppr_edge_weight(
+                    &edge,
+                    nb,
+                    intent,
+                    predicate_weights,
+                    graph,
+                    &mut label_cache,
+                );
                 if w <= 0.0 {
                     continue;
                 }
@@ -875,7 +878,14 @@ fn reachable_inject(
             let edges = graph.get_entity_relationships_limited(&u, Some(MAX_EDGES_PER_NODE))?;
             for edge in edges {
                 let nb = edge_neighbor(&edge, &u, dir_fix);
-                let w = ppr_edge_weight(&edge, nb, intent, predicate_weights, graph, &mut label_cache);
+                let w = ppr_edge_weight(
+                    &edge,
+                    nb,
+                    intent,
+                    predicate_weights,
+                    graph,
+                    &mut label_cache,
+                );
                 if w <= 0.0 {
                     continue;
                 }
@@ -952,7 +962,14 @@ fn traverse_beam(
                 if p.visited.contains(&nb) {
                     continue;
                 }
-                let w = ppr_edge_weight(&edge, nb, intent, predicate_weights, graph, &mut label_cache);
+                let w = ppr_edge_weight(
+                    &edge,
+                    nb,
+                    intent,
+                    predicate_weights,
+                    graph,
+                    &mut label_cache,
+                );
                 if w <= 0.0 {
                     continue;
                 }


### PR DESCRIPTION
From the KG audit (task #12). **No-op on the default path** — with `SHODH_GRAPH_EDGE_DIR` off, `edge_neighbor` returns `to_entity`, so `neighbor == edge.to_entity` and the label lookup is byte-identical.

`ppr_edge_weight` keyed the entity-type ontology penalty on `edge.to_entity`, but the endpoint activation actually flows to is `edge_neighbor(edge, current, dir_fix)` = `from_entity` when edge-dir routes an incoming edge. So flipping `SHODH_GRAPH_EDGE_DIR` on would silently penalise the *wrong* endpoint's labels in PPR / reach / beam. Fix passes the resolved neighbour into `ppr_edge_weight`. **Must land before edge-dir is ever promoted**, or the two changes fight (found in the #333 audit).