### PR TITLE
Expose process memory diagnostics in health checks

### DIFF
--- a/benches/associative_retrieval_benchmarks.rs
+++ b/benches/associative_retrieval_benchmarks.rs
@@ -70,6 +70,7 @@ fn create_relationship(
         entity_confidence: None,
         forman_curvature: None,
         endpoint_selectivity: None,
+        provenance: Vec::new(),
     }
 }
 

--- a/benches/graph_benchmarks.rs
+++ b/benches/graph_benchmarks.rs
@@ -85,6 +85,7 @@ fn create_relationship(
         entity_confidence: None,
         forman_curvature: None,
         endpoint_selectivity: None,
+        provenance: Vec::new(),
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -58,6 +58,7 @@ pub enum AppError {
 
     // Not Found Errors (404)
     MemoryNotFound(String),
+    EntityNotFound(String),
     UserNotFound(String),
     TodoNotFound(String),
     ProjectNotFound(String),
@@ -116,6 +117,7 @@ impl AppError {
             Self::AmbiguousMemoryId { .. } => "AMBIGUOUS_MEMORY_ID",
             Self::ResourceLimit { .. } => "RESOURCE_LIMIT",
             Self::MemoryNotFound(_) => "MEMORY_NOT_FOUND",
+            Self::EntityNotFound(_) => "ENTITY_NOT_FOUND",
             Self::UserNotFound(_) => "USER_NOT_FOUND",
             Self::TodoNotFound(_) => "TODO_NOT_FOUND",
             Self::ProjectNotFound(_) => "PROJECT_NOT_FOUND",
@@ -144,6 +146,7 @@ impl AppError {
             Self::ResourceLimit { .. } => StatusCode::TOO_MANY_REQUESTS,
 
             Self::MemoryNotFound(_)
+            | Self::EntityNotFound(_)
             | Self::UserNotFound(_)
             | Self::TodoNotFound(_)
             | Self::ProjectNotFound(_) => StatusCode::NOT_FOUND,
@@ -185,6 +188,7 @@ impl AppError {
                 format!("Resource limit exceeded for {resource}: current={current} MB, limit={limit} MB")
             }
             Self::MemoryNotFound(id) => format!("Memory not found: {id}"),
+            Self::EntityNotFound(name) => format!("Entity not found: {name}"),
             Self::UserNotFound(id) => format!("User not found: {id}"),
             Self::TodoNotFound(id) => format!("Todo not found: {id}"),
             Self::ProjectNotFound(id) => format!("Project not found: {id}"),

--- a/src/handlers/graph.rs
+++ b/src/handlers/graph.rs
@@ -111,22 +111,27 @@ pub async fn traverse_graph(
         .map_err(AppError::Internal)?;
 
     let entity_name = req.entity_name.clone();
+    let missing_entity_name = req.entity_name;
     let max_depth = req.max_depth.unwrap_or(2);
     let traversal = tokio::task::spawn_blocking(move || {
         let graph_guard = graph.read();
 
-        let entity = graph_guard
+        let Some(entity) = graph_guard
             .find_entity_by_name(&entity_name)
             .map_err(|e| anyhow::anyhow!(e))?
-            .ok_or_else(|| anyhow::anyhow!("Entity not found: {}", entity_name))?;
+        else {
+            return Ok(None);
+        };
 
-        graph_guard
+        let traversal = graph_guard
             .traverse_from_entity(&entity.uuid, max_depth)
-            .map_err(|e| anyhow::anyhow!(e))
+            .map_err(|e| anyhow::anyhow!(e))?;
+        Ok(Some(traversal))
     })
     .await
     .map_err(|e| AppError::Internal(anyhow::anyhow!("Task join error: {e}")))?
-    .map_err(AppError::Internal)?;
+    .map_err(AppError::Internal)?
+    .ok_or_else(|| AppError::EntityNotFound(missing_entity_name))?;
 
     Ok(Json(traversal))
 }

--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use super::state::MultiUserMemoryManager;
 use super::types::{ContextStatus, MemoryEvent};
 use crate::metrics;
+use crate::system_memory::SystemMemoryDiagnostics;
 
 /// Application state type alias
 pub type AppState = std::sync::Arc<MultiUserMemoryManager>;
@@ -28,6 +29,7 @@ pub struct HealthResponse {
     pub max_cache_size: usize,
     pub write_failures: u64,
     pub pending_retries: usize,
+    pub system_memory: SystemMemoryDiagnostics,
 }
 
 /// Main health check endpoint
@@ -37,6 +39,8 @@ pub async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
 
     // Aggregate write failure metrics across all cached users
     let (write_failures, pending_retries) = state.write_failure_metrics();
+    let system_memory = crate::system_memory::read_system_memory_diagnostics();
+    metrics::update_system_memory_metrics(&system_memory);
 
     Json(HealthResponse {
         status: "healthy".to_string(),
@@ -47,6 +51,7 @@ pub async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         max_cache_size: state.server_config().max_users_in_memory,
         write_failures,
         pending_retries,
+        system_memory,
     })
 }
 
@@ -195,6 +200,8 @@ pub async fn metrics_endpoint(State(state): State<AppState>) -> Result<String, S
         .set(total_longterm);
     metrics::MEMORY_HEAP_BYTES_TOTAL.set(total_heap);
     metrics::VECTOR_INDEX_SIZE_TOTAL.set(total_vectors);
+    let system_memory = crate::system_memory::read_system_memory_diagnostics();
+    metrics::update_system_memory_metrics(&system_memory);
 
     // Gather and encode metrics
     let encoder = prometheus::TextEncoder::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod serialization;
 pub mod server;
 pub mod similarity;
 pub mod streaming;
+pub mod system_memory;
 pub mod telemetry;
 pub mod token_estimation;
 pub mod tracing_setup;

--- a/src/memory/query_parser.rs
+++ b/src/memory/query_parser.rs
@@ -244,6 +244,8 @@ pub fn extract_temporal_refs(text: &str) -> TemporalExtraction {
     let mut refs = Vec::new();
     let mut earliest: Option<NaiveDate> = None;
     let mut latest: Option<NaiveDate> = None;
+    let explicit_dates = extract_explicit_dates(text);
+    let has_explicit_dates = !explicit_dates.is_empty();
 
     // Helper to validate date is in reasonable range (1900-2100)
     let is_valid_date = |date: &NaiveDate| -> bool {
@@ -251,44 +253,49 @@ pub fn extract_temporal_refs(text: &str) -> TemporalExtraction {
         (1900..=2100).contains(&year)
     };
 
-    // Try dateparser on the full text (returns Result, never panics)
-    if let Ok(parsed) = dateparser::parse(text) {
-        let date = parsed.date_naive();
-        if is_valid_date(&date) {
-            refs.push(TemporalRef {
-                date,
-                original_text: text.to_string(),
-                confidence: 0.8,
-                position: 0,
-                ref_type: classify_temporal_ref(text, &date, &now),
-            });
-            update_bounds(&mut earliest, &mut latest, date);
+    // Try dateparser on the full text (returns Result, never panics). Exact
+    // regex dates win because dateparser may timezone-shift an embedded ISO
+    // date at local midnight into the previous UTC day.
+    if !has_explicit_dates {
+        if let Ok(parsed) = dateparser::parse(text) {
+            let date = parsed.date_naive();
+            if is_valid_date(&date) {
+                refs.push(TemporalRef {
+                    date,
+                    original_text: text.to_string(),
+                    confidence: 0.8,
+                    position: 0,
+                    ref_type: classify_temporal_ref(text, &date, &now),
+                });
+                update_bounds(&mut earliest, &mut latest, date);
+            }
         }
     }
 
     // Try parsing individual sentences/phrases
-    for (pos, sentence) in split_temporal_phrases(text).iter().enumerate() {
-        if let Ok(parsed) = dateparser::parse(sentence) {
-            let date = parsed.date_naive();
-            if !is_valid_date(&date) {
-                continue;
+    if !has_explicit_dates {
+        for (pos, sentence) in split_temporal_phrases(text).iter().enumerate() {
+            if let Ok(parsed) = dateparser::parse(sentence) {
+                let date = parsed.date_naive();
+                if !is_valid_date(&date) {
+                    continue;
+                }
+                if refs.iter().any(|r| r.date == date) {
+                    continue;
+                }
+                refs.push(TemporalRef {
+                    date,
+                    original_text: sentence.to_string(),
+                    confidence: 0.7,
+                    position: pos,
+                    ref_type: classify_temporal_ref(sentence, &date, &now),
+                });
+                update_bounds(&mut earliest, &mut latest, date);
             }
-            if refs.iter().any(|r| r.date == date) {
-                continue;
-            }
-            refs.push(TemporalRef {
-                date,
-                original_text: sentence.to_string(),
-                confidence: 0.7,
-                position: pos,
-                ref_type: classify_temporal_ref(sentence, &date, &now),
-            });
-            update_bounds(&mut earliest, &mut latest, date);
         }
     }
 
     // Also use regex-based extraction for explicit date patterns
-    let explicit_dates = extract_explicit_dates(text);
     for (date, original, pos) in explicit_dates {
         if !is_valid_date(&date) {
             continue;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -264,6 +264,51 @@ pub static MEMORY_HEAP_BYTES_TOTAL: LazyLock<IntGauge> = LazyLock::new(|| {
     .expect("MEMORY_HEAP_BYTES_TOTAL metric must be valid at compile time")
 });
 
+/// Resident set size for the server process, when available.
+pub static PROCESS_RSS_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        "shodh_process_rss_bytes",
+        "Resident set size for the server process",
+    )
+    .expect("PROCESS_RSS_BYTES metric must be valid at compile time")
+});
+
+/// Peak resident set size for the server process, when available.
+pub static PROCESS_PEAK_RSS_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        "shodh_process_peak_rss_bytes",
+        "Peak resident set size for the server process",
+    )
+    .expect("PROCESS_PEAK_RSS_BYTES metric must be valid at compile time")
+});
+
+/// Virtual memory size for the server process, when available.
+pub static PROCESS_VIRTUAL_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        "shodh_process_virtual_bytes",
+        "Virtual memory size for the server process",
+    )
+    .expect("PROCESS_VIRTUAL_BYTES metric must be valid at compile time")
+});
+
+/// Current cgroup memory usage for the server, when available.
+pub static CGROUP_MEMORY_CURRENT_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        "shodh_cgroup_memory_current_bytes",
+        "Current cgroup memory usage for the server process",
+    )
+    .expect("CGROUP_MEMORY_CURRENT_BYTES metric must be valid at compile time")
+});
+
+/// Peak cgroup memory usage for the server, when available.
+pub static CGROUP_MEMORY_PEAK_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        "shodh_cgroup_memory_peak_bytes",
+        "Peak cgroup memory usage for the server process",
+    )
+    .expect("CGROUP_MEMORY_PEAK_BYTES metric must be valid at compile time")
+});
+
 // ============================================================================
 // Vector Index Metrics (aggregate)
 // ============================================================================
