### PR TITLE
feat(recall): provenance-driven multi-hop companion injection (Inc-2, default-off)

### DIFF
--- a/.github/workflows/multihop-companion-ab.yml
+++ b/.github/workflows/multihop-companion-ab.yml
@@ -82,23 +82,16 @@ jobs:
               try: return json.load(open(f))
               except Exception as e: return {"error": str(e)}
           a, b = load('mh-a.json'), load('mh-b.json')
-          def dig(d, *keys):
-              for k in keys:
-                  if isinstance(d, dict) and k in d: d = d[k]
-                  else: return None
-              return d
-          # tolerate either flat or nested report shapes
-          def metric(d, name):
-              for path in ((name,), ('summary', name), ('metrics', name)):
-                  v = dig(d, *path)
-                  if isinstance(v, (int, float)): return v
-              return None
-          rows = [("two-hop recall@10", "multihop_recall_at_10"), ("one-hop recall@10", "onehop_recall_at_10")]
-          print("| metric | A control | B companions | Δ |")
+          def full_row(d):
+              for r in d.get('rows', []):
+                  if r.get('layer') == 'full': return r
+              return {}
+          fa, fb = full_row(a), full_row(b)
+          print("| metric (full layer) | A control | B companions | delta |")
           print("| --- | --- | --- | --- |")
           verdict_gain, verdict_hold = None, None
-          for label, key in rows:
-              va, vb = metric(a, key), metric(b, key)
+          for label, key in (("two-hop recall@10", "multihop_recall_at_10"), ("one-hop recall@10", "onehop_recall_at_10")):
+              va, vb = fa.get(key), fb.get(key)
               if va is None or vb is None:
                   print(f"| {label} | ? | ? | parse miss ({key}) |"); continue
               print(f"| {label} | {va:.4f} | {vb:.4f} | {vb-va:+.4f} |")

--- a/.github/workflows/multihop-companion-ab.yml
+++ b/.github/workflows/multihop-companion-ab.yml
@@ -1,0 +1,125 @@
+# Inc-2 authenticity check — provenance-driven multi-hop companion injection.
+#
+# The original claim (branch feat/multihop-companions, 2026-06-28, old base):
+# planted 2-hop harness multi_hop recall@10 0.50 -> 0.60 (+0.10), 1-hop no loss.
+# That number predates three weeks of main evolution (PMI gate default-on,
+# provenance-at-birth, prune/delete changes). This A/B re-measures it on the
+# CURRENT port (feat/multihop-companions-v2) before any PR exists:
+#   A = control                          (SHODH_COMPANION_MULTIHOP_GATE unset)
+#   B = SHODH_COMPANION_MULTIHOP_GATE=1  (companion injection on)
+# PASS = B two-hop recall@10 gains materially over A with one-hop held.
+name: multihop companion A/B (Inc-2 authenticity)
+on:
+  workflow_dispatch:
+    inputs:
+      chains:
+        description: 'planted 2-hop chains (--mh-chains)'
+        required: false
+        default: '60'
+  push:
+    branches: [feat/multihop-companions-v2]
+    paths: ['.github/workflows/multihop-companion-ab.yml']
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mh-companion-ab-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ab:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: recall-eval
+      - name: Install LLVM (ONNX runtime build dep)
+        run: sudo apt-get update && sudo apt-get install -y llvm-dev libclang-dev clang
+      - name: Build recall-eval
+        run: cargo build --release --bin recall-eval
+      - name: Cache embedder model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/shodh-memory/models
+          key: shodh-models-minilm-c9745ed1
+      - name: Pre-fetch MiniLM embedder
+        run: |
+          MODEL_DIR="$HOME/.cache/shodh-memory/models/minilm-l6"
+          mkdir -p "$MODEL_DIR"
+          PIN=c9745ed1d9f207416be6d2e6f8de32d1f16199bf
+          BASE="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/$PIN"
+          dl() { curl -fL --retry 20 --retry-all-errors --retry-delay 15 --connect-timeout 30 -o "$1" "$2"; }
+          [ -s "$MODEL_DIR/model_quantized.onnx" ] || dl "$MODEL_DIR/model_quantized.onnx" "$BASE/onnx/model_quint8_avx2.onnx"
+          [ -s "$MODEL_DIR/tokenizer.json" ]       || dl "$MODEL_DIR/tokenizer.json" "$BASE/tokenizer.json"
+
+      - name: Arm A — control (gate off)
+        run: |
+          set -o pipefail
+          ./target/release/recall-eval \
+            --multi-hop mh-a.json --mh-chains "${{ github.event.inputs.chains || '60' }}" \
+            --output unused-a.json --storage ./mh-a-storage 2>&1 | tee a.log
+
+      - name: Arm B — SHODH_COMPANION_MULTIHOP_GATE=1
+        env:
+          SHODH_COMPANION_MULTIHOP_GATE: '1'
+        run: |
+          set -o pipefail
+          ./target/release/recall-eval \
+            --multi-hop mh-b.json --mh-chains "${{ github.event.inputs.chains || '60' }}" \
+            --output unused-b.json --storage ./mh-b-storage 2>&1 | tee b.log
+
+      - name: Compare
+        if: always()
+        run: |
+          echo "## Inc-2 authenticity — companion injection A/B (planted 2-hop, chains=${{ github.event.inputs.chains || '60' }})" >> "$GITHUB_STEP_SUMMARY"
+          python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+          import json
+          def load(f):
+              try: return json.load(open(f))
+              except Exception as e: return {"error": str(e)}
+          a, b = load('mh-a.json'), load('mh-b.json')
+          def dig(d, *keys):
+              for k in keys:
+                  if isinstance(d, dict) and k in d: d = d[k]
+                  else: return None
+              return d
+          # tolerate either flat or nested report shapes
+          def metric(d, name):
+              for path in ((name,), ('summary', name), ('metrics', name)):
+                  v = dig(d, *path)
+                  if isinstance(v, (int, float)): return v
+              return None
+          rows = [("two-hop recall@10", "multihop_recall_at_10"), ("one-hop recall@10", "onehop_recall_at_10")]
+          print("| metric | A control | B companions | Δ |")
+          print("| --- | --- | --- | --- |")
+          verdict_gain, verdict_hold = None, None
+          for label, key in rows:
+              va, vb = metric(a, key), metric(b, key)
+              if va is None or vb is None:
+                  print(f"| {label} | ? | ? | parse miss ({key}) |"); continue
+              print(f"| {label} | {va:.4f} | {vb:.4f} | {vb-va:+.4f} |")
+              if 'two' in label: verdict_gain = vb - va
+              else: verdict_hold = vb - va
+          print()
+          if verdict_gain is not None and verdict_hold is not None:
+              ok = verdict_gain >= 0.05 and verdict_hold >= -0.01
+              print(f"**Verdict: {'AUTHENTIC — gain reproduces on current main' if ok else 'NOT REPRODUCED as claimed'}** "
+                    f"(claimed +0.10 two-hop, no one-hop loss; measured {verdict_gain:+.4f} / {verdict_hold:+.4f})")
+          else:
+              print("**Verdict: could not parse — inspect artifacts (report shape drifted).**")
+          PY
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mh-companion-ab
+          path: |
+            mh-a.json
+            mh-b.json
+            a.log
+            b.log

