### PR TITLE
fix(metrics): avoid loading cold users during scrape

### DIFF
--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -170,13 +170,15 @@ pub async fn metrics_endpoint(State(state): State<AppState>) -> Result<String, S
     let users_in_cache = state.users_in_cache();
     metrics::ACTIVE_USERS.set(users_in_cache as i64);
 
-    // Aggregate metrics across all users
+    // Aggregate metrics across currently cached users only.
+    // list_users() returns filesystem directories; get_user_memory() would open
+    // RocksDB for cold users and make a metrics scrape increase memory/FD usage.
     let (mut total_working, mut total_session, mut total_longterm, mut total_heap) =
         (0i64, 0i64, 0i64, 0i64);
     let mut total_vectors = 0i64;
 
-    for user_id in state.list_users().iter().take(100) {
-        if let Ok(memory_sys) = state.get_user_memory(user_id) {
+    for user_id in state.list_cached_users() {
+        if let Ok(memory_sys) = state.get_user_memory(&user_id) {
             if let Some(guard) = memory_sys.try_read() {
                 let stats = guard.stats();
                 total_working += stats.working_memory_count as i64;
@@ -297,4 +299,42 @@ pub async fn get_context_status(State(state): State<AppState>) -> Json<Vec<Conte
         .collect();
     sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
     Json(sessions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ServerConfig;
+    use crate::handlers::state::MultiUserMemoryManager;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn metrics_endpoint_does_not_load_cold_disk_users() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        std::fs::create_dir(temp_dir.path().join("cold-user"))
+            .expect("failed to create cold user dir");
+        let config = ServerConfig {
+            storage_path: temp_dir.path().to_path_buf(),
+            backup_enabled: false,
+            ..ServerConfig::default()
+        };
+        let state = Arc::new(
+            MultiUserMemoryManager::new(temp_dir.path().to_path_buf(), config)
+                .expect("failed to create test manager"),
+        );
+
+        assert_eq!(state.list_users(), vec!["cold-user".to_string()]);
+        assert_eq!(state.users_in_cache(), 0);
+
+        metrics_endpoint(State(state.clone()))
+            .await
+            .expect("metrics endpoint failed");
+
+        assert_eq!(
+            state.users_in_cache(),
+            0,
+            "metrics scrape must not open cold user RocksDB instances"
+        );
+    }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -249,7 +249,10 @@ pub static ACTIVE_USERS: LazyLock<IntGauge> = LazyLock::new(|| {
 /// Total memories stored by tier (aggregate across all users)
 pub static MEMORIES_BY_TIER: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     IntGaugeVec::new(
-        Opts::new("shodh_memories_by_tier", "Total memories by tier"),
+        Opts::new(
+            "shodh_memories_by_tier",
+            "Total memories by tier across currently cached users",
+        ),
         &["tier"], // tier: "working", "session", "longterm"
     )
     .expect("MEMORIES_BY_TIER metric must be valid at compile time")
@@ -259,7 +262,7 @@ pub static MEMORIES_BY_TIER: LazyLock<IntGaugeVec> = LazyLock::new(|| {
 pub static MEMORY_HEAP_BYTES_TOTAL: LazyLock<IntGauge> = LazyLock::new(|| {
     IntGauge::new(
         "shodh_memory_heap_bytes_total",
-        "Total estimated heap usage across all users",
+        "Total estimated heap usage across currently cached users",
     )
     .expect("MEMORY_HEAP_BYTES_TOTAL metric must be valid at compile time")
 });
@@ -317,7 +320,7 @@ pub static CGROUP_MEMORY_PEAK_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
 pub static VECTOR_INDEX_SIZE_TOTAL: LazyLock<IntGauge> = LazyLock::new(|| {
     IntGauge::new(
         "shodh_vector_index_size_total",
-        "Total number of vectors in all indices",
+        "Total number of vectors across currently cached user indices",
     )
     .expect("VECTOR_INDEX_SIZE_TOTAL metric must be valid at compile time")
 });


### PR DESCRIPTION
## Description

Make `/metrics` aggregate per-user tier/vector/estimated-heap gauges from currently cached users only.

Previously the endpoint iterated over `list_users().take(100)` and called `get_user_memory()` for each entry. `list_users()` returns filesystem user directories, so a metrics scrape could open cold RocksDB-backed user instances and increase memory/FD pressure while observing memory.

This mirrors the existing `/health/index` aggregate path, which already uses `list_cached_users()` to keep the endpoint side-effect-light.

Refs #90.

## Testing

- `cargo test handlers::health::tests::metrics_endpoint_does_not_load_cold_disk_users --lib -- --exact --test-threads=1`
- `cargo test --lib -- --test-threads=1`
- `cargo clippy --lib --bins`
- `git diff --check`

## Notes

`cargo test --lib -- --test-threads=1` passed with 774 tests, 4 ignored.

`cargo clippy --lib --bins` exits 0, with existing warnings outside this diff. `cargo clippy --lib --bins -- -D warnings` is not currently a clean baseline in this checkout due to unrelated existing warnings, so this PR intentionally keeps those cleanup items out of the metrics behavior fix.