@@ -512,6 +557,27 @@ pub static EMBEDDING_CACHE_CONTENT_SIZE: LazyLock<IntGauge> = LazyLock::new(|| {
     .expect("EMBEDDING_CACHE_CONTENT_SIZE metric must be valid at compile time")
 });
 
+fn set_optional_gauge(gauge: &IntGauge, value: Option<u64>) {
+    if let Some(value) = value {
+        gauge.set(value.min(i64::MAX as u64) as i64);
+    }
+}
+
+/// Update best-effort process/cgroup memory gauges.
+pub fn update_system_memory_metrics(diagnostics: &crate::system_memory::SystemMemoryDiagnostics) {
+    set_optional_gauge(&PROCESS_RSS_BYTES, diagnostics.process_rss_bytes);
+    set_optional_gauge(&PROCESS_PEAK_RSS_BYTES, diagnostics.process_peak_rss_bytes);
+    set_optional_gauge(&PROCESS_VIRTUAL_BYTES, diagnostics.process_virtual_bytes);
+    set_optional_gauge(
+        &CGROUP_MEMORY_CURRENT_BYTES,
+        diagnostics.cgroup_memory_current_bytes,
+    );
+    set_optional_gauge(
+        &CGROUP_MEMORY_PEAK_BYTES,
+        diagnostics.cgroup_memory_peak_bytes,
+    );
+}
+
 /// Register all metrics with the global registry
 ///
 /// # Returns
