### PR TITLE
feat(anomaly): graph cross-highlight — flag → structure → provenance in one motion

### DIFF
--- a/src/handlers/anomalies.rs
+++ b/src/handlers/anomalies.rs
@@ -55,6 +55,15 @@ pub struct ComponentDeviation {
     pub z: f32,
 }
 
+/// An entity involved in an anomalous episode — the graph cross-highlight
+/// handle. `id` is the entity UUID (universe stars use the same id, so the
+/// dashboard matches by id in single-user mode and by name in group mode).
+#[derive(Debug, Clone, Serialize)]
+pub struct AnomalyEntity {
+    pub id: String,
+    pub name: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct AnomalyEntry {
     pub memory_id: String,
@@ -68,6 +77,9 @@ pub struct AnomalyEntry {
     /// Human-readable, deterministic explanation built from the top deviating
     /// components — the auditable "why was this flagged".
     pub explanation: String,
+    /// The episode's entities (resolved names), so a flag can be projected
+    /// onto the knowledge-graph view. Resolved only for returned entries.
+    pub entities: Vec<AnomalyEntity>,
 }
 
 #[derive(Serialize)]
@@ -103,124 +115,154 @@ pub async fn list_anomalies(
         .get_user_graph(&req.user_id)
         .map_err(AppError::Internal)?;
 
-    // Collect the scored episodes (those carrying surprise components) off
-    // the async executor — episode iteration is a full CF scan.
-    let mut scored: Vec<(
-        uuid::Uuid,
-        chrono::DateTime<chrono::Utc>,
-        String,
-        SurpriseComponents,
-    )> = tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<_>> {
-        let graph_guard = graph.read();
-        let episodes = graph_guard.get_all_episodes()?;
-        Ok(episodes
-            .into_iter()
-            .filter_map(|ep| {
-                let json = ep.metadata.get(SURPRISE_METADATA_KEY)?;
-                let components: SurpriseComponents = serde_json::from_str(json).ok()?;
-                let preview: String = ep.content.chars().take(160).collect();
-                Some((ep.uuid, ep.created_at, preview, components))
-            })
-            .collect())
-    })
-    .await
-    .map_err(|e| AppError::Internal(anyhow::anyhow!("Task join error: {}", e)))?
-    .map_err(AppError::Internal)?;
-
-    // Most recent first; the baseline is the rolling window of recent shape.
-    scored.sort_by(|a, b| b.1.cmp(&a.1));
-    scored.truncate(window);
-
-    if scored.len() < MIN_BASELINE_EPISODES {
-        return Ok(Json(AnomalyListResponse {
-            anomalies: Vec::new(),
-            episodes_scored: scored.len(),
-            baseline_window: window,
-            min_sigma,
-        }));
-    }
-
-    // Per-axis baseline over the window (population mean/std).
-    let n = scored.len() as f32;
-    let baselines: Vec<(f32, f32)> = AXES
-        .iter()
-        .map(|(_, extract)| {
-            let mean = scored.iter().map(|(_, _, _, s)| extract(s)).sum::<f32>() / n;
-            let var = scored
-                .iter()
-                .map(|(_, _, _, s)| {
-                    let d = extract(s) - mean;
-                    d * d
-                })
-                .sum::<f32>()
-                / n;
-            (mean, var.sqrt())
-        })
-        .collect();
-
-    let mut entries: Vec<AnomalyEntry> = scored
-        .into_iter()
-        .map(|(uuid, created_at, preview, components)| {
-            let deviations: Vec<ComponentDeviation> = AXES
-                .iter()
-                .zip(baselines.iter())
-                .map(|((name, extract), (mean, std))| {
-                    let value = extract(&components);
-                    // A degenerate axis (zero variance in the window) carries
-                    // no deviation signal: z = 0, never a false flag.
-                    let z = if *std > f32::EPSILON {
-                        (value - mean) / std
-                    } else {
-                        0.0
-                    };
-                    ComponentDeviation {
-                        component: name.to_string(),
-                        value,
-                        baseline_mean: *mean,
-                        baseline_std: *std,
-                        z,
-                    }
+    // ALL CPU work — the full episode scan, baselines, z-scores, ranking, and
+    // entity resolution — runs in ONE blocking section off the async executor,
+    // taking the read guard once. Entity names are resolved only for the
+    // RETURNED entries (top `limit`), not the whole baseline window: at the
+    // defaults that is 12 episodes' refs instead of 200's.
+    let (entries, episodes_scored) =
+        tokio::task::spawn_blocking(move || -> anyhow::Result<(Vec<AnomalyEntry>, usize)> {
+            let graph_guard = graph.read();
+            let episodes = graph_guard.get_all_episodes()?;
+            let mut scored: Vec<(
+                uuid::Uuid,
+                chrono::DateTime<chrono::Utc>,
+                String,
+                SurpriseComponents,
+                Vec<uuid::Uuid>,
+            )> = episodes
+                .into_iter()
+                .filter_map(|ep| {
+                    let json = ep.metadata.get(SURPRISE_METADATA_KEY)?;
+                    let components: SurpriseComponents = serde_json::from_str(json).ok()?;
+                    let preview: String = ep.content.chars().take(160).collect();
+                    Some((ep.uuid, ep.created_at, preview, components, ep.entity_refs))
                 })
                 .collect();
-            let max_abs_z = deviations.iter().map(|d| d.z.abs()).fold(0.0, f32::max);
-            let flagged = max_abs_z >= min_sigma;
 
-            // Deterministic explanation from the top-2 deviating axes.
-            let mut ranked: Vec<&ComponentDeviation> = deviations.iter().collect();
-            ranked.sort_by(|a, b| b.z.abs().total_cmp(&a.z.abs()));
-            let explanation = ranked
+            // Most recent first; the baseline is the rolling window of recent shape.
+            scored.sort_by(|a, b| b.1.cmp(&a.1));
+            scored.truncate(window);
+
+            if scored.len() < MIN_BASELINE_EPISODES {
+                return Ok((Vec::new(), scored.len()));
+            }
+
+            // Per-axis baseline over the window (population mean/std).
+            let n = scored.len() as f32;
+            let baselines: Vec<(f32, f32)> = AXES
                 .iter()
-                .take(2)
-                .filter(|d| d.z.abs() > f32::EPSILON)
-                .map(|d| {
-                    format!(
-                        "{} {:.1}σ {} baseline ({:.3} vs {:.3})",
-                        d.component,
-                        d.z.abs(),
-                        if d.z >= 0.0 { "above" } else { "below" },
-                        d.value,
-                        d.baseline_mean
+                .map(|(_, extract)| {
+                    let mean = scored.iter().map(|(_, _, _, s, _)| extract(s)).sum::<f32>() / n;
+                    let var = scored
+                        .iter()
+                        .map(|(_, _, _, s, _)| {
+                            let d = extract(s) - mean;
+                            d * d
+                        })
+                        .sum::<f32>()
+                        / n;
+                    (mean, var.sqrt())
+                })
+                .collect();
+
+            let episodes_scored = scored.len();
+            // Entries carry their entity refs alongside until ranking settles
+            // which ones are returned; only those get names resolved.
+            let mut ranked: Vec<(AnomalyEntry, Vec<uuid::Uuid>)> = scored
+                .into_iter()
+                .map(|(uuid, created_at, preview, components, entity_refs)| {
+                    let deviations: Vec<ComponentDeviation> = AXES
+                        .iter()
+                        .zip(baselines.iter())
+                        .map(|((name, extract), (mean, std))| {
+                            let value = extract(&components);
+                            // A degenerate axis (zero variance in the window) carries
+                            // no deviation signal: z = 0, never a false flag.
+                            let z = if *std > f32::EPSILON {
+                                (value - mean) / std
+                            } else {
+                                0.0
+                            };
+                            ComponentDeviation {
+                                component: name.to_string(),
+                                value,
+                                baseline_mean: *mean,
+                                baseline_std: *std,
+                                z,
+                            }
+                        })
+                        .collect();
+                    let max_abs_z = deviations.iter().map(|d| d.z.abs()).fold(0.0, f32::max);
+                    let flagged = max_abs_z >= min_sigma;
+
+                    // Deterministic explanation from the top-2 deviating axes.
+                    let mut by_z: Vec<&ComponentDeviation> = deviations.iter().collect();
+                    by_z.sort_by(|a, b| b.z.abs().total_cmp(&a.z.abs()));
+                    let explanation = by_z
+                        .iter()
+                        .take(2)
+                        .filter(|d| d.z.abs() > f32::EPSILON)
+                        .map(|d| {
+                            format!(
+                                "{} {:.1}σ {} baseline ({:.3} vs {:.3})",
+                                d.component,
+                                d.z.abs(),
+                                if d.z >= 0.0 { "above" } else { "below" },
+                                d.value,
+                                d.baseline_mean
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join("; ");
+
+                    (
+                        AnomalyEntry {
+                            memory_id: uuid.to_string(),
+                            created_at,
+                            content_preview: preview,
+                            components,
+                            deviations,
+                            max_abs_z,
+                            flagged,
+                            explanation,
+                            entities: Vec::new(),
+                        },
+                        entity_refs,
                     )
                 })
-                .collect::<Vec<_>>()
-                .join("; ");
+                .collect();
 
-            AnomalyEntry {
-                memory_id: uuid.to_string(),
-                created_at,
-                content_preview: preview,
-                components,
-                deviations,
-                max_abs_z,
-                flagged,
-                explanation,
-            }
+            ranked.sort_by(|a, b| b.0.max_abs_z.total_cmp(&a.0.max_abs_z));
+            ranked.truncate(limit);
+
+            let entries: Vec<AnomalyEntry> =
+                ranked
+                    .into_iter()
+                    .map(|(mut entry, refs)| {
+                        entry.entities =
+                            refs.iter()
+                                .filter_map(|u| {
+                                    // Unresolvable refs (entity since deleted) are skipped:
+                                    // they exist in neither the graph nor the universe view,
+                                    // so there is nothing to highlight.
+                                    graph_guard.get_entity(u).ok().flatten().map(|e| {
+                                        AnomalyEntity {
+                                            id: u.to_string(),
+                                            name: e.name,
+                                        }
+                                    })
+                                })
+                                .collect();
+                        entry
+                    })
+                    .collect();
+
+            Ok((entries, episodes_scored))
         })
-        .collect();
-
-    entries.sort_by(|a, b| b.max_abs_z.total_cmp(&a.max_abs_z));
-    let episodes_scored = entries.len();
-    entries.truncate(limit);
+        .await
+        .map_err(|e| AppError::Internal(anyhow::anyhow!("Task join error: {}", e)))?
+        .map_err(AppError::Internal)?;
 
     Ok(Json(AnomalyListResponse {
         anomalies: entries,

--- a/src/handlers/dashboard.html
+++ b/src/handlers/dashboard.html
@@ -264,6 +264,9 @@ main{flex:1;display:grid;grid-template-columns:380px 1fr 300px;min-height:0;}
 .anomfeed .anom{font-size:12.5px;padding:9px 0;}
 .anomfeed .anom .why{font-size:11px;}
 .workwrap{max-width:900px;margin:0 auto;}
+#anomdetail .ghl{margin-top:10px;background:none;border:1px solid var(--turmeric);color:var(--turmeric);
+  border-radius:5px;padding:5px 12px;font:600 10.5px Inter,sans-serif;cursor:pointer;letter-spacing:.6px;}
+#anomdetail .ghl:hover{background:rgba(230,160,60,.12);}
 
 /* anomaly feed — deviation from the user's own statistical baseline */
 .anom{padding:6px 0;border-top:1px solid var(--line);font-size:11px;line-height:1.45;}
@@ -666,11 +669,15 @@ function clearCanvas(){ const {w,h}=sizeCanvas(); ctx.setTransform(DPR,0,0,DPR,0
 // ════════════════════════════════════════════════════════════════════════════
 //  CLUSTER OVERVIEW  — the default, readable view
 // ════════════════════════════════════════════════════════════════════════════
+// Below this many entities the whole-graph entity view replaces cluster
+// bubbles (shared by showClusters and the activation/highlight logic).
+const SMALL_GRAPH_MAX = 40;
+
 function showClusters(){
   // SMALL-GRAPH MODE: cluster bubbles only earn their keep at scale. A demo
   // or young corpus (≤40 entities) reads far better as the actual entity
   // constellation — show it directly instead of 2-3 opaque super-nodes.
-  if(RAW.nodes.length>0 && RAW.nodes.length<=40){ return showWholeGraph(); }
+  if(RAW.nodes.length>0 && RAW.nodes.length<=SMALL_GRAPH_MAX){ return showWholeGraph(); }
   VIEW.level="clusters"; VIEW.clusterId=null;
   const {w,h}=sizeCanvas();
   const maxSize = d3.max(RAW.clusters, c=>c.size)||1;
@@ -823,7 +830,10 @@ function draw(){
   ctx.save();
   ctx.translate(GT.x, GT.y); ctx.scale(GT.k, GT.k);
 
-  const lit = VIEW.level==="clusters" ? activeClusters : activeMembers;
+  // Lit-set choice follows node KIND, not nav level: the whole-graph
+  // small-corpus view shows ENTITY nodes at the "clusters" level, and those
+  // light by member id — testing them against cluster ids lights nothing.
+  const lit = (VIEW.nodes.length && VIEW.nodes[0].kind==="cluster") ? activeClusters : activeMembers;
   const dimmed = !!lit;
 
   // edges first
@@ -1025,34 +1035,69 @@ function activateFromCascade(res){
   // keep the distinctive core (cap so dense corpora don't flood)
   const cap=Math.max(6, Math.min(28, Math.round(scored.length*0.6)));
   const core = scored.slice(0, scored.length<=10?scored.length:cap).map(x=>x.n);
+  lightUpMembers(core, null);
+}
+
+// Shared lighting mechanism: given graph entity nodes (RAW.nodes items),
+// light them exactly the way a recall cascade does — set the active sets,
+// pick the right view (dominant-cluster drill at scale, whole-graph when
+// small), set the ribbon, and frame the lit nodes. Both entry points
+// (recall cascade, anomaly cross-highlight) go through here so the visual
+// language stays one language.
+function lightUpMembers(core, ribbonText){
+  if(!core.length){ deactivate(); return; }
   activeMembers = new Set(core.map(n=>n.id));
-  // 2) which clusters do they fall in? weight clusters by core membership
+  // which clusters do they fall in? weight clusters by core membership
   const cw=new Map();
   for(const n of core){ cw.set(n.comm,(cw.get(n.comm)||0)+1); }
   const litClusters = [...cw.entries()].sort((a,b)=>b[1]-a[1]);
   activeClusters = new Set(litClusters.map(e=>e[0]));
 
-  const a=$("activ"); a.classList.add("on");
-  const topName = RAW.clusters[litClusters[0][0]].label;
+  $("activ").classList.add("on");
+  const topName = RAW.clusters[litClusters[0][0]] ? RAW.clusters[litClusters[0][0]].label : "";
+  const small = RAW.nodes.length<=SMALL_GRAPH_MAX;
 
-  // 3) focus: if one cluster dominates the surfaced set, drill into it so the
-  //    member nodes light up; otherwise stay in the overview and glow clusters.
-  const dominant = litClusters[0][1] >= Math.max(2, 0.5*core.length) && litClusters[0][1] >= (litClusters[1]?litClusters[1][1]:0);
+  // focus: if one cluster dominates, drill into it so members light up;
+  // in small-graph mode never drill — every entity is already on screen.
+  const dominant = !small && litClusters[0][1] >= Math.max(2, 0.5*core.length) && litClusters[0][1] >= (litClusters[1]?litClusters[1][1]:0);
   if(dominant){
     showCluster(litClusters[0][0]);
     const litNodes = VIEW.nodes.filter(nd=>activeMembers.has(nd.id));
-    const inView = litNodes.length;
-    $("activ-t").textContent = "⚡ "+inView+" entities lit in cluster “"+trim(topName,20)+"”";
+    $("activ-t").textContent = ribbonText || ("⚡ "+litNodes.length+" entities lit in cluster “"+trim(topName,20)+"”");
     // frame the lit members + a little surrounding context
     if(litNodes.length>=2) fitView(litNodes, 110, true);
     else fitView(VIEW.nodes, 60, true);
   } else {
     if(VIEW.level!=="clusters") showClusters();
-    $("activ-t").textContent = "⚡ "+core.length+" entities across "+activeClusters.size+" clusters — top: "+trim(topName,20);
-    const litNodes = VIEW.nodes.filter(nd=>activeClusters.has(nd.id));
+    const litNodes = small
+      ? VIEW.nodes.filter(nd=>activeMembers.has(nd.id))
+      : VIEW.nodes.filter(nd=>activeClusters.has(nd.id));
+    $("activ-t").textContent = ribbonText ||
+      (small ? "⚡ "+core.length+" entities lit"
+             : "⚡ "+core.length+" entities across "+activeClusters.size+" clusters — top: "+trim(topName,20));
     applyActivation();
     if(litNodes.length>=2) fitView(litNodes, 90, true); else draw();
   }
+}
+
+// Cross-highlight: project an anomaly onto the knowledge graph. Matches the
+// episode's entities to graph nodes by uuid (single-user view: star.id IS the
+// entity uuid) with a name-key fallback (group view re-keys merged nodes).
+function anomHighlight(i){
+  const row = ANOM_ROWS[i]; if(!row || !RAW) return;
+  const ents = row.a.entities || [];
+  const wantIds = new Set(), wantNames = new Set();
+  for(const e of ents){ if(e.id) wantIds.add(e.id); if(e.name) wantNames.add(nameKey(e.name)); }
+  const core = RAW.nodes.filter(n => wantIds.has(n.id) || wantNames.has(nameKey(n.name)));
+  showScreen('live');
+  sizeCanvas();   // showScreen's resize is debounced; fit needs real dims NOW
+  if(!core.length){
+    $("activ").classList.add("on");
+    $("activ-t").textContent = "⚠ this anomaly's entities are not in the current graph view";
+    draw();
+    return;
+  }
+  lightUpMembers(core, "⚡ anomaly "+row.a.max_abs_z.toFixed(1)+"σ — "+core.length+" entities lit");
 }
 function applyActivation(){ draw(); }
 function deactivate(){
@@ -1355,6 +1400,10 @@ function anomDetail(i){
       '<span>('+d.value.toFixed(3)+' vs baseline '+d.baseline_mean.toFixed(3)+' ± '+d.baseline_std.toFixed(3)+')</span></div>';
   });
   h += '<div class="line"><span>sample</span> '+a.components.pairs_scored+' pairs · '+a.components.entities_total+' entities · '+new Date(a.created_at).toLocaleString()+'</div>';
+  if((a.entities||[]).length){
+    h += '<div class="line"><span>involves</span> '+a.entities.map(e=>esc(e.name)).join(" · ")+'</div>';
+    h += '<button class="ghl" onclick="anomHighlight('+i+')">⚡ show in graph</button>';
+  }
   $("anomdetail").innerHTML = h;
 }
 


### PR DESCRIPTION
## What
From an anomaly's audit trail, **⚡ show in graph** lights the episode's entities in the knowledge-graph constellation — the missing connective tissue between the anomaly feed and the graph. The suspicious chain literally glows against the dimmed graph with an *anomaly 4.0σ — 4 entities lit* ribbon.

## Backend
- `AnomalyEntry.entities: [{id, name}]` — episode `entity_refs` resolved to names. `id` = entity uuid (universe stars carry the same id → direct match in single-user view; name-key fallback for the group view's merged nodes). **Additive JSON** — existing consumers unaffected.
- Handler restructured: the full pipeline (scan → baselines → z-scores → ranking → entity resolution) runs in **one** `spawn_blocking` section holding the read guard once, and names resolve **only for returned entries** (top `limit` = 12 episodes' refs instead of the whole 200-episode window).

## Dashboard
- **Latent bug fixed (found in study, not by symptom):** `draw()` chose the lit-set by nav *level*, so in small-corpus whole-graph mode a recall cascade dimmed everything and lit nothing (entity ids tested against cluster ids). Now follows node **kind** — with a CDP regression test proving cascade lighting in small mode.
- `activateFromCascade`'s lighting tail factored into `lightUpMembers()` — cascade and anomaly highlight share **one mechanism**, one visual language. Small mode never cluster-drills.
- Canvas-dims subtlety handled: `showScreen`'s resize is debounced 120ms, so the highlight sizes the canvas synchronously before framing — otherwise `fitView` computes on stale zero dims.
- Honest degradation: entities absent from the graph view → notice ribbon, no false light.

## Verification
`cargo check`/`clippy`/tests green. CDP end-to-end: anomalies screen → click 4.0σ row → audit trail shows *involves: Unmarked Truck · Transponder X-91 · Checkpoint-Delta · Net Bravo* + button → click → Live screen with **exactly those 4 entities lit and framed**; cascade small-mode regression passes; zero JS exceptions across the whole interaction.