### PR TITLE
fix(mcp): resolve displayed version from package metadata

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Shodh-Memory MCP Server</h1>
 
 <p align="center">
-  <strong>v0.1.90</strong> | Persistent cognitive memory for AI agents
+  Persistent cognitive memory for AI agents
 </p>
 
 <p align="center">

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -31,29 +31,12 @@ import { fileURLToPath } from "url";
 import { nextReconnectDelay, serializeAndValidateBody, shouldWarnInsecureApiUrl } from "./security-utils";
 import { stripSystemNoise, getContent as _getContent, getType as _getType, formatSurfacedMemories as _formatSurfacedMemories, formatToolCallContent } from "./string-utils";
 import { TokenTracker } from "./token-tracking";
+import { resolvePackageVersion } from "./version";
 
 const __filename = (typeof import.meta !== "undefined" && import.meta.url) ? fileURLToPath(import.meta.url) : "";
 const __dirname = __filename ? path.dirname(__filename) : process.cwd();
 
-// Resolve the package version from package.json so it cannot drift from the
-// published version. Tries the build layout (dist/index.js -> ../package.json)
-// then the dev layout (index.ts -> ./package.json); falls back to "unknown".
-function resolveVersion(): string {
-  const candidates = [
-    path.join(__dirname, "..", "package.json"),
-    path.join(__dirname, "package.json"),
-  ];
-  for (const candidate of candidates) {
-    try {
-      const pkg = JSON.parse(fs.readFileSync(candidate, "utf-8"));
-      if (typeof pkg.version === "string" && pkg.version) return pkg.version;
-    } catch {
-      // try next candidate
-    }
-  }
-  return "unknown";
-}
-const SERVER_VERSION = resolveVersion();
+const SERVER_VERSION = resolvePackageVersion(__dirname);
 
 // Configuration
 // Priority: SHODH_API_URL (full URL) > SHODH_HOST+SHODH_PORT (constructed) > localhost default

--- a/mcp-server/tests/version.test.ts
+++ b/mcp-server/tests/version.test.ts
@@ -1,0 +1,49 @@
+import path from "path";
+import { describe, expect, it } from "vitest";
+import { resolvePackageVersion } from "../version";
+
+function reader(files: Record<string, string>) {
+  return (filePath: string): string => {
+    const normalized = path.normalize(filePath);
+    const content = files[normalized];
+    if (content === undefined) {
+      throw new Error(`missing test file: ${normalized}`);
+    }
+    return content;
+  };
+}
+
+describe("resolvePackageVersion", () => {
+  it("reads the package version from the published dist layout", () => {
+    const root = path.join("pkg", "node_modules", "@shodh", "memory-mcp");
+    const baseDir = path.join(root, "dist");
+
+    expect(
+      resolvePackageVersion(
+        baseDir,
+        reader({
+          [path.normalize(path.join(root, "package.json"))]:
+            '{"version":"0.2.0"}',
+        }),
+      ),
+    ).toBe("0.2.0");
+  });
+
+  it("reads the package version from the development layout", () => {
+    const root = path.join("repo", "mcp-server");
+
+    expect(
+      resolvePackageVersion(
+        root,
+        reader({
+          [path.normalize(path.join(root, "package.json"))]:
+            '{"version":"0.2.1"}',
+        }),
+      ),
+    ).toBe("0.2.1");
+  });
+
+  it("falls back to unknown when no package version can be resolved", () => {
+    expect(resolvePackageVersion("repo/mcp-server", reader({}))).toBe("unknown");
+  });
+});

--- a/mcp-server/version.ts
+++ b/mcp-server/version.ts
@@ -1,0 +1,29 @@
+import fs from "fs";
+import path from "path";
+
+type ReadTextFile = (filePath: string) => string;
+
+function defaultReadTextFile(filePath: string): string {
+  return fs.readFileSync(filePath, "utf-8");
+}
+
+export function resolvePackageVersion(
+  baseDir: string,
+  readTextFile: ReadTextFile = defaultReadTextFile,
+): string {
+  const candidates = [
+    path.join(baseDir, "..", "package.json"),
+    path.join(baseDir, "package.json"),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      const pkg = JSON.parse(readTextFile(candidate));
+      if (typeof pkg.version === "string" && pkg.version) return pkg.version;
+    } catch {
+      // Try the next layout candidate.
+    }
+  }
+
+  return "unknown";
+}


### PR DESCRIPTION
## Why

Issue #360 reports the MCP wrapper logging `Shodh-Memory MCP server v0.1.90 running` while the backend `/health` endpoint reports `0.2.0`. The source already wants the wrapper version to come from package metadata, so this makes that path regression-tested and removes the remaining hard-coded `v0.1.90` from the MCP README.

## What

- Move MCP package-version resolution into a small `version.ts` helper.
- Keep both published `dist/index.js -> ../package.json` and development `index.ts -> ./package.json` layouts supported.
- Add unit coverage for both layouts and the `unknown` fallback.
- Remove the hard-coded `v0.1.90` badge text from `mcp-server/README.md`; the npm badge remains the source of displayed package version.

## Tested

- `bun -e ...` resolver smoke for dist layout, dev layout, and fallback
- `bun build index.ts --outdir "$tmpdir" --target node --external @modelcontextprotocol/sdk`
- `rg -n "0\.1\.90" mcp-server --glob "!node_modules"` (no matches)
- `git diff --check`

Not run locally: full `vitest` suite, because this checkout has no MCP server dependencies installed and both `bun install` / `npm exec --yes vitest` stalled while resolving packages.

Fixes #360