### PR TITLE
Fix proactive context dropping explicit overlap matches

### DIFF
--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -2054,10 +2054,15 @@ pub async fn proactive_context(
                     if alpha_count < 10 {
                         return false;
                     }
-                    // Anti-echo: skip memories that are just our own context echoed back
-                    // (auto-ingest stores context, which then gets retrieved for itself)
+                    // Anti-echo: skip auto-ingested memories that are just our own context
+                    // echoed back. Explicit memories can legitimately overlap the current
+                    // context and must still surface through proactive_context.
                     // Uses inline comparison to avoid allocating a HashSet<String> per candidate
-                    if !query_words.is_empty() {
+                    let is_auto_echo_candidate = m.experience.tags.iter().any(|tag| {
+                        tag.eq_ignore_ascii_case("auto-captured")
+                            || tag.eq_ignore_ascii_case("assistant-response")
+                    });
+                    if is_auto_echo_candidate && !query_words.is_empty() {
                         let mut mem_word_count = 0usize;
                         let mut overlap = 0usize;
                         for w in content.split_whitespace() {

--- a/src/handlers/recall.rs
+++ b/src/handlers/recall.rs
@@ -2291,20 +2291,23 @@ pub async fn proactive_context(
                 enriched.sort_by(|a, b| b.1.total_cmp(&a.1));
             }
 
-            // Drop results below minimum absolute score — don't pad with irrelevant filler
-            // Also drop results that are < 30% of the top score (too weak relative to best)
+            // Normalize scores before applying the public threshold. Raw pipeline scores are
+            // often tiny after proactive recency decay, while the API exposes scores on the
+            // same relative 0.0-0.95 scale as recall().
             let top_score = enriched.first().map(|(_, s, _)| *s).unwrap_or(0.0);
-            let abs_min = semantic_threshold;
-            let relative_min = top_score * 0.30;
-            let effective_min = abs_min.max(relative_min);
-            enriched.retain(|(_, s, _)| *s >= effective_min);
-
-            // Normalize scores for display: scale relative to top result
             if top_score > 0.0 {
                 for (_, score, _) in enriched.iter_mut() {
                     *score = (*score / top_score) * 0.95;
                 }
             }
+
+            // Drop results below minimum normalized score — don't pad with irrelevant filler.
+            // Also drop results that are < 30% of the top normalized score.
+            let top_normalized_score = if top_score > 0.0 { 0.95 } else { 0.0 };
+            let abs_min = semantic_threshold;
+            let relative_min = top_normalized_score * 0.30;
+            let effective_min = abs_min.max(relative_min);
+            enriched.retain(|(_, s, _)| *s >= effective_min);
 
             // (E) Update habituation state — record that these memories were surfaced.
             // Positive feedback resets count in Phase 0 of the next call.

--- a/tests/pipeline_integration_tests.rs
+++ b/tests/pipeline_integration_tests.rs
@@ -1476,6 +1476,56 @@ mod proactive_integration_tests {
     }
 
     #[tokio::test]
+    async fn proactive_context_keeps_explicit_memory_that_overlaps_context() {
+        let h = Harness::new();
+        let content = "Workflow preference: when running automated validation, use the existing local runner path and avoid duplicate remote automation runs. Do not create temporary branches or extra remote jobs unless explicitly requested.";
+        let memory_id = store_memory_full(
+            &h,
+            "test-user",
+            content,
+            "Decision",
+            vec!["workflow", "validation"],
+        )
+        .await;
+        wait_for_indexing().await;
+
+        let query =
+            "run automated validation using the local runner without duplicate remote automation";
+        let (status, recall_body) = recall(&h, "test-user", query).await;
+        assert_eq!(status, StatusCode::OK);
+        let recall_memories = recall_body["memories"].as_array().unwrap();
+        assert!(
+            recall_memories
+                .iter()
+                .any(|m| m["id"].as_str() == Some(memory_id.as_str())),
+            "explicit recall should find the stored memory: {recall_body}"
+        );
+
+        let (status, proactive_body) = json_of(
+            h.app(),
+            authed_post(
+                "/api/proactive_context",
+                json!({
+                    "user_id": "test-user",
+                    "context": query,
+                    "max_results": 10,
+                    "semantic_threshold": 0.1,
+                    "auto_ingest": false,
+                }),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let proactive_memories = proactive_body["memories"].as_array().unwrap();
+        assert!(
+            proactive_memories
+                .iter()
+                .any(|m| m["id"].as_str() == Some(memory_id.as_str())),
+            "proactive_context should not drop explicit memories as context echoes: {proactive_body}"
+        );
+    }
+
+    #[tokio::test]
     async fn proactive_context_respects_max_results() {
         let h = Harness::new();
         for i in 0..5 {

--- a/tests/pipeline_integration_tests.rs
+++ b/tests/pipeline_integration_tests.rs
@@ -151,6 +151,41 @@ async fn store_memory_full(
         .to_string()
 }
 
+/// Store a memory with an explicit creation timestamp.
+async fn store_memory_full_at(
+    h: &Harness,
+    user_id: &str,
+    content: &str,
+    memory_type: &str,
+    tags: Vec<&str>,
+    created_at: chrono::DateTime<chrono::Utc>,
+) -> String {
+    let (status, body) = json_of(
+        h.app(),
+        authed_post(
+            "/api/remember",
+            json!({
+                "user_id": user_id,
+                "content": content,
+                "memory_type": memory_type,
+                "tags": tags,
+                "created_at": created_at.to_rfc3339(),
+                "importance": 0.9,
+            }),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "store_memory_full_at failed: {body}"
+    );
+    body["id"]
+        .as_str()
+        .expect("missing id in response")
+        .to_string()
+}
+
 /// Recall memories for a user
 async fn recall(h: &Harness, user_id: &str, query: &str) -> (StatusCode, Value) {
     json_of(
@@ -1522,6 +1557,72 @@ mod proactive_integration_tests {
                 .iter()
                 .any(|m| m["id"].as_str() == Some(memory_id.as_str())),
             "proactive_context should not drop explicit memories as context echoes: {proactive_body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn proactive_context_threshold_uses_normalized_score_scale() {
+        let h = Harness::new();
+        let content = "Workflow preference: proactive context threshold calibration should surface durable old validation memories when recall ranks them as the best candidate.";
+        let created_at = chrono::Utc::now() - chrono::Duration::days(30);
+        let memory_id = store_memory_full_at(
+            &h,
+            "test-user",
+            content,
+            "Decision",
+            vec!["workflow", "threshold", "validation"],
+            created_at,
+        )
+        .await;
+        wait_for_indexing().await;
+
+        let query = "proactive context threshold calibration validation memories";
+        let (status, zero_threshold_body) = json_of(
+            h.app(),
+            authed_post(
+                "/api/proactive_context",
+                json!({
+                    "user_id": "test-user",
+                    "context": query,
+                    "max_results": 10,
+                    "semantic_threshold": 0.0,
+                    "auto_ingest": false,
+                }),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            zero_threshold_body["memories"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|m| m["id"].as_str() == Some(memory_id.as_str())),
+            "sanity check: zero threshold should surface the stored memory: {zero_threshold_body}"
+        );
+
+        let (status, tiny_threshold_body) = json_of(
+            h.app(),
+            authed_post(
+                "/api/proactive_context",
+                json!({
+                    "user_id": "test-user",
+                    "context": query,
+                    "max_results": 10,
+                    "semantic_threshold": 0.0001,
+                    "auto_ingest": false,
+                }),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            tiny_threshold_body["memories"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|m| m["id"].as_str() == Some(memory_id.as_str())),
+            "tiny positive threshold should use normalized score scale: {tiny_threshold_body}"
         );
     }
 


### PR DESCRIPTION
## Summary
- restrict proactive_context anti-echo filtering to auto-ingested memories only
- keep explicit user-saved memories eligible even when they strongly overlap the current context
- apply semantic_threshold after proactive scores are normalized to the public 0.0-0.95 score scale
- add regression coverage for both the recall/proactive_context divergence and the threshold=0 vs tiny-positive-threshold behavior reported in #283

Fixes #283.

## Tests
- LD_LIBRARY_PATH=/home/tanger/.cache/shodh-memory/onnxruntime${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} cargo test --test pipeline_integration_tests proactive_context_threshold_uses_normalized_score_scale -- --test-threads=1 --nocapture
- LD_LIBRARY_PATH=/home/tanger/.cache/shodh-memory/onnxruntime${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} cargo test --test pipeline_integration_tests proactive_context -- --test-threads=1 --nocapture
- LD_LIBRARY_PATH=/home/tanger/.cache/shodh-memory/onnxruntime${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} cargo test --test handler_pipeline_tests proactive_context -- --test-threads=1 --nocapture
- cargo fmt --all -- --check