--- a/.github/workflows/multihop-companion-longmemeval.yml
+++ b/.github/workflows/multihop-companion-longmemeval.yml
@@ -1,0 +1,138 @@
+# Inc-2 DECISIVE test — companion injection on the real corpus (LongMemEval-S).
+#
+# The planted-harness authenticity run reproduced +0.15 two-hop with zero
+# one-hop loss (run 28659034488). But the planted harness is synthetic; the
+# multi_hop wall lives here (0.56 on the canonical 50-q sample). This A/B is
+# the gate for any default-flip conversation:
+#   A = control                          (SHODH_COMPANION_MULTIHOP_GATE unset)
+#   B = SHODH_COMPANION_MULTIHOP_GATE=1
+# One shared fixture (built once), both arms on it. Read: multi_hop recall@10
+# must gain with single_hop/knowledge_update/temporal held. NOTE on power: at
+# limit=100 only ~28 multi_hop questions — directional, not definitive; a
+# clear positive earns a bigger confirm run.
+name: multihop companion — LongMemEval A/B
+on:
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: 'questions per arm (shared shuffled fixture). Default 100.'
+        required: false
+        default: '100'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mh-companion-lme
+  cancel-in-progress: true
+
+jobs:
+  ab:
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: recall-eval
+      - name: Install LLVM (ONNX runtime build dep)
+        run: sudo apt-get update && sudo apt-get install -y llvm-dev libclang-dev clang
+      - name: Build recall-eval
+        run: cargo build --release --bin recall-eval
+      - name: Cache embedder model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/shodh-memory/models
+          key: shodh-models-minilm-c9745ed1
+      - name: Pre-fetch MiniLM embedder
+        run: |
+          MODEL_DIR="$HOME/.cache/shodh-memory/models/minilm-l6"
+          mkdir -p "$MODEL_DIR"
+          PIN=c9745ed1d9f207416be6d2e6f8de32d1f16199bf
+          BASE="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/$PIN"
+          dl() { curl -fL --retry 20 --retry-all-errors --retry-delay 15 --connect-timeout 30 -o "$1" "$2"; }
+          [ -s "$MODEL_DIR/model_quantized.onnx" ] || dl "$MODEL_DIR/model_quantized.onnx" "$BASE/onnx/model_quint8_avx2.onnx"
+          [ -s "$MODEL_DIR/tokenizer.json" ]       || dl "$MODEL_DIR/tokenizer.json" "$BASE/tokenizer.json"
+
+      - name: Download LongMemEval-S (pinned) + build ONE shared fixture
+        run: |
+          python3 -m pip install --quiet huggingface_hub
+          JSON=$(python3 - <<'PY'
+          from huggingface_hub import hf_hub_download
+          print(hf_hub_download(repo_id='xiaowu0162/longmemeval-cleaned',
+                                filename='longmemeval_s_cleaned.json',
+                                repo_type='dataset',
+                                revision='98d7416c24c778c2fee6e6f3006e7a073259d48f'))
+          PY
+          )
+          python3 benchmarks/longmemeval_to_harness.py --input "$JSON" --shuffle \
+            --limit "${{ github.event.inputs.limit || '100' }}"
+          wc -l tests/recall/longmemeval/manifest.jsonl
+
+      - name: Arm A — control (gate off)
+        run: |
+          set -o pipefail
+          ./target/release/recall-eval \
+            --longmemeval tests/recall/longmemeval \
+            --output unused-a.json --storage ./lme-a-storage 2>a.log | tee a-stdout.log
+
+      - name: Arm B — SHODH_COMPANION_MULTIHOP_GATE=1
+        env:
+          SHODH_COMPANION_MULTIHOP_GATE: '1'
+        run: |
+          set -o pipefail
+          ./target/release/recall-eval \
+            --longmemeval tests/recall/longmemeval \
+            --output unused-b.json --storage ./lme-b-storage 2>b.log | tee b-stdout.log
+
+      - name: Compare
+        if: always()
+        run: |
+          echo "## Inc-2 real-corpus A/B — LongMemEval (limit=${{ github.event.inputs.limit || '100' }})" >> "$GITHUB_STEP_SUMMARY"
+          python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+          import re
+          def parse(fs):
+              overall=None; p1=None; cats={}
+              for f in fs:
+                  try: t=open(f, errors='ignore').read()
+                  except FileNotFoundError: continue
+                  m=re.search(r'LongMemEval-S:\s*\d+\s*questions.*?recall@10\s*=\s*([0-9.]+)', t)
+                  if m: overall=float(m.group(1))
+                  mp=re.search(r'p@1\s*=\s*([0-9.]+)', t)
+                  if mp: p1=float(mp.group(1))
+                  for cat,n,r in re.findall(r'^\s+(\w+)\s+n=(\d+)\s+recall@10\s*=\s*([0-9.]+)', t, re.M):
+                      cats[cat]=(int(n),float(r))
+              return overall,p1,cats
+          ao,ap,ac = parse(['a-stdout.log','a.log'])
+          bo,bp,bc = parse(['b-stdout.log','b.log'])
+          f=lambda x: f"{x:.4f}" if isinstance(x,float) else "?"
+          print("| metric | A control | B companions | delta |")
+          print("| --- | --- | --- | --- |")
+          if ao is not None and bo is not None:
+              print(f"| recall@10 ALL | {f(ao)} | {f(bo)} | {bo-ao:+.4f} |")
+          if ap is not None and bp is not None:
+              print(f"| p@1 ALL | {f(ap)} | {f(bp)} | {bp-ap:+.4f} |")
+          for cat in sorted(set(ac)|set(bc)):
+              na,ra = ac.get(cat,(0,None)); nb,rb = bc.get(cat,(0,None))
+              star=" **<-- the lever**" if cat=="multi_hop" else ""
+              if ra is not None and rb is not None:
+                  print(f"| {cat} (n={na}){star} | {f(ra)} | {f(rb)} | {rb-ra:+.4f} |")
+          if ac.get('multi_hop') and bc.get('multi_hop'):
+              d = bc['multi_hop'][1]-ac['multi_hop'][1]
+              others_ok = all(bc[c][1] >= ac[c][1]-0.02 for c in ac if c!='multi_hop' and c in bc)
+              print()
+              print(f"**Read: multi_hop {d:+.4f}; other categories {'held' if others_ok else 'REGRESSED — inspect'}.** "
+                    f"(n~{ac['multi_hop'][0]} — directional at limit=100; a clear positive earns a bigger confirm.)")
+          PY
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mh-companion-lme
+          path: |
+            a.log
+            b.log
+            a-stdout.log
+            b-stdout.log

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2842,6 +2842,44 @@ pub const LINEAGE_EXPANSION_MAX: usize = 3;
 pub const LINEAGE_EXPANSION_MIN_CONFIDENCE: f32 = 0.7;
 
 // =============================================================================
