### PR TITLE
ci: add optional PMI gate threshold sweeps

### DIFF
--- a/.github/workflows/pmi-gate-ablation.yml
+++ b/.github/workflows/pmi-gate-ablation.yml
@@ -23,6 +23,10 @@ on:
         description: 'SHODH_GRAPH_PMI_GATE_MIN (PMI floor; 0.0 = PPMI). Higher prunes more.'
         required: false
         default: '0.0'
+      gate_min_sweep:
+        description: 'Optional comma-separated SHODH_GRAPH_PMI_GATE_MIN values for extra gated arms.'
+        required: false
+        default: ''
       max_cases:
         description: 'SHODH_MAX_CASES cap (blank = all)'
         required: false
@@ -140,6 +144,98 @@ jobs:
               print(f"| {cat} | {a:.3f} | {b:.3f} | {b-a:+.3f} |")
           PY
 
+      - name: Optional gate-min sweep
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.gate_min_sweep != '' }}
+        env:
+          SHODH_GATE_MIN_SWEEP: ${{ github.event.inputs.gate_min_sweep }}
+          SHODH_SWEEP_SUITE: ${{ github.event.inputs.suite || 'locomo' }}
+          SHODH_SWEEP_MAX_CASES: ${{ github.event.inputs.max_cases }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import re
+          import subprocess
+
+          def parse_gates(raw):
+              gates = []
+              for token in raw.split(","):
+                  token = token.strip()
+                  if not token:
+                      continue
+                  float(token)
+                  gates.append(token)
+              if not gates:
+                  raise SystemExit("gate_min_sweep did not contain any numeric values")
+              return gates
+
+          def slug(value):
+              return re.sub(r"[^0-9A-Za-z_.-]", "_", value).replace("-", "neg")
+
+          def load_recall(path):
+              data = json.load(open(path))
+              full = data["layers"].get("full") or next(iter(data["layers"].values()))
+              return data, full
+
+          def edge_counts(path):
+              totals = dict(semantic=0, cue=0, pair_table=0, learned=0, generic=0,
+                            fragment_blocked=0, pmi_gated=0)
+              pat = re.compile(r"(\w+)=(\d+)")
+              for line in open(path, errors="ignore"):
+                  if "edge typing provenance" not in line:
+                      continue
+                  for key, value in pat.findall(line):
+                      if key in totals:
+                          totals[key] += int(value)
+              totals["stored_total"] = (
+                  totals["semantic"] + totals["cue"] + totals["pair_table"]
+                  + totals["learned"] + totals["generic"] + totals["fragment_blocked"]
+              )
+              return totals
+
+          suite = os.environ.get("SHODH_SWEEP_SUITE") or "locomo"
+          max_cases = os.environ.get("SHODH_SWEEP_MAX_CASES", "")
+          rows = []
+          for gate in parse_gates(os.environ["SHODH_GATE_MIN_SWEEP"]):
+              safe = slug(gate)
+              output = f"sweep-{safe}.json"
+              stdout_log = f"sweep-{safe}.stdout.log"
+              stderr_log = f"sweep-{safe}.log"
+              env = os.environ.copy()
+              env.update({
+                  "SHODH_GRAPH_PMI_GATE": "1",
+                  "SHODH_GRAPH_PMI_GATE_MIN": gate,
+                  "SHODH_MAX_CASES": max_cases,
+                  "RUST_LOG": "shodh_memory::handlers::state=info",
+              })
+              cmd = [
+                  "./target/release/recall-eval",
+                  "--suite", suite,
+                  "--output", output,
+                  "--storage", f"./sweep-{safe}-storage",
+              ]
+              with open(stdout_log, "w") as out, open(stderr_log, "w") as err:
+                  result = subprocess.run(cmd, stdout=out, stderr=err, env=env, text=True)
+              if result.returncode != 0:
+                  raise SystemExit(f"gate_min={gate} failed with exit code {result.returncode}")
+              data, full = load_recall(output)
+              edges = edge_counts(stderr_log)
+              rows.append((gate, data["case_count"], full, edges))
+
+          summary = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"])
+          with summary.open("a") as handle:
+              handle.write("\n### Optional PMI gate-min sweep\n")
+              handle.write("| gate_min | cases | recall@10 | ndcg@10 | mrr | stored edges | generic | pmi_gated |\n")
+              handle.write("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+              for gate, case_count, full, edges in rows:
+                  handle.write(
+                      f"| {gate} | {case_count} | {full['recall@10']:.4f} | "
+                      f"{full['ndcg@10']:.4f} | {full['mrr']:.4f} | "
+                      f"{edges['stored_total']} | {edges['generic']} | {edges['pmi_gated']} |\n"
+                  )
+          PY
+
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -150,3 +246,6 @@ jobs:
             b-recall.json
             a.log
             b.log
+            sweep-*.json
+            sweep-*.log
+            sweep-*.stdout.log

--- a/.github/workflows/pmi-gate-longmemeval.yml
+++ b/.github/workflows/pmi-gate-longmemeval.yml
@@ -24,7 +24,7 @@ on:
         required: false
         default: '0.0'
       gate_min_sweep:
-        description: 'Optional comma-separated SHODH_GRAPH_PMI_GATE_MIN values for extra gated arms.'
+        description: 'Optional SHODH_GRAPH_PMI_GATE_MIN value for one extra gated arm; run separate dispatches for more.'
         required: false
         default: ''
 
@@ -170,6 +170,12 @@ jobs:
                   gates.append(token)
               if not gates:
                   raise SystemExit("gate_min_sweep did not contain any numeric values")
+              if len(gates) > 1:
+                  raise SystemExit(
+                      "pmi-gate-longmemeval supports at most one extra gate_min_sweep value "
+                      "per dispatch; run separate dispatches for more values to stay under "
+                      "the 360-minute workflow timeout."
+                  )
               return gates
 
           def slug(value):
@@ -184,7 +190,8 @@ jobs:
               return float(match.group(1)) if match else None
 
           def edge_counts(path):
-              totals = dict(generic=0, pmi_gated=0, cue=0, semantic=0, pair_table=0, learned=0)
+              totals = dict(generic=0, pmi_gated=0, cue=0, semantic=0, pair_table=0,
+                            learned=0, fragment_blocked=0)
               try:
                   lines = open(path, errors="ignore")
               except FileNotFoundError:
@@ -197,7 +204,7 @@ jobs:
                           totals[key] += int(value)
               totals["stored_total"] = (
                   totals["generic"] + totals["cue"] + totals["semantic"]
-                  + totals["pair_table"] + totals["learned"]
+                  + totals["pair_table"] + totals["learned"] + totals["fragment_blocked"]
               )
               return totals
 

--- a/.github/workflows/pmi-gate-longmemeval.yml
+++ b/.github/workflows/pmi-gate-longmemeval.yml
@@ -23,6 +23,10 @@ on:
         description: 'SHODH_GRAPH_PMI_GATE_MIN (PMI floor).'
         required: false
         default: '0.0'
+      gate_min_sweep:
+        description: 'Optional comma-separated SHODH_GRAPH_PMI_GATE_MIN values for extra gated arms.'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -145,6 +149,108 @@ jobs:
           print('```'); print(open('b-summary.txt', errors='ignore').read() if __import__('os').path.exists('b-summary.txt') else '(none)'); print('```')
           PY
 
+      - name: Optional gate-min sweep
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.gate_min_sweep != '' }}
+        env:
+          SHODH_GATE_MIN_SWEEP: ${{ github.event.inputs.gate_min_sweep }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import pathlib
+          import re
+          import subprocess
+
+          def parse_gates(raw):
+              gates = []
+              for token in raw.split(","):
+                  token = token.strip()
+                  if not token:
+                      continue
+                  float(token)
+                  gates.append(token)
+              if not gates:
+                  raise SystemExit("gate_min_sweep did not contain any numeric values")
+              return gates
+
+          def slug(value):
+              return re.sub(r"[^0-9A-Za-z_.-]", "_", value).replace("-", "neg")
+
+          def overall(path):
+              try:
+                  text = open(path, errors="ignore").read()
+              except FileNotFoundError:
+                  return None
+              match = re.search(r"LongMemEval-S:.*?recall@10\s*=\s*([0-9.]+)", text)
+              return float(match.group(1)) if match else None
+
+          def edge_counts(path):
+              totals = dict(generic=0, pmi_gated=0, cue=0, semantic=0, pair_table=0, learned=0)
+              try:
+                  lines = open(path, errors="ignore")
+              except FileNotFoundError:
+                  return totals
+              for line in lines:
+                  if "edge typing provenance" not in line:
+                      continue
+                  for key, value in re.findall(r"(\w+)=(\d+)", line):
+                      if key in totals:
+                          totals[key] += int(value)
+              totals["stored_total"] = (
+                  totals["generic"] + totals["cue"] + totals["semantic"]
+                  + totals["pair_table"] + totals["learned"]
+              )
+              return totals
+
+          rows = []
+          for gate in parse_gates(os.environ["SHODH_GATE_MIN_SWEEP"]):
+              safe = slug(gate)
+              stdout_log = f"sweep-{safe}.stdout.log"
+              stderr_log = f"sweep-{safe}.log"
+              summary_log = f"sweep-{safe}.summary.txt"
+              env = os.environ.copy()
+              env.update({
+                  "SHODH_GRAPH_PMI_GATE": "1",
+                  "SHODH_GRAPH_PMI_GATE_MIN": gate,
+                  "RUST_LOG": "shodh_memory::handlers::state=info",
+              })
+              cmd = [
+                  "./target/release/recall-eval",
+                  "--longmemeval", "tests/recall/longmemeval",
+                  "--output", f"sweep-{safe}.json",
+                  "--storage", f"./lme-sweep-{safe}-storage",
+              ]
+              with open(stdout_log, "w") as out, open(stderr_log, "w") as err:
+                  result = subprocess.run(cmd, stdout=out, stderr=err, env=env, text=True)
+              if result.returncode != 0:
+                  raise SystemExit(f"gate_min={gate} failed with exit code {result.returncode}")
+              text = ""
+              for path in (stdout_log, stderr_log):
+                  try:
+                      text += open(path, errors="ignore").read()
+                  except FileNotFoundError:
+                      pass
+              with open(summary_log, "w") as handle:
+                  for line in text.splitlines():
+                      if "LongMemEval-S:" in line or "recall@" in line:
+                          handle.write(line + "\n")
+              recall = overall(stdout_log)
+              if recall is None:
+                  recall = overall(stderr_log)
+              rows.append((gate, recall, edge_counts(stderr_log)))
+
+          summary = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"])
+          with summary.open("a") as handle:
+              handle.write("\n### Optional PMI gate-min sweep\n")
+              handle.write("| gate_min | recall@10 | stored edges | generic | pmi_gated |\n")
+              handle.write("| --- | ---: | ---: | ---: | ---: |\n")
+              for gate, recall, edges in rows:
+                  recall_cell = f"{recall:.4f}" if recall is not None else "parse-failed"
+                  handle.write(
+                      f"| {gate} | {recall_cell} | {edges['stored_total']} | "
+                      f"{edges['generic']} | {edges['pmi_gated']} |\n"
+                  )
+          PY
+
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -155,3 +261,7 @@ jobs:
             b.log
             a-summary.txt
             b-summary.txt
+            sweep-*.json
+            sweep-*.log
+            sweep-*.stdout.log
+            sweep-*.summary.txt

--- a/docs/architecture/03-hebbian-learning.md
+++ b/docs/architecture/03-hebbian-learning.md
@@ -229,16 +229,18 @@ This boundary matters when interpreting graph-size measurements:
 
 1. The gate affects new graph construction only; it does not shrink an existing
    dense graph retroactively.
-2. The expected edge drop depends on corpus shape. Raw dialogue imports with a
-   large generic co-occurrence surface should show a larger effect than already
-   pre-processed or tag/entity-projected memory objects.
+2. The expected edge drop depends on corpus shape. The gate is a hub-noise
+   filter: it prunes generic pairs when the endpoint document frequencies make
+   the pair no more informative than chance. Hub-shaped corpora can shrink
+   sharply; clique-shaped corpora with many rare pairs per memory may not.
 3. A clean comparison needs an explicit control arm with `SHODH_GRAPH_PMI_GATE=0`
    because the current default is gated.
 
 The `pmi-gate-*` GitHub workflows keep the default A/B path unchanged and expose
 an optional `gate_min_sweep` input for manual threshold sweeps across corpus
-shapes. Use it when a single `gate_min=0.0` run does not explain a local graph
-profile.
+shapes. In the LongMemEval workflow, that sweep is intentionally limited to one
+extra value per dispatch so the default `limit=50` run stays under the workflow
+timeout; use separate dispatches for more values.
 
 ### Prometheus Metrics
 

--- a/docs/architecture/03-hebbian-learning.md
+++ b/docs/architecture/03-hebbian-learning.md
@@ -218,6 +218,28 @@ This simulates sleep-dependent memory consolidation.
 
 ## Metrics & Observability
 
+### PMI Edge-Gate Diagnostics
+
+`SHODH_GRAPH_PMI_GATE` is an edge-birth filter for generic graph links. It drops
+only incidental `CoOccurs` / `RelatedTo` candidate edges whose birth PMI is below
+`SHODH_GRAPH_PMI_GATE_MIN`. Typed links, cue-derived links, learned relation
+links, and fragment-safe bridges are not pruned by this gate.
+
+This boundary matters when interpreting graph-size measurements:
+
+1. The gate affects new graph construction only; it does not shrink an existing
+   dense graph retroactively.
+2. The expected edge drop depends on corpus shape. Raw dialogue imports with a
+   large generic co-occurrence surface should show a larger effect than already
+   pre-processed or tag/entity-projected memory objects.
+3. A clean comparison needs an explicit control arm with `SHODH_GRAPH_PMI_GATE=0`
+   because the current default is gated.
+
+The `pmi-gate-*` GitHub workflows keep the default A/B path unchanged and expose
+an optional `gate_min_sweep` input for manual threshold sweeps across corpus
+shapes. Use it when a single `gate_min=0.0` run does not explain a local graph
+profile.
+
 ### Prometheus Metrics
 
 ```


### PR DESCRIPTION
## Summary

Adds an opt-in `gate_min_sweep` workflow input to the existing PMI gate ablation workflows:

- `.github/workflows/pmi-gate-ablation.yml`
- `.github/workflows/pmi-gate-longmemeval.yml`

When left blank, the workflows behave exactly as they do today. When provided as comma-separated values, the workflow runs extra gated arms and appends a compact table with recall and edge-provenance counters for each `SHODH_GRAPH_PMI_GATE_MIN` value.

Also documents the PMI gate interpretation boundary: it only gates generic edge births, does not shrink existing graphs retroactively, and its effect can depend heavily on corpus shape.

## Why

A single `gate_min=0.0` A/B run can be inconclusive on corpora that are already pre-processed, tag/entity-projected, or otherwise not raw dialogue imports. The optional sweep gives maintainers a cheap manual diagnostic before changing defaults or interpreting a local graph profile.

## Verification

- Parsed both workflow YAML files with PyYAML.
- Parsed all embedded Python heredocs with `ast.parse`.
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo test --no-run`
- `cargo test --lib --bins` (`790` lib tests passed, `4` ignored; CLI `2` passed)

I did not run the full workflow bodies locally because they require the benchmark/model download path.