@@ -581,6 +647,11 @@ fn do_register_metrics() -> Result<(), MetricsError> {
     register!(ACTIVE_USERS, "ACTIVE_USERS");
     register!(MEMORIES_BY_TIER, "MEMORIES_BY_TIER");
     register!(MEMORY_HEAP_BYTES_TOTAL, "MEMORY_HEAP_BYTES_TOTAL");
+    register!(PROCESS_RSS_BYTES, "PROCESS_RSS_BYTES");
+    register!(PROCESS_PEAK_RSS_BYTES, "PROCESS_PEAK_RSS_BYTES");
+    register!(PROCESS_VIRTUAL_BYTES, "PROCESS_VIRTUAL_BYTES");
+    register!(CGROUP_MEMORY_CURRENT_BYTES, "CGROUP_MEMORY_CURRENT_BYTES");
+    register!(CGROUP_MEMORY_PEAK_BYTES, "CGROUP_MEMORY_PEAK_BYTES");
 
     // Vector index metrics (aggregate)
     register!(VECTOR_INDEX_SIZE_TOTAL, "VECTOR_INDEX_SIZE_TOTAL");

--- a/src/system_memory.rs
+++ b/src/system_memory.rs
@@ -1,0 +1,179 @@
+//! Best-effort process and cgroup memory diagnostics.
+//!
+//! These counters are intentionally observational. They make memory growth
+//! visible through health/metrics endpoints without changing readiness status.
+
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct SystemMemoryDiagnostics {
+    pub process_rss_bytes: Option<u64>,
+    pub process_peak_rss_bytes: Option<u64>,
+    pub process_virtual_bytes: Option<u64>,
+    pub cgroup_memory_current_bytes: Option<u64>,
+    pub cgroup_memory_peak_bytes: Option<u64>,
+}
+
+pub fn read_system_memory_diagnostics() -> SystemMemoryDiagnostics {
+    SystemMemoryDiagnostics {
+        process_rss_bytes: read_proc_status_bytes("VmRSS"),
+        process_peak_rss_bytes: read_proc_status_bytes("VmHWM"),
+        process_virtual_bytes: read_proc_status_bytes("VmSize"),
+        cgroup_memory_current_bytes: read_cgroup_memory_current_bytes(),
+        cgroup_memory_peak_bytes: read_cgroup_memory_peak_bytes(),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn read_proc_status_bytes(key: &str) -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    parse_proc_status_bytes(&status, key)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_proc_status_bytes(_key: &str) -> Option<u64> {
+    None
+}
+
+fn parse_proc_status_bytes(status: &str, key: &str) -> Option<u64> {
+    for line in status.lines() {
+        let Some(rest) = line.strip_prefix(key) else {
+            continue;
+        };
+        let rest = rest.trim_start().strip_prefix(':')?.trim_start();
+        let mut parts = rest.split_whitespace();
+        let value = parts.next()?.parse::<u64>().ok()?;
+        let unit = parts.next().unwrap_or("B");
+        return match unit {
+            "kB" => value.checked_mul(1024),
+            "mB" | "MB" => value.checked_mul(1024 * 1024),
+            "gB" | "GB" => value.checked_mul(1024 * 1024 * 1024),
+            "B" => Some(value),
+            _ => None,
+        };
+    }
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn read_cgroup_memory_current_bytes() -> Option<u64> {
+    read_cgroup_memory_metric("memory.current", "memory.usage_in_bytes")
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_cgroup_memory_current_bytes() -> Option<u64> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn read_cgroup_memory_peak_bytes() -> Option<u64> {
+    read_cgroup_memory_metric("memory.peak", "memory.max_usage_in_bytes")
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_cgroup_memory_peak_bytes() -> Option<u64> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn read_cgroup_memory_metric(v2_file: &str, v1_file: &str) -> Option<u64> {
+    let cgroup = std::fs::read_to_string("/proc/self/cgroup").ok()?;
+    for line in cgroup.lines() {
+        let mut parts = line.splitn(3, ':');
+        let _hierarchy = parts.next()?;
+        let controllers = parts.next()?;
+        let relative_path = parts.next()?;
+
+        if controllers.is_empty() {
+            if let Some(value) =
+                read_u64_file(cgroup_file_path("/sys/fs/cgroup", relative_path, v2_file))
+            {
+                return Some(value);
+            }
+        } else if controllers
+            .split(',')
+            .any(|controller| controller == "memory")
+        {
+            if let Some(value) = read_u64_file(cgroup_file_path(
+                "/sys/fs/cgroup/memory",
+                relative_path,
+                v1_file,
+            )) {
+                return Some(value);
+            }
+            if let Some(value) =
+                read_u64_file(cgroup_file_path("/sys/fs/cgroup", relative_path, v1_file))
+            {
+                return Some(value);
+            }
+        }
+    }
+
+    read_u64_file(Path::new("/sys/fs/cgroup").join(v2_file))
+        .or_else(|| read_u64_file(Path::new("/sys/fs/cgroup/memory").join(v1_file)))
+}
+
+fn cgroup_file_path(root: impl AsRef<Path>, relative_path: &str, file_name: &str) -> PathBuf {
+    let relative_path = relative_path.trim_start_matches('/');
+    if relative_path.is_empty() {
+        root.as_ref().join(file_name)
+    } else {
+        root.as_ref().join(relative_path).join(file_name)
+    }
+}
+
+fn read_u64_file(path: impl AsRef<Path>) -> Option<u64> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    parse_u64_file_value(&raw)
+}
+
+fn parse_u64_file_value(raw: &str) -> Option<u64> {
+    let trimmed = raw.trim();
+    if trimmed == "max" {
+        None
+    } else {
+        trimmed.parse::<u64>().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_proc_status_memory_values_as_bytes() {
+        let status = "\
+Name:\tshodh-memory\n\
+VmSize:\t  4096 kB\n\
+VmHWM:\t     7 kB\n\
+VmRSS:\t  1234 kB\n";
+
+        assert_eq!(parse_proc_status_bytes(status, "VmRSS"), Some(1234 * 1024));
+        assert_eq!(parse_proc_status_bytes(status, "VmHWM"), Some(7 * 1024));
+        assert_eq!(parse_proc_status_bytes(status, "VmSize"), Some(4096 * 1024));
+        assert_eq!(parse_proc_status_bytes(status, "VmSwap"), None);
+    }
+
+    #[test]
+    fn parse_u64_file_value_handles_cgroup_limits() {
+        assert_eq!(parse_u64_file_value("12345\n"), Some(12345));
+        assert_eq!(parse_u64_file_value("max\n"), None);
+        assert_eq!(parse_u64_file_value("not-a-number\n"), None);
+    }
+
+    #[test]
+    fn cgroup_file_path_handles_root_and_nested_paths() {
+        assert_eq!(
+            cgroup_file_path("/sys/fs/cgroup", "/", "memory.current"),
+            PathBuf::from("/sys/fs/cgroup/memory.current")
+        );
+        assert_eq!(
+            cgroup_file_path(
+                "/sys/fs/cgroup",
+                "/user.slice/user-1000.slice/app.slice",
+                "memory.current"
+            ),
+            PathBuf::from("/sys/fs/cgroup/user.slice/user-1000.slice/app.slice/memory.current")
+        );
+    }
+}

--- a/tests/graph_memory_tests.rs
+++ b/tests/graph_memory_tests.rs
@@ -113,6 +113,7 @@ fn create_relationship(
         entity_confidence: None,
         endpoint_selectivity: None,
         forman_curvature: None,
+        provenance: Vec::new(),
     }
 }
 
@@ -149,6 +150,7 @@ fn create_relationship_with_plasticity(
         entity_confidence: None,
         endpoint_selectivity: None,
         forman_curvature: None,
+        provenance: Vec::new(),
     }
 }
 

--- a/tests/handler_tests.rs
+++ b/tests/handler_tests.rs
@@ -21,7 +21,9 @@ use tower::ServiceExt;
 
 use shodh_memory::{
     config::ServerConfig,
-    handlers::{build_protected_routes, build_public_routes, MultiUserMemoryManager},
+    handlers::{
+        build_probe_routes, build_protected_routes, build_public_routes, MultiUserMemoryManager,
+    },
 };
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -37,6 +39,7 @@ fn init_env() {
         unsafe {
             std::env::set_var("SHODH_API_KEYS", TEST_KEY);
         }
+        let _ = shodh_memory::metrics::register_metrics();
     });
 }
 
@@ -65,11 +68,12 @@ impl Harness {
 
     fn app(&self) -> Router {
         // Mirror main.rs: auth middleware only wraps protected routes.
+        let probe = build_probe_routes(self.mgr.clone());
         let public = build_public_routes(self.mgr.clone());
         let protected = build_protected_routes(self.mgr.clone()).layer(axum::middleware::from_fn(
             shodh_memory::auth::auth_middleware,
         ));
-        Router::new().merge(public).merge(protected)
+        Router::new().merge(probe).merge(public).merge(protected)
     }
 }
 
@@ -222,6 +226,21 @@ async fn health_endpoint() {
         body.get("status").is_some(),
         "health response needs 'status' field"
     );
+    let system_memory = body["system_memory"]
+        .as_object()
+        .expect("health response needs 'system_memory' object");
+    for field in [
+        "process_rss_bytes",
+        "process_peak_rss_bytes",
+        "process_virtual_bytes",
+        "cgroup_memory_current_bytes",
+        "cgroup_memory_peak_bytes",
+    ] {
+        assert!(
+            system_memory.contains_key(field),
+            "system_memory missing '{field}'"
+        );
+    }
 }
 
 #[tokio::test]
@@ -249,11 +268,20 @@ async fn health_index() {
 #[tokio::test]
 async fn metrics_endpoint() {
     let h = Harness::new();
-    let status = status_of(h.app(), authed_get("/metrics")).await;
+    let (status, body) = json_of(h.app(), authed_get("/metrics")).await;
     // metrics handler should always return 200 in test harness
     assert!(
         status == StatusCode::OK,
         "unexpected metrics status: {status}"
+    );
+    let metrics = body.as_str().expect("metrics response should be text");
+    assert!(
+        metrics.contains("shodh_process_rss_bytes"),
+        "metrics response should include process RSS gauge"
+    );
+    assert!(
+        metrics.contains("shodh_cgroup_memory_current_bytes"),
+        "metrics response should include cgroup memory gauge"
     );
 }
 

--- a/tests/universe_tests.rs
+++ b/tests/universe_tests.rs
@@ -112,6 +112,7 @@ fn create_relationship(
         entity_confidence: None,
         endpoint_selectivity: None,
         forman_curvature: None,
+        provenance: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## Summary
- add best-effort process and cgroup memory diagnostics to `/health`
- expose matching Prometheus gauges for process RSS, peak RSS, virtual memory, and cgroup current/peak memory
- keep health status observational only, so high memory is visible without changing readiness semantics
- fix small CI blockers found while verifying locally: stale `RelationshipEdge` test fixtures, missing graph traversal 404, and explicit-date parsing drift

Refs #90.

## Tests
- `cargo fmt --all -- --check`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check origin/main..HEAD`
- `LIBCLANG_PATH=/home/tanger/.local/share/tanger/agent-system/build-deps/libclang LLVM_CONFIG_PATH=/usr/lib/llvm-16/bin/llvm-config cargo check`
- `LIBCLANG_PATH=/home/tanger/.local/share/tanger/agent-system/build-deps/libclang LLVM_CONFIG_PATH=/usr/lib/llvm-16/bin/llvm-config cargo clippy --all-targets -- -W clippy::all`
- `LD_LIBRARY_PATH=/home/tanger/.cache/shodh-memory/onnxruntime${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} cargo test --lib --no-fail-fast` (773 passed, 4 ignored)
- `LD_LIBRARY_PATH=/home/tanger/.cache/shodh-memory/onnxruntime${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} cargo test --test handler_tests -- --test-threads=1` (65 passed)
- `LD_LIBRARY_PATH=/home/tanger/.cache/shodh-memory/onnxruntime${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} cargo test --test handler_tests health_ -- --test-threads=1 --nocapture`
- `LD_LIBRARY_PATH=/home/tanger/.cache/shodh-memory/onnxruntime${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} cargo test --test handler_tests metrics_endpoint -- --test-threads=1 --nocapture`