### PR TITLE
feat(health): RocksDB memory decomposition — the #90 instrument

### DIFF
--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -3396,7 +3396,6 @@ impl GraphMemory {
         Ok(edge.uuid)
     }
 
-    /// Index an edge for an entity
     /// Drain the temporal anomalies queued by the strengthen path (dormant
     /// reactivations). Called by the ingest path after each graph write; the
     /// caller resolves entity names and emits SSE events.
@@ -3404,6 +3403,33 @@ impl GraphMemory {
         std::mem::take(&mut *self.pending_temporal_anomalies.lock())
     }
 
+    /// RocksDB in-process memory for this graph DB: (memtable bytes,
+    /// table-reader bytes), summed over all graph column families. The shared
+    /// block cache is deliberately excluded — it is one pool shared by every
+    /// DB instance and is reported once at the manager level.
+    pub fn rocksdb_memory_breakdown(&self) -> (u64, u64) {
+        let mut memtables = 0u64;
+        let mut readers = 0u64;
+        for cf_name in GRAPH_CF_NAMES {
+            if let Some(cf) = self.db.cf_handle(cf_name) {
+                if let Ok(Some(v)) = self
+                    .db
+                    .property_int_value_cf(cf, "rocksdb.cur-size-all-mem-tables")
+                {
+                    memtables += v;
+                }
+                if let Ok(Some(v)) = self
+                    .db
+                    .property_int_value_cf(cf, "rocksdb.estimate-table-readers-mem")
+                {
+                    readers += v;
+                }
+            }
+        }
+        (memtables, readers)
+    }
+
+    /// Index an edge for an entity
     fn index_entity_edge(&self, entity_uuid: &Uuid, edge_uuid: &Uuid) -> Result<()> {
         let key = format!("{entity_uuid}:{edge_uuid}");
         self.db
@@ -8532,6 +8558,35 @@ mod tests {
 
         // Drained means drained.
         assert!(graph.drain_temporal_anomalies().is_empty());
+    }
+
+    #[test]
+    fn rocksdb_memory_breakdown_reflects_writes() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let graph = GraphMemory::new(temp_dir.path(), None).unwrap();
+        // A fresh unflushed write lands in a memtable — the breakdown must see it.
+        let now = Utc::now();
+        graph
+            .add_entity(EntityNode {
+                uuid: Uuid::new_v4(),
+                name: "Breakdown Probe".to_string(),
+                labels: vec![EntityLabel::Concept],
+                created_at: now,
+                last_seen_at: now,
+                mention_count: 1,
+                summary: String::new(),
+                attributes: HashMap::new(),
+                name_embedding: None,
+                salience: 0.5,
+                is_proper_noun: false,
+                selectivity: None,
+            })
+            .unwrap();
+        let (memtables, _readers) = graph.rocksdb_memory_breakdown();
+        assert!(
+            memtables > 0,
+            "memtable bytes must be visible after an unflushed write, got {memtables}"
+        );
     }
 
     /// Create a test relationship edge with specified strength and last_activated (L1 tier)

--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -30,6 +30,7 @@ pub struct HealthResponse {
     pub write_failures: u64,
     pub pending_retries: usize,
     pub system_memory: SystemMemoryDiagnostics,
+    pub rocksdb_memory: crate::system_memory::RocksDbMemoryDiagnostics,
 }
 
 /// Main health check endpoint
@@ -41,6 +42,10 @@ pub async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     let (write_failures, pending_retries) = state.write_failure_metrics();
     let system_memory = crate::system_memory::read_system_memory_diagnostics();
     metrics::update_system_memory_metrics(&system_memory);
+    // RocksDB decomposition (#90): shared cache read once from the manager's
+    // handle; per-CF sums over CACHED users only (cold users stay cold).
+    let rocksdb_memory = state.rocksdb_memory_diagnostics();
+    metrics::update_rocksdb_memory_metrics(&rocksdb_memory);
 
     Json(HealthResponse {
         status: "healthy".to_string(),
@@ -52,6 +57,7 @@ pub async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
         write_failures,
         pending_retries,
         system_memory,
+        rocksdb_memory,
     })
 }
 
@@ -204,6 +210,9 @@ pub async fn metrics_endpoint(State(state): State<AppState>) -> Result<String, S
     metrics::VECTOR_INDEX_SIZE_TOTAL.set(total_vectors);
     let system_memory = crate::system_memory::read_system_memory_diagnostics();
     metrics::update_system_memory_metrics(&system_memory);
