### PR TITLE
diag(graph): measure causal reverse-collapse before deciding #8

### DIFF
--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -3083,6 +3083,30 @@ impl GraphMemory {
             &edge.to_entity,
             &edge.relation_type,
         )? {
+            // #8 DIAGNOSTIC (default-safe, log-only): the typed pair key is
+            // order-independent (pair_key sorts min/max UUID), so an incoming
+            // CAUSAL attestation whose direction is the REVERSE of the stored
+            // edge collapses into it silently — the stored cause→effect arrow
+            // is never flipped. Count how often that actually happens for causal
+            // relations: if it's frequent, the order-independent key is losing
+            // real direction and a direction-sensitive key + reindex is justified;
+            // if near-zero (expected, given the effect-first extractor already
+            // fixes most mis-direction), the migration isn't worth its cost.
+            // grep eval logs for "directed reverse-collapse".
+            if edge.relation_type.is_causal()
+                && existing.from_entity == edge.to_entity
+                && existing.to_entity == edge.from_entity
+            {
+                tracing::info!(
+                    target: "shodh::provenance",
+                    relation = ?edge.relation_type,
+                    "directed reverse-collapse: incoming {}->{} merged into stored {}->{}",
+                    edge.from_entity,
+                    edge.to_entity,
+                    existing.from_entity,
+                    existing.to_entity
+                );
+            }
             // Strengthen existing edge instead of creating duplicate
             let _ = existing.strengthen();
             let now = Utc::now();


### PR DESCRIPTION
## What
A **log-only** diagnostic (no behavior change) to decide whether #8 (direction-sensitive pair key) is worth its migration cost.

`typed_pair_key` is order-independent (`pair_key` sorts min/max UUID), so an incoming **causal** attestation whose direction is the reverse of the stored edge collapses into it silently — the stored cause→effect arrow is never flipped. This counts how often that actually happens: `add_relationship` emits `tracing::info!(target: "shodh::provenance", ...)` `"directed reverse-collapse: ..."` whenever it strengthens a causal edge with the opposite from/to of the incoming one.

## Why
The #8 fix (direction-sensitive key for directed relations) requires changing the persisted `entity_pair_index` key format → a one-time reindex/migration + potential edge doubling. Before paying that, measure the problem:
- **Frequent** reverse-collapse on causal edges → migration justified (real direction is being lost, dead-ending the lineage backward-walk).
- **Near-zero** → not worth it. This is my expectation: the shipped effect-first extractor (`extract_directed_predicate`) already corrects most mis-direction at typing time.

## How to read it
Run the recall/lineage eval with `RUST_LOG` capturing `shodh::provenance` and grep `directed reverse-collapse`. The count (and which relations) decides #8.

No default behavior change; scoped to causal relations (`is_causal()`). CI compiles it.