### PR TITLE
feat(config): tune RocksDB block cache capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ SHODH_PORT=3030                   # Port (default: 3030)
 SHODH_MEMORY_PATH=/var/lib/shodh  # Data directory
 SHODH_REQUEST_TIMEOUT=60          # Request timeout in seconds
 SHODH_MAX_CONCURRENT=200          # Max concurrent requests
+SHODH_ROCKSDB_BLOCK_CACHE_MB=256  # Shared RocksDB block cache (MiB)
 SHODH_CORS_ORIGINS=https://app.example.com
 ```
 </details>

--- a/src/config.rs
+++ b/src/config.rs
@@ -595,6 +595,7 @@ pub fn print_env_help() {
     println!("  SHODH_RATE_BURST       - Burst size (default: 8000)");
     println!("  SHODH_MAX_CONCURRENT   - Max concurrent requests (default: 200)");
     println!("  SHODH_REQUEST_TIMEOUT  - Request timeout in seconds (default: 60)");
+    println!("  SHODH_ROCKSDB_BLOCK_CACHE_MB - Shared RocksDB block cache in MiB (default: 256)");
     println!("  SHODH_AUDIT_MAX_ENTRIES    - Max audit entries per user (default: 10000)");
     println!("  SHODH_AUDIT_RETENTION_DAYS - Audit log retention days (default: 30)");
     println!();

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -760,6 +760,40 @@ pub const FACT_NEGATION_MARKERS: &[&str] = &[
 /// Families of all DB's managed by the process."
 pub const ROCKSDB_SHARED_CACHE_BYTES: usize = 256 * 1024 * 1024;
 
+/// Environment variable for overriding the shared RocksDB block cache capacity.
+///
+/// Value is in MiB. Invalid, zero, or overflowing values fall back to
+/// `ROCKSDB_SHARED_CACHE_BYTES`.
+pub const ROCKSDB_SHARED_CACHE_MB_ENV: &str = "SHODH_ROCKSDB_BLOCK_CACHE_MB";
+
+/// Parse a MiB override for the shared RocksDB block cache.
+pub(crate) fn parse_rocksdb_shared_cache_capacity_bytes(raw: &str) -> Option<usize> {
+    let mib = raw.trim().parse::<usize>().ok()?;
+    if mib == 0 {
+        return None;
+    }
+    mib.checked_mul(1024 * 1024)
+}
+
+/// Shared RocksDB block cache capacity after applying the optional env override.
+pub fn rocksdb_shared_cache_capacity_bytes() -> usize {
+    let Ok(raw) = std::env::var(ROCKSDB_SHARED_CACHE_MB_ENV) else {
+        return ROCKSDB_SHARED_CACHE_BYTES;
+    };
+    match parse_rocksdb_shared_cache_capacity_bytes(&raw) {
+        Some(bytes) => bytes,
+        None => {
+            tracing::warn!(
+                "{}={} is invalid; using default {}MiB RocksDB block cache",
+                ROCKSDB_SHARED_CACHE_MB_ENV,
+                raw,
+                ROCKSDB_SHARED_CACHE_BYTES / (1024 * 1024)
+            );
+            ROCKSDB_SHARED_CACHE_BYTES
+        }
+    }
+}
+
 /// Per-DB write buffer size for MemoryStorage (bytes).
 ///
 /// Reduced from 32MB to 8MB because total memtable memory is now bounded
@@ -3147,3 +3181,31 @@ pub const SEMANTIC_CLUSTER_SAMPLE_SIZE: usize = 50;
 ///   to keep the similarity triple count manageable (≤500 pairs).
 /// - Matches typical HNSW ef_search defaults for recall-oriented searches.
 pub const SEMANTIC_CLUSTER_NEIGHBOR_K: usize = 10;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_rocksdb_shared_cache_capacity_mib() {
+        assert_eq!(
+            parse_rocksdb_shared_cache_capacity_bytes("64"),
+            Some(64 * 1024 * 1024)
+        );
+        assert_eq!(
+            parse_rocksdb_shared_cache_capacity_bytes(" 128 "),
+            Some(128 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_rocksdb_shared_cache_capacity() {
+        assert_eq!(parse_rocksdb_shared_cache_capacity_bytes("0"), None);
+        assert_eq!(parse_rocksdb_shared_cache_capacity_bytes(""), None);
+        assert_eq!(parse_rocksdb_shared_cache_capacity_bytes("64MB"), None);
+        assert_eq!(
+            parse_rocksdb_shared_cache_capacity_bytes(&usize::MAX.to_string()),
+            None
+        );
+    }
+}

--- a/src/handlers/health.rs
+++ b/src/handlers/health.rs
@@ -102,11 +102,9 @@ pub async fn health_index(
             // open RocksDB for every user on disk, wasting FDs and memory.
             let users: Vec<(String, crate::memory::retrieval::IndexHealth)> = {
                 let mut results = Vec::new();
-                for user_id in state.list_cached_users() {
-                    if let Ok(memory) = state.get_user_memory(&user_id) {
-                        let guard = memory.read();
-                        results.push((user_id, guard.index_health()));
-                    }
+                for (user_id, memory) in state.cached_user_memories() {
+                    let guard = memory.read();
+                    results.push((user_id, guard.index_health()));
                 }
                 results
             };
@@ -183,16 +181,14 @@ pub async fn metrics_endpoint(State(state): State<AppState>) -> Result<String, S
         (0i64, 0i64, 0i64, 0i64);
     let mut total_vectors = 0i64;
 
-    for user_id in state.list_cached_users() {
-        if let Ok(memory_sys) = state.get_user_memory(&user_id) {
-            if let Some(guard) = memory_sys.try_read() {
-                let stats = guard.stats();
-                total_working += stats.working_memory_count as i64;
-                total_session += stats.session_memory_count as i64;
-                total_longterm += stats.long_term_memory_count as i64;
-                total_heap += (stats.total_memories * 250) as i64;
-                total_vectors += stats.total_memories as i64;
-            }
+    for (_user_id, memory_sys) in state.cached_user_memories() {
+        if let Some(guard) = memory_sys.try_read() {
+            let stats = guard.stats();
+            total_working += stats.working_memory_count as i64;
+            total_session += stats.session_memory_count as i64;
+            total_longterm += stats.long_term_memory_count as i64;
+            total_heap += (stats.total_memories * 250) as i64;
+            total_vectors += stats.total_memories as i64;
         }
     }
 

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -1664,6 +1664,18 @@ impl MultiUserMemoryManager {
             .collect()
     }
 
+    /// Snapshot cached user memories without creating/opening cold users.
+    ///
+    /// Observability paths must use this instead of `list_cached_users()` plus
+    /// `get_user_memory()`: if a user is evicted between those two calls,
+    /// `get_user_memory()` would reopen the RocksDB instance from disk.
+    pub fn cached_user_memories(&self) -> Vec<(String, Arc<parking_lot::RwLock<MemorySystem>>)> {
+        self.user_memories
+            .iter()
+            .map(|(id, memory)| (id.to_string(), memory.clone()))
+            .collect()
+    }
+
     /// RocksDB in-process memory, decomposed — the instrument for #90.
     ///
     /// - Shared block cache: read ONCE from the manager's own handle (it is a
@@ -1677,16 +1689,14 @@ impl MultiUserMemoryManager {
         let mut memtables = 0u64;
         let mut readers = 0u64;
         let mut users_counted = 0usize;
-        for user_id in self.list_cached_users() {
-            if let Ok(memory) = self.get_user_memory(&user_id) {
-                // try_read: a diagnostic must never block a writer; a user
-                // mid-write is simply skipped this scrape.
-                if let Some(guard) = memory.try_read() {
-                    let (m, r) = guard.rocksdb_memory_breakdown();
-                    memtables += m;
-                    readers += r;
-                    users_counted += 1;
-                }
+        for (_user_id, memory) in self.cached_user_memories() {
+            // try_read: a diagnostic must never block a writer; a user
+            // mid-write is simply skipped this scrape.
+            if let Some(guard) = memory.try_read() {
+                let (m, r) = guard.rocksdb_memory_breakdown();
+                memtables += m;
+                readers += r;
+                users_counted += 1;
             }
         }
         crate::system_memory::RocksDbMemoryDiagnostics {
@@ -1730,14 +1740,8 @@ impl MultiUserMemoryManager {
             .map_err(|e| anyhow::anyhow!("Failed to flush shared database: {e}"))?;
         info!("  Shared database flushed (todos, prospective, files, feedback, audit)");
 
-        let user_entries: Vec<(String, Arc<parking_lot::RwLock<MemorySystem>>)> = self
-            .user_memories
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.clone()))
-            .collect();
-
         let mut flushed = 0;
-        for (user_id, memory_system) in user_entries {
+        for (user_id, memory_system) in self.cached_user_memories() {
             if let Some(guard) = memory_system.try_read() {
                 if let Err(e) = guard.flush_storage() {
                     tracing::warn!("  Failed to flush database for user {}: {}", user_id, e);
@@ -1761,14 +1765,8 @@ impl MultiUserMemoryManager {
     pub fn save_all_vector_indices(&self) -> Result<()> {
         info!("Saving vector indices to disk...");
 
-        let user_entries: Vec<(String, Arc<parking_lot::RwLock<MemorySystem>>)> = self
-            .user_memories
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.clone()))
-            .collect();
-
         let mut saved = 0;
-        for (user_id, memory_system) in user_entries {
+        for (user_id, memory_system) in self.cached_user_memories() {
             if let Some(guard) = memory_system.try_read() {
                 let index_path = self.base_path.join(&user_id).join("vector_index");
                 if let Err(e) = guard.save_vector_index(&index_path) {
@@ -2429,12 +2427,10 @@ impl MultiUserMemoryManager {
     pub fn write_failure_metrics(&self) -> (u64, usize) {
         let mut total_failures = 0u64;
         let mut total_pending = 0usize;
-        for (user_id, _) in self.user_memories.iter() {
-            if let Ok(memory_lock) = self.get_user_memory(user_id.as_ref()) {
-                let memory = memory_lock.read();
-                total_failures += memory.total_write_failures();
-                total_pending += memory.pending_write_retries();
-            }
+        for (_user_id, memory_lock) in self.cached_user_memories() {
+            let memory = memory_lock.read();
+            total_failures += memory.total_write_failures();
+            total_pending += memory.pending_write_retries();
         }
         (total_failures, total_pending)
     }
@@ -4082,5 +4078,37 @@ mod tests {
                 word
             );
         }
+    }
+
+    #[test]
+    fn cached_user_memories_snapshot_does_not_reopen_evicted_users() {
+        let temp_dir = tempfile::TempDir::new().expect("failed to create temp dir");
+        let config = ServerConfig {
+            storage_path: temp_dir.path().to_path_buf(),
+            backup_enabled: false,
+            ..ServerConfig::default()
+        };
+        let manager = MultiUserMemoryManager::new(temp_dir.path().to_path_buf(), config)
+            .expect("failed to create manager");
+
+        manager
+            .get_user_memory("warm-user")
+            .expect("failed to create warm user memory");
+        let cached = manager.cached_user_memories();
+        assert_eq!(cached.len(), 1);
+
+        manager.evict_user("warm-user");
+        assert_eq!(manager.users_in_cache(), 0);
+
+        let (_user_id, memory) = cached.into_iter().next().expect("cached snapshot");
+        assert!(
+            memory.try_read().is_some(),
+            "snapshot should hold the cached memory handle directly"
+        );
+        assert_eq!(
+            manager.users_in_cache(),
+            0,
+            "reading the snapshot must not recreate the evicted cache entry"
+        );
     }
 }

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -705,6 +705,7 @@ pub struct MultiUserMemoryManager {
     /// Without this, each user's MemoryStorage + GraphMemory allocates ~96MB in
     /// independent caches — 6 users = 576MB just in block caches alone.
     shared_rocksdb_cache: rocksdb::Cache,
+    shared_rocksdb_cache_capacity_bytes: usize,
 
     /// Per-user, per-memory habituation tracker for proactive_context.
     /// Tracks how many times a memory was surfaced without positive feedback,
@@ -902,13 +903,15 @@ impl MultiUserMemoryManager {
         // Single shared LRU block cache for ALL RocksDB instances (per-user memory DBs,
         // per-user graph DBs, and the global shared DB). Provides a hard memory ceiling
         // regardless of how many users are active. Without this, each user allocates
-        // ~96MB in independent caches — the shared cache collapses that to a single
-        // 256MB pool with LRU eviction of the coldest blocks across all users.
+        // ~96MB in independent caches — the shared cache collapses that to one
+        // configured pool (256MiB by default) with LRU eviction of the coldest blocks.
+        let shared_rocksdb_cache_capacity_bytes =
+            crate::constants::rocksdb_shared_cache_capacity_bytes();
         let shared_rocksdb_cache =
-            rocksdb::Cache::new_lru_cache(crate::constants::ROCKSDB_SHARED_CACHE_BYTES);
+            rocksdb::Cache::new_lru_cache(shared_rocksdb_cache_capacity_bytes);
         info!(
             "Shared RocksDB block cache initialized ({}MB)",
-            crate::constants::ROCKSDB_SHARED_CACHE_BYTES / (1024 * 1024)
+            shared_rocksdb_cache_capacity_bytes / (1024 * 1024)
         );
 
         // Open a single shared DB for all global stores (todos, reminders, files, feedback, audit).
@@ -1044,6 +1047,7 @@ impl MultiUserMemoryManager {
             user_memory_init_locks: DashMap::new(),
             user_graph_init_locks: DashMap::new(),
             shared_rocksdb_cache,
+            shared_rocksdb_cache_capacity_bytes,
             habituation_tracker,
             task_tracker: tokio_util::task::TaskTracker::new(),
             consolidation_locks: DashMap::new(),
@@ -1688,7 +1692,7 @@ impl MultiUserMemoryManager {
         crate::system_memory::RocksDbMemoryDiagnostics {
             shared_block_cache_usage_bytes: self.shared_rocksdb_cache.get_usage() as u64,
             shared_block_cache_pinned_bytes: self.shared_rocksdb_cache.get_pinned_usage() as u64,
-            shared_block_cache_capacity_bytes: crate::constants::ROCKSDB_SHARED_CACHE_BYTES as u64,
+            shared_block_cache_capacity_bytes: self.shared_rocksdb_cache_capacity_bytes as u64,
             user_memtables_bytes: memtables,
             user_table_readers_bytes: readers,
             users_counted,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -285,6 +285,15 @@ pub static ROCKSDB_BLOCK_CACHE_PINNED_BYTES: LazyLock<IntGauge> = LazyLock::new(
     .expect("ROCKSDB_BLOCK_CACHE_PINNED_BYTES metric must be valid at compile time")
 });
 
+/// Configured shared RocksDB block cache capacity.
+pub static ROCKSDB_BLOCK_CACHE_CAPACITY_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+    IntGauge::new(
+        "shodh_rocksdb_block_cache_capacity_bytes",
+        "Configured capacity of the shared RocksDB block cache",
+    )
+    .expect("ROCKSDB_BLOCK_CACHE_CAPACITY_BYTES metric must be valid at compile time")
+});
+
 /// Sum of memtable bytes across all CFs of all cached users' DBs.
 pub static ROCKSDB_MEMTABLES_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
     IntGauge::new(
@@ -598,8 +607,12 @@ pub static EMBEDDING_CACHE_CONTENT_SIZE: LazyLock<IntGauge> = LazyLock::new(|| {
 
 fn set_optional_gauge(gauge: &IntGauge, value: Option<u64>) {
     if let Some(value) = value {
-        gauge.set(value.min(i64::MAX as u64) as i64);
+        set_u64_gauge(gauge, value);
     }
+}
+
+fn set_u64_gauge(gauge: &IntGauge, value: u64) {
+    gauge.set(value.min(i64::MAX as u64) as i64);
 }
 
 /// Update best-effort process/cgroup memory gauges.
@@ -619,10 +632,20 @@ pub fn update_system_memory_metrics(diagnostics: &crate::system_memory::SystemMe
 
 /// Update the RocksDB memory-decomposition gauges (the #90 instrument).
 pub fn update_rocksdb_memory_metrics(d: &crate::system_memory::RocksDbMemoryDiagnostics) {
-    ROCKSDB_BLOCK_CACHE_USAGE_BYTES.set(d.shared_block_cache_usage_bytes as i64);
-    ROCKSDB_BLOCK_CACHE_PINNED_BYTES.set(d.shared_block_cache_pinned_bytes as i64);
-    ROCKSDB_MEMTABLES_BYTES.set(d.user_memtables_bytes as i64);
-    ROCKSDB_TABLE_READERS_BYTES.set(d.user_table_readers_bytes as i64);
+    set_u64_gauge(
+        &ROCKSDB_BLOCK_CACHE_USAGE_BYTES,
+        d.shared_block_cache_usage_bytes,
+    );
+    set_u64_gauge(
+        &ROCKSDB_BLOCK_CACHE_PINNED_BYTES,
+        d.shared_block_cache_pinned_bytes,
+    );
+    set_u64_gauge(
+        &ROCKSDB_BLOCK_CACHE_CAPACITY_BYTES,
+        d.shared_block_cache_capacity_bytes,
+    );
+    set_u64_gauge(&ROCKSDB_MEMTABLES_BYTES, d.user_memtables_bytes);
+    set_u64_gauge(&ROCKSDB_TABLE_READERS_BYTES, d.user_table_readers_bytes);
 }
 
 /// Register all metrics with the global registry
@@ -706,6 +729,10 @@ fn do_register_metrics() -> Result<(), MetricsError> {
     register!(
         ROCKSDB_BLOCK_CACHE_PINNED_BYTES,
         "ROCKSDB_BLOCK_CACHE_PINNED_BYTES"
+    );
+    register!(
+        ROCKSDB_BLOCK_CACHE_CAPACITY_BYTES,
+        "ROCKSDB_BLOCK_CACHE_CAPACITY_BYTES"
     );
     register!(ROCKSDB_MEMTABLES_BYTES, "ROCKSDB_MEMTABLES_BYTES");
     register!(ROCKSDB_TABLE_READERS_BYTES, "ROCKSDB_TABLE_READERS_BYTES");

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -92,14 +92,9 @@ fn collect_heartbeat(
 
     // Count memories from cached users only (avoids loading every user from disk)
     let total_memories: u64 = manager
-        .list_cached_users()
+        .cached_user_memories()
         .iter()
-        .filter_map(|uid| {
-            manager
-                .get_user_memory(uid)
-                .ok()
-                .map(|ms| ms.read().stats().total_memories as u64)
-        })
+        .map(|(_, ms)| ms.read().stats().total_memories as u64)
         .sum();
 
     // Approximate storage size (walk top-level directory)

--- a/tests/handler_tests.rs
+++ b/tests/handler_tests.rs
@@ -283,6 +283,10 @@ async fn metrics_endpoint() {
         metrics.contains("shodh_cgroup_memory_current_bytes"),
         "metrics response should include cgroup memory gauge"
     );
+    assert!(
+        metrics.contains("shodh_rocksdb_block_cache_capacity_bytes"),
+        "metrics response should include RocksDB block cache capacity gauge"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why
#90 decomposed the steady-state RSS plateau into a warm shared RocksDB block cache, ONNX arenas, and baseline process memory. The shared block cache is intentionally bounded, but today its 256MiB ceiling is hard-coded. That is a good default for general workloads, while edge/local deployments may want to trade cache hit rate for lower steady-state RSS.

While tightening that observability path, I also found a cached-user race: some health/metrics/telemetry aggregations listed cached user IDs and then called `get_user_memory()`. If a user was evicted between those two steps, the observation path could reopen a cold RocksDB instance from disk, which works against the "diagnostics must not create the pressure they observe" guard.

## What
- Add `SHODH_ROCKSDB_BLOCK_CACHE_MB` as an optional MiB override for the shared RocksDB block cache.
- Keep the existing 256MiB default when the env var is unset, zero, invalid, or overflowing.
- Store the actual configured capacity on the manager so `/health.rocksdb_memory.shared_block_cache_capacity_bytes` reports the real ceiling.
- Expose `shodh_rocksdb_block_cache_capacity_bytes` in Prometheus metrics so operators can alert on cache usage relative to the configured ceiling.
- Add a cached memory snapshot helper and use it in health, metrics, write-failure aggregation, flush/save loops, and telemetry paths that must not reopen cold users.
- Document the env var in README production config and CLI env help.

## Tested
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check`
- `cargo test rocksdb_shared_cache_capacity`
- `cargo test metrics_endpoint`
- `cargo test cached_user_memories_snapshot_does_not_reopen_evicted_users`
- `cargo test rocksdb_diagnostics_do_not_load_cold_disk_users`
- `cargo test metrics_endpoint_does_not_load_cold_disk_users`
- `cargo test --lib --bins`
- `cargo clippy --all-targets -- -W clippy::all`

Note: I did not run `cargo build` because this repo's `CLAUDE.md` says not to run `cargo build` or `cargo run` unless explicitly asked.

Refs #90