### PR TITLE
feat(graph): PMI edge-gate default ON — prune incidental co-occurrence at birth

### DIFF
--- a/.github/workflows/pmi-gate-ablation.yml
+++ b/.github/workflows/pmi-gate-ablation.yml
@@ -72,6 +72,9 @@ jobs:
 
       - name: Arm A — control (full co-occurrence graph)
         env:
+          # Pinned explicitly: the gate is default-ON since 2026-07-03, so the
+          # control arm must opt out rather than rely on the default.
+          SHODH_GRAPH_PMI_GATE: '0'
           SHODH_MAX_CASES: ${{ github.event.inputs.max_cases }}
           RUST_LOG: shodh_memory::handlers::state=info
         run: |

--- a/.github/workflows/pmi-gate-longmemeval.yml
+++ b/.github/workflows/pmi-gate-longmemeval.yml
@@ -81,6 +81,9 @@ jobs:
 
       - name: Arm A — control (no gate)
         env:
+          # Pinned explicitly: the gate is default-ON since 2026-07-03, so the
+          # control arm must opt out rather than rely on the default.
+          SHODH_GRAPH_PMI_GATE: '0'
           RUST_LOG: shodh_memory::handlers::state=info
         run: |
           ./target/release/recall-eval \

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -3385,10 +3385,16 @@ impl MultiUserMemoryManager {
         // endpoint) is never stored at all. Typed edges (cue/semantic/learned/label) and
         // fragment bridges always survive — they carry grounding the PMI lacks. The point:
         // a co-occurrence graph is >80% incidental edges; dropping them shrinks the graph
-        // AND removes noise. Default OFF — A/B for graph SIZE + edge precision, not just recall@10.
+        // AND removes noise.
+        // Default ON (flipped 2026-07-03): our A/B measured −97.4% edges with recall
+        // UNCHANGED, and production data confirmed the cost of the dense default —
+        // issue #90 reported 240k edges from 3k memories (~79/memory) with RSS growth
+        // to match. Gating applies at edge BIRTH; existing dense graphs don't shrink
+        // retroactively. Opt out with SHODH_GRAPH_PMI_GATE=0 (the pmi-gate-* workflows
+        // pin their control arms to 0 explicitly).
         let pmi_gate: bool = std::env::var("SHODH_GRAPH_PMI_GATE")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
+            .map(|v| !(v == "0" || v.eq_ignore_ascii_case("false")))
+            .unwrap_or(true);
         // PPMI floor by default: prune generic edges whose PMI < 0.0 (they co-occur no more
         // than chance). Raise it to prune more aggressively; lower (negative) to keep more.
         let pmi_gate_min: f32 = std::env::var("SHODH_GRAPH_PMI_GATE_MIN")


### PR DESCRIPTION
## What
`SHODH_GRAPH_PMI_GATE` flips **default-off → default-on**. Generic co-occurrence edges whose birth-PMI is below the PPMI floor (co-occur no more than chance) are never stored. Typed edges (cue/semantic/learned/label-pair) and fragment bridges always survive — semantics unchanged, only the default. Opt out: `SHODH_GRAPH_PMI_GATE=0`.

## Why now
- **Our measurement**: the pmi-gate A/B measured **−97.4% edges with recall unchanged**.
- **Production evidence (#90)**: 240,502 edges from 3,037 memories (~79/memory) on a real deployment, with matching RSS growth and compaction pressure. The dense default costs real memory for zero recall benefit.

## Blast-radius checks done
- Both `pmi-gate-*` A/B workflows relied on the old default for their **control arms** — now pinned to `=0` explicitly so the flip doesn't silently turn control into treatment.
- No tests assume default-off (grepped).
- Gating applies at edge **birth** — existing dense graphs don't shrink retroactively (a user with a dense store keeps it until re-ingest; noted for release notes).
- Interaction: the anomaly `pmi_gated_ratio` surprise component becomes a live axis by default (it was structurally zero with the gate off) — intended.

## Post-merge verification plan
Dispatch `pmi-gate-longmemeval` (A pinned =0 vs B — now the default) on merged main as the decisive re-confirmation on the production benchmark.

Tested locally: handlers::state (22) + graph_memory (79) green; check/fmt clean.