+    // RocksDB decomposition (#90) — cached users only, shared cache read once.
+    let rocksdb_memory = state.rocksdb_memory_diagnostics();
+    metrics::update_rocksdb_memory_metrics(&rocksdb_memory);
 
     // Gather and encode metrics
     let encoder = prometheus::TextEncoder::new();
@@ -308,6 +317,36 @@ mod tests {
     use crate::handlers::state::MultiUserMemoryManager;
     use std::sync::Arc;
     use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn rocksdb_diagnostics_do_not_load_cold_disk_users() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        std::fs::create_dir(temp_dir.path().join("cold-user"))
+            .expect("failed to create cold user dir");
+        let config = ServerConfig {
+            storage_path: temp_dir.path().to_path_buf(),
+            backup_enabled: false,
+            ..ServerConfig::default()
+        };
+        let state = Arc::new(
+            MultiUserMemoryManager::new(temp_dir.path().to_path_buf(), config)
+                .expect("failed to create test manager"),
+        );
+        assert_eq!(state.users_in_cache(), 0);
+
+        let d = state.rocksdb_memory_diagnostics();
+
+        assert_eq!(
+            state.users_in_cache(),
+            0,
+            "the diagnostic must not open cold user RocksDB instances"
+        );
+        assert_eq!(d.users_counted, 0, "no cached users → nothing counted");
+        assert!(
+            d.shared_block_cache_capacity_bytes > 0,
+            "shared cache capacity must report the configured ceiling"
+        );
+    }
 
     #[tokio::test]
     async fn metrics_endpoint_does_not_load_cold_disk_users() {

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -1660,6 +1660,41 @@ impl MultiUserMemoryManager {
             .collect()
     }
 
+    /// RocksDB in-process memory, decomposed — the instrument for #90.
+    ///
+    /// - Shared block cache: read ONCE from the manager's own handle (it is a
+    ///   single LRU pool wired into every DB instance; summing the per-CF
+    ///   property would count the same pool once per column family).
+    /// - Memtables / table readers: per-CF, genuinely additive — summed across
+    ///   the DBs of currently CACHED users only. Cold users on disk are never
+    ///   opened by a diagnostic (the #362 lesson: observation must not create
+    ///   the pressure it observes).
+    pub fn rocksdb_memory_diagnostics(&self) -> crate::system_memory::RocksDbMemoryDiagnostics {
+        let mut memtables = 0u64;
+        let mut readers = 0u64;
+        let mut users_counted = 0usize;
+        for user_id in self.list_cached_users() {
+            if let Ok(memory) = self.get_user_memory(&user_id) {
+                // try_read: a diagnostic must never block a writer; a user
+                // mid-write is simply skipped this scrape.
+                if let Some(guard) = memory.try_read() {
+                    let (m, r) = guard.rocksdb_memory_breakdown();
+                    memtables += m;
+                    readers += r;
+                    users_counted += 1;
+                }
+            }
+        }
+        crate::system_memory::RocksDbMemoryDiagnostics {
+            shared_block_cache_usage_bytes: self.shared_rocksdb_cache.get_usage() as u64,
+            shared_block_cache_pinned_bytes: self.shared_rocksdb_cache.get_pinned_usage() as u64,
+            shared_block_cache_capacity_bytes: crate::constants::ROCKSDB_SHARED_CACHE_BYTES as u64,
+            user_memtables_bytes: memtables,
+            user_table_readers_bytes: readers,
+            users_counted,
+        }
+    }
+
     /// Get audit logs for a user
     pub fn get_audit_logs(&self, user_id: &str, limit: usize) -> Vec<AuditEvent> {
         let mut events: Vec<AuditEvent> = Vec::new();

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -716,6 +716,19 @@ impl MemorySystem {
         self.graph_memory.as_ref()
     }
 
+    /// RocksDB in-process memory for this user's DBs (memory storage + graph):
+    /// (memtable bytes, table-reader bytes). Shared block cache excluded —
+    /// reported once at the manager level.
+    pub fn rocksdb_memory_breakdown(&self) -> (u64, u64) {
+        let (mut memtables, mut readers) = self.long_term_memory.rocksdb_memory_breakdown();
+        if let Some(graph) = self.graph_memory.as_ref() {
+            let (gm, gr) = graph.read().rocksdb_memory_breakdown();
+            memtables += gm;
+            readers += gr;
+        }
+        (memtables, readers)
+    }
+
     /// Age the knowledge-graph edges by `total_days` of simulated time, applying
     /// decay in `cadence_hours` steps (production runs the heavy maintenance
     /// cycle ~every 6h).

--- a/src/memory/storage.rs
+++ b/src/memory/storage.rs
@@ -3051,6 +3051,33 @@ impl MemoryStorage {
     }
 
     /// Flush all column families to ensure data is persisted (critical for graceful shutdown)
+    /// RocksDB in-process memory for this storage DB: (memtable bytes,
+    /// table-reader bytes), summed over its column families. Block cache is
+    /// NOT included here — it is shared across all DBs and reported once at
+    /// the manager level (summing it per-CF would count the same pool many
+    /// times over).
+    pub fn rocksdb_memory_breakdown(&self) -> (u64, u64) {
+        let mut memtables = 0u64;
+        let mut readers = 0u64;
+        for cf_name in ["default", CF_INDEX] {
+            if let Some(cf) = self.db.cf_handle(cf_name) {
+                if let Ok(Some(v)) = self
+                    .db
+                    .property_int_value_cf(cf, "rocksdb.cur-size-all-mem-tables")
+                {
+                    memtables += v;
+                }
+                if let Ok(Some(v)) = self
+                    .db
+                    .property_int_value_cf(cf, "rocksdb.estimate-table-readers-mem")
+                {
+                    readers += v;
+                }
+            }
+        }
+        (memtables, readers)
+    }
+
     pub fn flush(&self) -> Result<()> {
         use rocksdb::FlushOptions;
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -267,6 +267,42 @@ pub static MEMORY_HEAP_BYTES_TOTAL: LazyLock<IntGauge> = LazyLock::new(|| {
     .expect("MEMORY_HEAP_BYTES_TOTAL metric must be valid at compile time")
 });
 
+/// Shared RocksDB block cache usage (single pool across all DB instances).
+pub static ROCKSDB_BLOCK_CACHE_USAGE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        "shodh_rocksdb_block_cache_usage_bytes",
+        "Bytes used in the shared RocksDB block cache (single pool across all DBs)",
+    )
+    .expect("ROCKSDB_BLOCK_CACHE_USAGE_BYTES metric must be valid at compile time")
+});
+
+/// Bytes pinned (unevictable) in the shared RocksDB block cache.
+pub static ROCKSDB_BLOCK_CACHE_PINNED_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        "shodh_rocksdb_block_cache_pinned_bytes",
+        "Bytes pinned in the shared RocksDB block cache",
+    )
+    .expect("ROCKSDB_BLOCK_CACHE_PINNED_BYTES metric must be valid at compile time")
+});
+
+/// Sum of memtable bytes across all CFs of all cached users' DBs.
+pub static ROCKSDB_MEMTABLES_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        "shodh_rocksdb_memtables_bytes",
+        "Active+immutable memtable bytes summed across cached users' DBs",
+    )
+    .expect("ROCKSDB_MEMTABLES_BYTES metric must be valid at compile time")
+});
+
+/// Sum of table-reader (index/filter) bytes outside the block cache.
+pub static ROCKSDB_TABLE_READERS_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        "shodh_rocksdb_table_readers_bytes",
+        "Estimated table-reader bytes outside the block cache, cached users' DBs",
+    )
+    .expect("ROCKSDB_TABLE_READERS_BYTES metric must be valid at compile time")
+});
+
 /// Resident set size for the server process, when available.
 pub static PROCESS_RSS_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
     IntGauge::new(
@@ -581,6 +617,14 @@ pub fn update_system_memory_metrics(diagnostics: &crate::system_memory::SystemMe
     );
 }
 
