### PR TITLE
docs: truth pass — tool counts (51) + benchmark version attribution

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # Shodh-Memory Performance Benchmarks
 
-Comprehensive performance measurements for shodh-memory v0.1.5+.
+Comprehensive performance measurements for shodh-memory (last measured on v0.1.5; current release v0.2.0).
 
 **Test Environment:** Windows 11, Intel i7-1355U (10 cores, 12 threads), Rust 1.75, Release build with LTO
 

--- a/README.md
+++ b/README.md
@@ -179,14 +179,26 @@ This is based on [Cowan's working memory model](https://doi.org/10.1177/09637214
 
 Single binary. No GPU required. Content-hash dedup ensures identical memories are never stored twice.
 
-## 37 MCP Tools
+## 51 MCP Tools
 
 Full list of tools available to Claude, Cursor, and other MCP clients:
 
 <details>
 <summary>Memory</summary>
 
-`remember` · `recall` · `proactive_context` · `context_summary` · `list_memories` · `read_memory` · `forget`
+`remember` · `recall` · `recall_by_tags` · `proactive_context` · `context_summary` · `list_memories` · `read_memory` · `forget`
+</details>
+
+<details>
+<summary>Search & Insight</summary>
+
+`quick_recall` · `query` · `topic` · `what_i_know` · `recent_memories` · `pending_work` · `count` · `memory_health` · `session_summary`
+</details>
+
+<details>
+<summary>Sessions & Facts</summary>
+
+`session_digest` · `session_history` · `fact_narratives` · `purge_facts`
 </details>
 
 <details>

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -97,7 +97,6 @@ env = { SHODH_API_KEY = "your-api-key-here" }
 | `list_memories` | List all stored memories |
 | `read_memory` | Read full content of a specific memory by ID |
 | `forget` | Delete a specific memory by ID |
-| `reinforce` | Reinforce a memory (boost importance) |
 </details>
 
 <details>

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -83,7 +83,7 @@ env = { SHODH_API_KEY = "your-api-key-here" }
 | `SHODH_STREAM` | Enable/disable streaming ingestion | `true` |
 | `SHODH_PROACTIVE` | Enable/disable proactive memory surfacing | `true` |
 
-## MCP Tools (47 total)
+## MCP Tools (51 total)
 
 <details>
 <summary><b>Memory</b> — Store, search, and manage memories</summary>


### PR DESCRIPTION
First adoption-audit fix (A1). README claimed **37** MCP tools, mcp-server README claimed **47** — the actual `index.ts` count is **51** (verified by parsing the tools array). Added the 14 unlisted tools (`quick_recall`, `query`, `topic`, `what_i_know`, `recent_memories`, `pending_work`, `count`, `memory_health`, `session_summary`, `session_digest`, `session_history`, `fact_narratives`, `purge_facts`, `recall_by_tags`) under two new groups. BENCHMARKS.md now honestly attributes measurements to v0.1.5 instead of implying they cover v0.2.0. Docs-only.