### PR TITLE
feat(anomaly): pattern/anomaly finder — ingest surprise components + /api/anomalies deviation feed (B1+B2)

### DIFF
--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -2048,6 +2048,38 @@ pub enum EpisodeSource {
     Observation,
 }
 
+/// Minimum dormancy (days since last activation) for an edge re-attestation
+/// to count as a [`TemporalAnomalyKind::DormantReactivation`] event.
+const DORMANT_REACTIVATION_MIN_DAYS: f32 = 7.0;
+
+/// Backstop cap on the pending temporal-anomaly queue (drained by the ingest
+/// path; the cap only matters if nothing drains it).
+const TEMPORAL_EVENT_QUEUE_CAP: usize = 1024;
+
+/// What kind of temporal anomaly the LTP/strengthen machinery surfaced.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub enum TemporalAnomalyKind {
+    /// An edge dormant for at least [`DORMANT_REACTIVATION_MIN_DAYS`] was
+    /// re-attested — a stale pattern suddenly became live again.
+    DormantReactivation,
+}
+
+/// A temporal anomaly detected at edge-strengthen time — SURFACED from the
+/// dynamics the Hebbian/decay machinery already runs, not re-detected.
+/// Queued on the graph (mirroring `pending_prune`) and drained by the ingest
+/// path, which resolves entity names and emits the event on SSE.
+#[derive(Debug, Clone, Serialize)]
+pub struct TemporalAnomalyEvent {
+    pub kind: TemporalAnomalyKind,
+    pub edge_uuid: Uuid,
+    pub from_entity: Uuid,
+    pub to_entity: Uuid,
+    pub relation_type: RelationType,
+    /// Days the edge sat dormant before this reactivation.
+    pub gap_days: f32,
+    pub detected_at: DateTime<Utc>,
+}
+
 /// Graph memory storage and operations
 ///
 /// Uses a single RocksDB instance with 9 column families for all graph data.
@@ -2091,6 +2123,10 @@ pub struct GraphMemory {
     /// Edges found below prune threshold during lazy-decay reads.
     /// Flushed as batch deletes on each maintenance cycle (no full scan needed).
     pending_prune: parking_lot::Mutex<Vec<Uuid>>,
+
+    /// Temporal anomalies surfaced at strengthen time (dormant reactivation),
+    /// drained by the ingest path and emitted on SSE. Capped backstop.
+    pending_temporal_anomalies: parking_lot::Mutex<Vec<TemporalAnomalyEvent>>,
 
     /// Entities that may have become orphaned from pruned edges.
     /// Checked during flush_pending_maintenance().
@@ -2244,6 +2280,7 @@ impl GraphMemory {
             synapse_update_lock: Arc::new(parking_lot::Mutex::new(())),
             entity_embedding_cache: Arc::new(parking_lot::RwLock::new(entity_embedding_cache)),
             pending_prune: parking_lot::Mutex::new(Vec::new()),
+            pending_temporal_anomalies: parking_lot::Mutex::new(Vec::new()),
             pending_orphan_checks: parking_lot::Mutex::new(Vec::new()),
         };
 
@@ -3213,9 +3250,31 @@ impl GraphMemory {
                     existing.to_entity
                 );
             }
+            // Temporal anomaly (B4): a long-dormant edge being re-attested is a
+            // pattern reactivation. Measured BEFORE strengthen()/last_activated
+            // overwrite the gap; queued for the ingest path to drain + emit.
+            let now = Utc::now();
+            let gap_days = now
+                .signed_duration_since(existing.last_activated)
+                .num_seconds() as f32
+                / 86_400.0;
+            if gap_days >= DORMANT_REACTIVATION_MIN_DAYS {
+                let mut queue = self.pending_temporal_anomalies.lock();
+                if queue.len() < TEMPORAL_EVENT_QUEUE_CAP {
+                    queue.push(TemporalAnomalyEvent {
+                        kind: TemporalAnomalyKind::DormantReactivation,
+                        edge_uuid: existing.uuid,
+                        from_entity: existing.from_entity,
+                        to_entity: existing.to_entity,
+                        relation_type: existing.relation_type.clone(),
+                        gap_days,
+                        detected_at: now,
+                    });
+                }
+            }
+
             // Strengthen existing edge instead of creating duplicate
             let _ = existing.strengthen();
-            let now = Utc::now();
             existing.last_activated = now;
 
             // Update context if new context is more informative
@@ -3322,6 +3381,13 @@ impl GraphMemory {
     }
 
     /// Index an edge for an entity