+/// Update the RocksDB memory-decomposition gauges (the #90 instrument).
+pub fn update_rocksdb_memory_metrics(d: &crate::system_memory::RocksDbMemoryDiagnostics) {
+    ROCKSDB_BLOCK_CACHE_USAGE_BYTES.set(d.shared_block_cache_usage_bytes as i64);
+    ROCKSDB_BLOCK_CACHE_PINNED_BYTES.set(d.shared_block_cache_pinned_bytes as i64);
+    ROCKSDB_MEMTABLES_BYTES.set(d.user_memtables_bytes as i64);
+    ROCKSDB_TABLE_READERS_BYTES.set(d.user_table_readers_bytes as i64);
+}
+
 /// Register all metrics with the global registry
 ///
 /// # Returns
@@ -655,6 +699,16 @@ fn do_register_metrics() -> Result<(), MetricsError> {
     register!(PROCESS_VIRTUAL_BYTES, "PROCESS_VIRTUAL_BYTES");
     register!(CGROUP_MEMORY_CURRENT_BYTES, "CGROUP_MEMORY_CURRENT_BYTES");
     register!(CGROUP_MEMORY_PEAK_BYTES, "CGROUP_MEMORY_PEAK_BYTES");
+    register!(
+        ROCKSDB_BLOCK_CACHE_USAGE_BYTES,
+        "ROCKSDB_BLOCK_CACHE_USAGE_BYTES"
+    );
+    register!(
+        ROCKSDB_BLOCK_CACHE_PINNED_BYTES,
+        "ROCKSDB_BLOCK_CACHE_PINNED_BYTES"
+    );
+    register!(ROCKSDB_MEMTABLES_BYTES, "ROCKSDB_MEMTABLES_BYTES");
+    register!(ROCKSDB_TABLE_READERS_BYTES, "ROCKSDB_TABLE_READERS_BYTES");
 
     // Vector index metrics (aggregate)
     register!(VECTOR_INDEX_SIZE_TOTAL, "VECTOR_INDEX_SIZE_TOTAL");

--- a/src/system_memory.rs
+++ b/src/system_memory.rs
@@ -136,6 +136,40 @@ fn parse_u64_file_value(raw: &str) -> Option<u64> {
     }
 }
 