+// PROVENANCE-DRIVEN MULTI-HOP COMPANION INJECTION (Increment 2)
+// =============================================================================
+//
+// multi_hop questions have MULTIPLE gold turns; recall reliably surfaces the
+// best anchor, but companion evidence ranks 11-50 and falls outside the top-k.
+// An edge's `provenance` trail (Increment 1) lists every source episode that
+// attested it. When recall touches such an edge — via the entities of the
+// memories it already returned — those source episodes are exactly the
+// companion turns. Injecting them (gated, sub-source, accumulate-not-displace)
+// gives the missing gold a path into the result set.
+//
+// Gated behind `SHODH_COMPANION_MULTIHOP_GATE=1` AND a positive multi-hop
+// intent classification. Default OFF → zero overhead and byte-identical recall.
+
+/// Minimum confidence for a provenance record to seed a companion candidate.
+///
+/// Provenance confidence is optional (legacy/co-occurrence edges record `None`);
+/// when absent we fall back to the edge's `effective_strength()`. This bar
+/// (0.5, matching `LINEAGE_RETRIEVAL_MIN_CONFIDENCE`) filters weakly-attested
+/// edges so a single noisy co-occurrence cannot drag in an unrelated episode.
+pub const COMPANION_INJECTION_MIN_CONFIDENCE: f32 = 0.5;
+
+/// Maximum number of provenance companions injected into a single recall.
+///
+/// Caps the blast radius so a hub entity with many attesting episodes cannot
+/// flood the result tail. Five is enough to cover the companion turns of a
+/// typical multi-hop chain without overwhelming genuine top-k results.
+pub const COMPANION_INJECTION_MAX: usize = 5;
+
+/// Score factor applied to an injected companion (sub-source).
+///
+/// A companion's score = source_score × confidence-weight × this factor. At
+/// 0.5 a perfectly-attested companion of the top result scores at most half of
+/// it, so it sorts strictly below its source and only enters the kept window
+/// when a slot is open — it never displaces a genuinely higher-scored result.
+pub const COMPANION_SCORE_FACTOR: f32 = 0.5;
+
+// =============================================================================
 // CONSTANTS USAGE DOCUMENTATION
 // =============================================================================
 //

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1434,7 +1434,9 @@ impl MemorySystem {
             std::collections::HashMap::new();
 
         'outer: for mem in memories {
-            let source_score = mem.score.unwrap_or_else(|| mem.salience_score_with_access());
+            let source_score = mem
+                .score
+                .unwrap_or_else(|| mem.salience_score_with_access());
             if source_score <= 0.0 {
                 continue;
             }
@@ -1461,7 +1463,9 @@ impl MemorySystem {
                         // Confidence: record-level when present (provenance-aware
                         // edges), else the edge's effective strength (co-occurrence
                         // / legacy edges store None). Filter weak attestations.
-                        let conf = record.confidence.unwrap_or_else(|| edge.effective_strength());
+                        let conf = record
+                            .confidence
+                            .unwrap_or_else(|| edge.effective_strength());
                         if conf < COMPANION_INJECTION_MIN_CONFIDENCE {
                             continue;
                         }
@@ -10049,11 +10053,7 @@ mod companion_injection_tests {
         (system, temp_dir)
     }
 
-    fn remember_with_entities(
-        system: &MemorySystem,
-        content: &str,
-        entities: &[&str],
-    ) -> MemoryId {
+    fn remember_with_entities(system: &MemorySystem, content: &str, entities: &[&str]) -> MemoryId {
         let experience = Experience {
             content: content.to_string(),
             entities: entities.iter().map(|s| s.to_string()).collect(),
@@ -10155,7 +10155,8 @@ mod companion_injection_tests {
         let (system, _t) = setup();
         // Companion is a separate stored memory; anchor exposes entity "A".
         let companion_id = remember_with_entities(&system, "Companion turn about B and C.", &["B"]);
-        let anchor_id = remember_with_entities(&system, "Anchor turn mentions A and B.", &["A", "B"]);
+        let anchor_id =
+            remember_with_entities(&system, "Anchor turn mentions A and B.", &["A", "B"]);
         let mut anchor = system.get_memory(&anchor_id).unwrap();
         anchor.set_score(1.0);
 
@@ -10171,7 +10172,11 @@ mod companion_injection_tests {
         let companions =
             system.harvest_provenance_companions(&system.graph_memory().unwrap().read(), &ranked);
 
-        assert_eq!(companions.len(), 1, "the single attesting companion is harvested");
+        assert_eq!(
+            companions.len(),
+            1,
+            "the single attesting companion is harvested"
+        );
         let (mem, score) = &companions[0];
         assert_eq!(mem.id, companion_id, "harvested the attesting episode");
         // Sub-source: 1.0 (source) * 0.9 (conf) * 0.5 (factor) = 0.45 < 1.0.
@@ -10226,11 +10231,8 @@ mod companion_injection_tests {
             let a = add_entity(&graph, "A");
             // cap + 3 distinct companion episodes, each attesting its own edge off A.
             for i in 0..(cap + 3) {
-                let companion = remember_with_entities(
-                    &system,
-                    &format!("Companion episode number {i}."),
-                    &[],
-                );
+                let companion =
+                    remember_with_entities(&system, &format!("Companion episode number {i}."), &[]);
                 let other = add_entity(&graph, &format!("Other{i}"));
                 add_edge_with_provenance(&graph, a, other, companion.0, Some(0.9));
             }
@@ -10239,7 +10241,11 @@ mod companion_injection_tests {
         let ranked: Vec<SharedMemory> = vec![Arc::new(anchor)];
         let companions =
             system.harvest_provenance_companions(&system.graph_memory().unwrap().read(), &ranked);
-        assert_eq!(companions.len(), cap, "injection is bounded by COMPANION_INJECTION_MAX");
+        assert_eq!(
+            companions.len(),
+            cap,
+            "injection is bounded by COMPANION_INJECTION_MAX"
+        );
     }
 
     /// No provenance on the incident edges → nothing to harvest (no-op).

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -67,6 +67,16 @@ pub(crate) fn scoring_now() -> chrono::DateTime<chrono::Utc> {
         .unwrap_or_else(chrono::Utc::now)
 }
 
+/// `SHODH_COMPANION_MULTIHOP_GATE=1` — enable provenance-driven multi-hop
+/// companion injection (Increment 2). Default OFF → recall is byte-identical and
+/// no extra graph reads are performed. The flag only ARMS the feature; injection
+/// still fires solely on `Full`-layer recalls classified as multi-hop intent.
+fn companion_gate_enabled() -> bool {
+    std::env::var("SHODH_COMPANION_MULTIHOP_GATE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
 use crate::constants::{
     DEFAULT_COMPRESSION_AGE_DAYS, DEFAULT_IMPORTANCE_THRESHOLD, DEFAULT_MAX_HEAP_PER_USER_MB,
     DEFAULT_SESSION_MEMORY_SIZE_MB, DEFAULT_WORKING_MEMORY_SIZE, EDGE_SEMANTIC_WEIGHT_FLOOR,
@@ -1380,6 +1390,106 @@ impl MemorySystem {
         std::env::var("SHODH_RECALL_READONLY")
             .map(|v| v == "1")
             .unwrap_or(false)
+    }
+
+    /// Harvest provenance companions for the already-ranked `memories`.
+    ///
+    /// Increment 2 — provenance-driven multi-hop recall. For each ranked memory
+    /// we look up the knowledge-graph entities it exposes, walk each entity's
+    /// relationship edges, and read the `provenance` trail Increment 1 attached
+    /// to every edge. Each `ProvenanceRecord.source_episode_id` is a companion
+    /// episode that attested an edge the recalled memory is incident to — exactly
+    /// the multi-hop companion turn that fell outside the top-k. We:
+    ///
+    /// - confidence-filter each record (record confidence, or the edge's
+    ///   `effective_strength()` when the record carries none — co-occurrence and
+    ///   legacy edges record `None`),
+    /// - skip any episode already in the result set or already harvested (dedup),
+    /// - derive a SUB-source score = `source_score × conf-weight ×
+    ///   COMPANION_SCORE_FACTOR`, so a companion sorts strictly below the memory
+    ///   that reached it and can only occupy an OPEN top-k slot — it never
+    ///   displaces a higher-scored genuine result (accumulate-not-displace),
+    /// - cap the total at `COMPANION_INJECTION_MAX`.
+    ///
+    /// Returns `(Memory, derived_score)` pairs; the caller sets the score and
+    /// appends them before the final sort+truncate. A no-op (empty Vec) when no
+    /// edge carries qualifying provenance.
+    fn harvest_provenance_companions(
+        &self,
+        graph: &crate::graph_memory::GraphMemory,
+        memories: &[SharedMemory],
+    ) -> Vec<(Memory, f32)> {
+        use crate::constants::{
+            COMPANION_INJECTION_MAX, COMPANION_INJECTION_MIN_CONFIDENCE, COMPANION_SCORE_FACTOR,
+        };
+
+        let existing_ids: HashSet<uuid::Uuid> = memories.iter().map(|m| m.id.0).collect();
+        let mut harvested: HashSet<uuid::Uuid> = HashSet::new();
+        let mut companions: Vec<(Memory, f32)> = Vec::new();
+
+        // Resolve each entity name to a graph node at most once across all ranked
+        // memories — a memory's entities frequently repeat (the bridge entity is
+        // shared by the seed and link turns of a chain).
+        let mut entity_uuid_cache: std::collections::HashMap<String, Option<uuid::Uuid>> =
+            std::collections::HashMap::new();
+
+        'outer: for mem in memories {
+            let source_score = mem.score.unwrap_or_else(|| mem.salience_score_with_access());
+            if source_score <= 0.0 {
+                continue;
+            }
+
+            for name in &mem.experience.entities {
+                let key = name.to_lowercase();
+                let entity_uuid = *entity_uuid_cache.entry(key).or_insert_with(|| {
+                    graph
+                        .find_entity_by_name_strict(name)
+                        .ok()
+                        .flatten()
+                        .map(|e| e.uuid)
+                });
+                let Some(entity_uuid) = entity_uuid else {
+                    continue;
+                };
+
+                let Ok(edges) = graph.get_entity_relationships(&entity_uuid) else {
+                    continue;
+                };
+
+                for edge in &edges {
+                    for record in &edge.provenance {
+                        // Confidence: record-level when present (provenance-aware
+                        // edges), else the edge's effective strength (co-occurrence
+                        // / legacy edges store None). Filter weak attestations.
+                        let conf = record.confidence.unwrap_or_else(|| edge.effective_strength());
+                        if conf < COMPANION_INJECTION_MIN_CONFIDENCE {
+                            continue;
+                        }
+
+                        let src = record.source_episode_id;
+                        if existing_ids.contains(&src) || !harvested.insert(src) {
+                            continue;
+                        }
+
+                        let Ok(companion) = self.get_memory(&MemoryId(src)) else {
+                            // get_memory failed (episode not a stored memory) —
+                            // drop from the harvested set so it can't block a
+                            // later, fetchable attestation of the same id.
+                            harvested.remove(&src);
+                            continue;
+                        };
+
+                        let derived_score = source_score * conf * COMPANION_SCORE_FACTOR;
+                        companions.push((companion, derived_score));
+                        if companions.len() >= COMPANION_INJECTION_MAX {
+                            break 'outer;
+                        }
+                    }
+                }
+            }
+        }
+
+        companions
     }
 
     pub fn recall(&self, query: &Query) -> Result<Vec<SharedMemory>> {
@@ -4921,6 +5031,45 @@ impl MemorySystem {
         if layer_full {
             let mut seen_ids: HashSet<MemoryId> = memories.iter().map(|m| m.id.clone()).collect();
             self.expand_with_hierarchy(&mut memories, &mut seen_ids);
+        }
+
+        // ===========================================================================
+        // PROVENANCE-DRIVEN MULTI-HOP COMPANION INJECTION (Increment 2)
+        // ===========================================================================
+        // multi_hop questions have MULTIPLE gold turns; the pipeline above surfaces
+        // the best anchor, but companion evidence often ranks 11-50 and misses the
+        // top-k. Each knowledge-graph edge carries a `provenance` trail (Increment 1)
+        // listing every source episode that attested it. By walking the edges of the
+        // entities the recalled memories already expose, we reach exactly those
+        // companion episodes and inject them with a SUB-source score so they
+        // accumulate into open top-k slots without ever displacing a higher-scored
+        // genuine result. Gated: `SHODH_COMPANION_MULTIHOP_GATE=1` AND a positive
+        // multi-hop intent classification AND `Full` layer (production path only).
+        // Default OFF → byte-identical recall and zero graph reads.
+        if layer_full && companion_gate_enabled() {
+            let q_entities: &[String] = query.ner_entities.as_deref().unwrap_or(&[]);
+            let relation_surfaces: Vec<String> = onto_intent
+                .relation_types
+                .iter()
+                .map(|r| format!("{r:?}"))
+                .collect();
+            // entity_count combines query-NER grounding with the focal entities the
+            // analyzer parsed, so an under-counting NER still clears the floor when
+            // the surface structure is unambiguous.
+            let entity_count = q_entities.len().max(query_analysis.focal_entities.len());
+            let multihop_intent =
+                query_parser::detect_multihop_intent(query_text, entity_count, &relation_surfaces);
+
+            if multihop_intent {
+                if let Some(graph) = self.graph_memory.as_ref() {
+                    let companions = self.harvest_provenance_companions(&graph.read(), &memories);
+                    for (mem, score) in companions {
+                        let mut cloned: Memory = mem;
+                        cloned.set_score(score);
+                        memories.push(Arc::new(cloned));
+                    }
+                }
+            }
         }
 
         // Re-sort by score and trim to max_results after expansion.
@@ -9871,5 +10020,270 @@ impl Drop for MemorySystem {
         if let Err(e) = self.long_term_memory.flush() {
             tracing::error!("Failed to flush storage on shutdown: {}", e);
         }
+    }
+}
+
+#[cfg(test)]
+mod companion_injection_tests {
+    use super::*;
+    use crate::graph_memory::{
+        EntityLabel, EntityNode, GraphMemory, ProvenanceRecord, RelationType, RelationshipEdge,
+    };
+    use crate::memory::types::Experience;
+    use std::collections::HashMap as StdHashMap;
+
+    fn setup() -> (MemorySystem, tempfile::TempDir) {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let config = MemoryConfig {
+            storage_path: temp_dir.path().to_path_buf(),
+            working_memory_size: 50,
+            session_memory_size_mb: 50,
+            max_heap_per_user_mb: 200,
+            auto_compress: false,
+            compression_age_days: 1,
+            importance_threshold: 0.0,
+        };
+        let mut system = MemorySystem::new(config, None).expect("memory system");
+        let graph = GraphMemory::new(&temp_dir.path().join("graph"), None).expect("graph");
+        system.set_graph_memory(Arc::new(parking_lot::RwLock::new(graph)));
+        (system, temp_dir)
+    }
+
+    fn remember_with_entities(
+        system: &MemorySystem,
+        content: &str,
+        entities: &[&str],
+    ) -> MemoryId {
+        let experience = Experience {
+            content: content.to_string(),
+            entities: entities.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        };
+        system.remember(experience, None).expect("remember")
+    }
+
+    fn add_entity(graph: &GraphMemory, name: &str) -> uuid::Uuid {
+        let node = EntityNode {
+            uuid: uuid::Uuid::new_v4(),
+            name: name.to_string(),
+            labels: vec![EntityLabel::Person],
+            created_at: chrono::Utc::now(),
+            last_seen_at: chrono::Utc::now(),
+            mention_count: 1,
+            summary: String::new(),
+            attributes: StdHashMap::new(),
+            name_embedding: None,
+            salience: 1.0,
+            is_proper_noun: true,
+            selectivity: None,
+        };
+        graph.add_entity(node).expect("add entity")
+    }
+
+    fn add_edge_with_provenance(
+        graph: &GraphMemory,
+        from: uuid::Uuid,
+        to: uuid::Uuid,
+        source_episode: uuid::Uuid,
+        confidence: Option<f32>,
+    ) {
+        let now = chrono::Utc::now();
+        let edge = RelationshipEdge {
+            uuid: uuid::Uuid::new_v4(),
+            from_entity: from,
+            to_entity: to,
+            relation_type: RelationType::CoOccurs,
+            strength: 1.0,
+            created_at: now,
+            valid_at: now,
+            invalidated_at: None,
+            source_episode_id: Some(source_episode),
+            context: String::new(),
+            last_activated: now,
+            activation_count: 1,
+            ltp_status: crate::graph_memory::LtpStatus::None,
+            tier: crate::graph_memory::EdgeTier::L1Working,
+            activation_timestamps: None,
+            entity_confidence: None,
+            forman_curvature: None,
+            endpoint_selectivity: None,
+            provenance: vec![ProvenanceRecord {
+                source_episode_id: source_episode,
+                mention_count: 1,
+                first_observed: now,
+                last_observed: now,
+                confidence,
+                evidence_span: None,
+                typed_by: None,
+            }],
+        };
+        graph.add_relationship(edge).expect("add edge");
+    }
+
+    /// Add an edge carrying NO provenance and no source episode — the harvester
+    /// must treat it as a no-op.
+    fn add_edge_no_provenance(graph: &GraphMemory, from: uuid::Uuid, to: uuid::Uuid) {
+        let now = chrono::Utc::now();
+        let edge = RelationshipEdge {
+            uuid: uuid::Uuid::new_v4(),
+            from_entity: from,
+            to_entity: to,
+            relation_type: RelationType::CoOccurs,
+            strength: 1.0,
+            created_at: now,
+            valid_at: now,
+            invalidated_at: None,
+            source_episode_id: None,
+            context: String::new(),
+            last_activated: now,
+            activation_count: 1,
+            ltp_status: crate::graph_memory::LtpStatus::None,
+            tier: crate::graph_memory::EdgeTier::L1Working,
+            activation_timestamps: None,
+            entity_confidence: None,
+            forman_curvature: None,
+            endpoint_selectivity: None,
+            provenance: Vec::new(),
+        };
+        graph.add_relationship(edge).expect("add edge");
+    }
+
+    /// A high-confidence provenance edge incident to a ranked memory's entity
+    /// surfaces the attesting companion episode, scored strictly below its source.
+    #[test]
+    fn companion_is_harvested_and_scored_sub_source() {
+        let (system, _t) = setup();
+        // Companion is a separate stored memory; anchor exposes entity "A".
+        let companion_id = remember_with_entities(&system, "Companion turn about B and C.", &["B"]);
+        let anchor_id = remember_with_entities(&system, "Anchor turn mentions A and B.", &["A", "B"]);
+        let mut anchor = system.get_memory(&anchor_id).unwrap();
+        anchor.set_score(1.0);
+
+        {
+            let graph = system.graph_memory().unwrap().write();
+            let a = add_entity(&graph, "A");
+            let b = add_entity(&graph, "B");
+            // Edge A->B attested by the COMPANION episode (provenance points to it).
+            add_edge_with_provenance(&graph, a, b, companion_id.0, Some(0.9));
+        }
+
+        let ranked: Vec<SharedMemory> = vec![Arc::new(anchor)];
+        let companions =
+            system.harvest_provenance_companions(&system.graph_memory().unwrap().read(), &ranked);
+
+        assert_eq!(companions.len(), 1, "the single attesting companion is harvested");
+        let (mem, score) = &companions[0];
+        assert_eq!(mem.id, companion_id, "harvested the attesting episode");
+        // Sub-source: 1.0 (source) * 0.9 (conf) * 0.5 (factor) = 0.45 < 1.0.
+        assert!(*score < 1.0, "companion scores strictly below its source");
+        assert!((*score - 0.45).abs() < 1e-4, "score = source*conf*factor");
+    }
+
+    /// Companions already present in the ranked set are not re-injected (dedup),
+    /// and a single source episode attesting many edges is harvested once.
+    #[test]
+    fn dedup_against_ranked_and_across_edges() {
+        let (system, _t) = setup();
+        let anchor_id = remember_with_entities(&system, "Anchor with A and B.", &["A", "B"]);
+        let companion_id = remember_with_entities(&system, "Companion with C.", &["C"]);
+        let mut anchor = system.get_memory(&anchor_id).unwrap();
+        anchor.set_score(1.0);
+
+        {
+            let graph = system.graph_memory().unwrap().write();
+            let a = add_entity(&graph, "A");
+            let b = add_entity(&graph, "B");
+            // Two edges off A, BOTH attested by the same companion episode → one companion.
+            add_edge_with_provenance(&graph, a, b, companion_id.0, Some(0.9));
+            let c = add_entity(&graph, "Cnode");
+            add_edge_with_provenance(&graph, a, c, companion_id.0, Some(0.9));
+            // An edge attested by the ANCHOR itself must be skipped (already ranked).
+            add_edge_with_provenance(&graph, b, a, anchor_id.0, Some(0.9));
+        }
+
+        let ranked: Vec<SharedMemory> = vec![Arc::new(anchor)];
+        let companions =
+            system.harvest_provenance_companions(&system.graph_memory().unwrap().read(), &ranked);
+        assert_eq!(
+            companions.len(),
+            1,
+            "one unique companion (dedup across edges + skip already-ranked source)"
+        );
+        assert_eq!(companions[0].0.id, companion_id);
+    }
+
+    /// The cap bounds the number of injected companions.
+    #[test]
+    fn respects_injection_cap() {
+        let (system, _t) = setup();
+        let anchor_id = remember_with_entities(&system, "Anchor with A.", &["A"]);
+        let mut anchor = system.get_memory(&anchor_id).unwrap();
+        anchor.set_score(1.0);
+
+        let cap = crate::constants::COMPANION_INJECTION_MAX;
+        {
+            let graph = system.graph_memory().unwrap().write();
+            let a = add_entity(&graph, "A");
+            // cap + 3 distinct companion episodes, each attesting its own edge off A.
+            for i in 0..(cap + 3) {
+                let companion = remember_with_entities(
+                    &system,
+                    &format!("Companion episode number {i}."),
+                    &[],
+                );
+                let other = add_entity(&graph, &format!("Other{i}"));
+                add_edge_with_provenance(&graph, a, other, companion.0, Some(0.9));
+            }
+        }
+
+        let ranked: Vec<SharedMemory> = vec![Arc::new(anchor)];
+        let companions =
+            system.harvest_provenance_companions(&system.graph_memory().unwrap().read(), &ranked);
+        assert_eq!(companions.len(), cap, "injection is bounded by COMPANION_INJECTION_MAX");
+    }
+
+    /// No provenance on the incident edges → nothing to harvest (no-op).
+    #[test]
+    fn no_op_when_provenance_empty() {
+        let (system, _t) = setup();
+        let anchor_id = remember_with_entities(&system, "Anchor with A.", &["A"]);
+        let mut anchor = system.get_memory(&anchor_id).unwrap();
+        anchor.set_score(1.0);
+
+        {
+            let graph = system.graph_memory().unwrap().write();
+            let a = add_entity(&graph, "A");
+            let b = add_entity(&graph, "B");
+            // Edge with no source episode and an empty provenance trail.
+            add_edge_no_provenance(&graph, a, b);
+        }
+
+        let ranked: Vec<SharedMemory> = vec![Arc::new(anchor)];
+        let companions =
+            system.harvest_provenance_companions(&system.graph_memory().unwrap().read(), &ranked);
+        assert!(companions.is_empty(), "no provenance → no companions");
+    }
+
+    /// Low-confidence provenance is filtered out.
+    #[test]
+    fn filters_low_confidence_attestation() {
+        let (system, _t) = setup();
+        let anchor_id = remember_with_entities(&system, "Anchor with A.", &["A"]);
+        let companion_id = remember_with_entities(&system, "Companion with C.", &["C"]);
+        let mut anchor = system.get_memory(&anchor_id).unwrap();
+        anchor.set_score(1.0);
+
+        {
+            let graph = system.graph_memory().unwrap().write();
+            let a = add_entity(&graph, "A");
+            let b = add_entity(&graph, "B");
+            // confidence below COMPANION_INJECTION_MIN_CONFIDENCE (0.5).
+            add_edge_with_provenance(&graph, a, b, companion_id.0, Some(0.1));
+        }
+
+        let ranked: Vec<SharedMemory> = vec![Arc::new(anchor)];
+        let companions =
+            system.harvest_provenance_companions(&system.graph_memory().unwrap().read(), &ranked);
+        assert!(companions.is_empty(), "weak attestations are filtered");
     }
 }

--- a/src/memory/query_parser.rs
+++ b/src/memory/query_parser.rs
@@ -4632,7 +4632,11 @@ mod tests {
         let q = "Who does the colleague that Vorland works closely with manage?";
         let analysis = analyze_query(q);
         let onto = infer_ontological_intent(q, &analysis);
-        let relations: Vec<String> = onto.relation_types.iter().map(|r| format!("{r:?}")).collect();
+        let relations: Vec<String> = onto
+            .relation_types
+            .iter()
+            .map(|r| format!("{r:?}"))
+            .collect();
         let entity_count = analysis.focal_entities.len();
         assert!(
             detect_multihop_intent(q, entity_count, &relations),

--- a/src/memory/query_parser.rs
+++ b/src/memory/query_parser.rs
@@ -914,6 +914,106 @@ pub fn detect_temporal_intent(query: &str) -> TemporalIntent {
     TemporalIntent::None
 }
 
+// ============================================================================
+// MULTI-HOP QUERY DETECTION
+// ============================================================================
+// Detect when a query bridges two entities through an intermediate relation
+// (e.g. "who does the colleague that X works with manage?"). Such queries have
+// multiple gold turns spread across episodes; the answer turn is reachable only
+// by following a relation from an anchor the query does NOT name directly.
+//
+// Prior finding (companion-coverage thread): a single-conversation / single-
+// session signal is a BAD multi-hop proxy. This classifier instead keys on the
+// query's own structure — two or more grounded entities AND a relational bridge
+// (a connective relation OR a bridge verb OR a "who/how does X … Y" frame) — so
+// it does not rely on corpus partitioning.
+
+/// Bridge verbs that signal a relation linking two entities through an
+/// intermediate party (the hop). Lower-cased, matched as whole-ish tokens.
+const MULTIHOP_BRIDGE_VERBS: &[&str] = &[
+    "work",
+    "works",
+    "worked",
+    "working",
+    "manage",
+    "manages",
+    "managed",
+    "managing",
+    "collaborate",
+    "collaborates",
+    "collaborated",
+    "report",
+    "reports",
+    "reported",
+    "reporting",
+    "depend",
+    "depends",
+    "depended",
+    "lead",
+    "leads",
+    "led",
+    "leading",
+    "supervise",
+    "supervises",
+    "oversee",
+    "oversees",
+    "partner",
+    "partners",
+    "partnered",
+];
+
+/// Connective phrases that chain one relation into another (the linguistic
+/// signature of a 2-hop question).
+const MULTIHOP_CONNECTIVES: &[&str] = &[
+    "that ",
+    " who ",
+    " whom ",
+    " which ",
+    "the colleague",
+    "the person who",
+    "the one who",
+    "together with",
+    "along with",
+    " and also ",
+];
+
+/// Detect whether a query is asking a multi-hop (bridge) question.
+///
+/// Returns `true` when there are at least two grounded entities AND the query
+/// carries a relational bridge: a connective phrase, a bridge verb, or a
+/// "who/how does … " frame. `entity_count` is the number of entities the query
+/// NER resolved; `relations` are any relation cues already parsed from the
+/// query (e.g. ontological relation surface forms). Either source of relational
+/// signal qualifies, so the classifier degrades gracefully when NER under-counts
+/// entities but the surface structure is unambiguous.
+pub fn detect_multihop_intent(query: &str, entity_count: usize, relations: &[String]) -> bool {
+    let q = query.to_lowercase();
+
+    // A relational bridge present in the parsed relations is the strongest
+    // signal and does not require the entity-count floor (the parser already
+    // grounded the relation).
+    let has_parsed_relation = !relations.is_empty();
+
+    let has_connective = MULTIHOP_CONNECTIVES.iter().any(|c| q.contains(c));
+
+    // Bridge verb: split on non-alphanumeric so "works." / "works," match.
+    let tokens: Vec<&str> = q
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .collect();
+    let has_bridge_verb = tokens.iter().any(|t| MULTIHOP_BRIDGE_VERBS.contains(t));
+
+    // "who/how does X … Y" interrogative frame.
+    let has_bridge_frame = (q.starts_with("who ") || q.starts_with("how "))
+        && (q.contains(" does ") || q.contains(" do ") || q.contains(" did "));
+
+    let bridge = has_connective || has_bridge_verb || has_bridge_frame;
+
+    // Two grounded entities + a bridge, OR an already-parsed relation with at
+    // least one grounded entity, is a multi-hop question.
+    (entity_count >= 2 && bridge) || (has_parsed_relation && entity_count >= 1 && bridge)
+}
+
 /// Check if a query requires temporal filtering for accurate retrieval
 ///
 /// Returns true if the query has a temporal component that should be used
@@ -4487,6 +4587,68 @@ mod polar_negation_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn multihop_intent_fires_on_bridge_question_with_two_entities() {
+        // The canonical planted 2-hop query: two grounded entities + connective
+        // "that" + bridge verbs "works"/"manage".
+        assert!(detect_multihop_intent(
+            "Who does the colleague that Vorland works closely with manage?",
+            2,
+            &[],
+        ));
+    }
+
+    #[test]
+    fn multihop_intent_fires_on_parsed_relation_with_single_entity() {
+        // A parsed relation grounds the bridge even when NER counted one entity.
+        assert!(detect_multihop_intent(
+            "who manages the team Vorland leads?",
+            1,
+            &["WorksWith".to_string()],
+        ));
+    }
+
+    #[test]
+    fn multihop_intent_false_on_simple_lookup() {
+        // Single entity, no bridge structure — a 1-hop lookup, not multi-hop.
+        assert!(!detect_multihop_intent("What is Vorland's email?", 1, &[]));
+        // Two entities but no relational bridge.
+        assert!(!detect_multihop_intent("Vorland and Meslin", 2, &[]));
+    }
+
+    #[test]
+    fn multihop_intent_false_without_entity_floor() {
+        // Bridge verb present but no grounded entities and no parsed relation:
+        // not enough to assert a multi-hop question.
+        assert!(!detect_multihop_intent("who works here", 0, &[]));
+    }
+
+    #[test]
+    fn multihop_intent_fires_on_planted_harness_query() {
+        // The exact 2-hop query generated by the multi-hop harness. Verifies the
+        // gate fires end-to-end (analyze_query → ontological intent → gate) so the
+        // companion A/B actually exercises the feature on the planted corpus.
+        let q = "Who does the colleague that Vorland works closely with manage?";
+        let analysis = analyze_query(q);
+        let onto = infer_ontological_intent(q, &analysis);
+        let relations: Vec<String> = onto.relation_types.iter().map(|r| format!("{r:?}")).collect();
+        let entity_count = analysis.focal_entities.len();
+        assert!(
+            detect_multihop_intent(q, entity_count, &relations),
+            "planted 2-hop query must classify as multi-hop (focal_entities={entity_count}, relations={relations:?})"
+        );
+    }
+
+    #[test]
+    fn multihop_intent_handles_punctuated_bridge_verbs() {
+        // Bridge verb adjacent to punctuation must still tokenize/match.
+        assert!(detect_multihop_intent(
+            "Who is the person who Vorland works, then Meslin manages?",
+            2,
+            &[],
+        ));
+    }
 
     #[test]
     fn extract_relative_dates_does_not_overflow_on_absurd_values() {


### PR DESCRIPTION
## What
Increment 2 of the edge-provenance line — the designated `multi_hop` lever. multi-hop questions have multiple gold turns; recall surfaces the best anchor while companion evidence ranks 11–50 and misses top-k. Every edge now carries a provenance trail of attesting episodes (Inc-1, #340/#346): when recall touches an edge via its ranked memories' entities, those attesting episodes ARE the companion turns. `semantic_retrieve_inner` harvests them on the Full-layer path — intent-gated, accumulate-not-displace, sub-source scored.

**Default OFF** (`SHODH_COMPANION_MULTIHOP_GATE=1` to enable).

## Authenticity (re-measured before this PR existed, per review gate)
Original claim (2026-06-28, old base): planted 2-hop harness +0.10, no 1-hop loss. **Re-run on this port against current main** (run 28659034488, chains=60):

| layer | 2-hop A | 2-hop B | Δ | 1-hop Δ |
|---|---|---|---|---|
| vamana → +facts | — | — | +0.0000 each (flag inert below Full — clean isolation) | 0 |
| **full** | 0.4667 | **0.6167** | **+0.1500** | **0.0000** (1.0→1.0) |

The gain reproduces **larger than claimed** (+0.15 vs +0.10) — plausibly because current main populates multi-source provenance at edge birth (#346), fuel the original base lacked.

## Port notes
Single commit `9c5dcbef` cherry-picked onto current main (clean, 3 files +614); the branch's stale provenance-capture base commit was deliberately dropped — main carries that machinery in evolved form. Compile/clippy clean; the commit's 11 unit tests pass locally.

## What this does NOT yet claim
The planted harness is synthetic. The decisive real-corpus test — LongMemEval `multi_hop` A/B with this flag — is the follow-up before any default-flip conversation (current wall: 0.56 LongMemEval / 0.31 LoCoMo held-out). The `multihop-companion-ab.yml` workflow added here is the repeatable authenticity harness.