+    /// Drain the temporal anomalies queued by the strengthen path (dormant
+    /// reactivations). Called by the ingest path after each graph write; the
+    /// caller resolves entity names and emits SSE events.
+    pub fn drain_temporal_anomalies(&self) -> Vec<TemporalAnomalyEvent> {
+        std::mem::take(&mut *self.pending_temporal_anomalies.lock())
+    }
+
     fn index_entity_edge(&self, entity_uuid: &Uuid, edge_uuid: &Uuid) -> Result<()> {
         let key = format!("{entity_uuid}:{edge_uuid}");
         self.db
@@ -4138,6 +4204,7 @@ impl GraphMemory {
         // Drain pending maintenance queues — they reference now-deleted entities/edges
         let _ = std::mem::take(&mut *self.pending_prune.lock());
         let _ = std::mem::take(&mut *self.pending_orphan_checks.lock());
+        let _ = std::mem::take(&mut *self.pending_temporal_anomalies.lock());
 
         tracing::info!(
             "Graph data cleared (GDPR erasure): {} entities, {} relationships, {} episodes",
@@ -8381,6 +8448,74 @@ mod tests {
             graph.get_relationship(&edge_uuid).unwrap().is_none(),
             "an edge with no remaining attesting episode must be deleted"
         );
+    }
+
+    #[test]
+    fn dormant_reactivation_is_queued_and_drained() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let graph = GraphMemory::new(temp_dir.path(), None).unwrap();
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let now = Utc::now();
+
+        let make_edge = || RelationshipEdge {
+            uuid: Uuid::new_v4(),
+            from_entity: a,
+            to_entity: b,
+            relation_type: RelationType::CoOccurs,
+            strength: 0.5,
+            created_at: now,
+            valid_at: now,
+            invalidated_at: None,
+            source_episode_id: None,
+            context: String::new(),
+            last_activated: now,
+            activation_count: 1,
+            ltp_status: LtpStatus::None,
+            tier: EdgeTier::L2Episodic,
+            activation_timestamps: None,
+            entity_confidence: None,
+            forman_curvature: None,
+            endpoint_selectivity: None,
+            provenance: Vec::new(),
+        };
+
+        let edge_uuid = graph.add_relationship(make_edge()).unwrap();
+
+        // Fresh re-attestation (gap ~0): strengthen fires, but no event.
+        graph.add_relationship(make_edge()).unwrap();
+        assert!(
+            graph.drain_temporal_anomalies().is_empty(),
+            "a fresh re-attestation must not be a dormant reactivation"
+        );
+
+        // Backdate the stored edge 8 days, then re-attest: event queued.
+        let mut stored = graph.get_relationship(&edge_uuid).unwrap().unwrap();
+        stored.last_activated = now - Duration::days(8);
+        let encoded = crate::serialization::encode(&stored).unwrap();
+        graph
+            .db
+            .put_cf(graph.relationships_cf(), stored.uuid.as_bytes(), encoded)
+            .unwrap();
+
+        graph.add_relationship(make_edge()).unwrap();
+        let events = graph.drain_temporal_anomalies();
+        assert_eq!(
+            events.len(),
+            1,
+            "8-day dormancy must queue exactly one event"
+        );
+        let ev = &events[0];
+        assert_eq!(ev.kind, TemporalAnomalyKind::DormantReactivation);
+        assert_eq!(ev.edge_uuid, edge_uuid);
+        assert!(
+            ev.gap_days >= 7.9 && ev.gap_days <= 8.1,
+            "gap_days should be ~8, got {}",
+            ev.gap_days
+        );
+
+        // Drained means drained.
+        assert!(graph.drain_temporal_anomalies().is_empty());
     }
 
     /// Create a test relationship edge with specified strength and last_activated (L1 tier)

--- a/src/handlers/anomalies.rs
+++ b/src/handlers/anomalies.rs
@@ -1,0 +1,270 @@
+//! Anomaly Feed Handlers
+//!
+//! Read-time deviation scoring over the per-episode surprise components
+//! captured at ingest (see [`crate::memory::types::SurpriseComponents`]).
+//!
+//! Design: ingest stores FACTS (the episode's statistical shape); this
+//! endpoint computes DEVIATION — per-component z-scores against the user's
+//! own rolling baseline. Keeping the scoring at read time means thresholds
+//! are tunable without re-ingesting, and every flag is explainable
+//! component-by-component ("mean_pmi 3.2σ below baseline"), deterministically
+//! and without any LLM in the loop.
+
+use axum::{extract::State, response::Json};
+use serde::{Deserialize, Serialize};
+
+use super::state::MultiUserMemoryManager;
+use crate::errors::{AppError, ValidationErrorExt};
+use crate::memory::types::{SurpriseComponents, SURPRISE_METADATA_KEY};
+use crate::validation;
+use std::sync::Arc;
+
+type AppState = Arc<MultiUserMemoryManager>;
+
+/// Default number of most-recent scored episodes forming the rolling baseline.
+const DEFAULT_BASELINE_WINDOW: usize = 200;
+/// Default number of anomalies returned.
+const DEFAULT_LIMIT: usize = 20;
+/// Default |z| threshold for the `flagged` marker.
+const DEFAULT_MIN_SIGMA: f32 = 2.0;
+/// Minimum episodes needed before deviation is meaningful; below this the
+/// endpoint returns an empty feed rather than z-scores against noise.
+const MIN_BASELINE_EPISODES: usize = 10;
+
+#[derive(Deserialize)]
+pub struct AnomalyListRequest {
+    pub user_id: String,
+    /// Rolling-baseline window (most recent N scored episodes). Default 200.
+    #[serde(default)]
+    pub window: Option<usize>,
+    /// Maximum entries returned, ranked by max |z|. Default 20.
+    #[serde(default)]
+    pub limit: Option<usize>,
+    /// |z| at or above which an entry is `flagged`. Default 2.0.
+    #[serde(default)]
+    pub min_sigma: Option<f32>,
+}
+
+/// One component's deviation, kept explicit for explainability.
+#[derive(Debug, Clone, Serialize)]
+pub struct ComponentDeviation {
+    pub component: String,
+    pub value: f32,
+    pub baseline_mean: f32,
+    pub baseline_std: f32,
+    pub z: f32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AnomalyEntry {
+    pub memory_id: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub content_preview: String,
+    pub components: SurpriseComponents,
+    pub deviations: Vec<ComponentDeviation>,
+    pub max_abs_z: f32,
+    /// True when `max_abs_z >= min_sigma`.
+    pub flagged: bool,
+    /// Human-readable, deterministic explanation built from the top deviating
+    /// components — the auditable "why was this flagged".
+    pub explanation: String,
+}
+
+#[derive(Serialize)]
+pub struct AnomalyListResponse {
+    pub anomalies: Vec<AnomalyEntry>,
+    pub episodes_scored: usize,
+    pub baseline_window: usize,
+    pub min_sigma: f32,
+}
+
+/// The component axes scored against the baseline. Extraction is a function
+/// pointer per axis so baseline and per-episode paths cannot drift apart.
+const AXES: &[(&str, fn(&SurpriseComponents) -> f32)] = &[
+    ("mean_pmi", |s| s.mean_pmi),
+    ("novel_entity_ratio", |s| s.novel_entity_ratio),
+    ("untyped_ratio", |s| s.untyped_ratio),
+    ("pmi_gated_ratio", |s| s.pmi_gated_ratio),
+    ("low_selectivity_share", |s| s.low_selectivity_share),
+];
+
+/// POST /api/anomalies - rank recent episodes by statistical deviation
+pub async fn list_anomalies(
+    State(state): State<AppState>,
+    Json(req): Json<AnomalyListRequest>,
+) -> Result<Json<AnomalyListResponse>, AppError> {
+    validation::validate_user_id(&req.user_id).map_validation_err("user_id")?;
+
+    let window = req.window.unwrap_or(DEFAULT_BASELINE_WINDOW).max(1);
+    let limit = req.limit.unwrap_or(DEFAULT_LIMIT).max(1);
+    let min_sigma = req.min_sigma.unwrap_or(DEFAULT_MIN_SIGMA).max(0.0);
+
+    let graph = state
+        .get_user_graph(&req.user_id)
+        .map_err(AppError::Internal)?;
+
+    // Collect the scored episodes (those carrying surprise components) off
+    // the async executor — episode iteration is a full CF scan.
+    let mut scored: Vec<(
+        uuid::Uuid,
+        chrono::DateTime<chrono::Utc>,
+        String,
+        SurpriseComponents,
+    )> = tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<_>> {
+        let graph_guard = graph.read();
+        let episodes = graph_guard.get_all_episodes()?;
+        Ok(episodes
+            .into_iter()
+            .filter_map(|ep| {
+                let json = ep.metadata.get(SURPRISE_METADATA_KEY)?;
+                let components: SurpriseComponents = serde_json::from_str(json).ok()?;
+                let preview: String = ep.content.chars().take(160).collect();
+                Some((ep.uuid, ep.created_at, preview, components))
+            })
+            .collect())
+    })
+    .await
+    .map_err(|e| AppError::Internal(anyhow::anyhow!("Task join error: {}", e)))?
+    .map_err(AppError::Internal)?;
+
+    // Most recent first; the baseline is the rolling window of recent shape.
+    scored.sort_by(|a, b| b.1.cmp(&a.1));
+    scored.truncate(window);
+
+    if scored.len() < MIN_BASELINE_EPISODES {
+        return Ok(Json(AnomalyListResponse {
+            anomalies: Vec::new(),
+            episodes_scored: scored.len(),
+            baseline_window: window,
+            min_sigma,
+        }));
+    }
+
+    // Per-axis baseline over the window (population mean/std).
+    let n = scored.len() as f32;
+    let baselines: Vec<(f32, f32)> = AXES
+        .iter()
+        .map(|(_, extract)| {
+            let mean = scored.iter().map(|(_, _, _, s)| extract(s)).sum::<f32>() / n;
+            let var = scored
+                .iter()
+                .map(|(_, _, _, s)| {
+                    let d = extract(s) - mean;
+                    d * d
+                })
+                .sum::<f32>()
+                / n;
+            (mean, var.sqrt())
+        })
+        .collect();
+
+    let mut entries: Vec<AnomalyEntry> = scored
+        .into_iter()
+        .map(|(uuid, created_at, preview, components)| {
+            let deviations: Vec<ComponentDeviation> = AXES
+                .iter()
+                .zip(baselines.iter())
+                .map(|((name, extract), (mean, std))| {
+                    let value = extract(&components);
+                    // A degenerate axis (zero variance in the window) carries
+                    // no deviation signal: z = 0, never a false flag.
+                    let z = if *std > f32::EPSILON {
+                        (value - mean) / std
+                    } else {
+                        0.0
+                    };
+                    ComponentDeviation {
+                        component: name.to_string(),
+                        value,
+                        baseline_mean: *mean,
+                        baseline_std: *std,
+                        z,
+                    }
+                })
+                .collect();
+            let max_abs_z = deviations.iter().map(|d| d.z.abs()).fold(0.0, f32::max);
+            let flagged = max_abs_z >= min_sigma;
+
+            // Deterministic explanation from the top-2 deviating axes.
+            let mut ranked: Vec<&ComponentDeviation> = deviations.iter().collect();
+            ranked.sort_by(|a, b| b.z.abs().total_cmp(&a.z.abs()));
+            let explanation = ranked
+                .iter()
+                .take(2)
+                .filter(|d| d.z.abs() > f32::EPSILON)
+                .map(|d| {
+                    format!(
+                        "{} {:.1}σ {} baseline ({:.3} vs {:.3})",
+                        d.component,
+                        d.z.abs(),
+                        if d.z >= 0.0 { "above" } else { "below" },
+                        d.value,
+                        d.baseline_mean
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+
+            AnomalyEntry {
+                memory_id: uuid.to_string(),
+                created_at,
+                content_preview: preview,
+                components,
+                deviations,
+                max_abs_z,
+                flagged,
+                explanation,
+            }
+        })
+        .collect();
+
+    entries.sort_by(|a, b| b.max_abs_z.total_cmp(&a.max_abs_z));
+    let episodes_scored = entries.len();
+    entries.truncate(limit);
+
+    Ok(Json(AnomalyListResponse {
+        anomalies: entries,
+        episodes_scored,
+        baseline_window: window,
+        min_sigma,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn comp(mean_pmi: f32, novel: f32) -> SurpriseComponents {
+        SurpriseComponents {
+            mean_pmi,
+            novel_entity_ratio: novel,
+            untyped_ratio: 0.5,
+            pmi_gated_ratio: 0.0,
+            low_selectivity_share: 0.0,
+            pairs_scored: 6,
+            entities_total: 4,
+        }
+    }
+
+    #[test]
+    fn axes_extractors_cover_all_scored_fields() {
+        let s = comp(1.5, 0.25);
+        let values: Vec<f32> = AXES.iter().map(|(_, f)| f(&s)).collect();
+        assert_eq!(values, vec![1.5, 0.25, 0.5, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn zero_variance_axis_never_flags() {
+        // All-identical window → std 0 on every axis → z must be 0, not NaN.
+        let s = comp(2.0, 0.1);
+        let mean = 2.0f32;
+        let std = 0.0f32;
+        let z = if std > f32::EPSILON {
+            (s.mean_pmi - mean) / std
+        } else {
+            0.0
+        };
+        assert_eq!(z, 0.0);
+        assert!(z.is_finite());
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -13,6 +13,7 @@ pub mod health;
 pub mod utils;
 
 // Memory core operations
+pub mod anomalies;
 pub mod crud;
 pub mod recall;
 pub mod remember;

--- a/src/handlers/remember.rs
+++ b/src/handlers/remember.rs
@@ -773,14 +773,33 @@ pub async fn remember(
                 }
             };
 
-            // Task 1: Build episodic graph (entities + episode + relationships)
-            if let Err(e) = state.process_experience_into_graph(
+            // Task 1: Build episodic graph (entities + episode + relationships).
+            // On success the episode's surprise components come back — emit them
+            // on the SSE stream so live consumers (dashboard anomaly feed) see
+            // each episode's statistical shape as it lands. Read-time deviation
+            // scoring stays in /api/anomalies; this event carries the raw facts.
+            match state.process_experience_into_graph(
                 &user_id,
                 &experience,
                 &memory_id,
                 entity_embeddings.as_ref(),
             ) {
-                tracing::debug!("Graph processing failed (non-fatal): {}", e);
+                Ok(Some(surprise)) => {
+                    state.emit_event(MemoryEvent {
+                        event_type: "surprise".to_string(),
+                        timestamp: chrono::Utc::now(),
+                        user_id: user_id.clone(),
+                        memory_id: Some(memory_id.0.to_string()),
+                        content_preview: Some(experience.content.chars().take(100).collect()),
+                        memory_type: None,
+                        importance: None,
+                        count: None,
+                        entities: None,
+                        results: serde_json::to_value(&surprise).ok(),
+                    });
+                }
+                Ok(None) => {}
+                Err(e) => tracing::debug!("Graph processing failed (non-fatal): {}", e),
             }
 
             // Task 2: Set parent_id for hierarchical organization

--- a/src/handlers/router.rs
+++ b/src/handlers/router.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use super::state::MultiUserMemoryManager;
 use super::{
-    ab_testing, compression, consolidation, crud, export, facts, files, graph, health,
+    ab_testing, anomalies, compression, consolidation, crud, export, facts, files, graph, health,
     integrations, lineage, mif, recall, remember, search, sessions, todos, users, visualization,
     webhooks,
 };
@@ -191,6 +191,7 @@ pub fn build_protected_routes(state: AppState) -> Router {
             "/api/consolidation/events",
             get(consolidation::get_consolidation_events),
         )
+        .route("/api/anomalies", post(anomalies::list_anomalies))
         .route("/api/backup/create", post(consolidation::create_backup))
         .route("/api/backup/list", post(consolidation::list_backups))
         .route("/api/backups", post(consolidation::list_backups)) // MCP alias

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -3766,6 +3766,45 @@ impl MultiUserMemoryManager {
             }
             Some(surprise)
         };
+
+        // Temporal anomalies (B4): drain what the strengthen path surfaced
+        // during this (or any prior) graph write, resolve entity names while
+        // the guard is held, and emit each on the SSE stream.
+        for ev in graph_guard.drain_temporal_anomalies() {
+            let name_of = |u: &uuid::Uuid| {
+                graph_guard
+                    .get_entity(u)
+                    .ok()
+                    .flatten()
+                    .map(|e| e.name)
+                    .unwrap_or_else(|| u.to_string())
+            };
+            let from_name = name_of(&ev.from_entity);
+            let to_name = name_of(&ev.to_entity);
+            tracing::info!(
+                kind = ?ev.kind,
+                from = %from_name,
+                to = %to_name,
+                relation = ?ev.relation_type,
+                gap_days = ev.gap_days,
+                "temporal anomaly"
+            );
+            self.emit_event(MemoryEvent {
+                event_type: "temporal_anomaly".to_string(),
+                timestamp: ev.detected_at,
+                user_id: user_id.to_string(),
+                memory_id: Some(memory_id.0.to_string()),
+                content_preview: Some(format!(
+                    "{} —{:?}→ {} reactivated after {:.1} days dormant",
+                    from_name, ev.relation_type, to_name, ev.gap_days
+                )),
+                memory_type: None,
+                importance: None,
+                count: None,
+                entities: Some(vec![from_name, to_name]),
+                results: serde_json::to_value(&ev).ok(),
+            });
+        }
         // Lock released here
 
         if typed_semantic

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -2564,13 +2564,16 @@ impl MultiUserMemoryManager {
     /// - All-caps terms (API, TUI, NER, etc.)
     /// - Issue IDs (SHO-XX pattern)
     /// - Semantic similarity edges between memories
+    /// Returns the episode's raw [`SurpriseComponents`] when the graph pass ran
+    /// (also persisted on the episode's metadata); `None` when skipped
+    /// (idempotent replay or an entity-less episode).
     pub fn process_experience_into_graph(
         &self,
         user_id: &str,
         experience: &Experience,
         memory_id: &MemoryId,
         entity_name_embeddings: Option<&HashMap<String, Vec<f32>>>,
-    ) -> Result<()> {
+    ) -> Result<Option<crate::memory::types::SurpriseComponents>> {
         let graph = self.get_user_graph(user_id)?;
 
         // =====================================================================
@@ -3252,10 +3255,16 @@ impl MultiUserMemoryManager {
                 "Episode {} already processed, skipping graph rebuild",
                 &memory_id.0.to_string()[..8]
             );
-            return Ok(());
+            return Ok(None);
         }
 
         let mut entity_uuids: Vec<(String, uuid::Uuid, EntityLabel)> = Vec::new();
+
+        // Surprise component: entities lexically new to this user's graph.
+        // Pre-checked against the O(1) name index before add_entity runs its
+        // dedup (tier-4 embedding merge may still fold some in — this counts
+        // "never seen this name", which is the explainable novelty signal).
+        let mut novel_entities: u32 = 0;
 
         // Insert all pre-built entities
         for (name, entity) in all_entities {
@@ -3264,6 +3273,9 @@ impl MultiUserMemoryManager {
                 .first()
                 .cloned()
                 .unwrap_or(EntityLabel::Concept);
+            if matches!(graph_guard.find_entity_by_name(&name), Ok(None)) {
+                novel_entities += 1;
+            }
             match graph_guard.add_entity(entity) {
                 Ok(uuid) => entity_uuids.push((name, uuid, primary_label)),
                 Err(e) => tracing::debug!("Failed to add entity {}: {}", name, e),
@@ -3281,7 +3293,11 @@ impl MultiUserMemoryManager {
                 .collect::<Vec<_>>()
         );
 
-        let episode = EpisodicNode {
+        // `mut` + clone-at-add: after the pair loop the computed surprise
+        // components are inserted into this episode's metadata and the episode
+        // is re-put (add_episode overwrite is idempotent — `already_existed`
+        // guards the counter and the index puts are same-key).
+        let mut episode = EpisodicNode {
             uuid: memory_id.0,
             name: format!("Memory {}", &memory_id.0.to_string()[..8]),
             content: experience.content.clone(),
@@ -3292,7 +3308,7 @@ impl MultiUserMemoryManager {
             metadata: experience.metadata.clone(),
         };
 
-        match graph_guard.add_episode(episode) {
+        match graph_guard.add_episode(episode.clone()) {
             Ok(uuid) => {
                 tracing::debug!(
                     "Episode {} added with {} entity refs",
@@ -3436,11 +3452,36 @@ impl MultiUserMemoryManager {
             })
             .collect();
 
+        // Surprise-component accumulators (see `SurpriseComponents`): counted
+        // over ALL candidate pairs, before any quality-gate `continue`, so the
+        // ratios share one stable denominator.
+        let mut pairs_scored: u32 = 0;
+        let mut pmi_sum: f32 = 0.0;
+        let mut low_selectivity_pairs: u32 = 0;
+
         for i in 0..entity_uuids.len() {
             for j in (i + 1)..entity_uuids.len() {
                 // Edge quality gate using graph reputation
                 let rep_i = graph_guard.get_entity_reputation(&entity_uuids[i].0);
                 let rep_j = graph_guard.get_entity_reputation(&entity_uuids[j].0);
+
+                // Birth-PMI for this pair — log2(N / (df_i·df_j)) at co=1.
+                // Computed once here; reused by the strength weighting, the
+                // PMI gate, and the surprise components below.
+                let df_i = rep_i.as_ref().map(|r| r.mention_count).unwrap_or(1).max(1) as f32;
+                let df_j = rep_j.as_ref().map(|r| r.mention_count).unwrap_or(1).max(1) as f32;
+                let birth_pmi = (total_episodes / (df_i * df_j)).log2();
+
+                pairs_scored += 1;
+                pmi_sum += birth_pmi;
+                let min_sel = rep_i
+                    .as_ref()
+                    .map(|r| r.selectivity)
+                    .unwrap_or(1.0)
+                    .min(rep_j.as_ref().map(|r| r.selectivity).unwrap_or(1.0));
+                if min_sel < 0.2 {
+                    low_selectivity_pairs += 1;
+                }
 
                 // Skip: both endpoints are low-selectivity (co-occurrence is meaningless)
                 if let (Some(ri), Some(rj)) = (&rep_i, &rep_j) {
@@ -3480,10 +3521,7 @@ impl MultiUserMemoryManager {
                 // edge through add_relationship's Hebbian path. Falls back to the
                 // selectivity-IDF proxy, then to raw strength.
                 let pair_strength = if pmi_edges {
-                    let df_i = rep_i.as_ref().map(|r| r.mention_count).unwrap_or(1).max(1) as f32;
-                    let df_j = rep_j.as_ref().map(|r| r.mention_count).unwrap_or(1).max(1) as f32;
-                    let pmi = (total_episodes / (df_i * df_j)).log2();
-                    let factor = (pmi.max(0.0) / pmi_norm)
+                    let factor = (birth_pmi.max(0.0) / pmi_norm)
                         .clamp(crate::constants::GRAPH_PMI_WEIGHT_FLOOR, 1.0);
                     edge_strength * factor
                 } else if idf_edges {
@@ -3633,16 +3671,12 @@ impl MultiUserMemoryManager {
                         crate::graph_memory::RelationType::CoOccurs
                             | crate::graph_memory::RelationType::RelatedTo
                     )
+                    && birth_pmi < pmi_gate_min
                 {
-                    let df_i = rep_i.as_ref().map(|r| r.mention_count).unwrap_or(1).max(1) as f32;
-                    let df_j = rep_j.as_ref().map(|r| r.mention_count).unwrap_or(1).max(1) as f32;
-                    let pmi = (total_episodes / (df_i * df_j)).log2();
-                    if pmi < pmi_gate_min {
-                        pmi_gated += 1;
-                        // it was tallied as generic above; move the tally to pmi_gated
-                        untyped_generic = untyped_generic.saturating_sub(1);
-                        continue;
-                    }
+                    pmi_gated += 1;
+                    // it was tallied as generic above; move the tally to pmi_gated
+                    untyped_generic = untyped_generic.saturating_sub(1);
+                    continue;
                 }
 
                 // Evidence span: `truncated_context` is the first 150 CHARS of the
@@ -3687,6 +3721,51 @@ impl MultiUserMemoryManager {
                 }
             }
         }
+
+        // Aggregate the episode's surprise components (raw facts only —
+        // deviation/z-scoring happens at read time against the user's rolling
+        // baseline) and persist them on the episode via an idempotent re-put.
+        let surprise = if entity_uuids.is_empty() {
+            None
+        } else {
+            let pairs_f = pairs_scored.max(1) as f32;
+            let surprise = crate::memory::types::SurpriseComponents {
+                mean_pmi: if pairs_scored > 0 {
+                    pmi_sum / pairs_f
+                } else {
+                    0.0
+                },
+                novel_entity_ratio: novel_entities as f32 / entity_uuids.len() as f32,
+                untyped_ratio: untyped_generic as f32 / pairs_f,
+                pmi_gated_ratio: pmi_gated as f32 / pairs_f,
+                low_selectivity_share: low_selectivity_pairs as f32 / pairs_f,
+                pairs_scored,
+                entities_total: entity_uuids.len() as u32,
+            };
+            tracing::info!(
+                mean_pmi = surprise.mean_pmi,
+                novel_entity_ratio = surprise.novel_entity_ratio,
+                untyped_ratio = surprise.untyped_ratio,
+                pmi_gated_ratio = surprise.pmi_gated_ratio,
+                low_selectivity_share = surprise.low_selectivity_share,
+                pairs = surprise.pairs_scored,
+                entities = surprise.entities_total,
+                "episode surprise components"
+            );
+            match serde_json::to_string(&surprise) {
+                Ok(json) => {
+                    episode.metadata.insert(
+                        crate::memory::types::SURPRISE_METADATA_KEY.to_string(),
+                        json,
+                    );
+                    if let Err(e) = graph_guard.add_episode(episode) {
+                        tracing::debug!("Failed to persist surprise components: {}", e);
+                    }
+                }
+                Err(e) => tracing::debug!("Failed to serialize surprise components: {}", e),
+            }
+            Some(surprise)
+        };
         // Lock released here
 
         if typed_semantic
@@ -3710,7 +3789,7 @@ impl MultiUserMemoryManager {
             );
         }
 
-        Ok(())
+        Ok(surprise)
     }
 }
 

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -621,6 +621,42 @@ pub struct NerEntityRecord {
     pub end_char: Option<usize>,
 }
 
+/// Raw per-episode surprise components, computed at ingest from graph
+/// statistics already in hand in the entity-pair loop (PMI document
+/// frequencies, typing-chain counters, entity reputations). These are the
+/// FACTS of the episode's statistical shape — deliberately NOT a single
+/// weighted "anomaly score". Deviation scoring (z-scores against the user's
+/// rolling baseline) happens at READ time so thresholds stay tunable without
+/// re-ingesting, and every flag stays explainable component-by-component
+/// ("mean PMI 3σ below corpus norm; 60% never-seen entities").
+///
+/// Persisted as JSON under [`SURPRISE_METADATA_KEY`] in the graph episode's
+/// metadata map — additive, no storage schema change.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SurpriseComponents {
+    /// Mean birth-PMI across scored pairs: log2(N / (df_i·df_j)) at co=1.
+    /// LOW mean = the episode's pairs co-occur no more than chance given how
+    /// common the entities are — an unusual combination of familiar things.
+    pub mean_pmi: f32,
+    /// Fraction of this episode's entities never seen before (lexically new
+    /// to the name index; embedding-merge in add_entity may still dedup some).
+    pub novel_entity_ratio: f32,
+    /// Fraction of pairs the typing chain could NOT type (generic CoOccurs):
+    /// unrecognized structure. High = novel relational shape.
+    pub untyped_ratio: f32,
+    /// Fraction of pairs dropped by the PMI gate as chance-level co-occurrence.
+    pub pmi_gated_ratio: f32,
+    /// Fraction of pairs whose weaker endpoint has hub-like (low) selectivity.
+    pub low_selectivity_share: f32,
+    /// Number of entity pairs the components were computed over.
+    pub pairs_scored: u32,
+    /// Number of entities in the episode.
+    pub entities_total: u32,
+}
+
+/// Episode-metadata key under which [`SurpriseComponents`] is stored as JSON.
+pub const SURPRISE_METADATA_KEY: &str = "shodh.surprise";
+
 /// Raw experience data to be stored (ENHANCED with smart defaults)
 ///
 /// Only `content` is required. All other fields have intelligent defaults:
@@ -4456,6 +4492,30 @@ pub struct GraphDecayResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn surprise_components_json_roundtrip() {
+        // The components are persisted as JSON in episode metadata under
+        // SURPRISE_METADATA_KEY; the anomaly read path depends on this
+        // roundtrip staying stable.
+        let s = SurpriseComponents {
+            mean_pmi: -1.25,
+            novel_entity_ratio: 0.6,
+            untyped_ratio: 0.4,
+            pmi_gated_ratio: 0.1,
+            low_selectivity_share: 0.2,
+            pairs_scored: 10,
+            entities_total: 5,
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let back: SurpriseComponents = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.pairs_scored, 10);
+        assert_eq!(back.entities_total, 5);
+        assert!((back.mean_pmi - (-1.25)).abs() < f32::EPSILON);
+        assert!((back.novel_entity_ratio - 0.6).abs() < f32::EPSILON);
+        // Key is namespaced so it can't collide with user metadata.
+        assert!(SURPRISE_METADATA_KEY.starts_with("shodh."));
+    }
 
     #[test]
     fn test_geo_filter_haversine_distance() {


### PR DESCRIPTION
## What
First build step of the **anomaly-finder track**: every ingested episode now gets its raw statistical shape computed in the existing pair loop and persisted on the graph episode (`shodh.surprise` metadata key, JSON):

| Component | Signal |
|---|---|
| `mean_pmi` | familiar entities in an unfamiliar combination (low = surprising) |
| `novel_entity_ratio` | never-seen entities |
| `untyped_ratio` | relational structure the typing chain didn't recognize |
| `pmi_gated_ratio` | chance-level co-occurrence share |
| `low_selectivity_share` | hub-anchored pairs (noise risk) |
| `pairs_scored` / `entities_total` | sample sizes for read-time weighting |

## Design decision (the explainability moat)
These are **facts, not a score**. Z-scoring against the user's rolling baseline happens at **read time** (B2's `/api/anomalies`): thresholds stay tunable without re-ingesting, and every flag explains itself — *"mean PMI 3.2σ below your corpus norm; 60% never-seen entities"* — deterministic and auditable, which no LLM-in-the-loop competitor can offer.

## Mechanics / safety
- All inputs were already computed in the pair loop (entity reputations, PMI dfs, typing counters) — aggregation is O(pairs) additions, **no new I/O in the hot path** except one idempotent episode re-put under the same lock.
- Birth-PMI **hoisted** to one computation per pair (was duplicated in strength weighting + PMI gate; gate's nested if collapsed — clippy clean).
- Persisted in episode `metadata` (HashMap) — **zero storage-schema change**, no migration.
- `process_experience_into_graph` returns `Option<SurpriseComponents>` — verified all 8 callers ignored the Ok payload. Idempotent replay / entity-less episodes → `None`.
- **No recall-behavior change** — nothing reads the components yet (that's B2).

Verified locally: `cargo check`, `cargo clippy` (fixed the one warning my change introduced), `cargo test` roundtrip test green.

Next in track: B2 `/api/anomalies` + SSE emit → B3 dashboard panel → B4 temporal events.