+/// RocksDB in-process memory, decomposed — the instrument for #90.
+///
+/// Process RSS growth (see [`SystemMemoryDiagnostics`]) tells you THAT memory
+/// grows; this tells you WHERE inside RocksDB it sits:
+/// - `shared_block_cache_*`: the single LRU pool shared by every DB instance
+///   (per-user memory DBs, per-user graph DBs, the global shared DB). Bounded
+///   by capacity — growth here plateaus by construction.
+/// - `user_memtables_bytes` / `user_table_readers_bytes`: per-column-family
+///   write buffers and index/filter readers, summed across CACHED users only
+///   (never loads cold users — the #362 lesson). These are the unbounded-ish
+///   suspects: they scale with open CFs per cached user.
+///
+/// The decisive read: if RSS climbs while all of these plateau, the growth is
+/// OUTSIDE RocksDB (allocator retention, our own caches); if memtables/readers
+/// climb with RSS, it's RocksDB tuning.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct RocksDbMemoryDiagnostics {
+    /// Bytes currently used in the shared LRU block cache.
+    pub shared_block_cache_usage_bytes: u64,
+    /// Bytes pinned in the shared cache (in active use, can't be evicted).
+    pub shared_block_cache_pinned_bytes: u64,
+    /// Configured capacity of the shared cache (the hard ceiling).
+    pub shared_block_cache_capacity_bytes: u64,
+    /// Sum of active+immutable memtable bytes across all CFs of all CACHED
+    /// users' DBs (memory storage + graph).
+    pub user_memtables_bytes: u64,
+    /// Sum of estimated table-reader (index/filter) bytes outside the block
+    /// cache, same scope as `user_memtables_bytes`.
+    pub user_table_readers_bytes: u64,
+    /// How many cached users the per-user sums cover (cold users on disk are
+    /// deliberately not opened by this diagnostic).
+    pub users_counted: usize,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What
Decomposes RocksDB's in-process memory so #90's ~800MB plateau can be attributed instead of guessed. `/health.rocksdb_memory` + four Prometheus gauges:

| field | semantics |
|---|---|
| `shared_block_cache_usage_bytes` / `_pinned_bytes` / `_capacity_bytes` | the **single** LRU pool shared by every DB instance — read ONCE from the manager's own cache handle (summing the per-CF property would count the same pool once per column family) |
| `user_memtables_bytes` | active+immutable memtables, summed per-CF across **cached users only** (storage + graph DBs) |
| `user_table_readers_bytes` | index/filter reader bytes outside the cache, same scope |
| `users_counted` | coverage honesty — cold users on disk are never opened by a diagnostic (the #362 property, tested for this path too) |

## Why this shape
- The shared-cache-vs-per-CF distinction is load-bearing: we wire one 256MB pool into all DBs (state.rs), so naive per-CF summation would report N× the real number.
- `try_read` per user — a diagnostic never blocks a writer; a mid-write user is skipped that scrape.
- The decisive #90 read: if RSS plateaus while these plateau **below** it, the remainder is outside RocksDB (ort inference arenas, jemalloc retention, our in-memory indexes) — that decides the next instrument.

## Tests
`rocksdb_diagnostics_do_not_load_cold_disk_users` (cold-user safety) + `rocksdb_memory_breakdown_reflects_writes` (memtable visibility after an unflushed write). Local: check/fmt clean, both tests green.