### PR TITLE
fix(graph): populate edge provenance at birth (#4, #7)

### DIFF
--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -5152,7 +5152,18 @@ impl GraphMemory {
                     entity_confidence: Some(confidence),
                     forman_curvature: None,
                     endpoint_selectivity: None,
-                    provenance: Vec::new(),
+                    // Lineage bridge edge: the source episode is known and the
+                    // bridge confidence is meaningful, so seed the attestation
+                    // trail here (typed_by left None — no dedicated lineage method).
+                    provenance: vec![ProvenanceRecord {
+                        source_episode_id: *from_memory_uuid,
+                        mention_count: 1,
+                        first_observed: now,
+                        last_observed: now,
+                        confidence: Some(confidence),
+                        evidence_span: None,
+                        typed_by: None,
+                    }],
                 };
                 if self.add_relationship(edge).is_ok() {
                     created += 1;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -7644,6 +7644,25 @@ impl MemorySystem {
                             _ => 1.0,
                         };
 
+                        // Provenance: record EVERY source memory that attests this
+                        // fact, not just the first. A SemanticFact is the one place
+                        // the system holds an explicit multi-episode attestation set
+                        // (fact.source_memories), so capture all of them — the richest
+                        // companion signal for provenance-driven multi-hop recall (Inc2).
+                        // add_relationship caps + dedups the trail.
+                        let provenance: Vec<crate::graph_memory::ProvenanceRecord> = fact
+                            .source_memories
+                            .iter()
+                            .map(|mid| crate::graph_memory::ProvenanceRecord {
+                                source_episode_id: mid.0,
+                                mention_count: 1,
+                                first_observed: now,
+                                last_observed: now,
+                                confidence: Some(fact.confidence),
+                                evidence_span: None,
+                                typed_by: Some(crate::graph_memory::TypingMethod::LabelPair),
+                            })
+                            .collect();
                         let edge = crate::graph_memory::RelationshipEdge {
                             uuid: Uuid::new_v4(),
                             from_entity: e1.uuid,
@@ -7675,7 +7694,7 @@ impl MemorySystem {
                             entity_confidence: Some(fact.confidence),
                             forman_curvature: None,
                             endpoint_selectivity: None,
-                            provenance: Vec::new(),
+                            provenance,
                         };
                         if graph_guard.add_relationship(edge).is_ok() {
                             edges_added += 1;
@@ -8021,6 +8040,19 @@ impl MemorySystem {
                             _ => 1.0,
                         };
 
+                        // Provenance: the single source episode that produced this
+                        // co-occurrence edge. This is the primary ingest path (the
+                        // majority of edges), so populating it here gives most of the
+                        // graph a real attestation trail + confidence at edge birth.
+                        let provenance = vec![crate::graph_memory::ProvenanceRecord {
+                            source_episode_id: memory.id.0,
+                            mention_count: 1,
+                            first_observed: now,
+                            last_observed: now,
+                            confidence: entity_confidence,
+                            evidence_span: None,
+                            typed_by: Some(crate::graph_memory::TypingMethod::CoOccurrence),
+                        }];
                         let edge = crate::graph_memory::RelationshipEdge {
                             uuid: Uuid::new_v4(),
                             from_entity: e1.uuid,
@@ -8040,7 +8072,7 @@ impl MemorySystem {
                             entity_confidence,
                             forman_curvature: None,
                             endpoint_selectivity: None,
-                            provenance: Vec::new(),
+                            provenance,
                         };
 
                         if let Err(e) = graph_guard.add_relationship(edge) {


### PR DESCRIPTION
## What
Three production edge-creation sites birthed edges with `provenance: Vec::new()`, throwing away attestation data the caller already had.

| Site | Before | After |
|------|--------|-------|
| Co-occurrence ingest edge (`mod.rs`, majority of the graph) | empty | 1 record: source episode + `entity_confidence` + `typed_by=CoOccurrence` |
| Fact-consolidation edge (`mod.rs`) | kept only `source_memories.first()` | **all** attesting source memories, `typed_by=LabelPair`, `confidence` |
| Lineage bridge edge (`graph_memory.rs::create_lineage_graph_edges`) | empty | 1 record from known source episode + bridge confidence |

## Why
Increment 1 added `ProvenanceRecord` but only the strengthen path merged it — fresh edges were born blank. This closes audit findings **#4** (consolidation captured only the first source) and **#7** (confidence/mention_count/typed_by never populated at birth). The full multi-episode trail is the structural companion-finder that Increment 2 (provenance-driven multi-hop recall) reads.

## Safety
Pure **capture** enrichment. Provenance is written but **not yet read by retrieval**, so there is **no default recall-behavior change** — a strict superset of what was stored before. `add_relationship` already caps (`SHODH_PROVENANCE_MAX_SOURCES`, default 8) and dedups by source episode.

Memory↔memory `CoRetrieved`/replay edges are intentionally **left empty** — `source_episode_id` is `None` (no single attesting episode; the endpoints are themselves episodes). Import/export/MIF reconstruct from serialized data. Test fixtures unchanged.

CI compiles + runs the graph tests (local build is unavailable on the author's machine).