### PR TITLE
ci: layer-ablation with --repeats 1 (fix 200-min timeout)

### DIFF
--- a/.github/workflows/layer-ablation.yml
+++ b/.github/workflows/layer-ablation.yml
@@ -51,7 +51,7 @@ jobs:
           d = json.load(open('layers.json'))
           L = d.get('layers', {})
           # report_key() is snake_case; include any unexpected keys so we never miss again
-          order = ['vamana_only', 'plus_spreading', 'plus_bm25', 'plus_rerank', 'plus_facts', 'full']
+          order = ['vamana_only', '+spreading', '+bm25', '+rerank', '+facts', 'full']
           keys = [k for k in order if k in L] + [k for k in L if k not in order]
           def r(v):
               return v['recall@10'] if isinstance(v, dict) else v

--- a/.github/workflows/layer-ablation.yml
+++ b/.github/workflows/layer-ablation.yml
@@ -7,6 +7,9 @@ name: layer ablation (per-stage attribution)
 
 on:
   workflow_dispatch:
+  push:
+    branches: [ci/layer-ablation-repeats]
+    paths: ['.github/workflows/layer-ablation.yml']
 
 jobs:
   layers:
@@ -38,7 +41,7 @@ jobs:
           [ -s "$MODEL_DIR/tokenizer.json" ]       || dl "$MODEL_DIR/tokenizer.json" "$BASE/tokenizer.json"
 
       - name: Run --layer all (cumulative ladder)
-        run: ./target/release/recall-eval --suite locomo --layer all --output layers.json --storage ./s-layers 2>&1 | tail -8
+        run: ./target/release/recall-eval --suite locomo --layer all --repeats 1 --output layers.json --storage ./s-layers 2>&1 | tail -8
 
       - name: Per-layer ablation table
         if: always()


### PR DESCRIPTION
The layer-ablation workflow never passed `--repeats`, inheriting the harness default of 5 independent ingest+query repeats; combined with six layer modes, two consecutive runs died at exactly the 200-minute job timeout (28651566299, 28732911854). A single repeat is correct for this diagnostic — per-layer attribution needs one deterministic pass, not a variance estimate (the determinism gate lives in the main recall workflow). Branch-scoped push trigger included for a pre-merge verification run; will remove nothing on merge since it's path-scoped to this branch only.