### PR TITLE
feat(ner): vendor spacy-rusty dependency parser in-engine (ER Phase 1.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,12 +384,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1198,11 +1213,22 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -3732,6 +3758,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "safetensors"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3802,7 +3838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80ee4d89b4a3f29cd09fc8dd79c26531298035276cdfd0673ec7e543fff32e51"
 dependencies = [
  "either",
- "fancy-regex",
+ "fancy-regex 0.14.0",
  "htmlize",
  "itertools 0.14.0",
 ]
@@ -3821,6 +3857,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4048,6 +4095,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "spacy-rusty",
  "tantivy",
  "tar",
  "tempfile",
@@ -4129,6 +4177,18 @@ checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "spacy-rusty"
+version = "0.1.0"
+dependencies = [
+ "fancy-regex 0.13.0",
+ "safetensors",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,10 @@ name = "recall-eval"
 path = "src/bin/recall_eval.rs"
 
 [dependencies]
+# Vendored pure-Rust spaCy pipeline (dependency-head parser + POS + lemma) for
+# entity-resolution span-cleaning. Native, no external fetch. Model bundle loaded
+# at runtime from SHODH_SPACY_MODEL_PATH (asset not committed, like GLiNER/MiniLM).
+spacy-rusty = { path = "crates/spacy-rusty" }
 # MCP Protocol
 rmcp = { version = "0.12", features = ["server", "macros", "transport-io"] }
 clap = { version = "4.5", features = ["derive", "env"] }
@@ -317,3 +321,4 @@ rocksdb = { version = "0.24", default-features = false, features = ["lz4"] }
 
 [workspace]
 # Standalone workspace - not part of parent kalki-v2
+members = ["crates/spacy-rusty"]

--- a/crates/spacy-rusty/Cargo.toml
+++ b/crates/spacy-rusty/Cargo.toml
@@ -1,0 +1,40 @@
+# Vendored from https://github.com/maymaywa/spacy-rusty (MIT OR Apache-2.0).
+# A pure-Rust reimplementation of spaCy's English pipeline (tokenizer, tagger,
+# parser, lemmatizer, NER, vectors) loading weights exported from en_core_web_sm.
+# Vendored (not a git/path dep to an external checkout) for sovereignty: the
+# engine ships deterministic, auditable, no external fetch. See NOTICE for the
+# spaCy attribution. Model bundle (model.json + model.safetensors, ~15 MB) is
+# NOT committed — it is loaded at runtime from SHODH_SPACY_MODEL_PATH, mirroring
+# the GLiNER/MiniLM asset convention.
+[package]
+name = "spacy-rusty"
+version = "0.1.0"
+edition = "2021"
+description = "spaCy's English pipeline (tokens, POS, parser, lemmatizer, NER, vectors) as pure Rust — no Python."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/maymaywa/spacy-rusty"
+keywords = ["nlp", "spacy", "ner", "parser"]
+categories = ["text-processing", "science"]
+
+[features]
+# In-engine we build native only; the wasm bindings (bindgen/capi) are
+# target_arch = "wasm32" gated and never compile here. Default off so no wasm
+# binding code is even referenced in the native build graph.
+default = []
+bindgen = []  # wasm-bindgen browser bindings (mod wasm)
+capi = []     # plain C-ABI exports for wasmtime / non-JS hosts (mod capi)
+
+[dependencies]
+fancy-regex = "0.13"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+safetensors = "0.4"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.6"
+
+[lib]
+# rlib only: consumed as a normal Rust library by shodh-memory. The upstream
+# cdylib target exists for wasm; we do not need it in-engine.
+crate-type = ["rlib"]

--- a/crates/spacy-rusty/LICENSE-APACHE
+++ b/crates/spacy-rusty/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work, excluding
+          those notices that do not pertain to any part of the Derivative
+          Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one of
+          the following places: within a NOTICE text file distributed as
+          part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and do
+          not modify the License. You may add Your own attribution notices
+          within Derivative Works that You distribute, alongside or as an
+          addendum to the NOTICE text from the Work, provided that such
+          additional attribution notices cannot be construed as modifying
+          the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Mayer Unterberg
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/spacy-rusty/LICENSE-MIT
+++ b/crates/spacy-rusty/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mayer Unterberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/spacy-rusty/NOTICE
+++ b/crates/spacy-rusty/NOTICE
@@ -1,0 +1,39 @@
+spacy-rusty
+Copyright 2026 Mayer Unterberg
+
+This product is an independent, clean-room-style reimplementation of the
+inference pipeline of spaCy and its machine-learning library Thinc. It is not
+affiliated with or endorsed by Explosion AI.
+
+spaCy and Thinc are developed by Explosion AI and released under the MIT
+License:
+
+  - spaCy — https://github.com/explosion/spaCy   (MIT License)
+  - Thinc — https://github.com/explosion/thinc    (MIT License)
+
+At runtime, spacy-rusty loads model artifacts (weights, vocab, tokenizer rules,
+labels) that are exported from spaCy's own trained pipelines
+(en_core_web_sm / md / lg). Those model artifacts are the property of their
+respective authors and are distributed under their own licenses (the
+en_core_web_* models are released by Explosion AI under the MIT License).
+Users who redistribute exported model bundles are responsible for complying
+with the license of the corresponding spaCy model.
+
+No spaCy or Thinc source code is included in this repository. Algorithm
+behavior was matched against spaCy's public releases and verified with golden
+fixtures generated from spaCy itself.
+
+--------------------------------------------------------------------------------
+Modifications by the shodh-memory project (vendored copy)
+--------------------------------------------------------------------------------
+
+This is a vendored copy of spacy-rusty. The following changes were made from
+the upstream source and do not alter any numerical inference output:
+
+  - Shared static-vector table changed from `Rc<Vectors>` to `Arc<Vectors>`
+    (ner.rs, pipeline.rs, tok2vec.rs) so a single loaded pipeline can be shared
+    read-only across the server's async worker threads. Refcount primitive only;
+    identical parse/tag/lemma results.
+  - Cargo.toml: crate-type reduced to `rlib` and default features set to none
+    (the wasm bindgen/capi bindings are target_arch = "wasm32" gated and unused
+    in-engine); the workspace root owns the release profile.

--- a/crates/spacy-rusty/rustfmt.toml
+++ b/crates/spacy-rusty/rustfmt.toml
@@ -1,0 +1,2 @@
+# Vendored crate: tracked to upstream, not reformatted to our style.
+disable_all_formatting = true

--- a/crates/spacy-rusty/src/attribute_ruler.rs
+++ b/crates/spacy-rusty/src/attribute_ruler.rs
@@ -1,0 +1,228 @@
+//! attribute_ruler: maps fine-grained TAG (+ LOWER/ORTH/DEP/IS_SPACE rules,
+//! including Matcher operators IN/NOT_IN/REGEX) to coarse POS, MORPH, TAG.
+//! Patterns apply in manifest order (later overrides earlier), matching spaCy.
+
+use crate::lexeme::is_space;
+use fancy_regex::Regex;
+use serde_json::Value;
+use std::collections::HashSet;
+
+#[derive(Default, Clone)]
+pub struct Anno {
+    pub text: String,
+    pub tag: String,
+    pub pos: String,
+    pub morph: String,
+    pub dep: String,
+    pub lemma: String, // set by LEMMA patterns (irregulars/pronouns); "" = unset
+}
+
+enum Attr {
+    Tag,
+    Lower,
+    Orth,
+    Dep,
+    Pos,
+}
+
+enum Constraint {
+    Eq(String),
+    In(HashSet<String>),
+    NotIn(HashSet<String>),
+    Regex(Regex),
+}
+
+struct TokenSpec {
+    // string-attr constraints
+    str_c: Vec<(Attr, Constraint)>,
+    is_space: Option<bool>,
+    /// a key/value we couldn't interpret -> this spec can never match
+    unmatchable: bool,
+}
+
+struct Pattern {
+    specs: Vec<TokenSpec>,
+    index: i64,
+    set_tag: Option<String>,
+    set_pos: Option<String>,
+    set_morph: Option<String>,
+    set_lemma: Option<String>,
+}
+
+pub struct AttributeRuler {
+    patterns: Vec<Pattern>,
+}
+
+fn attr_of(key: &str) -> Option<Attr> {
+    match key {
+        "TAG" => Some(Attr::Tag),
+        "LOWER" => Some(Attr::Lower),
+        "ORTH" | "TEXT" => Some(Attr::Orth),
+        "DEP" => Some(Attr::Dep),
+        "POS" => Some(Attr::Pos),
+        _ => None,
+    }
+}
+
+fn set_of(v: &Value) -> HashSet<String> {
+    v.as_array()
+        .map(|a| a.iter().filter_map(|x| x.as_str().map(|s| s.to_string())).collect())
+        .unwrap_or_default()
+}
+
+fn parse_spec(v: &Value) -> TokenSpec {
+    let mut spec = TokenSpec { str_c: vec![], is_space: None, unmatchable: false };
+    let obj = match v.as_object() {
+        Some(o) => o,
+        None => {
+            spec.unmatchable = true;
+            return spec;
+        }
+    };
+    for (key, val) in obj {
+        if key == "IS_SPACE" {
+            match val.as_bool() {
+                Some(b) => spec.is_space = Some(b),
+                None => spec.unmatchable = true,
+            }
+            continue;
+        }
+        let attr = match attr_of(key) {
+            Some(a) => a,
+            None => {
+                spec.unmatchable = true; // unknown key -> can't match safely
+                continue;
+            }
+        };
+        let constraint = if let Some(s) = val.as_str() {
+            Constraint::Eq(s.to_string())
+        } else if let Some(o) = val.as_object() {
+            if let Some(inv) = o.get("IN") {
+                Constraint::In(set_of(inv))
+            } else if let Some(ni) = o.get("NOT_IN") {
+                Constraint::NotIn(set_of(ni))
+            } else if let Some(rx) = o.get("REGEX").and_then(|x| x.as_str()) {
+                match Regex::new(rx) {
+                    Ok(r) => Constraint::Regex(r),
+                    Err(_) => {
+                        spec.unmatchable = true;
+                        continue;
+                    }
+                }
+            } else {
+                spec.unmatchable = true;
+                continue;
+            }
+        } else {
+            spec.unmatchable = true;
+            continue;
+        };
+        spec.str_c.push((attr, constraint));
+    }
+    spec
+}
+
+impl AttributeRuler {
+    pub fn load(man: &Value) -> AttributeRuler {
+        let mut patterns = Vec::new();
+        if let Some(arr) = man["attribute_ruler"]["patterns"].as_array() {
+            for p in arr {
+                let attrs = &p["attrs"];
+                let index = p["index"].as_i64().unwrap_or(0);
+                let set_tag = attrs.get("TAG").and_then(|x| x.as_str()).map(|s| s.to_string());
+                let set_pos = attrs.get("POS").and_then(|x| x.as_str()).map(|s| s.to_string());
+                let set_morph = attrs.get("MORPH").and_then(|x| x.as_str()).map(|s| s.to_string());
+                let set_lemma = attrs.get("LEMMA").and_then(|x| x.as_str()).map(|s| s.to_string());
+                // A single AR entry may hold several alternative token-patterns
+                // (e.g. [[gets], [got]]) sharing the same attrs — emit one
+                // internal pattern per alternative.
+                let Some(alts) = p["patterns"].as_array() else { continue };
+                for alt in alts {
+                    let specs: Vec<TokenSpec> = alt
+                        .as_array()
+                        .map(|toks| toks.iter().map(parse_spec).collect())
+                        .unwrap_or_default();
+                    if specs.is_empty() {
+                        continue;
+                    }
+                    patterns.push(Pattern {
+                        specs,
+                        index,
+                        set_tag: set_tag.clone(),
+                        set_pos: set_pos.clone(),
+                        set_morph: set_morph.clone(),
+                        set_lemma: set_lemma.clone(),
+                    });
+                }
+            }
+        }
+        AttributeRuler { patterns }
+    }
+
+    fn token_val(attr: &Attr, t: &Anno) -> String {
+        match attr {
+            Attr::Tag => t.tag.clone(),
+            Attr::Lower => t.text.to_lowercase(),
+            Attr::Orth => t.text.clone(),
+            Attr::Dep => t.dep.clone(),
+            Attr::Pos => t.pos.clone(),
+        }
+    }
+
+    fn spec_matches(spec: &TokenSpec, t: &Anno) -> bool {
+        if spec.unmatchable {
+            return false;
+        }
+        if let Some(b) = spec.is_space {
+            if is_space(&t.text) != b {
+                return false;
+            }
+        }
+        for (attr, c) in &spec.str_c {
+            let tv = Self::token_val(attr, t);
+            let ok = match c {
+                Constraint::Eq(v) => &tv == v,
+                Constraint::In(set) => set.contains(&tv),
+                Constraint::NotIn(set) => !set.contains(&tv),
+                Constraint::Regex(r) => r.is_match(&tv).unwrap_or(false),
+            };
+            if !ok {
+                return false;
+            }
+        }
+        true
+    }
+
+    pub fn apply(&self, toks: &mut [Anno]) {
+        let n = toks.len();
+        for p in &self.patterns {
+            let plen = p.specs.len();
+            if plen == 0 || plen > n {
+                continue;
+            }
+            for start in 0..=(n - plen) {
+                if (0..plen).all(|k| Self::spec_matches(&p.specs[k], &toks[start + k])) {
+                    let idx = if p.index >= 0 {
+                        start + p.index as usize
+                    } else {
+                        ((start + plen) as i64 + p.index) as usize
+                    };
+                    if idx < n {
+                        if let Some(ref v) = p.set_tag {
+                            toks[idx].tag = v.clone();
+                        }
+                        if let Some(ref v) = p.set_pos {
+                            toks[idx].pos = v.clone();
+                        }
+                        if let Some(ref v) = p.set_morph {
+                            toks[idx].morph = if v == "_" { String::new() } else { v.clone() };
+                        }
+                        if let Some(ref v) = p.set_lemma {
+                            toks[idx].lemma = v.clone();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/spacy-rusty/src/capi.rs
+++ b/crates/spacy-rusty/src/capi.rs
@@ -1,0 +1,136 @@
+//! Plain C-ABI exports (no wasm-bindgen) so the runtime can be driven from any
+//! WASM host — e.g. `wasmtime` in Python. The host allocates buffers with
+//! `rt_alloc`, copies the bundle bytes in, calls `rt_load` to get an opaque
+//! pipeline handle, then `rt_process(handle, text)` which returns a pointer to
+//! UTF-8 JSON (the full Doc) and writes its length through `out_len`. Free
+//! returned/own buffers with `rt_free`.
+//!
+//! Build: `cargo build --target wasm32-unknown-unknown --release \
+//!         --no-default-features --features capi`
+
+use crate::pipeline::Pipeline;
+use std::alloc::{alloc, dealloc, Layout};
+use std::slice;
+
+fn layout(len: usize) -> Layout {
+    Layout::from_size_align(len.max(1), 1).unwrap()
+}
+
+/// Allocate `len` bytes in WASM linear memory; returns the pointer.
+#[no_mangle]
+pub extern "C" fn rt_alloc(len: usize) -> *mut u8 {
+    unsafe { alloc(layout(len)) }
+}
+
+/// Free a buffer previously returned by `rt_alloc`/`rt_process`.
+#[no_mangle]
+pub extern "C" fn rt_free(ptr: *mut u8, len: usize) {
+    if !ptr.is_null() {
+        unsafe { dealloc(ptr, layout(len)) }
+    }
+}
+
+/// Build a pipeline from bundle bytes. `k_*` may be (null, 0) when the model
+/// has no static vectors. Returns an opaque handle (leaked `Box<Pipeline>`),
+/// or null on failure. Free with `rt_drop`.
+///
+/// # Safety
+/// Pointers must reference `*_len` valid bytes in WASM memory.
+#[no_mangle]
+pub unsafe extern "C" fn rt_load(
+    m_ptr: *const u8,
+    m_len: usize,
+    st_ptr: *const u8,
+    st_len: usize,
+    k_ptr: *const u8,
+    k_len: usize,
+    r_ptr: *const u8,
+    r_len: usize,
+) -> *mut Pipeline {
+    let manifest = match std::str::from_utf8(slice::from_raw_parts(m_ptr, m_len)) {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null_mut(),
+    };
+    let st = slice::from_raw_parts(st_ptr, st_len);
+    let k2r = if k_len > 0 {
+        std::str::from_utf8(slice::from_raw_parts(k_ptr, k_len)).ok()
+    } else {
+        None
+    };
+    let r2w = if r_len > 0 {
+        std::str::from_utf8(slice::from_raw_parts(r_ptr, r_len)).ok()
+    } else {
+        None
+    };
+    let pipe = Pipeline::from_bytes_full(manifest, st, k2r, r2w);
+    Box::into_raw(Box::new(pipe))
+}
+
+/// Free a pipeline handle from `rt_load`.
+///
+/// # Safety
+/// `handle` must be a live pointer from `rt_load`.
+#[no_mangle]
+pub unsafe extern "C" fn rt_drop(handle: *mut Pipeline) {
+    if !handle.is_null() {
+        drop(Box::from_raw(handle));
+    }
+}
+
+/// Process `text` and return a pointer to UTF-8 JSON (the full Doc), writing
+/// its byte length through `out_len`. Free the returned buffer with `rt_free`.
+///
+/// # Safety
+/// `handle` must be from `rt_load`; `text_ptr`/`text_len` valid; `out_len` writable.
+#[no_mangle]
+pub unsafe extern "C" fn rt_process(
+    handle: *mut Pipeline,
+    text_ptr: *const u8,
+    text_len: usize,
+    out_len: *mut usize,
+) -> *mut u8 {
+    let pipe = &*handle;
+    let text = match std::str::from_utf8(slice::from_raw_parts(text_ptr, text_len)) {
+        Ok(s) => s,
+        Err(_) => {
+            *out_len = 0;
+            return std::ptr::null_mut();
+        }
+    };
+    let doc = pipe.process(text);
+    let json = serde_json::to_string(&doc).unwrap_or_else(|_| "{}".into());
+    let bytes = json.into_bytes();
+    let len = bytes.len();
+    let out = rt_alloc(len);
+    std::ptr::copy_nonoverlapping(bytes.as_ptr(), out, len);
+    *out_len = len;
+    out
+}
+
+/// Process `text` and return spaCy `Doc.to_json()`-shaped JSON (see `rt_process`).
+///
+/// # Safety
+/// Same as `rt_process`.
+#[no_mangle]
+pub unsafe extern "C" fn rt_to_json(
+    handle: *mut Pipeline,
+    text_ptr: *const u8,
+    text_len: usize,
+    out_len: *mut usize,
+) -> *mut u8 {
+    let pipe = &*handle;
+    let text = match std::str::from_utf8(slice::from_raw_parts(text_ptr, text_len)) {
+        Ok(s) => s,
+        Err(_) => {
+            *out_len = 0;
+            return std::ptr::null_mut();
+        }
+    };
+    let json = pipe.process(text).to_spacy_json().to_string();
+    let bytes = json.into_bytes();
+    let len = bytes.len();
+    let out = rt_alloc(len);
+    std::ptr::copy_nonoverlapping(bytes.as_ptr(), out, len);
+    *out_len = len;
+    out
+}

--- a/crates/spacy-rusty/src/features.rs
+++ b/crates/spacy-rusty/src/features.rs
@@ -1,0 +1,81 @@
+//! Compute the tok2vec feature keys for a token from text, including NORM
+//! resolution (special-case override -> lexeme_norm lookup -> BASE_NORMS ->
+//! lowercase), matching spaCy.
+
+use crate::hash::string_id;
+use crate::lexeme;
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub struct Features {
+    pub symbols: HashMap<String, u64>,
+    /// lexeme_norm lookups, keyed by string_id(orth)
+    lexeme_norm: HashMap<u64, String>,
+    /// BASE_NORMS, keyed by orth string
+    base_norms: HashMap<String, String>,
+}
+
+impl Features {
+    pub fn from_manifest(man: &Value) -> Features {
+        let mut symbols = HashMap::new();
+        if let Some(obj) = man["symbols"].as_object() {
+            for (k, v) in obj {
+                if let Some(n) = v.as_u64() {
+                    symbols.insert(k.clone(), n);
+                }
+            }
+        }
+        let mut lexeme_norm = HashMap::new();
+        if let Some(obj) = man["norm_exceptions"].as_object() {
+            for (k, v) in obj {
+                if let (Ok(h), Some(s)) = (k.parse::<u64>(), v.as_str()) {
+                    lexeme_norm.insert(h, s.to_string());
+                }
+            }
+        }
+        let mut base_norms = HashMap::new();
+        if let Some(obj) = man["base_norms"].as_object() {
+            for (k, v) in obj {
+                if let Some(s) = v.as_str() {
+                    base_norms.insert(k.clone(), s.to_string());
+                }
+            }
+        }
+        Features { symbols, lexeme_norm, base_norms }
+    }
+
+    pub fn sid(&self, s: &str) -> u64 {
+        string_id(s, &self.symbols)
+    }
+
+    pub fn norm(&self, text: &str, override_norm: Option<&str>) -> String {
+        if let Some(n) = override_norm {
+            return n.to_string();
+        }
+        if let Some(n) = self.lexeme_norm.get(&string_id(text, &self.symbols)) {
+            return n.clone();
+        }
+        if let Some(n) = self.base_norms.get(text) {
+            return n.clone();
+        }
+        text.to_lowercase()
+    }
+
+    /// The 6 feature keys [NORM, PREFIX, SUFFIX, SHAPE, SPACY, IS_SPACE].
+    pub fn keys(&self, text: &str, norm_override: Option<&str>, trailing_space: bool) -> Vec<u64> {
+        let norm = self.norm(text, norm_override);
+        vec![
+            self.sid(&norm),
+            self.sid(&lexeme::prefix(text)),
+            self.sid(&lexeme::suffix(text)),
+            self.sid(&lexeme::shape(text)),
+            if trailing_space { 1 } else { 0 },
+            if lexeme::is_space(text) { 1 } else { 0 },
+        ]
+    }
+
+    /// ORTH key for static-vector lookup.
+    pub fn orth(&self, text: &str) -> u64 {
+        self.sid(text)
+    }
+}

--- a/crates/spacy-rusty/src/hash.rs
+++ b/crates/spacy-rusty/src/hash.rs
@@ -1,0 +1,116 @@
+//! The two hash functions spaCy/Thinc use, ported bit-exactly.
+//!
+//! 1. `hash_string` — spaCy StringStore: MurmurHash64A over UTF-8 bytes, seed 1
+//!    (spacy/strings.pyx -> murmurhash.mrmr.hash64). Turns an attr string into
+//!    the u64 feature key.
+//! 2. `hashembed_hashes` — Thinc HashEmbed: MurmurHash3_x86_128_uint64 over the
+//!    u64 key (thinc/backends/numpy_ops.pyx). Pure u64 arithmetic, no byte reads
+//!    -> endianness-independent. Returns 4 u32; each `% nV` indexes a row, and
+//!    the 4 rows are gather-summed.
+
+use std::collections::HashMap;
+
+/// spaCy StringStore hash: MurmurHash64A(bytes, seed=1).
+pub fn hash_string(s: &str) -> u64 {
+    murmurhash64a(s.as_bytes(), 1)
+}
+
+/// spaCy `get_string_id`: registered symbols return their reserved integer id;
+/// the empty string returns 0; everything else hashes via `hash_string`.
+pub fn string_id(s: &str, symbols: &HashMap<String, u64>) -> u64 {
+    if s.is_empty() {
+        return 0;
+    }
+    if let Some(&id) = symbols.get(s) {
+        return id;
+    }
+    hash_string(s)
+}
+
+fn murmurhash64a(data: &[u8], seed: u64) -> u64 {
+    const M: u64 = 0xc6a4a7935bd1e995;
+    const R: u32 = 47;
+    let len = data.len();
+    let mut h: u64 = seed ^ (len as u64).wrapping_mul(M);
+
+    let nblocks = len / 8;
+    for i in 0..nblocks {
+        let mut k = u64::from_le_bytes(data[i * 8..i * 8 + 8].try_into().unwrap());
+        k = k.wrapping_mul(M);
+        k ^= k >> R;
+        k = k.wrapping_mul(M);
+        h ^= k;
+        h = h.wrapping_mul(M);
+    }
+
+    let tail = &data[nblocks * 8..];
+    let rem = len & 7;
+    // MurmurHash64A tail switch (fallthrough high->low byte, then one *M).
+    if rem >= 7 {
+        h ^= (tail[6] as u64) << 48;
+    }
+    if rem >= 6 {
+        h ^= (tail[5] as u64) << 40;
+    }
+    if rem >= 5 {
+        h ^= (tail[4] as u64) << 32;
+    }
+    if rem >= 4 {
+        h ^= (tail[3] as u64) << 24;
+    }
+    if rem >= 3 {
+        h ^= (tail[2] as u64) << 16;
+    }
+    if rem >= 2 {
+        h ^= (tail[1] as u64) << 8;
+    }
+    if rem >= 1 {
+        h ^= tail[0] as u64;
+        h = h.wrapping_mul(M);
+    }
+
+    h ^= h >> R;
+    h = h.wrapping_mul(M);
+    h ^= h >> R;
+    h
+}
+
+#[inline]
+fn fmix64(mut k: u64) -> u64 {
+    k ^= k >> 33;
+    k = k.wrapping_mul(0xff51afd7ed558ccd);
+    k ^= k >> 33;
+    k = k.wrapping_mul(0xc4ceb9fe1a85ec53);
+    k ^= k >> 33;
+    k
+}
+
+/// Thinc HashEmbed hash: MurmurHash3_x86_128_uint64(val, seed) -> 4 u32.
+pub fn hashembed_hashes(val: u64, seed: u32) -> [u32; 4] {
+    let mut h1: u64 = val;
+    h1 = h1.wrapping_mul(0x87c37b91114253d5);
+    h1 = h1.rotate_left(31);
+    h1 = h1.wrapping_mul(0x4cf5ad432745937f);
+    h1 ^= seed as u64;
+    h1 ^= 8;
+    let mut h2: u64 = seed as u64;
+    h2 ^= 8;
+    h1 = h1.wrapping_add(h2);
+    h2 = h2.wrapping_add(h1);
+    h1 = fmix64(h1);
+    h2 = fmix64(h2);
+    h1 = h1.wrapping_add(h2);
+    h2 = h2.wrapping_add(h1);
+    [
+        (h1 & 0xffff_ffff) as u32,
+        (h1 >> 32) as u32,
+        (h2 & 0xffff_ffff) as u32,
+        (h2 >> 32) as u32,
+    ]
+}
+
+/// The 4 embedding row indices for a key in a table of `n_rows` rows.
+pub fn hashembed_rows(val: u64, seed: u32, n_rows: u32) -> [u32; 4] {
+    let h = hashembed_hashes(val, seed);
+    [h[0] % n_rows, h[1] % n_rows, h[2] % n_rows, h[3] % n_rows]
+}

--- a/crates/spacy-rusty/src/lemmatizer.rs
+++ b/crates/spacy-rusty/src/lemmatizer.rs
@@ -1,0 +1,183 @@
+//! Rule-based lemmatizer (spaCy mode="rule"): per-POS suffix rules + word
+//! exceptions + a valid-lemma index, with an English `is_base_form`
+//! short-circuit over the morphological features. Faithful port of
+//! spacy/pipeline/lemmatizer.py::rule_lemmatize and
+//! spacy/lang/en/lemmatizer.py::is_base_form. Returns the first candidate lemma
+//! (spaCy assigns token.lemma_ = lemmatize(token)[0]).
+
+use crate::model::Bundle;
+use std::collections::{HashMap, HashSet};
+
+struct PosTables {
+    rules: Vec<(String, String)>,        // (old_suffix, new_suffix)
+    exc: HashMap<String, Vec<String>>,   // surface (lowercased) -> lemmas
+    index: HashSet<String>,              // valid lemmas
+}
+
+pub struct Lemmatizer {
+    tables: HashMap<String, PosTables>, // keyed by lowercase UPOS
+}
+
+impl Lemmatizer {
+    pub fn load(b: &Bundle) -> Option<Lemmatizer> {
+        let lem = b.manifest.get("lemmatizer")?;
+        if lem.is_null() {
+            return None;
+        }
+        let tbls = &lem["tables"];
+        let (rules_t, exc_t, index_t) =
+            (&tbls["lemma_rules"], &tbls["lemma_exc"], &tbls["lemma_index"]);
+
+        let mut pos_keys: HashSet<String> = HashSet::new();
+        for t in [rules_t, exc_t, index_t] {
+            if let Some(o) = t.as_object() {
+                pos_keys.extend(o.keys().cloned());
+            }
+        }
+        let mut tables = HashMap::new();
+        for pos in pos_keys {
+            let rules = rules_t
+                .get(&pos)
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|p| {
+                            let p = p.as_array()?;
+                            let old = p.first()?.as_str()?.to_string();
+                            let new = p.get(1).and_then(|x| x.as_str()).unwrap_or("").to_string();
+                            Some((old, new))
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let exc = exc_t
+                .get(&pos)
+                .and_then(|v| v.as_object())
+                .map(|o| {
+                    o.iter()
+                        .map(|(w, lemmas)| {
+                            let ls = lemmas
+                                .as_array()
+                                .map(|a| a.iter().filter_map(|x| x.as_str().map(String::from)).collect())
+                                .unwrap_or_default();
+                            (w.clone(), ls)
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let index = index_t
+                .get(&pos)
+                .and_then(|v| v.as_array())
+                .map(|a| a.iter().filter_map(|x| x.as_str().map(String::from)).collect())
+                .unwrap_or_default();
+            tables.insert(pos, PosTables { rules, exc, index });
+        }
+        Some(Lemmatizer { tables })
+    }
+
+    /// Lemmatize one token from its surface text, final UPOS, and morph features.
+    pub fn lemmatize(&self, text: &str, pos: &str, morph: &HashMap<String, String>) -> String {
+        let univ_pos = pos.to_lowercase();
+        if univ_pos.is_empty() || univ_pos == "eol" || univ_pos == "space" {
+            return text.to_lowercase();
+        }
+        if is_base_form(&univ_pos, morph) {
+            return text.to_lowercase();
+        }
+        let tbl = self.tables.get(&univ_pos);
+        let has_any = tbl
+            .map(|t| !t.index.is_empty() || !t.exc.is_empty() || !t.rules.is_empty())
+            .unwrap_or(false);
+        if !has_any {
+            return if univ_pos == "propn" { text.to_string() } else { text.to_lowercase() };
+        }
+        let tbl = tbl.unwrap();
+        let orig = text.to_string();
+        let string = text.to_lowercase();
+        let mut forms: Vec<String> = Vec::new();
+        let mut oov: Vec<String> = Vec::new();
+        for (old, new) in &tbl.rules {
+            if string.ends_with(old.as_str()) {
+                let form = format!("{}{}", &string[..string.len() - old.len()], new);
+                if form.is_empty() {
+                    // pass
+                } else if tbl.index.contains(&form) {
+                    forms.insert(0, form); // in-vocab -> front
+                } else if !is_alpha(&form) {
+                    forms.push(form); // non-alpha (e.g. punctuation) -> back
+                } else {
+                    oov.push(form);
+                }
+            }
+        }
+        dedupe_in_place(&mut forms);
+        // exceptions take priority (inserted at the front)
+        if let Some(exs) = tbl.exc.get(&string) {
+            for form in exs {
+                if !forms.contains(form) {
+                    forms.insert(0, form.clone());
+                }
+            }
+        }
+        if forms.is_empty() {
+            forms.extend(oov);
+        }
+        if forms.is_empty() {
+            forms.push(orig);
+        }
+        forms.into_iter().next().unwrap()
+    }
+}
+
+fn is_base_form(univ_pos: &str, m: &HashMap<String, String>) -> bool {
+    let get = |k: &str| m.get(k).map(|s| s.as_str());
+    if univ_pos == "noun" && get("Number") == Some("Sing") {
+        return true;
+    }
+    if univ_pos == "verb" && get("VerbForm") == Some("Inf") {
+        return true;
+    }
+    if univ_pos == "verb"
+        && get("VerbForm") == Some("Fin")
+        && get("Tense") == Some("Pres")
+        && get("Number").is_none()
+    {
+        return true;
+    }
+    if univ_pos == "adj" && get("Degree") == Some("Pos") {
+        return true;
+    }
+    if get("VerbForm") == Some("Inf") {
+        return true;
+    }
+    if get("VerbForm") == Some("None") {
+        return true; // spaCy literally compares to the string "None"
+    }
+    if get("Degree") == Some("Pos") {
+        return true;
+    }
+    false
+}
+
+fn is_alpha(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_alphabetic())
+}
+
+fn dedupe_in_place(v: &mut Vec<String>) {
+    let mut seen = HashSet::new();
+    v.retain(|x| seen.insert(x.clone()));
+}
+
+/// Parse spaCy's `str(token.morph)` ("Feat=Val|Feat2=Val2", or "" / "_") into a map.
+pub fn parse_morph(s: &str) -> HashMap<String, String> {
+    let mut m = HashMap::new();
+    if s.is_empty() || s == "_" {
+        return m;
+    }
+    for feat in s.split('|') {
+        if let Some((k, v)) = feat.split_once('=') {
+            m.insert(k.to_string(), v.to_string());
+        }
+    }
+    m
+}

--- a/crates/spacy-rusty/src/lexeme.rs
+++ b/crates/spacy-rusty/src/lexeme.rs
@@ -1,0 +1,192 @@
+//! Lexical attributes feeding tok2vec: NORM, PREFIX, SUFFIX, SHAPE, SPACY,
+//! IS_SPACE — computed to match spaCy's Lexeme / lang.lex_attrs.
+
+use std::collections::HashMap;
+
+/// NORM: lowercased orth, overridden by the `lexeme_norm` lookup table when
+/// present. (Per-token special-case NORM overrides are applied at the token
+/// level, not here.)
+pub fn norm(text: &str, norm_table: &HashMap<String, String>) -> String {
+    if let Some(n) = norm_table.get(text) {
+        return n.clone();
+    }
+    text.to_lowercase()
+}
+
+/// PREFIX: first character of the orth.
+pub fn prefix(text: &str) -> String {
+    text.chars().next().map(|c| c.to_string()).unwrap_or_default()
+}
+
+/// SUFFIX: last 3 characters of the orth.
+pub fn suffix(text: &str) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    let start = chars.len().saturating_sub(3);
+    chars[start..].iter().collect()
+}
+
+/// SHAPE: spaCy `word_shape` — alpha->X/x, digit->d, other->self, runs of the
+/// same shape-char capped at 4.
+pub fn shape(text: &str) -> String {
+    if text.chars().count() >= 100 {
+        return "LONG".to_string();
+    }
+    let mut out = String::new();
+    let mut last: Option<char> = None;
+    let mut seq = 0usize;
+    for c in text.chars() {
+        let sc = if c.is_alphabetic() {
+            if c.is_uppercase() {
+                'X'
+            } else {
+                'x'
+            }
+        } else if c.is_ascii_digit() {
+            'd'
+        } else {
+            c
+        };
+        if last == Some(sc) {
+            seq += 1;
+        } else {
+            seq = 0;
+            last = Some(sc);
+        }
+        if seq < 4 {
+            out.push(sc);
+        }
+    }
+    out
+}
+
+/// IS_SPACE: orth is non-empty and entirely whitespace.
+pub fn is_space(text: &str) -> bool {
+    !text.is_empty() && text.chars().all(|c| c.is_whitespace())
+}
+
+/// IS_ALPHA: non-empty and every char is alphabetic (Python `str.isalpha`).
+pub fn is_alpha(text: &str) -> bool {
+    !text.is_empty() && text.chars().all(|c| c.is_alphabetic())
+}
+
+/// IS_DIGIT: non-empty and every char is an ASCII digit (Python `str.isdigit`).
+pub fn is_digit(text: &str) -> bool {
+    !text.is_empty() && text.chars().all(|c| c.is_ascii_digit())
+}
+
+/// IS_PUNCT: non-empty and every char is punctuation.
+pub fn is_punct(text: &str) -> bool {
+    !text.is_empty()
+        && text.chars().all(|c| {
+            c.is_ascii_punctuation()
+                || matches!(c, '\u{00A1}' | '\u{00BF}' | '\u{2010}'..='\u{2027}' | '\u{2030}'..='\u{205E}')
+        })
+}
+
+/// IS_LOWER: has a cased char and all cased chars are lowercase (`str.islower`).
+pub fn is_lower(text: &str) -> bool {
+    let mut cased = false;
+    for c in text.chars() {
+        if c.is_uppercase() {
+            return false;
+        }
+        if c.is_lowercase() {
+            cased = true;
+        }
+    }
+    cased
+}
+
+/// IS_UPPER: has a cased char and all cased chars are uppercase (`str.isupper`).
+pub fn is_upper(text: &str) -> bool {
+    let mut cased = false;
+    for c in text.chars() {
+        if c.is_lowercase() {
+            return false;
+        }
+        if c.is_uppercase() {
+            cased = true;
+        }
+    }
+    cased
+}
+
+/// IS_TITLE: Python `str.istitle` — every run of cased chars starts uppercase
+/// and continues lowercase, with at least one such run.
+pub fn is_title(text: &str) -> bool {
+    let mut cased = false;
+    let mut prev_cased = false; // previous char was a cased letter
+    for c in text.chars() {
+        if c.is_uppercase() {
+            if prev_cased {
+                return false; // uppercase following a cased letter
+            }
+            cased = true;
+            prev_cased = true;
+        } else if c.is_lowercase() {
+            if !prev_cased {
+                return false; // lowercase starting a word
+            }
+            cased = true;
+            prev_cased = true;
+        } else {
+            prev_cased = false;
+        }
+    }
+    cased
+}
+
+const NUM_WORDS: &[&str] = &[
+    "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+    "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen",
+    "nineteen", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety",
+    "hundred", "thousand", "million", "billion", "trillion", "quadrillion", "quintillion",
+    "sextillion", "septillion", "octillion", "nonillion", "decillion", "gajillion", "bazillion",
+];
+const ORDINAL_WORDS: &[&str] = &[
+    "first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth", "tenth",
+    "eleventh", "twelfth", "thirteenth", "fourteenth", "fifteenth", "sixteenth", "seventeenth",
+    "eighteenth", "nineteenth", "twentieth", "thirtieth", "fortieth", "fiftieth", "sixtieth",
+    "seventieth", "eightieth", "ninetieth", "hundredth", "thousandth", "millionth", "billionth",
+    "trillionth", "quadrillionth", "quintillionth", "sextillionth", "septillionth", "octillionth",
+    "nonillionth", "decillionth", "gajillionth", "bazillionth",
+];
+
+fn all_ascii_digits(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())
+}
+
+/// LIKE_NUM: faithful port of spaCy `lang/en/lex_attrs.like_num`.
+/// spaCy strips a leading sign, then commas/dots, and runs every subsequent
+/// check on that stripped string.
+pub fn like_num(text: &str) -> bool {
+    let mut t = text;
+    if let Some(c) = t.chars().next() {
+        if matches!(c, '+' | '-' | '±' | '~') {
+            t = &t[c.len_utf8()..];
+        }
+    }
+    let s: String = t.chars().filter(|&c| c != ',' && c != '.').collect();
+    if all_ascii_digits(&s) {
+        return true;
+    }
+    if s.matches('/').count() == 1 {
+        let mut it = s.split('/');
+        if let (Some(a), Some(b)) = (it.next(), it.next()) {
+            if all_ascii_digits(a) && all_ascii_digits(b) {
+                return true;
+            }
+        }
+    }
+    let lower = s.to_lowercase();
+    if NUM_WORDS.contains(&lower.as_str()) || ORDINAL_WORDS.contains(&lower.as_str()) {
+        return true;
+    }
+    if lower.ends_with("st") || lower.ends_with("nd") || lower.ends_with("rd") || lower.ends_with("th") {
+        let head = &lower[..lower.len() - 2];
+        if all_ascii_digits(head) {
+            return true;
+        }
+    }
+    false
+}

--- a/crates/spacy-rusty/src/lib.rs
+++ b/crates/spacy-rusty/src/lib.rs
@@ -1,0 +1,34 @@
+//! Native spaCy-compatible inference runtime.
+//!
+//! v1 scope: tokenizer + tok2vec + tagger + attribute_ruler + NER, loading
+//! weights/config exported from a spaCy pipeline (see ../../export). Compiles
+//! native (for tests) and to wasm32 (browser; added in a later story).
+
+// Vendored third-party crate (see NOTICE): tracked against upstream, not linted
+// to this workspace's clippy style. Behavior is pinned by golden-parity tests,
+// not by lints, so we allow upstream idioms (e.g. single-pass `for` loops that
+// destructure-and-return) rather than diverge from the source we vendor.
+#![allow(clippy::all)]
+
+pub mod attribute_ruler;
+pub mod features;
+pub mod hash;
+pub mod lemmatizer;
+pub mod lexeme;
+pub mod matcher;
+pub mod ml;
+pub mod model;
+pub mod ner;
+pub mod parser;
+pub mod pipeline;
+pub mod tagger;
+pub mod tok2vec;
+pub mod tokenizer;
+pub mod transition;
+pub mod vectors;
+
+#[cfg(all(target_arch = "wasm32", feature = "bindgen"))]
+mod wasm;
+
+#[cfg(all(target_arch = "wasm32", feature = "capi"))]
+mod capi;

--- a/crates/spacy-rusty/src/matcher.rs
+++ b/crates/spacy-rusty/src/matcher.rs
@@ -1,0 +1,476 @@
+//! Rule-based matching: a user-facing `Matcher` (token patterns with the
+//! IN/NOT_IN/REGEX operators, numeric LENGTH comparisons, and the ?/*/+
+//! quantifiers), a `PhraseMatcher` (exact attr-sequence matching), and an
+//! `EntityRuler` (patterns -> non-overlapping entity spans). Operates over the
+//! per-token attributes the pipeline already produces (see `Pipeline::match_tokens`).
+
+use fancy_regex::Regex;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+
+/// Per-token attributes the matcher reads.
+#[derive(Clone)]
+pub struct MatchToken {
+    pub orth: String,
+    pub lower: String,
+    pub norm: String,
+    pub shape: String,
+    pub lemma: String,
+    pub pos: String,
+    pub tag: String,
+    pub dep: String,
+    pub ent_type: String,
+    pub is_alpha: bool,
+    pub is_digit: bool,
+    pub is_punct: bool,
+    pub is_space: bool,
+    pub is_lower: bool,
+    pub is_upper: bool,
+    pub is_title: bool,
+    pub like_num: bool,
+    pub length: i64,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum Attr {
+    Orth,
+    Lower,
+    Norm,
+    Shape,
+    Lemma,
+    Pos,
+    Tag,
+    Dep,
+    EntType,
+    Length,
+    IsAlpha,
+    IsDigit,
+    IsPunct,
+    IsSpace,
+    IsLower,
+    IsUpper,
+    IsTitle,
+    LikeNum,
+}
+
+fn attr_of(key: &str) -> Option<Attr> {
+    Some(match key {
+        "ORTH" | "TEXT" => Attr::Orth,
+        "LOWER" => Attr::Lower,
+        "NORM" => Attr::Norm,
+        "SHAPE" => Attr::Shape,
+        "LEMMA" => Attr::Lemma,
+        "POS" => Attr::Pos,
+        "TAG" => Attr::Tag,
+        "DEP" => Attr::Dep,
+        "ENT_TYPE" => Attr::EntType,
+        "LENGTH" => Attr::Length,
+        "IS_ALPHA" => Attr::IsAlpha,
+        "IS_DIGIT" => Attr::IsDigit,
+        "IS_PUNCT" => Attr::IsPunct,
+        "IS_SPACE" => Attr::IsSpace,
+        "IS_LOWER" => Attr::IsLower,
+        "IS_UPPER" => Attr::IsUpper,
+        "IS_TITLE" => Attr::IsTitle,
+        "LIKE_NUM" => Attr::LikeNum,
+        _ => return None,
+    })
+}
+
+fn str_attr<'a>(a: Attr, t: &'a MatchToken) -> Option<&'a str> {
+    Some(match a {
+        Attr::Orth => &t.orth,
+        Attr::Lower => &t.lower,
+        Attr::Norm => &t.norm,
+        Attr::Shape => &t.shape,
+        Attr::Lemma => &t.lemma,
+        Attr::Pos => &t.pos,
+        Attr::Tag => &t.tag,
+        Attr::Dep => &t.dep,
+        Attr::EntType => &t.ent_type,
+        _ => return None,
+    })
+}
+
+fn bool_attr(a: Attr, t: &MatchToken) -> Option<bool> {
+    Some(match a {
+        Attr::IsAlpha => t.is_alpha,
+        Attr::IsDigit => t.is_digit,
+        Attr::IsPunct => t.is_punct,
+        Attr::IsSpace => t.is_space,
+        Attr::IsLower => t.is_lower,
+        Attr::IsUpper => t.is_upper,
+        Attr::IsTitle => t.is_title,
+        Attr::LikeNum => t.like_num,
+        _ => return None,
+    })
+}
+
+enum Cons {
+    StrEq(String),
+    StrIn(HashSet<String>),
+    StrNotIn(HashSet<String>),
+    Regex(Regex),
+    Bool(bool),
+    NumEq(i64),
+    NumNe(i64),
+    NumGe(i64),
+    NumLe(i64),
+    NumGt(i64),
+    NumLt(i64),
+    NumIn(HashSet<i64>),
+    NumNotIn(HashSet<i64>),
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Op {
+    One,
+    Opt,  // ?
+    Star, // *
+    Plus, // +
+}
+
+struct TokenPat {
+    cons: Vec<(Attr, Cons)>,
+    op: Op,
+    unmatchable: bool,
+}
+
+fn str_set(v: &Value) -> HashSet<String> {
+    v.as_array()
+        .map(|a| a.iter().filter_map(|x| x.as_str().map(|s| s.to_string())).collect())
+        .unwrap_or_default()
+}
+fn num_set(v: &Value) -> HashSet<i64> {
+    v.as_array()
+        .map(|a| a.iter().filter_map(|x| x.as_i64()).collect())
+        .unwrap_or_default()
+}
+
+fn parse_token(v: &Value) -> TokenPat {
+    let mut tp = TokenPat { cons: vec![], op: Op::One, unmatchable: false };
+    let Some(obj) = v.as_object() else {
+        tp.unmatchable = true;
+        return tp;
+    };
+    if obj.is_empty() {
+        return tp; // {} matches any single token
+    }
+    for (key, val) in obj {
+        if key == "OP" {
+            tp.op = match val.as_str() {
+                Some("?") => Op::Opt,
+                Some("*") => Op::Star,
+                Some("+") => Op::Plus,
+                Some("!") => {
+                    tp.unmatchable = true; // negation quantifier not supported
+                    Op::One
+                }
+                _ => Op::One,
+            };
+            continue;
+        }
+        let Some(attr) = attr_of(key) else {
+            tp.unmatchable = true;
+            continue;
+        };
+        let is_bool = matches!(
+            attr,
+            Attr::IsAlpha | Attr::IsDigit | Attr::IsPunct | Attr::IsSpace
+                | Attr::IsLower | Attr::IsUpper | Attr::IsTitle | Attr::LikeNum
+        );
+        let is_num = attr == Attr::Length;
+        let cons = if is_bool {
+            match val.as_bool() {
+                Some(b) => Cons::Bool(b),
+                None => {
+                    tp.unmatchable = true;
+                    continue;
+                }
+            }
+        } else if is_num {
+            if let Some(n) = val.as_i64() {
+                Cons::NumEq(n)
+            } else if let Some(o) = val.as_object() {
+                match parse_num_op(o) {
+                    Some(c) => c,
+                    None => {
+                        tp.unmatchable = true;
+                        continue;
+                    }
+                }
+            } else {
+                tp.unmatchable = true;
+                continue;
+            }
+        } else if let Some(s) = val.as_str() {
+            Cons::StrEq(s.to_string())
+        } else if let Some(o) = val.as_object() {
+            if let Some(iv) = o.get("IN") {
+                Cons::StrIn(str_set(iv))
+            } else if let Some(nv) = o.get("NOT_IN") {
+                Cons::StrNotIn(str_set(nv))
+            } else if let Some(rx) = o.get("REGEX").and_then(|x| x.as_str()) {
+                match Regex::new(rx) {
+                    Ok(r) => Cons::Regex(r),
+                    Err(_) => {
+                        tp.unmatchable = true;
+                        continue;
+                    }
+                }
+            } else {
+                tp.unmatchable = true;
+                continue;
+            }
+        } else {
+            tp.unmatchable = true;
+            continue;
+        };
+        tp.cons.push((attr, cons));
+    }
+    tp
+}
+
+fn parse_num_op(o: &serde_json::Map<String, Value>) -> Option<Cons> {
+    if let Some(iv) = o.get("IN") {
+        return Some(Cons::NumIn(num_set(iv)));
+    }
+    if let Some(nv) = o.get("NOT_IN") {
+        return Some(Cons::NumNotIn(num_set(nv)));
+    }
+    for (k, v) in o {
+        let n = v.as_i64()?;
+        return Some(match k.as_str() {
+            "==" => Cons::NumEq(n),
+            "!=" => Cons::NumNe(n),
+            ">=" => Cons::NumGe(n),
+            "<=" => Cons::NumLe(n),
+            ">" => Cons::NumGt(n),
+            "<" => Cons::NumLt(n),
+            _ => return None,
+        });
+    }
+    None
+}
+
+fn cons_matches(attr: Attr, c: &Cons, t: &MatchToken) -> bool {
+    match c {
+        Cons::Bool(b) => bool_attr(attr, t) == Some(*b),
+        Cons::StrEq(s) => str_attr(attr, t) == Some(s.as_str()),
+        Cons::StrIn(set) => str_attr(attr, t).is_some_and(|v| set.contains(v)),
+        Cons::StrNotIn(set) => str_attr(attr, t).is_some_and(|v| !set.contains(v)),
+        Cons::Regex(r) => str_attr(attr, t).is_some_and(|v| r.is_match(v).unwrap_or(false)),
+        Cons::NumEq(n) => num_val(attr, t) == Some(*n),
+        Cons::NumNe(n) => num_val(attr, t).is_some_and(|v| v != *n),
+        Cons::NumGe(n) => num_val(attr, t).is_some_and(|v| v >= *n),
+        Cons::NumLe(n) => num_val(attr, t).is_some_and(|v| v <= *n),
+        Cons::NumGt(n) => num_val(attr, t).is_some_and(|v| v > *n),
+        Cons::NumLt(n) => num_val(attr, t).is_some_and(|v| v < *n),
+        Cons::NumIn(set) => num_val(attr, t).is_some_and(|v| set.contains(&v)),
+        Cons::NumNotIn(set) => num_val(attr, t).is_some_and(|v| !set.contains(&v)),
+    }
+}
+
+fn num_val(attr: Attr, t: &MatchToken) -> Option<i64> {
+    match attr {
+        Attr::Length => Some(t.length),
+        _ => None,
+    }
+}
+
+fn token_matches(tp: &TokenPat, t: &MatchToken) -> bool {
+    if tp.unmatchable {
+        return false;
+    }
+    tp.cons.iter().all(|(a, c)| cons_matches(*a, c, t))
+}
+
+/// A `Matcher`: named token-pattern rules. Returns all (key, start, end)
+/// matches, like spaCy's default (non-greedy) Matcher.
+pub struct Matcher {
+    rules: Vec<(String, Vec<TokenPat>)>,
+}
+
+impl Default for Matcher {
+    fn default() -> Self {
+        Matcher::new()
+    }
+}
+
+impl Matcher {
+    pub fn new() -> Matcher {
+        Matcher { rules: vec![] }
+    }
+
+    /// Add a rule under `key`. `pattern` is a JSON array of token dicts.
+    pub fn add(&mut self, key: &str, pattern: &Value) {
+        let pats: Vec<TokenPat> =
+            pattern.as_array().map(|a| a.iter().map(parse_token).collect()).unwrap_or_default();
+        if !pats.is_empty() {
+            self.rules.push((key.to_string(), pats));
+        }
+    }
+
+    /// All matches as (key, start_token, end_token_exclusive), sorted by
+    /// (start, end, key).
+    pub fn find(&self, toks: &[MatchToken]) -> Vec<(String, usize, usize)> {
+        let mut out: Vec<(String, usize, usize)> = vec![];
+        for (key, pats) in &self.rules {
+            for start in 0..=toks.len() {
+                for end in match_ends(pats, toks, start) {
+                    if end > start {
+                        out.push((key.clone(), start, end));
+                    }
+                }
+            }
+        }
+        out.sort_by(|a, b| a.1.cmp(&b.1).then(a.2.cmp(&b.2)).then(a.0.cmp(&b.0)));
+        out.dedup();
+        out
+    }
+}
+
+/// All end positions where `pats` fully matches starting at `start` (NFA over
+/// the ?/*/+ quantifiers; `visited` keeps it linear and avoids blow-up).
+fn match_ends(pats: &[TokenPat], toks: &[MatchToken], start: usize) -> Vec<usize> {
+    let mut ends: HashSet<usize> = HashSet::new();
+    let mut visited: HashSet<(usize, usize)> = HashSet::new();
+    let mut stack = vec![(0usize, start)];
+    while let Some((k, pos)) = stack.pop() {
+        if !visited.insert((k, pos)) {
+            continue;
+        }
+        if k == pats.len() {
+            ends.insert(pos);
+            continue;
+        }
+        let p = &pats[k];
+        let m = pos < toks.len() && token_matches(p, &toks[pos]);
+        match p.op {
+            Op::One => {
+                if m {
+                    stack.push((k + 1, pos + 1));
+                }
+            }
+            Op::Opt => {
+                stack.push((k + 1, pos)); // zero
+                if m {
+                    stack.push((k + 1, pos + 1)); // one
+                }
+            }
+            Op::Star => {
+                stack.push((k + 1, pos)); // zero
+                if m {
+                    stack.push((k, pos + 1)); // one+, stay
+                }
+            }
+            Op::Plus => {
+                if m {
+                    stack.push((k + 1, pos + 1)); // last one
+                    stack.push((k, pos + 1)); // more
+                }
+            }
+        }
+    }
+    ends.into_iter().collect()
+}
+
+/// A `PhraseMatcher`: exact contiguous match of an attribute sequence.
+pub struct PhraseMatcher {
+    attr: Attr,
+    rules: Vec<(String, Vec<String>)>, // (key, attr-value sequence)
+}
+
+impl PhraseMatcher {
+    /// `attr` is "ORTH"/"LOWER"/"NORM"/"LEMMA"/... (defaults to ORTH if unknown).
+    pub fn new(attr: &str) -> PhraseMatcher {
+        PhraseMatcher { attr: attr_of(attr).unwrap_or(Attr::Orth), rules: vec![] }
+    }
+
+    /// Add a phrase as the attribute-value sequence of its tokens (caller
+    /// produces this via `Pipeline::phrase_key`).
+    pub fn add(&mut self, key: &str, seq: Vec<String>) {
+        if !seq.is_empty() {
+            self.rules.push((key.to_string(), seq));
+        }
+    }
+
+    pub fn find(&self, toks: &[MatchToken]) -> Vec<(String, usize, usize)> {
+        let mut out = vec![];
+        let vals: Vec<&str> = toks.iter().map(|t| str_attr(self.attr, t).unwrap_or("")).collect();
+        for (key, seq) in &self.rules {
+            let m = seq.len();
+            if m == 0 || m > vals.len() {
+                continue;
+            }
+            for start in 0..=vals.len() - m {
+                if (0..m).all(|i| vals[start + i] == seq[i]) {
+                    out.push((key.clone(), start, start + m));
+                }
+            }
+        }
+        out.sort_by(|a, b| a.1.cmp(&b.1).then(a.2.cmp(&b.2)).then(a.0.cmp(&b.0)));
+        out.dedup();
+        out
+    }
+}
+
+/// spaCy `util.filter_spans`: keep longest spans first (ties: leftmost), drop
+/// any that overlap an already-kept span, then return sorted by start.
+pub fn filter_spans(mut spans: Vec<(String, usize, usize)>) -> Vec<(String, usize, usize)> {
+    spans.sort_by(|a, b| {
+        let la = a.2 - a.1;
+        let lb = b.2 - b.1;
+        lb.cmp(&la).then(a.1.cmp(&b.1)) // length desc, then start asc
+    });
+    let mut taken: HashSet<usize> = HashSet::new();
+    let mut kept: Vec<(String, usize, usize)> = vec![];
+    for s in spans {
+        if (s.1..s.2).any(|i| taken.contains(&i)) {
+            continue;
+        }
+        for i in s.1..s.2 {
+            taken.insert(i);
+        }
+        kept.push(s);
+    }
+    kept.sort_by(|a, b| a.1.cmp(&b.1));
+    kept
+}
+
+/// An `EntityRuler`: token-pattern and phrase rules labelled with entity types;
+/// produces non-overlapping spans via `filter_spans`.
+pub struct EntityRuler {
+    matcher: Matcher,
+    phrase: HashMap<Attr, PhraseMatcher>,
+}
+
+impl Default for EntityRuler {
+    fn default() -> Self {
+        EntityRuler::new()
+    }
+}
+
+impl EntityRuler {
+    pub fn new() -> EntityRuler {
+        EntityRuler { matcher: Matcher::new(), phrase: HashMap::new() }
+    }
+
+    pub fn add_token_pattern(&mut self, label: &str, pattern: &Value) {
+        self.matcher.add(label, pattern);
+    }
+
+    pub fn add_phrase(&mut self, label: &str, attr: &str, seq: Vec<String>) {
+        let a = attr_of(attr).unwrap_or(Attr::Orth);
+        self.phrase.entry(a).or_insert_with(|| PhraseMatcher::new(attr)).add(label, seq);
+    }
+
+    /// Entity spans (label, start, end), filtered to non-overlapping.
+    pub fn find(&self, toks: &[MatchToken]) -> Vec<(String, usize, usize)> {
+        let mut all = self.matcher.find(toks);
+        for pm in self.phrase.values() {
+            all.extend(pm.find(toks));
+        }
+        filter_spans(all)
+    }
+}

--- a/crates/spacy-rusty/src/ml.rs
+++ b/crates/spacy-rusty/src/ml.rs
@@ -1,0 +1,342 @@
+//! Small dense ops matching Thinc's inference math.
+//!
+//! The dot product accumulates in f32 across four independent lanes — the same
+//! f32 arithmetic Thinc/blis (`sgemm`) uses, so this is *more* faithful to real
+//! spaCy than our earlier f64 path, not less. Four lanes break the dependent
+//! FMA chain so the compiler emits NEON/SSE `fmla` (latency-bound scalar ->
+//! throughput-bound, ~2x). The fixed 4-way reassociation + f32 rounding leaves
+//! every downstream argmax/threshold decision unchanged: tests/perf_identity.rs
+//! verifies the full annotation set is byte-identical to the prior f64 runtime
+//! across all 1000 held-out sentences for sm/md/lg, and golden_tok2vec still
+//! matches spaCy's doc.tensor to <1e-4.
+
+/// `acc + w*x`, lane-wise. With `relaxed-simd` this is `f32x4_relaxed_madd`
+/// (a single fused multiply-add, the same op blis/Thinc `sgemm` uses — so it is
+/// at least as faithful to real spaCy as the split mul+add); otherwise it is the
+/// strict `add(mul(w,x), acc)` that reproduces the captured baseline bit-for-bit.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[inline(always)]
+fn madd(
+    acc: core::arch::wasm32::v128,
+    w: core::arch::wasm32::v128,
+    x: core::arch::wasm32::v128,
+) -> core::arch::wasm32::v128 {
+    use core::arch::wasm32::*;
+    #[cfg(target_feature = "relaxed-simd")]
+    {
+        f32x4_relaxed_madd(w, x, acc)
+    }
+    #[cfg(not(target_feature = "relaxed-simd"))]
+    {
+        f32x4_add(acc, f32x4_mul(w, x))
+    }
+}
+
+/// Dot product of a weight row and `x` (f32 accumulation, 4 lanes; widened to
+/// f64 only at the return so callers' bias adds keep a little headroom).
+///
+/// On wasm with simd128 this uses one `f32x4` accumulator: lane `j` accumulates
+/// exactly the same terms (w[j], w[j+4], …) the scalar lane `aj` would, and the
+/// final reduction `((a0+a1)+(a2+a3))+tail` is identical — so every downstream
+/// argmax/threshold is bit-for-bit unchanged (perf_identity.rs holds).
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[inline]
+pub(crate) fn dot(wrow: &[f32], x: &[f32]) -> f64 {
+    use core::arch::wasm32::*;
+    let n = wrow.len();
+    let mut acc = f32x4_splat(0.0);
+    let wp = wrow.as_ptr();
+    let xp = x.as_ptr();
+    let mut i = 0;
+    while i + 4 <= n {
+        // SAFETY: i+4<=n and both slices hold >= n elements; wasm v128 loads
+        // are alignment-agnostic.
+        unsafe {
+            let wv = v128_load(wp.add(i) as *const v128);
+            let xv = v128_load(xp.add(i) as *const v128);
+            acc = madd(acc, wv, xv);
+        }
+        i += 4;
+    }
+    let a0 = f32x4_extract_lane::<0>(acc);
+    let a1 = f32x4_extract_lane::<1>(acc);
+    let a2 = f32x4_extract_lane::<2>(acc);
+    let a3 = f32x4_extract_lane::<3>(acc);
+    let mut tail = 0f32;
+    while i < n {
+        tail += wrow[i] * x[i];
+        i += 1;
+    }
+    (((a0 + a1) + (a2 + a3)) + tail) as f64
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_feature = "simd128")))]
+#[inline]
+pub(crate) fn dot(wrow: &[f32], x: &[f32]) -> f64 {
+    let n = wrow.len();
+    let (mut a0, mut a1, mut a2, mut a3) = (0f32, 0f32, 0f32, 0f32);
+    let mut i = 0;
+    while i + 4 <= n {
+        a0 += wrow[i] * x[i];
+        a1 += wrow[i + 1] * x[i + 1];
+        a2 += wrow[i + 2] * x[i + 2];
+        a3 += wrow[i + 3] * x[i + 3];
+        i += 4;
+    }
+    let mut tail = 0f32;
+    while i < n {
+        tail += wrow[i] * x[i];
+        i += 1;
+    }
+    (((a0 + a1) + (a2 + a3)) + tail) as f64
+}
+
+/// Four dot products (four weight rows `w0..w3`, all against the same `x`).
+///
+/// Register-blocked: one `x` load feeds all four rows and the four `f32x4`
+/// accumulators form four independent dependency chains, hiding add latency.
+/// Each row's lane layout and final reduction are identical to `dot`, so the
+/// result of `dot4(...)[k]` equals `dot(wk, x)` bit-for-bit.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[inline]
+fn dot4(w0: &[f32], w1: &[f32], w2: &[f32], w3: &[f32], x: &[f32]) -> [f64; 4] {
+    use core::arch::wasm32::*;
+    let n = x.len();
+    let (mut a0, mut a1, mut a2, mut a3) =
+        (f32x4_splat(0.0), f32x4_splat(0.0), f32x4_splat(0.0), f32x4_splat(0.0));
+    let (p0, p1, p2, p3, px) =
+        (w0.as_ptr(), w1.as_ptr(), w2.as_ptr(), w3.as_ptr(), x.as_ptr());
+    let mut i = 0;
+    while i + 4 <= n {
+        // SAFETY: i+4<=n and every slice holds >= n elements; wasm v128 loads
+        // are alignment-agnostic.
+        unsafe {
+            let xv = v128_load(px.add(i) as *const v128);
+            a0 = madd(a0, v128_load(p0.add(i) as *const v128), xv);
+            a1 = madd(a1, v128_load(p1.add(i) as *const v128), xv);
+            a2 = madd(a2, v128_load(p2.add(i) as *const v128), xv);
+            a3 = madd(a3, v128_load(p3.add(i) as *const v128), xv);
+        }
+        i += 4;
+    }
+    #[inline]
+    fn red(a: core::arch::wasm32::v128) -> f32 {
+        use core::arch::wasm32::*;
+        let l0 = f32x4_extract_lane::<0>(a);
+        let l1 = f32x4_extract_lane::<1>(a);
+        let l2 = f32x4_extract_lane::<2>(a);
+        let l3 = f32x4_extract_lane::<3>(a);
+        (l0 + l1) + (l2 + l3)
+    }
+    let (mut s0, mut s1, mut s2, mut s3) = (red(a0), red(a1), red(a2), red(a3));
+    let (mut t0, mut t1, mut t2, mut t3) = (0f32, 0f32, 0f32, 0f32);
+    while i < n {
+        t0 += w0[i] * x[i];
+        t1 += w1[i] * x[i];
+        t2 += w2[i] * x[i];
+        t3 += w3[i] * x[i];
+        i += 1;
+    }
+    s0 += t0;
+    s1 += t1;
+    s2 += t2;
+    s3 += t3;
+    [s0 as f64, s1 as f64, s2 as f64, s3 as f64]
+}
+
+/// Eight dot products sharing one `x` — like `dot4` with twice the independent
+/// accumulator chains, which hides `f32x4_add` latency on the wide window
+/// matmul. `dot8(...)[k] == dot(wk, x)` bit-for-bit.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[inline]
+fn dot8(w: [&[f32]; 8], x: &[f32]) -> [f64; 8] {
+    use core::arch::wasm32::*;
+    let n = x.len();
+    let mut a = [f32x4_splat(0.0); 8];
+    let p: [*const f32; 8] = [
+        w[0].as_ptr(), w[1].as_ptr(), w[2].as_ptr(), w[3].as_ptr(),
+        w[4].as_ptr(), w[5].as_ptr(), w[6].as_ptr(), w[7].as_ptr(),
+    ];
+    let px = x.as_ptr();
+    let mut i = 0;
+    while i + 4 <= n {
+        // SAFETY: i+4<=n and every slice holds >= n elements; wasm v128 loads
+        // are alignment-agnostic.
+        unsafe {
+            let xv = v128_load(px.add(i) as *const v128);
+            a[0] = madd(a[0], v128_load(p[0].add(i) as *const v128), xv);
+            a[1] = madd(a[1], v128_load(p[1].add(i) as *const v128), xv);
+            a[2] = madd(a[2], v128_load(p[2].add(i) as *const v128), xv);
+            a[3] = madd(a[3], v128_load(p[3].add(i) as *const v128), xv);
+            a[4] = madd(a[4], v128_load(p[4].add(i) as *const v128), xv);
+            a[5] = madd(a[5], v128_load(p[5].add(i) as *const v128), xv);
+            a[6] = madd(a[6], v128_load(p[6].add(i) as *const v128), xv);
+            a[7] = madd(a[7], v128_load(p[7].add(i) as *const v128), xv);
+        }
+        i += 4;
+    }
+    let red = |v: v128| -> f32 {
+        let l0 = f32x4_extract_lane::<0>(v);
+        let l1 = f32x4_extract_lane::<1>(v);
+        let l2 = f32x4_extract_lane::<2>(v);
+        let l3 = f32x4_extract_lane::<3>(v);
+        (l0 + l1) + (l2 + l3)
+    };
+    let mut s = [red(a[0]), red(a[1]), red(a[2]), red(a[3]),
+                 red(a[4]), red(a[5]), red(a[6]), red(a[7])];
+    while i < n {
+        for k in 0..8 {
+            s[k] += w[k][i] * x[i];
+        }
+        i += 1;
+    }
+    [s[0] as f64, s[1] as f64, s[2] as f64, s[3] as f64,
+     s[4] as f64, s[5] as f64, s[6] as f64, s[7] as f64]
+}
+
+/// Maxout into a caller-provided `out` buffer (no allocation). See `maxout`.
+///
+/// On wasm/simd128 each `o`-block's outputs share `x` loads across their weight
+/// rows for a given piece (`dot8`/`dot4`), then reduce over pieces. Arithmetic
+/// per (o,p) is identical to the scalar path → bit-for-bit output.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+pub fn maxout_into(x: &[f32], w: &[f32], b: &[f32], n_o: usize, n_p: usize, n_i: usize, out: &mut [f32]) {
+    debug_assert_eq!(x.len(), n_i);
+    debug_assert_eq!(out.len(), n_o);
+    let row = |o: usize, p: usize| -> &[f32] {
+        let r = (o * n_p + p) * n_i;
+        &w[r..r + n_i]
+    };
+    let mut o = 0;
+    while o + 8 <= n_o {
+        let mut m = [f64::NEG_INFINITY; 8];
+        for p in 0..n_p {
+            let d = dot8(
+                [row(o, p), row(o + 1, p), row(o + 2, p), row(o + 3, p),
+                 row(o + 4, p), row(o + 5, p), row(o + 6, p), row(o + 7, p)],
+                x,
+            );
+            for k in 0..8 {
+                let v = b[(o + k) * n_p + p] as f64 + d[k];
+                if v > m[k] { m[k] = v; }
+            }
+        }
+        for k in 0..8 {
+            out[o + k] = m[k] as f32;
+        }
+        o += 8;
+    }
+    while o + 4 <= n_o {
+        let (mut m0, mut m1, mut m2, mut m3) =
+            (f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY);
+        for p in 0..n_p {
+            let d = dot4(row(o, p), row(o + 1, p), row(o + 2, p), row(o + 3, p), x);
+            let v0 = b[(o + 0) * n_p + p] as f64 + d[0];
+            let v1 = b[(o + 1) * n_p + p] as f64 + d[1];
+            let v2 = b[(o + 2) * n_p + p] as f64 + d[2];
+            let v3 = b[(o + 3) * n_p + p] as f64 + d[3];
+            if v0 > m0 { m0 = v0; }
+            if v1 > m1 { m1 = v1; }
+            if v2 > m2 { m2 = v2; }
+            if v3 > m3 { m3 = v3; }
+        }
+        out[o + 0] = m0 as f32;
+        out[o + 1] = m1 as f32;
+        out[o + 2] = m2 as f32;
+        out[o + 3] = m3 as f32;
+        o += 4;
+    }
+    while o < n_o {
+        let mut best = f64::NEG_INFINITY;
+        for p in 0..n_p {
+            let wbase = (o * n_p + p) * n_i;
+            let acc = b[o * n_p + p] as f64 + dot(&w[wbase..wbase + n_i], x);
+            if acc > best {
+                best = acc;
+            }
+        }
+        out[o] = best as f32;
+        o += 1;
+    }
+}
+
+/// Maxout into a caller-provided `out` buffer (no allocation). See `maxout`.
+#[cfg(not(all(target_arch = "wasm32", target_feature = "simd128")))]
+pub fn maxout_into(x: &[f32], w: &[f32], b: &[f32], n_o: usize, n_p: usize, n_i: usize, out: &mut [f32]) {
+    debug_assert_eq!(x.len(), n_i);
+    debug_assert_eq!(out.len(), n_o);
+    for o in 0..n_o {
+        let mut best = f64::NEG_INFINITY;
+        for p in 0..n_p {
+            let wbase = (o * n_p + p) * n_i;
+            let acc = b[o * n_p + p] as f64 + dot(&w[wbase..wbase + n_i], x);
+            if acc > best {
+                best = acc;
+            }
+        }
+        out[o] = best as f32;
+    }
+}
+
+/// Maxout: W is [nO, nP, nI] row-major, b is [nO, nP]. Returns nO values,
+/// each `max_p ( W[o,p,:]·x + b[o,p] )`.
+pub fn maxout(x: &[f32], w: &[f32], b: &[f32], n_o: usize, n_p: usize, n_i: usize) -> Vec<f32> {
+    let mut out = vec![0f32; n_o];
+    maxout_into(x, w, b, n_o, n_p, n_i, &mut out);
+    out
+}
+
+/// Affine: W is [nO, nI] row-major, b is [nO]. Returns nO values `W·x + b`.
+pub fn affine(x: &[f32], w: &[f32], b: &[f32], n_o: usize, n_i: usize) -> Vec<f32> {
+    debug_assert_eq!(x.len(), n_i);
+    let mut out = vec![0f32; n_o];
+    for o in 0..n_o {
+        out[o] = (b[o] as f64 + dot(&w[o * n_i..o * n_i + n_i], x)) as f32;
+    }
+    out
+}
+
+/// Linear (no bias): W is [nO, nI] row-major. Returns nO values `W·x`.
+/// Numerically identical to `affine` with a zero bias, without allocating one.
+pub fn linear(x: &[f32], w: &[f32], n_o: usize, n_i: usize) -> Vec<f32> {
+    debug_assert_eq!(x.len(), n_i);
+    let mut out = vec![0f32; n_o];
+    for o in 0..n_o {
+        out[o] = dot(&w[o * n_i..o * n_i + n_i], x) as f32;
+    }
+    out
+}
+
+/// Thinc LayerNorm (in place): mu/var over the row, var += 1e-8, then scale+shift.
+pub fn layernorm(x: &mut [f32], g: &[f32], b: &[f32]) {
+    let n = x.len();
+    let mut mean = 0f64;
+    for &v in x.iter() {
+        mean += v as f64;
+    }
+    mean /= n as f64;
+    let mut var = 0f64;
+    for &v in x.iter() {
+        let d = v as f64 - mean;
+        var += d * d;
+    }
+    var = var / n as f64 + 1e-8;
+    let inv = var.sqrt().recip();
+    for i in 0..n {
+        let xhat = (x[i] as f64 - mean) * inv;
+        x[i] = (xhat as f32) * g[i] + b[i];
+    }
+}
+
+/// Argmax over a slice.
+pub fn argmax(x: &[f32]) -> usize {
+    let mut bi = 0;
+    let mut bv = f32::NEG_INFINITY;
+    for (i, &v) in x.iter().enumerate() {
+        if v > bv {
+            bv = v;
+            bi = i;
+        }
+    }
+    bi
+}

--- a/crates/spacy-rusty/src/model.rs
+++ b/crates/spacy-rusty/src/model.rs
@@ -1,0 +1,77 @@
+//! Bundle loader: reads model.json (manifest) + model.safetensors (f32 weights).
+
+use safetensors::SafeTensors;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+pub struct Tensor {
+    pub shape: Vec<usize>,
+    pub data: Vec<f32>,
+}
+
+impl Tensor {
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+pub struct Bundle {
+    pub manifest: Value,
+    pub tensors: HashMap<String, Tensor>,
+}
+
+impl Bundle {
+    pub fn load(dir: &Path) -> Bundle {
+        let manifest = fs::read_to_string(dir.join("model.json")).unwrap();
+        let buf = fs::read(dir.join("model.safetensors")).unwrap();
+        Bundle::from_bytes(&manifest, &buf)
+    }
+
+    /// Load from in-memory bytes (browser/wasm: no filesystem).
+    pub fn from_bytes(manifest_json: &str, safetensors: &[u8]) -> Bundle {
+        let manifest: Value = serde_json::from_str(manifest_json).unwrap();
+        let st = SafeTensors::deserialize(safetensors).unwrap();
+        let mut tensors = HashMap::new();
+        for (name, view) in st.tensors() {
+            assert_eq!(
+                view.dtype(),
+                safetensors::Dtype::F32,
+                "tensor {} is not f32",
+                name
+            );
+            let data: Vec<f32> = view
+                .data()
+                .chunks_exact(4)
+                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect();
+            tensors.insert(
+                name.to_string(),
+                Tensor { shape: view.shape().to_vec(), data },
+            );
+        }
+        Bundle { manifest, tensors }
+    }
+
+    pub fn get(&self, key: &str) -> &Tensor {
+        self.tensors
+            .get(key)
+            .unwrap_or_else(|| panic!("missing tensor: {}", key))
+    }
+
+    pub fn symbols(&self) -> HashMap<String, u64> {
+        let mut m = HashMap::new();
+        if let Some(obj) = self.manifest["symbols"].as_object() {
+            for (k, v) in obj {
+                if let Some(n) = v.as_u64() {
+                    m.insert(k.clone(), n);
+                }
+            }
+        }
+        m
+    }
+}

--- a/crates/spacy-rusty/src/ner.rs
+++ b/crates/spacy-rusty/src/ner.rs
@@ -1,0 +1,142 @@
+//! Transition-based NER (BiluoPushDown), greedy decode.
+//!
+//! Pipeline: NER's own 4-attr tok2vec -> reduce(96->64) -> PrecomputableAffine
+//! lower (nF=3, nP=2) -> maxout -> upper linear (->74 moves). State features
+//! are B(0), E(0) (open-entity start or -1), B(0)-1 (prev, or -1). Each step:
+//! gather the 3 precomputed feature blocks (pad row for -1), sum + bias,
+//! maxout over pieces, upper-score, mask invalid moves, argmax, transition.
+
+use crate::model::Bundle;
+use crate::tok2vec::Tok2Vec;
+use crate::transition::Scorer;
+use crate::vectors::Vectors;
+use std::sync::Arc;
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum Action {
+    Begin,
+    In,
+    Last,
+    Unit,
+    Out,
+}
+
+pub struct Ner {
+    tok2vec: Tok2Vec,
+    scorer: Scorer,
+    moves: Vec<(Action, Option<String>)>,
+}
+
+fn parse_move(name: &str) -> (Action, Option<String>) {
+    if name == "O" {
+        return (Action::Out, None);
+    }
+    let (pfx, rest) = name.split_at(1);
+    let label = rest.strip_prefix('-').unwrap_or(rest);
+    let action = match pfx {
+        "B" => Action::Begin,
+        "I" => Action::In,
+        "L" => Action::Last,
+        "U" => Action::Unit,
+        _ => Action::Out,
+    };
+    let lbl = if label.is_empty() { None } else { Some(label.to_string()) };
+    (action, lbl)
+}
+
+impl Ner {
+    pub fn load(b: &Bundle, vectors: Option<Arc<Vectors>>) -> Ner {
+        let cfg = &b.manifest["ner"];
+        let t2v_cfg = cfg["tok2vec"].clone();
+        let uses_static = t2v_cfg["include_static_vectors"].as_bool().unwrap_or(false);
+        let tok2vec = Tok2Vec::load(b, &t2v_cfg, "ner.tok2vec", if uses_static { vectors } else { None });
+        let scorer = Scorer::load(b, "ner");
+        let moves: Vec<(Action, Option<String>)> = cfg["moves"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|m| parse_move(m.as_str().unwrap()))
+            .collect();
+        Ner { tok2vec, scorer, moves }
+    }
+
+    /// Predict entity token spans (start, end_exclusive, label).
+    /// `feats4[t]` are the 4 NER hash keys; `is_space[t]` flags whitespace tokens.
+    pub fn predict(
+        &self,
+        feats4: &[Vec<u64>],
+        orths: Option<&[u64]>,
+        is_space: &[bool],
+    ) -> Vec<(usize, usize, String)> {
+        let n = feats4.len();
+        if n == 0 {
+            return vec![];
+        }
+        let tokvecs = self.tok2vec.forward(feats4, orths);
+        let yf = self.scorer.precompute(&tokvecs);
+
+        // greedy decode
+        let mut i = 0usize;
+        let mut open = false;
+        let mut ent_start = 0usize;
+        let mut ent_label = String::new();
+        let mut ents: Vec<(usize, usize, String)> = vec![];
+
+        while i < n {
+            let e0: i64 = if open { ent_start as i64 } else { -1 };
+            let ids: [i64; 3] = [
+                i as i64,
+                e0,
+                if e0 == -1 { -1 } else { i as i64 - 1 },
+            ];
+            let scores = self.scorer.score(&yf, &ids);
+
+            // pick argmax over valid moves
+            let remaining = n - i;
+            let cur_space = is_space[i];
+            let mut best_c: isize = -1;
+            let mut best_s = f32::NEG_INFINITY;
+            for (c, (action, label)) in self.moves.iter().enumerate() {
+                let valid = match action {
+                    Action::Begin => !open && remaining >= 2 && label.is_some() && !cur_space,
+                    Action::In => {
+                        open && remaining >= 2 && label.as_deref() == Some(ent_label.as_str())
+                    }
+                    Action::Last => {
+                        open && label.as_deref() == Some(ent_label.as_str())
+                    }
+                    Action::Unit => !open && label.is_some() && !cur_space,
+                    Action::Out => !open,
+                };
+                if valid && scores[c] > best_s {
+                    best_s = scores[c];
+                    best_c = c as isize;
+                }
+            }
+            if best_c < 0 {
+                // no valid move (shouldn't happen) — treat as OUT
+                i += 1;
+                continue;
+            }
+            let (action, label) = &self.moves[best_c as usize];
+            match action {
+                Action::Begin => {
+                    open = true;
+                    ent_start = i;
+                    ent_label = label.clone().unwrap();
+                }
+                Action::In => {}
+                Action::Last => {
+                    ents.push((ent_start, i + 1, ent_label.clone()));
+                    open = false;
+                }
+                Action::Unit => {
+                    ents.push((i, i + 1, label.clone().unwrap()));
+                }
+                Action::Out => {}
+            }
+            i += 1;
+        }
+        ents
+    }
+}

--- a/crates/spacy-rusty/src/parser.rs
+++ b/crates/spacy-rusty/src/parser.rs
@@ -1,0 +1,417 @@
+//! Transition-based dependency parser (spaCy's arc-eager system), greedy decode.
+//!
+//! Unlike NER, the parser shares the MAIN tok2vec via a Tok2VecListener, so it
+//! takes the already-computed 96-d token vectors and runs only reduce(96->64) ->
+//! PrecomputableAffine lower (nF=8) -> maxout -> upper (-> n_moves). The 8 state
+//! features are B(0),B(1),S(0),S(1),S(2),L(B(0),1),L(S(0),1),R(S(0),1). Moves
+//! are S(shift) / D(reduce) / L-<dep>(left-arc) / R-<dep>(right-arc) / B(break).
+//! Faithful port of spacy/pipeline/_parser_internals/{arc_eager,_state}.
+
+use crate::model::Bundle;
+use crate::transition::Scorer;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Clone)]
+enum PMove {
+    Shift,
+    Reduce,
+    LeftArc(String),
+    RightArc(String),
+    Break,
+}
+
+fn parse_pmove(name: &str) -> PMove {
+    if name == "S" {
+        PMove::Shift
+    } else if name == "D" {
+        PMove::Reduce
+    } else if let Some(l) = name.strip_prefix("L-") {
+        PMove::LeftArc(l.to_string())
+    } else if let Some(l) = name.strip_prefix("R-") {
+        PMove::RightArc(l.to_string())
+    } else {
+        // "B" / "B-ROOT": Break ignores its label (it only marks a sent start).
+        PMove::Break
+    }
+}
+
+/// Per-token parse result. `head` is the head token index (== own index for a
+/// root), `dep` the dependency label ("ROOT" for roots), `is_sent_start` true
+/// for token 0 and every token a BREAK marked as a new sentence.
+pub struct ParseOut {
+    pub head: usize,
+    pub dep: String,
+    pub is_sent_start: bool,
+}
+
+pub struct Parser {
+    scorer: Scorer,
+    moves: Vec<PMove>,
+}
+
+impl Parser {
+    /// Load the parser if present in the bundle (returns None otherwise).
+    pub fn load(b: &Bundle) -> Option<Parser> {
+        let present = b.manifest.get("parser").map(|v| !v.is_null()).unwrap_or(false);
+        if !present {
+            return None;
+        }
+        let scorer = Scorer::load(b, "parser");
+        let moves: Vec<PMove> = b.manifest["parser"]["moves"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|m| parse_pmove(m.as_str().unwrap()))
+            .collect();
+        Some(Parser { scorer, moves })
+    }
+
+    /// Parse a sequence, given the SHARED tok2vec output (one 96-d vec / token).
+    pub fn predict(&self, vecs: &[Vec<f32>]) -> Vec<ParseOut> {
+        let n = vecs.len();
+        if n == 0 {
+            return vec![];
+        }
+        let yf = self.scorer.precompute(vecs);
+        let mut st = State::new(n);
+        let max_iter = 3 * n + 5; // arc-eager terminates in <=2n (+breaks); guard anyway
+        let mut it = 0;
+        while !st.is_final() {
+            it += 1;
+            if it > max_iter {
+                break;
+            }
+            let ids = st.context8();
+            let scores = self.scorer.score(&yf, &ids);
+            // argmax over grammar-valid moves
+            let mut best_c: isize = -1;
+            let mut best_s = f32::NEG_INFINITY;
+            for (c, mv) in self.moves.iter().enumerate() {
+                if st.is_valid(mv) && scores[c] > best_s {
+                    best_s = scores[c];
+                    best_c = c as isize;
+                }
+            }
+            if best_c < 0 {
+                break; // no valid move (shouldn't happen before final)
+            }
+            st.apply(&self.moves[best_c as usize]);
+        }
+        // Sentence starts come from the parse TREE, not the BREAK transition
+        // (spaCy's set_children_from_heads): each root marks the leftmost token
+        // of its subtree (l_edge) as a sentence start; token 0 is always one.
+        // BREAK still matters during decode — it gates move validity via
+        // is_sent_start — but the final flag is derived here.
+        let heads_idx: Vec<usize> =
+            (0..n).map(|i| if st.heads[i] < 0 { i } else { st.heads[i] as usize }).collect();
+        let mut l_edge: Vec<usize> = (0..n).collect();
+        let mut guard = 0;
+        loop {
+            // Relax l_edge[head] = min(l_edge over subtree); repeat until stable
+            // (handles non-projective parses, as spaCy does).
+            let mut changed = false;
+            for i in 0..n {
+                let h = heads_idx[i];
+                if l_edge[i] < l_edge[h] {
+                    l_edge[h] = l_edge[i];
+                    changed = true;
+                }
+            }
+            guard += 1;
+            if !changed || guard > n + 10 {
+                break;
+            }
+        }
+        let mut sent_start = vec![false; n];
+        for i in 0..n {
+            if heads_idx[i] == i {
+                sent_start[l_edge[i]] = true; // root -> leftmost token of its subtree
+            }
+        }
+        sent_start[0] = true; // first token is always a sentence start (issue #2869)
+
+        (0..n)
+            .map(|i| {
+                let (head, dep) = if st.heads[i] < 0 {
+                    (i, "ROOT".to_string()) // head offset 0 == self == root
+                } else {
+                    (st.heads[i] as usize, st.deps[i].clone())
+                };
+                ParseOut { head, dep, is_sent_start: sent_start[i] }
+            })
+            .collect()
+    }
+}
+
+/// Arc-eager parser state (port of StateC). Buffer is `b_i..n` plus a LIFO
+/// `rebuffer` of tokens pushed back by REDUCE-unshift; `stack` is a LIFO of
+/// token indices; arcs are kept per-head (left = head>child) so L()/R() can
+/// fetch the nth child.
+struct State {
+    n: usize,
+    stack: Vec<usize>,
+    rebuffer: Vec<usize>,
+    b_i: usize,
+    heads: Vec<i32>,            // -1 = no head yet
+    deps: Vec<String>,         // dep label of the arc into each token
+    left_arcs: HashMap<usize, Vec<i32>>,  // head -> children (-1 = tombstone)
+    right_arcs: HashMap<usize, Vec<i32>>,
+    sent_starts: HashSet<usize>,
+    unshiftable: Vec<bool>,
+}
+
+impl State {
+    fn new(n: usize) -> State {
+        State {
+            n,
+            stack: Vec::new(),
+            rebuffer: Vec::new(),
+            b_i: 0,
+            heads: vec![-1; n],
+            deps: vec![String::new(); n],
+            left_arcs: HashMap::new(),
+            right_arcs: HashMap::new(),
+            sent_starts: HashSet::new(),
+            unshiftable: vec![false; n],
+        }
+    }
+
+    fn s(&self, i: i64) -> i64 {
+        if i < 0 {
+            return -1;
+        }
+        let i = i as usize;
+        if i >= self.stack.len() {
+            -1
+        } else {
+            self.stack[self.stack.len() - 1 - i] as i64
+        }
+    }
+
+    fn b(&self, i: i64) -> i64 {
+        if i < 0 {
+            return -1;
+        }
+        let i = i as usize;
+        if i < self.rebuffer.len() {
+            self.rebuffer[self.rebuffer.len() - 1 - i] as i64
+        } else {
+            let bi = self.b_i + (i - self.rebuffer.len());
+            if bi >= self.n {
+                -1
+            } else {
+                bi as i64
+            }
+        }
+    }
+
+    fn stack_depth(&self) -> usize {
+        self.stack.len()
+    }
+
+    fn buffer_length(&self) -> usize {
+        (self.n - self.b_i) + self.rebuffer.len()
+    }
+
+    fn is_final(&self) -> bool {
+        self.stack.is_empty() && self.buffer_length() == 0
+    }
+
+    fn has_head(&self, c: i64) -> bool {
+        c >= 0 && self.heads[c as usize] >= 0
+    }
+
+    fn is_sent_start(&self, w: i64) -> bool {
+        w >= 0 && (w as usize) < self.n && self.sent_starts.contains(&(w as usize))
+    }
+
+    // Our inputs never pre-set token.sent_start = -1, so a token can always
+    // start a sentence (matches spaCy when the parser runs from scratch).
+    fn cannot_sent_start(&self, _w: i64) -> bool {
+        false
+    }
+
+    fn is_unshiftable(&self, item: i64) -> bool {
+        item >= 0 && (item as usize) < self.unshiftable.len() && self.unshiftable[item as usize]
+    }
+
+    fn nth_child(map: &HashMap<usize, Vec<i32>>, head: i64, idx: usize) -> i64 {
+        if idx < 1 || head < 0 {
+            return -1;
+        }
+        if let Some(arcs) = map.get(&(head as usize)) {
+            let mut count = 0;
+            for &child in arcs.iter().rev() {
+                if child != -1 {
+                    count += 1;
+                    if count == idx {
+                        return child as i64;
+                    }
+                }
+            }
+        }
+        -1
+    }
+
+    fn l(&self, head: i64, idx: usize) -> i64 {
+        Self::nth_child(&self.left_arcs, head, idx)
+    }
+
+    fn r(&self, head: i64, idx: usize) -> i64 {
+        Self::nth_child(&self.right_arcs, head, idx)
+    }
+
+    fn context8(&self) -> [i64; 8] {
+        // offset is always 0 for a from-scratch single-doc parse, so the
+        // spaCy `ids[i] += offset` step is a no-op.
+        [
+            self.b(0),
+            self.b(1),
+            self.s(0),
+            self.s(1),
+            self.s(2),
+            self.l(self.b(0), 1),
+            self.l(self.s(0), 1),
+            self.r(self.s(0), 1),
+        ]
+    }
+
+    fn push(&mut self) {
+        let b0 = if let Some(x) = self.rebuffer.pop() {
+            x
+        } else {
+            let x = self.b_i;
+            self.b_i += 1;
+            x
+        };
+        self.stack.push(b0);
+    }
+
+    fn pop(&mut self) {
+        self.stack.pop();
+    }
+
+    fn unshift(&mut self) {
+        let s0 = *self.stack.last().unwrap();
+        self.unshiftable[s0] = true;
+        self.rebuffer.push(s0);
+        self.stack.pop();
+    }
+
+    fn set_reshiftable(&mut self, item: i64) {
+        if item >= 0 && (item as usize) < self.unshiftable.len() {
+            self.unshiftable[item as usize] = false;
+        }
+    }
+
+    fn set_sent_start(&mut self, w: i64) {
+        if w >= 0 {
+            self.sent_starts.insert(w as usize);
+        }
+    }
+
+    fn add_arc(&mut self, head: i64, child: i64, label: &str) {
+        let c = child as usize;
+        if self.heads[c] >= 0 {
+            self.del_arc(self.heads[c], child);
+        }
+        if head > child {
+            self.left_arcs.entry(head as usize).or_default().push(child as i32);
+        } else {
+            self.right_arcs.entry(head as usize).or_default().push(child as i32);
+        }
+        self.heads[c] = head as i32;
+        self.deps[c] = label.to_string();
+    }
+
+    fn del_arc(&mut self, h: i32, c: i64) {
+        let ci = c as i32;
+        let map = if (h as i64) > c { &mut self.left_arcs } else { &mut self.right_arcs };
+        if let Some(arcs) = map.get_mut(&(h as usize)) {
+            if arcs.is_empty() {
+                return;
+            }
+            if *arcs.last().unwrap() == ci {
+                arcs.pop();
+            } else {
+                let scan = arcs.len() - 1; // spaCy scans [0, size-1), tombstoning the first match
+                for i in 0..scan {
+                    if arcs[i] == ci {
+                        arcs[i] = -1;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    fn is_valid(&self, mv: &PMove) -> bool {
+        match mv {
+            PMove::Shift => {
+                if self.stack_depth() == 0 {
+                    true
+                } else if self.buffer_length() < 2 {
+                    false
+                } else if self.is_sent_start(self.b(0)) {
+                    false
+                } else {
+                    !self.is_unshiftable(self.b(0))
+                }
+            }
+            PMove::Reduce => {
+                if self.stack_depth() == 0 {
+                    false
+                } else if self.buffer_length() == 0 {
+                    true
+                } else if self.stack_depth() == 1 && self.cannot_sent_start(self.b(0)) {
+                    false
+                } else {
+                    true
+                }
+            }
+            // SUBTOK_LABEL constraint omitted: en_core_web_sm/md have no subtok move.
+            PMove::LeftArc(_) | PMove::RightArc(_) => {
+                self.stack_depth() > 0 && self.buffer_length() > 0 && !self.is_sent_start(self.b(0))
+            }
+            PMove::Break => {
+                if self.buffer_length() < 2 {
+                    false
+                } else if self.b(1) != self.b(0) + 1 {
+                    false
+                } else if self.is_sent_start(self.b(1)) {
+                    false
+                } else {
+                    !self.cannot_sent_start(self.b(1))
+                }
+            }
+        }
+    }
+
+    fn apply(&mut self, mv: &PMove) {
+        match mv {
+            PMove::Shift => self.push(),
+            PMove::Reduce => {
+                if self.has_head(self.s(0)) || self.stack_depth() == 1 {
+                    self.pop();
+                } else {
+                    self.unshift();
+                }
+            }
+            PMove::LeftArc(label) => {
+                let (b0, s0) = (self.b(0), self.s(0));
+                self.add_arc(b0, s0, label);
+                self.set_reshiftable(b0);
+                self.pop();
+            }
+            PMove::RightArc(label) => {
+                let (s0, b0) = (self.s(0), self.b(0));
+                self.add_arc(s0, b0, label);
+                self.push();
+            }
+            PMove::Break => {
+                let b1 = self.b(1);
+                self.set_sent_start(b1);
+            }
+        }
+    }
+}

--- a/crates/spacy-rusty/src/pipeline.rs
+++ b/crates/spacy-rusty/src/pipeline.rs
@@ -1,0 +1,642 @@
+//! The full inference pipeline: text -> tokens + POS + NER, loadable from
+//! in-memory bytes (for wasm/browser). Ties tokenizer, features, tok2vec,
+//! tagger, attribute_ruler, and NER.
+
+use crate::attribute_ruler::{Anno, AttributeRuler};
+use crate::features::Features;
+use crate::lemmatizer::{parse_morph, Lemmatizer};
+use crate::lexeme;
+use crate::lexeme::is_space;
+use crate::matcher::MatchToken;
+use crate::model::Bundle;
+use crate::ner::Ner;
+use crate::parser::Parser;
+use crate::tagger::Tagger;
+use crate::tok2vec::Tok2Vec;
+use crate::tokenizer::Tokenizer;
+use crate::vectors::Vectors;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Serialize, Clone)]
+pub struct TokenOut {
+    pub i: usize,
+    pub text: String,
+    pub idx: usize,
+    pub ws: bool,
+    pub tag: String,
+    pub pos: String,
+    pub morph: String,
+    pub ent_iob: String,
+    pub ent_type: String,
+    pub head: usize,        // parser: head token index (== i for a root)
+    pub dep: String,        // parser: dependency label ("ROOT" for roots, "" if no parser)
+    pub is_sent_start: bool,
+    pub lemma: String,      // rule lemmatizer
+    pub has_vector: bool,   // token has a static word vector
+    pub vector_norm: f32,   // L2 norm of the token's vector (0.0 if none)
+}
+
+#[derive(Serialize, Clone)]
+pub struct EntOut {
+    pub start: usize,
+    pub end: usize,
+    pub label: String,
+    pub text: String,
+}
+
+#[derive(Serialize, Clone)]
+pub struct SentOut {
+    pub start: usize, // char offset
+    pub end: usize,
+    pub start_token: usize,
+    pub end_token: usize, // exclusive
+}
+
+#[derive(Serialize, Clone)]
+pub struct ChunkOut {
+    pub start: usize, // char offset
+    pub end: usize,
+    pub start_token: usize,
+    pub end_token: usize, // exclusive
+    pub root: usize,      // root token index of the chunk
+    pub text: String,
+}
+
+#[derive(Serialize, Clone)]
+pub struct DocOut {
+    pub text: String,
+    pub tokens: Vec<TokenOut>,
+    pub ents: Vec<EntOut>,
+    pub sents: Vec<SentOut>,
+    pub noun_chunks: Vec<ChunkOut>,
+}
+
+/// A token-range view over a `DocOut` (spaCy `Span`).
+#[derive(Serialize, Clone)]
+pub struct SpanView {
+    pub start: usize,       // char offset
+    pub end: usize,         // char offset (exclusive)
+    pub start_token: usize,
+    pub end_token: usize,   // exclusive
+    pub root: usize,        // index of the span's syntactic root token
+    pub text: String,
+}
+
+impl DocOut {
+    fn chars(&self) -> Vec<char> {
+        self.text.chars().collect()
+    }
+
+    /// Slice `[start_token, end_token)` into a `Span` (spaCy `doc[a:b]`).
+    pub fn span(&self, start_token: usize, end_token: usize) -> SpanView {
+        let n = self.tokens.len();
+        let s = start_token.min(n);
+        let e = end_token.min(n).max(s);
+        let chars = self.chars();
+        let (start, end) = if e > s {
+            let cs = self.tokens[s].idx;
+            let last = &self.tokens[e - 1];
+            (cs, last.idx + last.text.chars().count())
+        } else {
+            (0, 0)
+        };
+        let root = self.span_root(s, e);
+        SpanView {
+            start,
+            end,
+            start_token: s,
+            end_token: e,
+            root,
+            text: chars[start..end].iter().collect(),
+        }
+    }
+
+    /// spaCy `Span.root`: the token with the shortest path to the sentence
+    /// root. An in-span sentence root wins immediately (first one); otherwise
+    /// argmin over tokens whose head lies outside the span; ties -> first.
+    fn span_root(&self, start: usize, end: usize) -> usize {
+        if end <= start {
+            return start;
+        }
+        for i in start..end {
+            if self.tokens[i].head == i {
+                return i; // sentence root inside the span
+            }
+        }
+        let n_tokens = self.tokens.len();
+        // a token has children iff some other token's head points to it
+        let mut has_child = vec![false; n_tokens];
+        for i in 0..n_tokens {
+            let h = self.tokens[i].head;
+            if h != i {
+                has_child[h] = true;
+            }
+        }
+        let words_to_root = |start_i: usize| -> usize {
+            // spaCy `_count_words_to_root`: a childless punct/space token is
+            // penalised to sent_length-1 so it doesn't become a span root.
+            let txt = &self.tokens[start_i].text;
+            if !has_child[start_i]
+                && (lexeme::is_punct(txt) || lexeme::is_space(txt))
+            {
+                return n_tokens - 1;
+            }
+            let mut cur = start_i;
+            let mut n = 0usize;
+            while self.tokens[cur].head != cur {
+                cur = self.tokens[cur].head;
+                n += 1;
+                if n >= n_tokens {
+                    break;
+                }
+            }
+            n
+        };
+        let mut best = usize::MAX;
+        let mut root = start;
+        let mut found = false;
+        for i in start..end {
+            let h = self.tokens[i].head;
+            if start <= h && h < end {
+                continue; // head inside span
+            }
+            let w = words_to_root(i);
+            if w < best {
+                best = w;
+                root = i;
+                found = true;
+            }
+        }
+        if found {
+            root
+        } else {
+            start
+        }
+    }
+
+    /// Serialize to spaCy's `Doc.to_json()` structure exactly: `text`, `ents`
+    /// (char offsets + label), `sents` (char offsets), and `tokens`
+    /// (id/start/end char offsets, tag/pos/morph/lemma/dep/head).
+    pub fn to_spacy_json(&self) -> Value {
+        let tokens: Vec<Value> = self
+            .tokens
+            .iter()
+            .map(|t| {
+                serde_json::json!({
+                    "id": t.i,
+                    "start": t.idx,
+                    "end": t.idx + t.text.chars().count(),
+                    "tag": t.tag,
+                    "pos": t.pos,
+                    "morph": t.morph,
+                    "lemma": t.lemma,
+                    "dep": t.dep,
+                    "head": t.head,
+                })
+            })
+            .collect();
+        let ents: Vec<Value> = self
+            .ents
+            .iter()
+            .map(|e| serde_json::json!({"start": e.start, "end": e.end, "label": e.label}))
+            .collect();
+        let sents: Vec<Value> =
+            self.sents.iter().map(|s| serde_json::json!({"start": s.start, "end": s.end})).collect();
+        serde_json::json!({"text": self.text, "ents": ents, "sents": sents, "tokens": tokens})
+    }
+}
+
+/// spaCy's English `noun_chunks` syntax iterator over a dependency parse.
+/// `heads[i]` is i's head (== i for a root), `deps[i]` the dependency label,
+/// `pos[i]` the UPOS. Returns base-NP spans as (start_token, end_token, root).
+fn noun_chunks(heads: &[usize], deps: &[String], pos: &[String]) -> Vec<(usize, usize, usize)> {
+    let n = heads.len();
+    // left_edge[i]: leftmost index in i's subtree (incl. i), via relaxation.
+    let mut l: Vec<usize> = (0..n).collect();
+    let mut guard = 0;
+    loop {
+        let mut changed = false;
+        for i in 0..n {
+            let h = heads[i];
+            if l[i] < l[h] {
+                l[h] = l[i];
+                changed = true;
+            }
+        }
+        guard += 1;
+        if !changed || guard > n + 10 {
+            break;
+        }
+    }
+    const LABELS: &[&str] = &[
+        "oprd", "nsubj", "dobj", "nsubjpass", "pcomp", "pobj", "dative", "appos", "attr", "ROOT",
+    ];
+    let is_np = |d: &str| LABELS.contains(&d);
+    let mut out = Vec::new();
+    let mut prev_end: i64 = -1;
+    for i in 0..n {
+        if pos[i] != "NOUN" && pos[i] != "PROPN" && pos[i] != "PRON" {
+            continue;
+        }
+        if (l[i] as i64) <= prev_end {
+            continue; // prevent nested/overlapping chunks
+        }
+        if is_np(&deps[i]) {
+            prev_end = i as i64;
+            out.push((l[i], i + 1, i));
+        } else if deps[i] == "conj" {
+            // walk up the conj chain to the head it coordinates with
+            let mut head = heads[i];
+            while deps[head] == "conj" && heads[head] < head {
+                head = heads[head];
+            }
+            if is_np(&deps[head]) {
+                prev_end = i as i64;
+                out.push((l[i], i + 1, i));
+            }
+        }
+    }
+    out
+}
+
+pub struct Pipeline {
+    tokenizer: Tokenizer,
+    features: Features,
+    tok2vec: Tok2Vec,
+    tagger: Tagger,
+    parser: Option<Parser>,
+    ruler: AttributeRuler,
+    lemmatizer: Option<Lemmatizer>,
+    ner: Ner,
+    vectors: Option<Arc<Vectors>>,
+    uses_static: bool,
+    pub model_name: String,
+}
+
+fn parse_row2word(json: Option<&str>) -> Vec<String> {
+    json.and_then(|s| serde_json::from_str::<Vec<String>>(s).ok()).unwrap_or_default()
+}
+
+fn parse_key2row(json: Option<&str>) -> HashMap<u64, usize> {
+    let mut m = HashMap::new();
+    if let Some(s) = json {
+        if let Ok(v) = serde_json::from_str::<Value>(s) {
+            if let Some(obj) = v.as_object() {
+                for (k, r) in obj {
+                    if let (Ok(key), Some(row)) = (k.parse::<u64>(), r.as_u64()) {
+                        m.insert(key, row as usize);
+                    }
+                }
+            }
+        }
+    }
+    m
+}
+
+impl Pipeline {
+    pub fn from_bytes(manifest_json: &str, safetensors: &[u8], key2row_json: Option<&str>) -> Pipeline {
+        Pipeline::from_bytes_full(manifest_json, safetensors, key2row_json, None)
+    }
+
+    /// As `from_bytes`, plus the row->word table that enables `most_similar` to
+    /// return readable neighbor words (`vectors_row2word.json`).
+    pub fn from_bytes_full(
+        manifest_json: &str,
+        safetensors: &[u8],
+        key2row_json: Option<&str>,
+        row2word_json: Option<&str>,
+    ) -> Pipeline {
+        let bundle = Bundle::from_bytes(manifest_json, safetensors);
+        let key2row = parse_key2row(key2row_json);
+        let row2word = parse_row2word(row2word_json);
+        let cfg = &bundle.manifest["tok2vec"];
+        let uses_static = cfg["include_static_vectors"].as_bool().unwrap_or(false);
+        let model_name =
+            bundle.manifest["model_name"].as_str().unwrap_or("unknown").to_string();
+        let tokenizer = Tokenizer::from_manifest(&bundle.manifest["tokenizer"]);
+        let features = Features::from_manifest(&bundle.manifest);
+        // One shared vectors table (held once, used by tok2vec, NER, and the API).
+        let vectors = Vectors::load(&bundle, key2row, row2word).map(Arc::new);
+        let tok2vec = Tok2Vec::load(&bundle, cfg, "tok2vec", vectors.clone());
+        let tagger = Tagger::load(&bundle);
+        let parser = Parser::load(&bundle);
+        let ruler = AttributeRuler::load(&bundle.manifest);
+        let lemmatizer = Lemmatizer::load(&bundle);
+        let ner = Ner::load(&bundle, vectors.clone());
+        Pipeline {
+            tokenizer, features, tok2vec, tagger, parser, ruler, lemmatizer, ner, vectors,
+            uses_static, model_name,
+        }
+    }
+
+    pub fn process(&self, text: &str) -> DocOut {
+        let toks = self.tokenizer.tokenize(text);
+        let n = toks.len();
+        let feats6: Vec<Vec<u64>> =
+            toks.iter().map(|t| self.features.keys(&t.text, t.norm.as_deref(), t.ws)).collect();
+        let orths: Vec<u64> = toks.iter().map(|t| self.features.orth(&t.text)).collect();
+        let orths_opt = if self.uses_static { Some(orths.as_slice()) } else { None };
+
+        let vecs = self.tok2vec.forward(&feats6, orths_opt);
+        let tags = self.tagger.predict(&vecs);
+        // The parser shares the main tok2vec output (Tok2VecListener): feed it
+        // the same vecs. It yields head/dep_ and sentence starts.
+        let parse = self.parser.as_ref().map(|p| p.predict(&vecs));
+
+        let mut annos: Vec<Anno> = toks
+            .iter()
+            .zip(tags.iter())
+            .enumerate()
+            .map(|(i, (t, tg))| Anno {
+                text: t.text.clone(),
+                tag: tg.clone(),
+                // Populate dep_ BEFORE the attribute_ruler so its DEP-conditioned
+                // patterns fire (matches spaCy's order parser -> attribute_ruler;
+                // this is what closes the v1 pos_ gap vs the full pipeline).
+                dep: parse.as_ref().map(|p| p[i].dep.clone()).unwrap_or_default(),
+                ..Default::default()
+            })
+            .collect();
+        self.ruler.apply(&mut annos);
+
+        // Lemma: the attribute_ruler sets irregular/pronoun lemmas (LEMMA attr);
+        // the rule lemmatizer (overwrite=false) fills only tokens it left unset,
+        // using the FINAL pos_/morph.
+        let lemmas: Vec<String> = (0..n)
+            .map(|i| {
+                if !annos[i].lemma.is_empty() {
+                    annos[i].lemma.clone()
+                } else {
+                    match self.lemmatizer.as_ref() {
+                        Some(l) => {
+                            l.lemmatize(&annos[i].text, &annos[i].pos, &parse_morph(&annos[i].morph))
+                        }
+                        None => String::new(),
+                    }
+                }
+            })
+            .collect();
+
+        let feats4: Vec<Vec<u64>> = feats6.iter().map(|f| f[..4].to_vec()).collect();
+        let spaces: Vec<bool> = toks.iter().map(|t| is_space(&t.text)).collect();
+        let ents_tok = self.ner.predict(&feats4, orths_opt, &spaces);
+
+        let mut iob = vec!["O".to_string(); n];
+        let mut etype = vec![String::new(); n];
+        for (s, e, lab) in &ents_tok {
+            for k in *s..*e {
+                iob[k] = if k == *s { "B".into() } else { "I".into() };
+                etype[k] = lab.clone();
+            }
+        }
+
+        let chars: Vec<char> = text.chars().collect();
+        let tokens: Vec<TokenOut> = toks
+            .iter()
+            .enumerate()
+            .map(|(i, t)| TokenOut {
+                i,
+                text: t.text.clone(),
+                idx: t.start,
+                ws: t.ws,
+                tag: annos[i].tag.clone(),
+                pos: annos[i].pos.clone(),
+                morph: annos[i].morph.clone(),
+                ent_iob: iob[i].clone(),
+                ent_type: etype[i].clone(),
+                head: parse.as_ref().map(|p| p[i].head).unwrap_or(i),
+                dep: annos[i].dep.clone(),
+                is_sent_start: parse.as_ref().map(|p| p[i].is_sent_start).unwrap_or(i == 0),
+                lemma: lemmas[i].clone(),
+                has_vector: self.vectors.as_ref().map(|v| v.has_vector(orths[i])).unwrap_or(false),
+                vector_norm: self
+                    .vectors
+                    .as_ref()
+                    .map(|v| Vectors::norm(&v.get(orths[i])))
+                    .unwrap_or(0.0),
+            })
+            .collect();
+        let ents: Vec<EntOut> = ents_tok
+            .iter()
+            .map(|(s, e, lab)| {
+                let cs = toks[*s].start;
+                let ce = toks[*e - 1].end;
+                EntOut {
+                    start: cs,
+                    end: ce,
+                    label: lab.clone(),
+                    text: chars[cs..ce].iter().collect(),
+                }
+            })
+            .collect();
+
+        // doc.sents: split at each is_sent_start token (token 0 always starts one)
+        let sents: Vec<SentOut> = match parse.as_ref() {
+            Some(p) if n > 0 => {
+                let mut out = Vec::new();
+                let mut start = 0usize;
+                for i in 1..n {
+                    if p[i].is_sent_start {
+                        out.push(SentOut {
+                            start: toks[start].start,
+                            end: toks[i - 1].end,
+                            start_token: start,
+                            end_token: i,
+                        });
+                        start = i;
+                    }
+                }
+                out.push(SentOut {
+                    start: toks[start].start,
+                    end: toks[n - 1].end,
+                    start_token: start,
+                    end_token: n,
+                });
+                out
+            }
+            _ => vec![],
+        };
+
+        // doc.noun_chunks: base noun phrases from the parse (needs final pos_/dep_)
+        let noun_chunks: Vec<ChunkOut> = match parse.as_ref() {
+            Some(p) if n > 0 => {
+                let heads: Vec<usize> = (0..n).map(|i| p[i].head).collect();
+                let deps: Vec<String> = (0..n).map(|i| annos[i].dep.clone()).collect();
+                let poss: Vec<String> = (0..n).map(|i| annos[i].pos.clone()).collect();
+                noun_chunks(&heads, &deps, &poss)
+                    .into_iter()
+                    .map(|(s, e, root)| {
+                        let cs = toks[s].start;
+                        let ce = toks[e - 1].end;
+                        ChunkOut {
+                            start: cs,
+                            end: ce,
+                            start_token: s,
+                            end_token: e,
+                            root,
+                            text: chars[cs..ce].iter().collect(),
+                        }
+                    })
+                    .collect()
+            }
+            _ => vec![],
+        };
+
+        DocOut { text: text.to_string(), tokens, ents, sents, noun_chunks }
+    }
+
+    /// Per-token attributes for the rule matcher (matcher.rs operates on these).
+    pub fn match_tokens(&self, text: &str) -> Vec<MatchToken> {
+        let doc = self.process(text);
+        let toks = self.tokenizer.tokenize(text);
+        doc.tokens
+            .iter()
+            .zip(toks.iter())
+            .map(|(t, tk)| {
+                let orth = t.text.clone();
+                MatchToken {
+                    lower: orth.to_lowercase(),
+                    norm: self.features.norm(&orth, tk.norm.as_deref()),
+                    shape: lexeme::shape(&orth),
+                    lemma: t.lemma.clone(),
+                    pos: t.pos.clone(),
+                    tag: t.tag.clone(),
+                    dep: t.dep.clone(),
+                    ent_type: t.ent_type.clone(),
+                    is_alpha: lexeme::is_alpha(&orth),
+                    is_digit: lexeme::is_digit(&orth),
+                    is_punct: lexeme::is_punct(&orth),
+                    is_space: lexeme::is_space(&orth),
+                    is_lower: lexeme::is_lower(&orth),
+                    is_upper: lexeme::is_upper(&orth),
+                    is_title: lexeme::is_title(&orth),
+                    like_num: lexeme::like_num(&orth),
+                    length: orth.chars().count() as i64,
+                    orth,
+                }
+            })
+            .collect()
+    }
+
+    /// Run a token-pattern Matcher: `patterns` is a JSON object
+    /// `{ "KEY": [ [ {token}, ... ], ... ], ... }`. Returns (key, start, end).
+    pub fn run_matcher(&self, text: &str, patterns: &Value) -> Vec<(String, usize, usize)> {
+        let mut m = crate::matcher::Matcher::new();
+        if let Some(obj) = patterns.as_object() {
+            for (key, pats) in obj {
+                if let Some(arr) = pats.as_array() {
+                    for p in arr {
+                        m.add(key, p);
+                    }
+                }
+            }
+        }
+        m.find(&self.match_tokens(text))
+    }
+
+    /// Run a PhraseMatcher over `text` for the given `attr` and phrase strings.
+    /// Returns (phrase, start, end) using the phrase string as the key.
+    pub fn run_phrase(&self, text: &str, attr: &str, phrases: &[String]) -> Vec<(String, usize, usize)> {
+        let mut pm = crate::matcher::PhraseMatcher::new(attr);
+        for ph in phrases {
+            pm.add(ph, self.phrase_key(ph, attr));
+        }
+        pm.find(&self.match_tokens(text))
+    }
+
+    /// Run an EntityRuler: `patterns` is a JSON array of `{ "label", "pattern" }`
+    /// where pattern is a token list or a phrase string. Returns (label,start,end),
+    /// non-overlapping (spaCy `filter_spans`).
+    pub fn run_entity_ruler(&self, text: &str, patterns: &Value) -> Vec<(String, usize, usize)> {
+        let mut ruler = crate::matcher::EntityRuler::new();
+        if let Some(arr) = patterns.as_array() {
+            for r in arr {
+                let label = r["label"].as_str().unwrap_or("");
+                match &r["pattern"] {
+                    Value::String(s) => ruler.add_phrase(label, "ORTH", self.phrase_key(s, "ORTH")),
+                    p @ Value::Array(_) => ruler.add_token_pattern(label, p),
+                    _ => {}
+                }
+            }
+        }
+        ruler.find(&self.match_tokens(text))
+    }
+
+    /// The attribute-value sequence of `phrase`'s tokens, for a PhraseMatcher
+    /// keyed on `attr` ("ORTH"/"LOWER"/"NORM"/"LEMMA"/...).
+    pub fn phrase_key(&self, phrase: &str, attr: &str) -> Vec<String> {
+        self.match_tokens(phrase)
+            .iter()
+            .map(|t| match attr {
+                "LOWER" => t.lower.clone(),
+                "NORM" => t.norm.clone(),
+                "LEMMA" => t.lemma.clone(),
+                "SHAPE" => t.shape.clone(),
+                "POS" => t.pos.clone(),
+                "TAG" => t.tag.clone(),
+                _ => t.orth.clone(),
+            })
+            .collect()
+    }
+
+    /// ORTH keys for each token of `text` (the vector-lookup keys).
+    fn token_orths(&self, text: &str) -> Vec<u64> {
+        self.tokenizer.tokenize(text).iter().map(|t| self.features.orth(&t.text)).collect()
+    }
+
+    pub fn has_vectors(&self) -> bool {
+        self.vectors.is_some()
+    }
+
+    pub fn vector_dim(&self) -> usize {
+        self.vectors.as_ref().map(|v| v.dim).unwrap_or(0)
+    }
+
+    /// The static vector for a single word (zeros if OOV / no vectors).
+    pub fn word_vector(&self, word: &str) -> Vec<f32> {
+        match self.vectors.as_ref() {
+            Some(v) => v.get(self.features.orth(word)),
+            None => vec![],
+        }
+    }
+
+    /// Mean of `text`'s token vectors (spaCy `Doc.vector`).
+    pub fn doc_vector(&self, text: &str) -> Vec<f32> {
+        match self.vectors.as_ref() {
+            Some(v) => v.mean(&self.token_orths(text)),
+            None => vec![],
+        }
+    }
+
+    /// Mean of token vectors over `[start_token, end_token)` (spaCy `Span.vector`).
+    pub fn span_vector(&self, text: &str, start: usize, end: usize) -> Vec<f32> {
+        match self.vectors.as_ref() {
+            Some(v) => {
+                let orths = self.token_orths(text);
+                let s = start.min(orths.len());
+                let e = end.min(orths.len()).max(s);
+                v.mean(&orths[s..e])
+            }
+            None => vec![],
+        }
+    }
+
+    /// Cosine similarity of two texts' doc vectors (spaCy `Doc.similarity`).
+    pub fn similarity(&self, a: &str, b: &str) -> f32 {
+        if self.vectors.is_none() {
+            return 0.0;
+        }
+        Vectors::cosine(&self.doc_vector(a), &self.doc_vector(b))
+    }
+
+    /// The `n` words most similar to `word` (spaCy `Vectors.most_similar`).
+    pub fn most_similar(&self, word: &str, n: usize) -> Vec<(usize, String, f32)> {
+        match self.vectors.as_ref() {
+            Some(v) => v.most_similar(&v.get(self.features.orth(word)), n),
+            None => vec![],
+        }
+    }
+}

--- a/crates/spacy-rusty/src/tagger.rs
+++ b/crates/spacy-rusty/src/tagger.rs
@@ -1,0 +1,35 @@
+//! POS tagger: a single affine layer over the shared tok2vec output, argmax
+//! over the fine-grained TAG labels (softmax is unnormalized at inference).
+
+use crate::ml::{affine, argmax};
+use crate::model::Bundle;
+
+pub struct Tagger {
+    w: Vec<f32>,
+    b: Vec<f32>,
+    n_o: usize,
+    width: usize,
+    pub labels: Vec<String>,
+}
+
+impl Tagger {
+    pub fn load(b: &Bundle) -> Tagger {
+        let cfg = &b.manifest["tagger"];
+        let labels: Vec<String> =
+            cfg["labels"].as_array().unwrap().iter().map(|x| x.as_str().unwrap().to_string()).collect();
+        let n_o = cfg["nO"].as_u64().unwrap() as usize;
+        let wt = b.get("tagger.softmax.W");
+        let width = wt.shape[1];
+        Tagger { w: wt.data.clone(), b: b.get("tagger.softmax.b").data.clone(), n_o, width, labels }
+    }
+
+    /// Predict a fine-grained TAG label per token from its tok2vec vector.
+    pub fn predict(&self, vecs: &[Vec<f32>]) -> Vec<String> {
+        vecs.iter()
+            .map(|v| {
+                let scores = affine(v, &self.w, &self.b, self.n_o, self.width);
+                self.labels[argmax(&scores)].clone()
+            })
+            .collect()
+    }
+}

--- a/crates/spacy-rusty/src/tok2vec.rs
+++ b/crates/spacy-rusty/src/tok2vec.rs
@@ -1,0 +1,217 @@
+//! tok2vec forward pass: MultiHashEmbed (concat of per-table gather-add
+//! embeddings [+ optional static vectors], maxout-projection, layernorm)
+//! followed by a MaxoutWindowEncoder (residual window-CNN blocks).
+
+use crate::hash::hashembed_rows;
+use crate::ml::{dot, layernorm, maxout_into};
+use crate::model::Bundle;
+use crate::vectors::Vectors;
+use serde_json::Value;
+use std::sync::Arc;
+
+struct EncLayer {
+    w: Vec<f32>,
+    b: Vec<f32>,
+    ln_g: Vec<f32>,
+    ln_b: Vec<f32>,
+}
+
+pub struct Tok2Vec {
+    width: usize,
+    n_tables: usize,
+    rows: Vec<u32>,
+    seeds: Vec<u32>,
+    tables: Vec<Vec<f32>>, // each [nV * width]
+    include_static: bool,
+    static_w: Vec<f32>, // [width * vec_dim]
+    vec_dim: usize,
+    vectors: Option<Arc<Vectors>>, // shared static-vector table (ORTH key -> row)
+    proj_w: Vec<f32>,
+    proj_b: Vec<f32>,
+    proj_ln_g: Vec<f32>,
+    proj_ln_b: Vec<f32>,
+    proj_np: usize,
+    concat: usize,
+    enc: Vec<EncLayer>,
+    enc_np: usize,
+    window: usize,
+}
+
+fn vecf(b: &Bundle, key: &str) -> Vec<f32> {
+    b.get(key).data.clone()
+}
+
+impl Tok2Vec {
+    /// `cfg` is the manifest object for this tok2vec; `tp` is the tensor-key
+    /// prefix (e.g. "tok2vec" or "ner.tok2vec"). `vectors` is the shared static-
+    /// vector table (`None` if this tok2vec doesn't use static vectors).
+    pub fn load(b: &Bundle, cfg: &Value, tp: &str, vectors: Option<Arc<Vectors>>) -> Tok2Vec {
+        let width = cfg["width"].as_u64().unwrap() as usize;
+        let n_tables = cfg["n_tables"].as_u64().unwrap() as usize;
+        let rows: Vec<u32> =
+            cfg["rows"].as_array().unwrap().iter().map(|x| x.as_u64().unwrap() as u32).collect();
+        let seeds: Vec<u32> =
+            cfg["seeds"].as_array().unwrap().iter().map(|x| x.as_u64().unwrap() as u32).collect();
+        let tables: Vec<Vec<f32>> =
+            (0..n_tables).map(|c| vecf(b, &format!("{}.embed.table{}.E", tp, c))).collect();
+        let include_static = cfg["include_static_vectors"].as_bool().unwrap_or(false);
+        let (static_w, vec_dim, vectors) = if include_static {
+            let sw = vecf(b, &format!("{}.static.W", tp));
+            let vd = vectors.as_ref().map(|v| v.dim).unwrap_or(0);
+            (sw, vd, vectors)
+        } else {
+            (vec![], 0, None)
+        };
+        let concat = cfg["embed_proj"]["nI"].as_u64().unwrap() as usize;
+        let proj_np = cfg["embed_proj"]["nP"].as_u64().unwrap() as usize;
+        let enc_depth = cfg["encoder"]["depth"].as_u64().unwrap() as usize;
+        let enc_np = cfg["encoder"]["nP"].as_u64().unwrap() as usize;
+        let window = cfg["encoder"]["window"].as_u64().unwrap() as usize;
+        let enc: Vec<EncLayer> = (0..enc_depth)
+            .map(|k| EncLayer {
+                w: vecf(b, &format!("{}.encoder.L{}.maxout.W", tp, k)),
+                b: vecf(b, &format!("{}.encoder.L{}.maxout.b", tp, k)),
+                ln_g: vecf(b, &format!("{}.encoder.L{}.ln.G", tp, k)),
+                ln_b: vecf(b, &format!("{}.encoder.L{}.ln.b", tp, k)),
+            })
+            .collect();
+
+        Tok2Vec {
+            width,
+            n_tables,
+            rows,
+            seeds,
+            tables,
+            include_static,
+            static_w,
+            vec_dim,
+            vectors,
+            proj_w: vecf(b, &format!("{}.embed.proj.W", tp)),
+            proj_b: vecf(b, &format!("{}.embed.proj.b", tp)),
+            proj_ln_g: vecf(b, &format!("{}.embed.proj.ln.G", tp)),
+            proj_ln_b: vecf(b, &format!("{}.embed.proj.ln.b", tp)),
+            proj_np,
+            concat,
+            enc,
+            enc_np,
+            window,
+        }
+    }
+
+    /// Build the pre-projection embedding row (`concat`, length `self.concat`):
+    /// the per-table gather-add segments followed by the optional static-vector
+    /// projection. Same gather order / arithmetic as before.
+    fn embed_concat_into(&self, feats: &[u64], orth: Option<u64>, concat: &mut [f32]) {
+        let w = self.width;
+        for c in 0..self.n_tables {
+            let rows4 = hashembed_rows(feats[c], self.seeds[c], self.rows[c]);
+            let seg = &mut concat[c * w..(c + 1) * w];
+            seg.fill(0.0);
+            let table = &self.tables[c];
+            for &r in &rows4 {
+                let base = (r as usize) * w;
+                for i in 0..w {
+                    seg[i] += table[base + i];
+                }
+            }
+        }
+        if self.include_static {
+            let off = self.n_tables * w;
+            let seg = &mut concat[off..off + w];
+            // StaticVectors projection: V · Wᵀ, W is [width, vec_dim], no bias.
+            // No vector row -> V is zero -> projection is zero (no bias to add).
+            match orth.and_then(|key| {
+                self.vectors.as_ref().and_then(|vt| vt.row(key).map(|r| (vt, r)))
+            }) {
+                Some((vt, row)) => {
+                    let base = row * self.vec_dim;
+                    let v = &vt.data[base..base + self.vec_dim];
+                    for o in 0..w {
+                        seg[o] = dot(&self.static_w[o * self.vec_dim..(o + 1) * self.vec_dim], v) as f32;
+                    }
+                }
+                None => seg.fill(0.0),
+            }
+        }
+    }
+
+    /// Embed one token directly into `out` (length `width`), using `concat` as
+    /// reusable scratch (length `self.concat`). No per-token allocation. The
+    /// arithmetic — gather-add order, static projection, maxout, layernorm — is
+    /// identical to the previous `Vec`-returning path.
+    fn embed_into(&self, feats: &[u64], orth: Option<u64>, out: &mut [f32], concat: &mut [f32]) {
+        let w = self.width;
+        self.embed_concat_into(feats, orth, concat);
+        maxout_into(concat, &self.proj_w, &self.proj_b, w, self.proj_np, self.concat, out);
+        layernorm(out, &self.proj_ln_g, &self.proj_ln_b);
+    }
+
+    /// Embed-only output (MultiHashEmbed, before the window encoder).
+    pub fn embed_seq(&self, feats: &[Vec<u64>], orths: Option<&[u64]>) -> Vec<Vec<f32>> {
+        let mut concat = vec![0f32; self.concat];
+        (0..feats.len())
+            .map(|t| {
+                let mut out = vec![0f32; self.width];
+                self.embed_into(&feats[t], orths.map(|o| o[t]), &mut out, &mut concat);
+                out
+            })
+            .collect()
+    }
+
+    /// Run the full tok2vec over a sequence. `feats[t]` are the n_tables hash
+    /// keys; `orths[t]` is the ORTH key for static vectors (if used).
+    pub fn forward(&self, feats: &[Vec<u64>], orths: Option<&[u64]>) -> Vec<Vec<f32>> {
+        let w = self.width;
+        let n = feats.len();
+
+        // spaCy wraps the encoder in with_array(model, pad=receptive_field):
+        // the sequence is zero-padded by `pad` rows at each end ONCE, the whole
+        // residual stack runs over it (so the pad rows evolve and feed the real
+        // boundary tokens' windows), then the padding is stripped.
+        //
+        // Flat ping-pong buffers (`cur`/`next`, each [len*w]) + reused window
+        // and row scratch. The encoder is *token-stationary*: each token's
+        // window (`x`, ~winlen f32) is reused across all output rows of the
+        // maxout while it stays hot in registers/L1, and the layer's weight
+        // matrix is small enough to stay resident in L2 across tokens. (A
+        // weight-stationary batch variant was tried and measured slower — it
+        // re-streams the windowed inputs once per output row.) Same math and
+        // summation order as before → bit-for-bit identical.
+        let pad = self.window * self.enc.len();
+        let len = n + 2 * pad;
+        let mut cur = vec![0f32; len * w];
+        let mut concat = vec![0f32; self.concat];
+        for t in 0..n {
+            let s = (pad + t) * w;
+            self.embed_into(&feats[t], orths.map(|o| o[t]), &mut cur[s..s + w], &mut concat);
+        }
+        let mut next = vec![0f32; len * w];
+        let winlen = (2 * self.window + 1) * w;
+        let mut win = vec![0f32; winlen];
+        let mut row = vec![0f32; w];
+        let win_i = self.window as isize;
+        for layer in &self.enc {
+            for t in 0..len {
+                // expand_window(window): concat [t-window .. t+window]
+                for (k, d) in (-win_i..=win_i).enumerate() {
+                    let dst = &mut win[k * w..(k + 1) * w];
+                    let idx = t as isize + d;
+                    if idx < 0 || idx >= len as isize {
+                        dst.fill(0.0);
+                    } else {
+                        let s = idx as usize * w;
+                        dst.copy_from_slice(&cur[s..s + w]);
+                    }
+                }
+                maxout_into(&win, &layer.w, &layer.b, w, self.enc_np, winlen, &mut row);
+                layernorm(&mut row, &layer.ln_g, &layer.ln_b);
+                let base = t * w;
+                for i in 0..w {
+                    next[base + i] = row[i] + cur[base + i]; // residual
+                }
+            }
+            std::mem::swap(&mut cur, &mut next);
+        }
+        (0..n).map(|t| cur[(pad + t) * w..(pad + t + 1) * w].to_vec()).collect()
+    }
+}

--- a/crates/spacy-rusty/src/tokenizer.rs
+++ b/crates/spacy-rusty/src/tokenizer.rs
@@ -1,0 +1,363 @@
+//! Rule-based tokenizer — a faithful port of spaCy's `Tokenizer` (the
+//! `explain()` reference algorithm), its whitespace-token rule, and the
+//! post-tokenization special-case matcher. Carries per-token NORM overrides
+//! from special-case rules.
+//!
+//! Mirrors spacy/tokenizer.pyx + util.compile_{prefix,suffix,infix}_regex.
+//! Prefix/suffix/infix patterns use lookbehind, so we use `fancy-regex`.
+
+use fancy_regex::Regex;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Label {
+    Token,
+    Prefix,
+    Suffix,
+    Infix,
+    UrlMatch,
+    TokenMatch,
+    Special(usize),
+}
+
+impl fmt::Display for Label {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Label::Token => write!(f, "TOKEN"),
+            Label::Prefix => write!(f, "PREFIX"),
+            Label::Suffix => write!(f, "SUFFIX"),
+            Label::Infix => write!(f, "INFIX"),
+            Label::UrlMatch => write!(f, "URL_MATCH"),
+            Label::TokenMatch => write!(f, "TOKEN_MATCH"),
+            Label::Special(i) => write!(f, "SPECIAL-{}", i),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Piece {
+    label: Label,
+    text: String,
+    norm: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Token {
+    pub text: String,
+    /// char (code-point) offset into the source text, matching spaCy `token.idx`
+    pub start: usize,
+    pub end: usize,
+    /// trailing single space (spaCy `token.whitespace_ == " "`)
+    pub ws: bool,
+    /// NORM override from a special-case rule, if any
+    pub norm: Option<String>,
+}
+
+type Special = Vec<(String, Option<String>)>; // (ORTH, NORM?)
+
+pub struct Tokenizer {
+    prefix_re: Option<Regex>,
+    suffix_re: Option<Regex>,
+    infix_re: Option<Regex>,
+    url_re: Option<Regex>,
+    token_re: Option<Regex>,
+    specials: HashMap<String, Special>,
+    /// special matcher: first pattern token -> [(pattern token texts, replacement ORTHs)]
+    matcher: HashMap<String, Vec<(Vec<String>, Vec<String>)>>,
+}
+
+fn compile(pattern: &str) -> Regex {
+    Regex::new(pattern).unwrap_or_else(|e| panic!("regex compile failed for {:?}: {}", pattern, e))
+}
+
+fn join_list(v: &Value, wrap: impl Fn(&str) -> String) -> Option<String> {
+    let arr = v.as_array()?;
+    let parts: Vec<String> = arr
+        .iter()
+        .filter_map(|p| p.as_str())
+        .filter(|p| !p.trim().is_empty())
+        .map(|p| wrap(p))
+        .collect();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("|"))
+    }
+}
+
+impl Tokenizer {
+    pub fn from_manifest(tok: &Value) -> Self {
+        let prefix_re = join_list(&tok["prefixes"], |p| format!("^{}", p)).map(|s| compile(&s));
+        let suffix_re = join_list(&tok["suffixes"], |p| format!("{}$", p)).map(|s| compile(&s));
+        let infix_re = join_list(&tok["infixes"], |p| p.to_string()).map(|s| compile(&s));
+        let url_re = tok["url_match"].as_str().map(maybe_strip_u).map(|s| compile(&s));
+        let token_re = tok["token_match"].as_str().map(maybe_strip_u).map(|s| compile(&s));
+
+        let mut specials = HashMap::new();
+        if let Some(rules) = tok["rules"].as_object() {
+            for (orth, analyses) in rules {
+                let pieces: Special = analyses
+                    .as_array()
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|d| {
+                                d.get("ORTH").and_then(|x| x.as_str()).map(|o| {
+                                    let n = d.get("NORM").and_then(|x| x.as_str()).map(|s| s.to_string());
+                                    (o.to_string(), n)
+                                })
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                if !pieces.is_empty() {
+                    specials.insert(orth.clone(), pieces);
+                }
+            }
+        }
+
+        let mut t = Tokenizer {
+            prefix_re,
+            suffix_re,
+            infix_re,
+            url_re,
+            token_re,
+            specials,
+            matcher: HashMap::new(),
+        };
+        t.build_matcher();
+        t
+    }
+
+    fn build_matcher(&mut self) {
+        let mut matcher: HashMap<String, Vec<(Vec<String>, Vec<String>)>> = HashMap::new();
+        let keys: Vec<String> = self.specials.keys().cloned().collect();
+        for key in keys {
+            let pattern: Vec<String> =
+                self.tokenize_word(&key, false).into_iter().map(|p| p.text).collect();
+            if pattern.is_empty() {
+                continue;
+            }
+            let replacement: Vec<String> =
+                self.specials[&key].iter().map(|(o, _)| o.clone()).collect();
+            matcher.entry(pattern[0].clone()).or_default().push((pattern, replacement));
+        }
+        for bucket in matcher.values_mut() {
+            bucket.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+        }
+        self.matcher = matcher;
+    }
+
+    fn prefix_len(&self, s: &str) -> Option<usize> {
+        self.prefix_re.as_ref()?.find(s).ok().flatten().map(|m| m.end())
+    }
+    fn suffix_start(&self, s: &str) -> Option<usize> {
+        self.suffix_re.as_ref()?.find(s).ok().flatten().map(|m| m.start())
+    }
+    fn is_token_match(&self, s: &str) -> bool {
+        self.token_re.as_ref().map_or(false, |r| r.is_match(s).unwrap_or(false))
+    }
+    fn is_url_match(&self, s: &str) -> bool {
+        self.url_re.as_ref().map_or(false, |r| r.is_match(s).unwrap_or(false))
+    }
+
+    fn infix_split(&self, s: &str) -> Option<Vec<Piece>> {
+        let re = self.infix_re.as_ref()?;
+        let mut ranges: Vec<(usize, usize)> = Vec::new();
+        for m in re.find_iter(s).flatten() {
+            ranges.push((m.start(), m.end()));
+        }
+        if ranges.is_empty() {
+            return None;
+        }
+        let mut out = Vec::new();
+        let mut offset = 0usize;
+        for (st, en) in ranges {
+            if offset == 0 && st == 0 {
+                continue;
+            }
+            if st > offset {
+                out.push(piece(Label::Token, &s[offset..st]));
+            }
+            if en > st {
+                out.push(piece(Label::Infix, &s[st..en]));
+            }
+            offset = en;
+        }
+        if offset < s.len() {
+            out.push(piece(Label::Token, &s[offset..]));
+        }
+        Some(out)
+    }
+
+    fn specials_pieces(&self, s: &str) -> Vec<Piece> {
+        self.specials[s]
+            .iter()
+            .enumerate()
+            .map(|(i, (orth, norm))| Piece {
+                label: Label::Special(i + 1),
+                text: orth.clone(),
+                norm: norm.clone(),
+            })
+            .collect()
+    }
+
+    fn tokenize_word(&self, substring: &str, with_special: bool) -> Vec<Piece> {
+        let mut tokens: Vec<Piece> = Vec::new();
+        let mut suffixes: Vec<Piece> = Vec::new();
+        let mut s = substring.to_string();
+
+        while !s.is_empty() {
+            if with_special && self.specials.contains_key(&s) {
+                tokens.extend(self.specials_pieces(&s));
+                s.clear();
+                continue;
+            }
+
+            loop {
+                let has_pre = self.prefix_len(&s);
+                let has_suf = self.suffix_start(&s);
+                if has_pre.is_none() && has_suf.is_none() {
+                    break;
+                }
+                if self.is_token_match(&s) {
+                    break;
+                }
+                if with_special && self.specials.contains_key(&s) {
+                    break;
+                }
+                let mut progressed = false;
+                if let Some(end) = self.prefix_len(&s) {
+                    if end > 0 {
+                        tokens.push(piece(Label::Prefix, &s[..end]));
+                        s = s[end..].to_string();
+                        progressed = true;
+                        if with_special && self.specials.contains_key(&s) {
+                            continue;
+                        }
+                    }
+                }
+                if let Some(start) = self.suffix_start(&s) {
+                    if start < s.len() {
+                        suffixes.push(piece(Label::Suffix, &s[start..]));
+                        s = s[..start].to_string();
+                        progressed = true;
+                    }
+                }
+                if !progressed {
+                    break;
+                }
+            }
+
+            if self.is_token_match(&s) {
+                tokens.push(piece(Label::TokenMatch, &s));
+                s.clear();
+            } else if self.is_url_match(&s) {
+                tokens.push(piece(Label::UrlMatch, &s));
+                s.clear();
+            } else if with_special && self.specials.contains_key(&s) {
+                tokens.extend(self.specials_pieces(&s));
+                s.clear();
+            } else if let Some(splits) = self.infix_split(&s) {
+                tokens.extend(splits);
+                s.clear();
+            } else if !s.is_empty() {
+                tokens.push(piece(Label::Token, &s));
+                s.clear();
+            }
+        }
+
+        tokens.extend(suffixes.into_iter().rev());
+        tokens
+    }
+
+    fn apply_matcher(&self, pieces: Vec<(Label, String, usize)>) -> Vec<(Label, String, usize)> {
+        let n = pieces.len();
+        let mut out: Vec<(Label, String, usize)> = Vec::with_capacity(n);
+        let mut i = 0;
+        while i < n {
+            let mut hit: Option<&(Vec<String>, Vec<String>)> = None;
+            if let Some(bucket) = self.matcher.get(&pieces[i].1) {
+                for cand in bucket {
+                    let l = cand.0.len();
+                    if i + l <= n
+                        && (1..l).all(|k| pieces[i + k].2 == pieces[i].2)
+                        && (0..l).all(|k| pieces[i + k].1 == cand.0[k])
+                    {
+                        hit = Some(cand);
+                        break;
+                    }
+                }
+            }
+            if let Some((pattern, replacement)) = hit {
+                let sid = pieces[i].2;
+                for (k, orth) in replacement.iter().enumerate() {
+                    out.push((Label::Special(k + 1), orth.clone(), sid));
+                }
+                i += pattern.len();
+            } else {
+                out.push(pieces[i].clone());
+                i += 1;
+            }
+        }
+        out
+    }
+
+    /// Reproduce spaCy `tokenizer.explain(text)`.
+    pub fn explain(&self, text: &str) -> Vec<(String, String)> {
+        let mut pieces: Vec<(Label, String, usize)> = Vec::new();
+        for (sid, substring) in text.split_whitespace().enumerate() {
+            for p in self.tokenize_word(substring, true) {
+                pieces.push((p.label, p.text, sid));
+            }
+        }
+        self.apply_matcher(pieces).into_iter().map(|(l, t, _)| (l.to_string(), t)).collect()
+    }
+
+    /// Full tokenization into the Doc token list (incl. whitespace tokens),
+    /// with char offsets, trailing-space flags, and NORM overrides.
+    pub fn tokenize(&self, text: &str) -> Vec<Token> {
+        let chars: Vec<char> = text.chars().collect();
+        let n = chars.len();
+        let mut tokens: Vec<Token> = Vec::new();
+        let mut i = 0;
+        while i < n {
+            let start = i;
+            let is_ws = chars[i].is_whitespace();
+            while i < n && chars[i].is_whitespace() == is_ws {
+                i += 1;
+            }
+            if is_ws {
+                let first = chars[start];
+                if !tokens.is_empty() && first == ' ' {
+                    tokens.last_mut().unwrap().ws = true;
+                    if i - start > 1 {
+                        let txt: String = chars[start + 1..i].iter().collect();
+                        tokens.push(Token { text: txt, start: start + 1, end: i, ws: false, norm: None });
+                    }
+                } else {
+                    let txt: String = chars[start..i].iter().collect();
+                    tokens.push(Token { text: txt, start, end: i, ws: false, norm: None });
+                }
+            } else {
+                let substr: String = chars[start..i].iter().collect();
+                let mut off = start;
+                for p in self.tokenize_word(&substr, true) {
+                    let len = p.text.chars().count();
+                    tokens.push(Token { text: p.text, start: off, end: off + len, ws: false, norm: p.norm });
+                    off += len;
+                }
+            }
+        }
+        tokens
+    }
+}
+
+fn piece(label: Label, text: &str) -> Piece {
+    Piece { label, text: text.to_string(), norm: None }
+}
+
+fn maybe_strip_u(p: &str) -> String {
+    p.strip_prefix("(?u)").unwrap_or(p).to_string()
+}

--- a/crates/spacy-rusty/src/transition.rs
+++ b/crates/spacy-rusty/src/transition.rs
@@ -1,0 +1,109 @@
+//! Shared neural scoring for spaCy's transition-based parsers (NER + the
+//! dependency parser). Both use the SAME machinery — reduce(t2v_width -> hidden)
+//! -> PrecomputableAffine lower (nF state features, nP maxout pieces) -> maxout
+//! -> upper Linear(-> n_classes) — and differ only in the *feature indices* and
+//! the move grammar (which live in ner.rs / parser.rs). This module is just the
+//! math, so the two systems share one verified implementation.
+
+use crate::ml::{affine, dot};
+use crate::model::Bundle;
+
+pub struct Scorer {
+    reduce_w: Vec<f32>,
+    reduce_b: Vec<f32>,
+    reduce_no: usize, // hidden width (64)
+    reduce_ni: usize, // tok2vec width (96)
+    lower_w: Vec<f32>,   // [nF, nO, nP, nI]
+    lower_b: Vec<f32>,   // [nO, nP]
+    lower_pad: Vec<f32>, // [1, nF, nO, nP] -> used as [nF, nO, nP]
+    pub n_f: usize,
+    n_o: usize,
+    n_p: usize,
+    upper_w: Vec<f32>, // [n_classes, nO]
+    upper_b: Vec<f32>,
+    pub n_classes: usize,
+}
+
+impl Scorer {
+    /// Load `{prefix}.reduce/lower/upper` from the bundle, with dims read from
+    /// `manifest[prefix].{reduce,lower,upper}`.
+    pub fn load(b: &Bundle, prefix: &str) -> Scorer {
+        let cfg = &b.manifest[prefix];
+        let reduce = b.get(&format!("{}.reduce.W", prefix));
+        let lower = b.get(&format!("{}.lower.W", prefix));
+        let upper = b.get(&format!("{}.upper.W", prefix));
+        Scorer {
+            reduce_w: reduce.data.clone(),
+            reduce_b: b.get(&format!("{}.reduce.b", prefix)).data.clone(),
+            reduce_no: reduce.shape[0],
+            reduce_ni: reduce.shape[1],
+            lower_w: lower.data.clone(),
+            lower_b: b.get(&format!("{}.lower.b", prefix)).data.clone(),
+            lower_pad: b.get(&format!("{}.lower.pad", prefix)).data.clone(),
+            n_f: cfg["lower"]["nF"].as_u64().unwrap() as usize,
+            n_o: cfg["lower"]["nO"].as_u64().unwrap() as usize,
+            n_p: cfg["lower"]["nP"].as_u64().unwrap() as usize,
+            upper_w: upper.data.clone(),
+            upper_b: b.get(&format!("{}.upper.b", prefix)).data.clone(),
+            n_classes: upper.shape[0],
+        }
+    }
+
+    /// Reduce each token vector (t2v_width -> hidden), then precompute the lower
+    /// PrecomputableAffine output Yf[t], flattened as [f][o][p] (len nF*nO*nP).
+    /// `vecs` are the tok2vec outputs feeding this parser (NER's own tok2vec, or
+    /// the shared tok2vec for the dependency parser).
+    pub fn precompute(&self, vecs: &[Vec<f32>]) -> Vec<Vec<f32>> {
+        let fop = self.n_f * self.n_o * self.n_p;
+        let ni = self.reduce_no;
+        vecs.iter()
+            .map(|v| {
+                let x = affine(v, &self.reduce_w, &self.reduce_b, self.reduce_no, self.reduce_ni);
+                let mut out = vec![0f32; fop];
+                for f in 0..self.n_f {
+                    for o in 0..self.n_o {
+                        for p in 0..self.n_p {
+                            let wbase = (((f * self.n_o + o) * self.n_p) + p) * ni;
+                            out[f * self.n_o * self.n_p + o * self.n_p + p] =
+                                dot(&self.lower_w[wbase..wbase + ni], &x) as f32;
+                        }
+                    }
+                }
+                out
+            })
+            .collect()
+    }
+
+    /// Score all classes for a state whose nF feature-token ids are `ids`
+    /// (id < 0 => the lower `pad` row). `ids.len()` must equal `n_f`.
+    pub fn score(&self, yf: &[Vec<f32>], ids: &[i64]) -> Vec<f32> {
+        let op = self.n_o * self.n_p;
+        let mut unmaxed = vec![0f32; op];
+        for f in 0..self.n_f {
+            let block: &[f32] = if ids[f] < 0 {
+                &self.lower_pad[f * op..f * op + op]
+            } else {
+                &yf[ids[f] as usize][f * op..f * op + op]
+            };
+            for k in 0..op {
+                unmaxed[k] += block[k];
+            }
+        }
+        for k in 0..op {
+            unmaxed[k] += self.lower_b[k];
+        }
+        // maxout over pieces -> hidden (n_o)
+        let mut hidden = vec![0f32; self.n_o];
+        for o in 0..self.n_o {
+            let mut best = f32::NEG_INFINITY;
+            for p in 0..self.n_p {
+                let val = unmaxed[o * self.n_p + p];
+                if val > best {
+                    best = val;
+                }
+            }
+            hidden[o] = best;
+        }
+        affine(&hidden, &self.upper_w, &self.upper_b, self.n_classes, self.n_o)
+    }
+}

--- a/crates/spacy-rusty/src/vectors.rs
+++ b/crates/spacy-rusty/src/vectors.rs
@@ -1,0 +1,126 @@
+//! Static word vectors + similarity (spaCy `Vocab.vectors`, default mode).
+//!
+//! Owns the `[n_rows * dim]` table and the ORTH-key -> row map. Shared (via
+//! `Rc`) with the tok2vec static-vectors path so the table is held once. Exposes
+//! the spaCy vector API: per-word/doc/span vectors, cosine similarity, and
+//! `most_similar` (faithful to `Vectors.most_similar`).
+
+use crate::model::Bundle;
+use std::collections::HashMap;
+
+pub struct Vectors {
+    pub data: Vec<f32>, // [n_rows * dim], row-major
+    pub dim: usize,
+    pub n_rows: usize,
+    pub key2row: HashMap<u64, usize>,
+    row2word: Vec<String>,  // row -> representative word (for most_similar)
+    filled: Vec<usize>,     // sorted unique rows referenced by key2row
+}
+
+impl Vectors {
+    /// Build from the bundle's `vectors.data` tensor + the ORTH->row map and the
+    /// row->word table. Returns `None` if this model has no static vectors.
+    pub fn load(b: &Bundle, key2row: HashMap<u64, usize>, row2word: Vec<String>) -> Option<Vectors> {
+        let t = b.tensors.get("vectors.data")?;
+        let dim = t.shape[1];
+        let n_rows = t.shape[0];
+        let mut seen: Vec<usize> = key2row.values().copied().collect();
+        seen.sort_unstable();
+        seen.dedup();
+        Some(Vectors { data: t.data.clone(), dim, n_rows, key2row, row2word, filled: seen })
+    }
+
+    pub fn row(&self, orth: u64) -> Option<usize> {
+        self.key2row.get(&orth).copied()
+    }
+
+    pub fn has_vector(&self, orth: u64) -> bool {
+        self.key2row.contains_key(&orth)
+    }
+
+    /// The vector for an ORTH key (zeros if out-of-vocabulary).
+    pub fn get(&self, orth: u64) -> Vec<f32> {
+        match self.row(orth) {
+            Some(r) => self.data[r * self.dim..(r + 1) * self.dim].to_vec(),
+            None => vec![0f32; self.dim],
+        }
+    }
+
+    /// Mean of the given ORTH keys' vectors (spaCy Doc/Span `.vector`: an average
+    /// over *all* tokens, OOV contributing zeros). Empty -> zero vector.
+    pub fn mean(&self, orths: &[u64]) -> Vec<f32> {
+        let mut acc = vec![0f64; self.dim];
+        if orths.is_empty() {
+            return vec![0f32; self.dim];
+        }
+        for &o in orths {
+            if let Some(r) = self.row(o) {
+                let base = r * self.dim;
+                for i in 0..self.dim {
+                    acc[i] += self.data[base + i] as f64;
+                }
+            }
+        }
+        let n = orths.len() as f64;
+        acc.iter().map(|&x| (x / n) as f32).collect()
+    }
+
+    /// L2 norm of a vector.
+    pub fn norm(v: &[f32]) -> f32 {
+        let s: f64 = v.iter().map(|&x| (x as f64) * (x as f64)).sum();
+        s.sqrt() as f32
+    }
+
+    /// Cosine similarity (spaCy `.similarity`: 0.0 if either vector has 0 norm).
+    pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
+        let na = Self::norm(a) as f64;
+        let nb = Self::norm(b) as f64;
+        if na == 0.0 || nb == 0.0 {
+            return 0.0;
+        }
+        let dot: f64 = a.iter().zip(b).map(|(&x, &y)| (x as f64) * (y as f64)).sum();
+        (dot / (na * nb)) as f32
+    }
+
+    /// The n most similar entries to `query`, by cosine, over the filled rows.
+    /// Mirrors `Vectors.most_similar`: normalize rows + query, dot, top-n, round
+    /// scores to 4 decimals and clip to [-1, 1]. Returns (row, word, score).
+    pub fn most_similar(&self, query: &[f32], n: usize) -> Vec<(usize, String, f32)> {
+        let qn = {
+            let q = Self::norm(query) as f64;
+            if q == 0.0 { 1.0 } else { q }
+        };
+        let mut scored: Vec<(usize, f32)> = self
+            .filled
+            .iter()
+            .map(|&r| {
+                let base = r * self.dim;
+                let row = &self.data[base..base + self.dim];
+                let rn = {
+                    let v = Self::norm(row) as f64;
+                    if v == 0.0 { 1.0 } else { v }
+                };
+                let dot: f64 =
+                    query.iter().zip(row).map(|(&x, &y)| (x as f64) * (y as f64)).sum();
+                let mut s = (dot / (qn * rn)) as f32;
+                s = (s * 1e4).round() / 1e4; // spaCy rounds to 4 decimals
+                s = s.clamp(-1.0, 1.0);
+                (r, s)
+            })
+            .collect();
+        // Top-n by score desc; tie-break by row for determinism. (spaCy's
+        // argpartition leaves ties in arbitrary order, so only the *set* of
+        // returned rows/scores is well-defined when scores tie.)
+        scored.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1).unwrap().then(a.0.cmp(&b.0))
+        });
+        scored
+            .into_iter()
+            .take(n)
+            .map(|(r, s)| {
+                let w = self.row2word.get(r).cloned().unwrap_or_default();
+                (r, w, s)
+            })
+            .collect()
+    }
+}

--- a/crates/spacy-rusty/src/wasm.rs
+++ b/crates/spacy-rusty/src/wasm.rs
@@ -1,0 +1,136 @@
+//! wasm-bindgen bindings: load a model bundle from bytes and run inference,
+//! returning a JS object (or JSON string).
+
+use crate::pipeline::Pipeline;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct SpacyModel {
+    inner: Pipeline,
+}
+
+#[wasm_bindgen]
+impl SpacyModel {
+    /// Build from the bundle's model.json (string), model.safetensors (bytes),
+    /// and optional vectors_key2row.json + vectors_row2word.json (strings, for
+    /// `_md`/`_lg` static vectors; row2word enables readable `mostSimilar`).
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        manifest_json: String,
+        safetensors: Vec<u8>,
+        key2row_json: Option<String>,
+        row2word_json: Option<String>,
+    ) -> SpacyModel {
+        SpacyModel {
+            inner: Pipeline::from_bytes_full(
+                &manifest_json,
+                &safetensors,
+                key2row_json.as_deref(),
+                row2word_json.as_deref(),
+            ),
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        self.inner.model_name.clone()
+    }
+
+    /// Process text -> a JS object { text, tokens[], ents[] }.
+    pub fn process(&self, text: String) -> Result<JsValue, JsValue> {
+        let doc = self.inner.process(&text);
+        serde_wasm_bindgen::to_value(&doc).map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Process text -> JSON string (handy for debugging).
+    #[wasm_bindgen(js_name = processJson)]
+    pub fn process_json(&self, text: String) -> String {
+        serde_json::to_string(&self.inner.process(&text)).unwrap()
+    }
+
+    /// Whether this model has static word vectors (`_md`/`_lg`).
+    #[wasm_bindgen(getter, js_name = hasVectors)]
+    pub fn has_vectors(&self) -> bool {
+        self.inner.has_vectors()
+    }
+
+    /// The static vector for a single word as a Float32Array (empty if no vectors).
+    #[wasm_bindgen(js_name = wordVector)]
+    pub fn word_vector(&self, word: String) -> Vec<f32> {
+        self.inner.word_vector(&word)
+    }
+
+    /// The mean token-vector for `text` (spaCy `Doc.vector`) as a Float32Array.
+    #[wasm_bindgen(js_name = docVector)]
+    pub fn doc_vector(&self, text: String) -> Vec<f32> {
+        self.inner.doc_vector(&text)
+    }
+
+    /// Mean token-vector over `[start, end)` tokens (spaCy `Span.vector`).
+    #[wasm_bindgen(js_name = spanVector)]
+    pub fn span_vector(&self, text: String, start: usize, end: usize) -> Vec<f32> {
+        self.inner.span_vector(&text, start, end)
+    }
+
+    /// Cosine similarity of two texts' doc vectors (spaCy `Doc.similarity`).
+    pub fn similarity(&self, a: String, b: String) -> f32 {
+        self.inner.similarity(&a, &b)
+    }
+
+    /// The `n` words most similar to `word`: [{ word, row, score }, ...].
+    #[wasm_bindgen(js_name = mostSimilar)]
+    pub fn most_similar(&self, word: String, n: usize) -> Result<JsValue, JsValue> {
+        #[derive(serde::Serialize)]
+        struct Neighbor {
+            word: String,
+            row: usize,
+            score: f32,
+        }
+        let out: Vec<Neighbor> = self
+            .inner
+            .most_similar(&word, n)
+            .into_iter()
+            .map(|(row, word, score)| Neighbor { word, row, score })
+            .collect();
+        serde_wasm_bindgen::to_value(&out).map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Token-pattern Matcher. `patterns_json` is `{ "KEY": [[{token},...],...] }`.
+    /// Returns [{ key, start, end }, ...].
+    pub fn matcher(&self, text: String, patterns_json: String) -> Result<JsValue, JsValue> {
+        let pats: serde_json::Value =
+            serde_json::from_str(&patterns_json).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        spans_to_js(self.inner.run_matcher(&text, &pats), "key")
+    }
+
+    /// PhraseMatcher. `phrases_json` is a JSON array of strings; `attr` is e.g.
+    /// "ORTH"/"LOWER". Returns [{ key, start, end }, ...] (key = the phrase).
+    #[wasm_bindgen(js_name = phraseMatcher)]
+    pub fn phrase_matcher(&self, text: String, attr: String, phrases_json: String) -> Result<JsValue, JsValue> {
+        let phrases: Vec<String> =
+            serde_json::from_str(&phrases_json).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        spans_to_js(self.inner.run_phrase(&text, &attr, &phrases), "key")
+    }
+
+    /// EntityRuler. `patterns_json` is `[{ "label", "pattern" }, ...]` where
+    /// pattern is a token list or a phrase string. Returns [{ label, start, end }].
+    #[wasm_bindgen(js_name = entityRuler)]
+    pub fn entity_ruler(&self, text: String, patterns_json: String) -> Result<JsValue, JsValue> {
+        let pats: serde_json::Value =
+            serde_json::from_str(&patterns_json).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        spans_to_js(self.inner.run_entity_ruler(&text, &pats), "label")
+    }
+}
+
+#[derive(serde::Serialize)]
+struct MatchSpan {
+    key: String,
+    start: usize,
+    end: usize,
+}
+
+fn spans_to_js(spans: Vec<(String, usize, usize)>, _field: &str) -> Result<JsValue, JsValue> {
+    let out: Vec<MatchSpan> =
+        spans.into_iter().map(|(key, start, end)| MatchSpan { key, start, end }).collect();
+    serde_wasm_bindgen::to_value(&out).map_err(|e| JsValue::from_str(&e.to_string()))
+}

--- a/src/dep_parser.rs
+++ b/src/dep_parser.rs
@@ -1,0 +1,202 @@
+//! In-engine syntactic dependency parser (vendored `spacy-rusty`, en_core_web_sm).
+//!
+//! Provides POS + dependency-head + lemma for short entity mentions so entity
+//! resolution can span-clean and pick the syntactic head of a mention
+//! (`Port of Baltimore` → `Port`; `ship crashed` → verb-headed fragment). This
+//! is the FROZEN base of the entity-resolution roadmap (Phase 1): the parser
+//! never updates at runtime; only the resolver/matcher layers above it learn.
+//!
+//! The model bundle (`model.json` + `model.safetensors`, ~15 MB) is NOT shipped
+//! in the repo. It is loaded once from `SHODH_SPACY_MODEL_PATH`, mirroring the
+//! GLiNER/MiniLM asset convention. When the variable is unset or the bundle is
+//! missing, every entry point degrades to `None` so callers fall back exactly as
+//! they do today — the parser is additive, never load-bearing for a request.
+//!
+//! Concurrency: the vendored crate holds its static-vector table behind `Arc`
+//! (see the crate NOTICE), so a single loaded `Pipeline` is `Send + Sync` and is
+//! shared read-only across all async workers via a process-wide `OnceLock`.
+//! `Pipeline::process` takes `&self`, so concurrent parses are safe.
+
+use std::path::Path;
+use std::sync::{Arc, OnceLock};
+
+use spacy_rusty::pipeline::Pipeline;
+
+/// One parsed token: the fields entity resolution consumes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedToken {
+    /// Token index within the parsed text.
+    pub i: usize,
+    /// Surface text of the token.
+    pub text: String,
+    /// Index of this token's syntactic head; equals `i` for a sentence root.
+    pub head: usize,
+    /// Dependency label (`"ROOT"` for roots).
+    pub dep: String,
+    /// Coarse-grained part of speech (`PROPN`, `NOUN`, `VERB`, ...).
+    pub pos: String,
+    /// Fine-grained POS tag.
+    pub tag: String,
+    /// Rule-lemmatized form.
+    pub lemma: String,
+}
+
+impl ParsedToken {
+    /// True when this token is a syntactic root (`head == i`).
+    #[inline]
+    pub fn is_root(&self) -> bool {
+        self.head == self.i
+    }
+}
+
+/// Process-wide, lazily-initialized pipeline. `None` means "no model available";
+/// once resolved it never changes, so the 15 MB bundle is loaded at most once.
+static PIPELINE: OnceLock<Option<Arc<Pipeline>>> = OnceLock::new();
+
+/// Build a pipeline from an explicit bundle directory. Pure (no env, no global)
+/// so it is unit-testable by path — the env/`OnceLock` layer lives in
+/// [`pipeline`]. Returns `None` if the manifest/weights are missing or the
+/// bundle fails to construct (corrupt data), so a misconfigured model can never
+/// panic a request thread.
+fn load_from_dir(dir: &Path) -> Option<Arc<Pipeline>> {
+    let manifest = std::fs::read_to_string(dir.join("model.json")).ok()?;
+    let safetensors = std::fs::read(dir.join("model.safetensors")).ok()?;
+    // Optional: enables readable vector neighbors; parsing/POS/lemma do not need
+    // it, so `en_core_web_sm` (no static vectors) loads fine without it.
+    let key2row = std::fs::read_to_string(dir.join("vectors_key2row.json")).ok();
+
+    // `Pipeline::from_bytes` unwraps internally on malformed input. Contain any
+    // such panic here so a bad bundle degrades to `None` instead of aborting.
+    let built = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        Pipeline::from_bytes(&manifest, &safetensors, key2row.as_deref())
+    }));
+    match built {
+        Ok(pipeline) => Some(Arc::new(pipeline)),
+        Err(_) => {
+            tracing::warn!(
+                dir = %dir.display(),
+                "spacy-rusty bundle failed to load; dependency parser disabled"
+            );
+            None
+        }
+    }
+}
+
+/// Resolve the bundle directory from `SHODH_SPACY_MODEL_PATH` and load it.
+fn load_from_env() -> Option<Arc<Pipeline>> {
+    let dir = std::env::var_os("SHODH_SPACY_MODEL_PATH")?;
+    load_from_dir(Path::new(&dir))
+}
+
+/// The shared pipeline, or `None` when no model is configured/available.
+pub fn pipeline() -> Option<&'static Arc<Pipeline>> {
+    PIPELINE.get_or_init(load_from_env).as_ref()
+}
+
+/// Whether the dependency parser is available in this process.
+pub fn is_available() -> bool {
+    pipeline().is_some()
+}
+
+/// Parse `text` with an explicitly-provided pipeline (no global state). This is
+/// the core used by both [`parse`] and the parity tests.
+pub fn parse_with(pipeline: &Pipeline, text: &str) -> Vec<ParsedToken> {
+    pipeline
+        .process(text)
+        .tokens
+        .into_iter()
+        .map(|t| ParsedToken {
+            i: t.i,
+            text: t.text,
+            head: t.head,
+            dep: t.dep,
+            pos: t.pos,
+            tag: t.tag,
+            lemma: t.lemma,
+        })
+        .collect()
+}
+
+/// Parse `text` with the shared pipeline. `None` if no model is available.
+pub fn parse(text: &str) -> Option<Vec<ParsedToken>> {
+    let pipeline = pipeline()?;
+    Some(parse_with(pipeline, text))
+}
+
+/// The syntactic head of `text`: the first sentence root (`head == i`). For a
+/// short entity mention this is its head word, and the returned `pos` tells the
+/// resolver whether the mention is nominal (`PROPN`/`NOUN` → keep) or a
+/// verb-headed fragment (`VERB` → strip/reject). Falls back to the first token
+/// for degenerate inputs. `None` if no model is available.
+pub fn head_token(text: &str) -> Option<ParsedToken> {
+    let tokens = parse(text)?;
+    Some(head_of(&tokens))
+}
+
+/// Select the head token from an already-parsed token list: the first root, else
+/// the first token. Split out (pure) so head selection is testable without a model.
+fn head_of(tokens: &[ParsedToken]) -> ParsedToken {
+    tokens
+        .iter()
+        .find(|t| t.is_root())
+        .or_else(|| tokens.first())
+        .cloned()
+        .unwrap_or_else(|| ParsedToken {
+            i: 0,
+            text: String::new(),
+            head: 0,
+            dep: String::new(),
+            pos: String::new(),
+            tag: String::new(),
+            lemma: String::new(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tok(i: usize, text: &str, head: usize, pos: &str) -> ParsedToken {
+        ParsedToken {
+            i,
+            text: text.to_string(),
+            head,
+            dep: if head == i { "ROOT".into() } else { "dep".into() },
+            pos: pos.to_string(),
+            tag: pos.to_string(),
+            lemma: text.to_lowercase(),
+        }
+    }
+
+    #[test]
+    fn missing_bundle_dir_yields_none() {
+        // Pure loader, no env, no global: a nonexistent bundle degrades to None.
+        assert!(load_from_dir(Path::new("does/not/exist/en_core_web_sm")).is_none());
+    }
+
+    #[test]
+    fn head_of_picks_the_root_not_the_first_token() {
+        // "Port of Baltimore" shape: root is "Port" (i=0 here) — but prove we key
+        // on head==i, not position, by making the root the middle token.
+        let toks = vec![
+            tok(0, "the", 1, "DET"),
+            tok(1, "ship", 1, "NOUN"), // root
+            tok(2, "Dali", 1, "PROPN"),
+        ];
+        let head = head_of(&toks);
+        assert_eq!(head.text, "ship");
+        assert!(head.is_root());
+    }
+
+    #[test]
+    fn head_of_falls_back_to_first_token_when_no_root() {
+        let toks = vec![tok(0, "alpha", 1, "NOUN"), tok(1, "beta", 2, "NOUN")];
+        let head = head_of(&toks);
+        assert_eq!(head.text, "alpha");
+    }
+
+    #[test]
+    fn head_of_empty_is_safe() {
+        assert_eq!(head_of(&[]).text, "");
+    }
+}

--- a/src/dep_parser.rs
+++ b/src/dep_parser.rs
@@ -161,7 +161,11 @@ mod tests {
             i,
             text: text.to_string(),
             head,
-            dep: if head == i { "ROOT".into() } else { "dep".into() },
+            dep: if head == i {
+                "ROOT".into()
+            } else {
+                "dep".into()
+            },
             pos: pos.to_string(),
             tag: pos.to_string(),
             lemma: text.to_lowercase(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod backup;
 pub mod config;
 pub mod constants;
 pub mod decay;
+pub mod dep_parser;
 pub mod embeddings;
 pub mod errors;
 pub mod graph_memory;

--- a/tests/dep_parser_parity.rs
+++ b/tests/dep_parser_parity.rs
@@ -1,0 +1,83 @@
+//! Parity regression guard for the in-engine dependency parser (Task 1.1).
+//!
+//! The vendored `spacy-rusty` was validated at the binary level to reproduce
+//! Python spaCy's `en_core_web_sm` heads exactly (`py_heads.tsv` ==
+//! `rust_heads.tsv`, 669/669). This test re-proves that parity *through the
+//! in-engine integration surface* — the `SHODH_SPACY_MODEL_PATH` bundle load and
+//! the `dep_parser` wrapper — so a regression in loading, token mapping, or head
+//! selection is caught here rather than downstream in entity resolution.
+//!
+//! The 15 MB model bundle is not committed. Set `SHODH_SPACY_MODEL_PATH` to a
+//! directory containing `model.json` + `model.safetensors` to run it; without
+//! the model the test skips (parity cannot be checked, but nothing regresses).
+
+use shodh_memory::dep_parser;
+
+const GOLDEN: &str = include_str!("fixtures/en_core_web_sm_heads_golden.tsv");
+
+#[test]
+fn in_engine_heads_match_python_spacy_golden() {
+    if !dep_parser::is_available() {
+        eprintln!(
+            "SKIP in_engine_heads_match_python_spacy_golden: set SHODH_SPACY_MODEL_PATH \
+             to an en_core_web_sm bundle (model.json + model.safetensors) to run parity."
+        );
+        return;
+    }
+
+    let mut checked = 0usize;
+    let mut mismatches: Vec<String> = Vec::new();
+
+    for (lineno, line) in GOLDEN.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let cols: Vec<&str> = line.split('\t').collect();
+        assert!(
+            cols.len() >= 3,
+            "malformed golden row {} (expected mention\\troot\\tpos): {:?}",
+            lineno + 1,
+            line
+        );
+        let (mention, want_root, want_pos) = (cols[0], cols[1], cols[2]);
+
+        let head = dep_parser::head_token(mention)
+            .expect("parser available but returned no head");
+        checked += 1;
+
+        if head.text != want_root || head.pos != want_pos {
+            mismatches.push(format!(
+                "  {:?}: got ({:?}, {}) want ({:?}, {})",
+                mention, head.text, head.pos, want_root, want_pos
+            ));
+        }
+    }
+
+    assert!(checked > 600, "golden set unexpectedly small: {checked} rows");
+    assert!(
+        mismatches.is_empty(),
+        "{}/{} mentions diverged from Python spaCy golden heads:\n{}",
+        mismatches.len(),
+        checked,
+        mismatches.join("\n")
+    );
+    eprintln!("dep_parser parity: {checked}/{checked} heads match Python spaCy golden");
+}
+
+/// The two canonical span-head cases from the plan's success criterion, asserted
+/// explicitly so they are legible in the test output.
+#[test]
+fn canonical_span_heads() {
+    if !dep_parser::is_available() {
+        eprintln!("SKIP canonical_span_heads: SHODH_SPACY_MODEL_PATH unset");
+        return;
+    }
+    // "Port of Baltimore" → head "Port" (PROPN), not "Baltimore".
+    let port = dep_parser::head_token("Port of Baltimore").unwrap();
+    assert_eq!(port.text, "Port", "Port of Baltimore head");
+
+    // "ship crashed" → verb-headed fragment: the resolver uses pos == VERB to
+    // reject/strip it. Assert the head is the verb so that signal is intact.
+    let crashed = dep_parser::head_token("ship crashed").unwrap();
+    assert_eq!(crashed.pos, "VERB", "ship crashed should be verb-headed");
+}

--- a/tests/dep_parser_parity.rs
+++ b/tests/dep_parser_parity.rs
@@ -41,8 +41,7 @@ fn in_engine_heads_match_python_spacy_golden() {
         );
         let (mention, want_root, want_pos) = (cols[0], cols[1], cols[2]);
 
-        let head = dep_parser::head_token(mention)
-            .expect("parser available but returned no head");
+        let head = dep_parser::head_token(mention).expect("parser available but returned no head");
         checked += 1;
 
         if head.text != want_root || head.pos != want_pos {
@@ -53,7 +52,10 @@ fn in_engine_heads_match_python_spacy_golden() {
         }
     }
 
-    assert!(checked > 600, "golden set unexpectedly small: {checked} rows");
+    assert!(
+        checked > 600,
+        "golden set unexpectedly small: {checked} rows"
+    );
     assert!(
         mismatches.is_empty(),
         "{}/{} mentions diverged from Python spaCy golden heads:\n{}",

--- a/tests/fixtures/en_core_web_sm_heads_golden.tsv
+++ b/tests/fixtures/en_core_web_sm_heads_golden.tsv
@@ -1,0 +1,669 @@
+Baltimore	Baltimore	PROPN
+bridge collapses	collapses	NOUN
+Francis Scott Key Bridge	Bridge	PROPN
+bridge	bridge	PROPN
+Maryland	Maryland	PROPN
+early tuesday	tuesday	PROPN
+coast guard	guard	PROPN
+Patapsco River	River	PROPN
+Baltimore Fire Department	Department	PROPN
+cargo ship	ship	NOUN
+baltimore bridge	bridge	PROPN
+Tuesday	Tuesday	PROPN
+Wes Moore	Moore	PROPN
+Shannon Gilreath	Gilreath	PROPN
+Maryland Department of Transportation	Department	PROPN
+ship	ship	NOUN
+container ship	ship	NOUN
+major bridge	bridge	NOUN
+tuesday night	night	NOUN
+Gilreath	Gilreath	PROPN
+called dali	called	VERB
+baltimore early	baltimore	PROPN
+Rear Adm	Adm	PROPN
+presumed dead	presumed	VERB
+Kevin Cartwright	Cartwright	PROPN
+Maryland State Police	Police	PROPN
+maryland gov	gov	PROPN
+lost power	lost	VERB
+rear	rear	NOUN
+Shannon N	N	PROPN
+water temperatures	temperatures	NOUN
+Brandon M Scott	Scott	PROPN
+Hang Seng	Seng	PROPN
+river	river	NOUN
+adm	adm	PROPN
+Mass casualty event	event	NOUN
+rapid speed	speed	NOUN
+Brawner Builders.¬†	Brawner	NOUN
+Nikkei	Nikkei	PROPN
+SpaceX	SpaceX	PROPN
+SK Hynix‚Äôs	SK	PROPN
+Mayor	Mayor	PROPN
+Amazon‚Äôs	Amazon‚Äôs	NUM
+Associated Press	Press	PROPN
+enabling authorities	authorities	NOUN
+temperatures	temperatures	NOUN
+Dow	Dow	PROPN
+Nasdaq	Nasdaq	PROPN
+ship barreling	barreling	NOUN
+baltimore collapsed	collapsed	VERB
+Johnny Olszewski Jr	Jr	PROPN
+Nasdaq-100	Nasdaq-100	PUNCT
+Strait of Hormuz	Strait	PROPN
+Key Bridge	Bridge	PROPN
+search teams	teams	NOUN
+Paul Wiedefeld	Wiedefeld	PROPN
+Samsung	Samsung	PROPN
+gov	gov	PROPN
+Amazon	Amazon	PROPN
+Jeffrey Pritzker	Pritzker	PROPN
+Stawell	Stawell	PROPN
+vehicle traffic	traffic	NOUN
+Rear Admiral	Admiral	PROPN
+Sri Lanka	Lanka	PROPN
+multiple vehicles	vehicles	NOUN
+large ship	ship	NOUN
+mayday call	call	NOUN
+Micron	Micron	PROPN
+collapsed	collapsed	VERB
+ship lost	lost	VERB
+stop cars	stop	VERB
+Russel	Russel	NOUN
+rescue operation	operation	NOUN
+baltimore francis	francis	PROPN
+Xbox	Xbox	PROPN
+Baltimore Police Department	Department	PROPN
+Drago	Drago	NOUN
+construction workers	workers	NOUN
+mass casualty	casualty	NOUN
+rescued	rescued	VERB
+amazon readies	readies	NOUN
+construction crew	crew	NOUN
+Rivian‚Äôs	Rivian‚Äôs	NUM
+call moments	call	VERB
+authorities	authorities	NOUN
+Col Roland Butler	Butler	PROPN
+limit vehicle	vehicle	NOUN
+Baltimore County's	County	PROPN
+ship crashed	crashed	VERB
+executive vice	vice	NOUN
+NBC News	News	PROPN
+federal government	government	NOUN
+search	search	NOUN
+emergency personnel	personnel	NOUN
+crew issued	issued	VERB
+East Coast	Coast	PROPN
+livestream	livestream	NOUN
+ship collision	collision	NOUN
+admiral shannon	shannon	NOUN
+crew	crew	NOUN
+baltimore harbor	harbor	PROPN
+Joe Biden	Biden	PROPN
+governor	governor	NOUN
+early morning	morning	NOUN
+catastrophic	catastrophic	PROPN
+I-695 Key Bridge	I-695	PROPN
+James Wallace	Wallace	PROPN
+fire	fire	NOUN
+filling potholes	filling	VERB
+Reuters	Reuters	NOUN
+vehicles fell	fell	VERB
+BBC	BBC	PROPN
+ship rams	rams	NOUN
+local time	time	NOUN
+large vessel	vessel	NOUN
+baltimore biggest	biggest	ADJ
+water	water	NOUN
+Synergy Marine Group, LSEG	Group	PROPN
+director of communications	director	NOUN
+collapsed early	collapsed	VERB
+ship struck	struck	VERB
+powerless cargo	cargo	NOUN
+speed	speed	NOUN
+Social Media	Media	PROPN
+maryland governor	governor	NOUN
+city	city	NOUN
+kilometer	kilometer	PROPN
+black smoke	smoke	NOUN
+Jasper News	News	PROPN
+emergency crews	crews	NOUN
+Colombo	Colombo	NOUN
+multiple	multiple	NOUN
+port	port	NOUN
+people	people	NOUN
+drove amazon	drove	VERB
+major rescue	rescue	NOUN
+Prince Harry	Harry	PROPN
+extensive search	search	NOUN
+condition	condition	NOUN
+people missing	missing	VERB
+catastrophic collapse	collapse	NOUN
+transported	transported	VERB
+caught fire	caught	VERB
+boat struck	struck	VERB
+vix	vix	PROPN
+gst	gst	NOUN
+construction company	company	NOUN
+FTSE	FTSE	PROPN
+iconic francis	francis	NOUN
+Chief	Chief	NOUN
+Wall Street Journal	Journal	PROPN
+mid-Atlantic	-	PROPN
+Wilshire	Wilshire	NOUN
+travelling outbound	outbound	NOUN
+Getty Images	Images	PROPN
+shocking spectacle	spectacle	NOUN
+singapore-flagged	flagged	VERB
+Port of Baltimore	Port	PROPN
+Mr Cartwright	Cartwright	PROPN
+superintendent	superintendent	NOUN
+people believed	believed	VERB
+night	night	NOUN
+active search	search	NOUN
+LSEG	LSEG	PROPN
+updates	updates	VERB
+long bridge	bridge	NOUN
+Brandon Sun	Sun	PROPN
+Council	Council	PROPN
+dundalk hosted	hosted	VERB
+dire emergency	emergency	NOUN
+Jasper	Jasper	NOUN
+singapore-flagged cargo	cargo	NOUN
+Dundalk	Dundalk	NOUN
+chief james	james	NOUN
+gold price	price	NOUN
+authorities began	began	VERB
+Lutnick‚Äôs	Lutnick‚Äôs	NUM
+Miami	Miami	PROPN
+major portion	portion	NOUN
+deficit widen	widen	NOUN
+Interstate 695	Interstate	NOUN
+city police	police	NOUN
+National Transportation Security Board	Board	PROPN
+Marmot Basin	Basin	PROPN
+CNN‚Äôs	CNN‚Äôs	NOUN
+Singapore-based	based	VERB
+video	video	NOUN
+YouTube	YouTube	NOUN
+emergency	emergency	NOUN
+early hours	hours	NOUN
+rescue mission	mission	NOUN
+Turner Station	Station	PROPN
+EuroStoxx	EuroStoxx	PROPN
+began searching	began	VERB
+ship issued	issued	VERB
+editor	editor	NOUN
+senior executive	executive	NOUN
+baltimore fire	fire	NOUN
+collapsed tuesday	collapsed	VERB
+March 27	March	PROPN
+trauma center	center	NOUN
+large container	container	NOUN
+calls	calls	NOUN
+causing	causing	VERB
+E-Edition	Edition	PROPN
+repairing potholes	repairing	VERB
+paul	paul	PROPN
+large boat	boat	NOUN
+Financial Times	Times	PROPN
+Mr Moore	Moore	PROPN
+Cantor Fitzgerald	Fitzgerald	PROPN
+Baltimore‚Äôs	Baltimore‚Äôs	ADJ
+CFC	CFC	PROPN
+CNN	CNN	PROPN
+coverage updates	updates	VERB
+twitter	twitter	X
+transportation secretary	secretary	NOUN
+scott key	key	NOUN
+francis scott	scott	PROPN
+frigid waters	waters	NOUN
+WYPR	WYPR	PROPN
+live updates	updates	NOUN
+Olive Baptist Church	Church	PROPN
+developing mass	developing	VERB
+singapore-flagged container	container	NOUN
+interfaith prayer	interfaith	ADP
+12 million vehicles	vehicles	NOUN
+president	president	NOUN
+workers rescued	rescued	VERB
+Fiat‚Äôs	Fiat‚Äôs	ADV
+company brawner	brawner	NOUN
+county executive	executive	NOUN
+prayer vigil	vigil	NOUN
+Jennifer Homendy	Homendy	PROPN
+told reporters	told	VERB
+shipping port	port	NOUN
+bridge’s	bridge	PROPN
+Fifth Coast Guard District	District	PROPN
+Daily Mail	Mail	PROPN
+Shutterstock	Shutterstock	VERB
+major	major	ADJ
+entire road	road	NOUN
+families	families	NOUN
+individuals	individuals	NOUN
+operations	operations	NOUN
+multiple emergency	emergency	NOUN
+date march	march	PROPN
+mammoth cargo	cargo	NOUN
+bridge fell	fell	VERB
+feared dead	feared	VERB
+individual	individual	NOUN
+Widefield	Widefield	PROPN
+General News Grampians	Grampians	PROPN
+local	local	ADJ
+interfaith prayer vigil	interfaith	ADP
+seaboard	seaboard	PROPN
+American Pilots Association	Association	PROPN
+efforts	efforts	NOUN
+emergency rescue	rescue	NOUN
+detoured	detoured	VERB
+Stawell Warriors	Warriors	NOUN
+Wimmera	Wimmera	NOUN
+attacks	attacks	NOUN
+Hot Summer Guide	Guide	PROPN
+BALITMORE BRIDGE	BRIDGE	PROPN
+US National Data Buoy Centre	Centre	PROPN
+Patapsco	Patapsco	NOUN
+Clay Diamond	Diamond	PROPN
+auctions	auctions	NOUN
+fire department	department	NOUN
+biden vows	vows	NOUN
+shocking	shocking	ADJ
+dali rests	rests	VERB
+hormuz attacks	attacks	NOUN
+brug update	update	NOUN
+Rocky Mountain Outlook	Outlook	PROPN
+Buttigieg	Buttigieg	NOUN
+saved	saved	VERB
+column posted	posted	VERB
+causing multiple	causing	VERB
+channel made	made	VERB
+Canmore News	News	PROPN
+chip stocks	stocks	NOUN
+collision march	march	NOUN
+boat crashes	crashes	VERB
+vessel appeared	appeared	VERB
+bridge tumble	tumble	NOUN
+story	story	NOUN
+Guatemala	Guatemala	PROPN
+resume wednesday	resume	NOUN
+American	American	ADJ
+regular rate	rate	NOUN
+Fire Chief	Chief	PROPN
+fallen francis	francis	PROPN
+curtisbay; curtiscreek	curtisbay	PROPN
+painful today	painful	ADJ
+face major	face	VERB
+Baltimore bridge collapse disaster	disaster	NOUN
+effort continued	continued	VERB
+authority advised	advised	VERB
+collapse cellphone	cellphone	NOUN
+äôs crew	crew	NOUN
+toppled shortly	toppled	VERB
+morning due	due	ADJ
+politics growth	growth	NOUN
+ship warning	warning	NOUN
+rise	rise	VERB
+vehicles	vehicles	NOUN
+shipping vessel	vessel	NOUN
+Melissa Alonso	Alonso	PROPN
+21twelve	21twelve	NUM
+bbc reported	reported	VERB
+bridge causing	causing	VERB
+oeffff gaat	gaat	PROPN
+Foreign Office	Office	PROPN
+business directory	directory	NOUN
+search-and-rescue effort	effort	NOUN
+ship named	ship	NOUN
+lost hope	lost	VERB
+Nadine Yousif	Yousif	PROPN
+vessel dali	dali	PROPN
+regular	regular	ADJ
+department told	told	VERB
+price	price	NOUN
+puffs	puffs	NOUN
+busy francis	francis	PROPN
+believed dead	believed	VERB
+road structure	structure	NOUN
+passed	passed	VERB
+ship hit	hit	VERB
+people left	left	VERB
+support structures	structures	NOUN
+guide obits	guide	VERB
+Mexico	Mexico	PROPN
+äìsouth	äìsouth	PROPN
+Honduras	Honduras	NOUN
+toy	toy	NOUN
+supports	supports	VERB
+long francis	francis	PROPN
+increases	increases	VERB
+posted early	posted	VERB
+Jasper Transit	Transit	PROPN
+updated march	march	PROPN
+announce tonight	announce	VERB
+singapore-based cargo	cargo	NOUN
+latest stories	stories	NOUN
+search resuming	resuming	NOUN
+warning	warning	VERB
+enjoy unlimited	enjoy	VERB
+price increases	increases	NOUN
+Careers	Careers	NOUN
+cars fall	fall	VERB
+All	All	ADV
+James W	W	PROPN
+chip	chip	NOUN
+shocking video	video	NOUN
+harbour tunnel	tunnel	NOUN
+Greece	Greece	NOUN
+Commander	Commander	NOUN
+Jack Forrest	Forrest	PROPN
+longer	longer	ADV
+matter	matter	NOUN
+livestream captured	captured	VERB
+MD of Bighorn News	MD	PROPN
+moment francis	francis	NOUN
+dramatic footage	footage	NOUN
+Jonty30	Jonty30	PROPN
+writers today	writers	NOUN
+reporting	reporting	VERB
+time reporting	reporting	VERB
+collapse due	collapse	VERB
+alive	alive	ADJ
+keywords	keywords	VERB
+painful	painful	ADJ
+frigid patapsco	patapsco	NOUN
+usa collapsed	collapsed	VERB
+frantic search-and-rescue	search	NOUN
+Washington Post	Post	PROPN
+interstate highway	highway	NOUN
+offering plans	offering	VERB
+flag flies	flies	NOUN
+recovery mission	mission	NOUN
+passenger trains	trains	NOUN
+Kate Middleton's	Middleton	PROPN
+increasingly treacherous	treacherous	ADJ
+media	media	NOUN
+earnings beat	beat	NOUN
+governor vowed	vowed	VERB
+Press	Press	PROPN
+department chief	chief	NOUN
+turn back	turn	VERB
+nbc	nbc	PROPN
+Royal Farms	Farms	PROPN
+n’t imagine	imagine	VERB
+measures hitting	measures	NOUN
+Banff News	News	PROPN
+emergency operation	operation	NOUN
+major emergency	emergency	NOUN
+Colonel Roland Butler, Jr	Butler	PROPN
+file	file	NOUN
+banner earlier	banner	NOUN
+sea director	director	NOUN
+Spain	Spain	PROPN
+response agencies	agencies	NOUN
+guard rear	rear	PROPN
+registered owner	owner	NOUN
+mirror reports	reports	VERB
+routine work	work	NOUN
+guard called	called	VERB
+add free	add	VERB
+India	India	PROPN
+live baltimore	baltimore	NOUN
+Great West Digital Agency	Agency	PROPN
+award-winning app	app	NOUN
+officials	officials	NOUN
+STAWELL Lions	Lions	PROPN
+travelling	travelling	VERB
+micron stock	stock	NOUN
+Turkey	Turkey	PROPN
+utc tuesday	utc	PROPN
+All; Drago	Drago	PROPN
+massive cargo	cargo	NOUN
+badnav	badnav	PROPN
+updates newsletter	updates	VERB
+hospital	hospital	NOUN
+baltimore head	head	NOUN
+äòmove heaven	heaven	PROPN
+baltimore naar	naar	PROPN
+page sign	sign	NOUN
+advertisement read	read	VERB
+left unaccounted	left	VERB
+fearful	fearful	ADJ
+interactive puzzles	puzzles	NOUN
+unaccounted	unaccounted	VERB
+March 26, 2024	March	PROPN
+dead advertisement	advertisement	NOUN
+key points	points	NOUN
+DAX	DAX	PROPN
+heart	heart	NOUN
+Col	Col	PROPN
+Horsham	Horsham	PROPN
+maryland collapsed	collapsed	VERB
+company	company	NOUN
+workers believed	believed	VERB
+baltimore traffic	traffic	NOUN
+weeks	weeks	NOUN
+busiest ports	ports	NOUN
+advertisement nbc	advertisement	PROPN
+executive director	director	NOUN
+bridge toppled	toppled	VERB
+Antwerpen	Antwerpen	VERB
+dead	dead	ADJ
+eastern seaboard	seaboard	PROPN
+Tiffany Wertheimer	Wertheimer	PROPN
+continue overnight	continue	VERB
+lseg data	data	PROPN
+phase	phase	NOUN
+cnn heeft	heeft	VERB
+BNO News	News	PROPN
+setting sail	setting	VERB
+PDT	PDT	PROPN
+authority posted	posted	VERB
+THE Great Western	Western	PROPN
+conference earlier	conference	NOUN
+vessel neared	neared	VERB
+Stoney Nakoda News	News	PROPN
+Jacqueline Howard	Howard	PROPN
+Free Press	Press	PROPN
+bridge triggering	triggering	VERB
+Bay Area Mechanical Services	Services	PROPN
+alaskaerik	alaskaerik	PROPN
+Biden Administration	Administration	PROPN
+personnel	personnel	NOUN
+hit	hit	VERB
+recovered buttigieg	buttigieg	NOUN
+Andy Middleton	Middleton	PROPN
+dali monday	monday	PROPN
+announced tuesday	announced	VERB
+work filling	filling	VERB
+Jason Paterson	Paterson	PROPN
+farms convenience	convenience	NOUN
+Sonar	Sonar	NOUN
+state transportation	transportation	NOUN
+videos show	show	VERB
+bond offering	offering	NOUN
+Paul Widefield	Widefield	PROPN
+missing presumed	presumed	VERB
+guard officials	officials	NOUN
+support column	column	NOUN
+attacks lift	lift	VERB
+Lauren Mascarenhas	Mascarenhas	PROPN
+guard searching	searching	VERB
+british football	football	PROPN
+rate	rate	NOUN
+response moving	moving	VERB
+water oeffff	oeffff	PROPN
+partially crumbling	crumbling	VERB
+Madeline Halpert	Halpert	PROPN
+guard	guard	NOUN
+hours	hours	NOUN
+tractor-trailer	trailer	NOUN
+posted march	posted	VERB
+official called	called	VERB
+football pitches	pitches	NOUN
+conference tuesday	conference	NOUN
+terrible accident	accident	NOUN
+largest ports	ports	NOUN
+Six people	people	NOUN
+local company	company	NOUN
+trucks	trucks	NOUN
+seng	seng	PROPN
+deficit	deficit	NOUN
+diverting traffic	diverting	VERB
+ntsb chair	chair	NOUN
+crew made	made	VERB
+guard-listed vessels	vessels	NOUN
+Maine	Maine	NOUN
+smoke billowed	billowed	VERB
+Brandon Livesay	Livesay	PROPN
+America	America	PROPN
+day informed	informed	VERB
+based	based	VERB
+police officials	officials	NOUN
+treacherous currents	currents	NOUN
+pitches long	pitches	NOUN
+maryland early	maryland	PROPN
+campaign	campaign	NOUN
+Metro's	Metro	PROPN
+agency search	search	NOUN
+Harford County Volunteer Fire and EMS	Fire	PROPN
+lights flickered	flickered	VERB
+dali crash	crash	NOUN
+Tueday	Tueday	NOUN
+cards early	cards	NOUN
+qualified returning	returning	VERB
+amid	amid	ADP
+large	large	ADJ
+LEA SKENE	SKENE	PROPN
+cellphone video	video	NOUN
+rebuilding	rebuilding	VERB
+Rear Adm Shannon Gilreath	Gilreath	PROPN
+transition	transition	NOUN
+latest coverage	coverage	NOUN
+suspended	suspended	VERB
+data show	show	NOUN
+dark waters	waters	NOUN
+posted	posted	VERB
+american flag	flag	PROPN
+mirror	mirror	NOUN
+RMO 25	RMO	PROPN
+missing workers	workers	NOUN
+efforts turned	turned	VERB
+director andy	andy	PROPN
+NBC 5 DFW	DFW	PROPN
+handling	handling	VERB
+Home News	News	PROPN
+foreseeable future	future	NOUN
+vessel travelling	travelling	VERB
+NTSB	NTSB	PROPN
+stories start	start	VERB
+scene	scene	NOUN
+Ruth Comerford	Comerford	PROPN
+Treasury	Treasury	PROPN
+baltimore showed	showed	VERB
+ipo change	change	NOUN
+cold	cold	ADJ
+bow	bow	VERB
+naar colombo	colombo	NOUN
+ship hurtled	hurtled	VERB
+officials transitioned	transitioned	VERB
+secretary	secretary	NOUN
+Baltimore Banner	Banner	PROPN
+ship destroyed	destroyed	VERB
+light trucks	trucks	NOUN
+University of Maryland Medical Center	Center	PROPN
+workers possibly	workers	NOUN
+guard announced	announced	VERB
+survival diminished	diminished	VERB
+David Jones	Jones	PROPN
+moored boat	boat	NOUN
+major link	link	NOUN
+guard told	told	VERB
+Access News Break	Break	PROPN
+press conference	conference	NOUN
+search efforts	efforts	NOUN
+bridge gave	gave	VERB
+Baltimore Sun	Sun	PROPN
+Amy Simonson	Simonson	PROPN
+crumbled early	crumbled	VERB
+Grace Ocean Pte Ltd	Ltd	PROPN
+biggest bridge	bridge	NOUN
+El Salvador	Salvador	PROPN
+evening press	press	NOUN
+water early	water	NOUN
+Francis Scott Key Ridge	Ridge	PROPN
+Apostleship of the Sea	Apostleship	PROPN
+saved lives	saved	VERB
+mayday shortly	mayday	NOUN
+Lake Louise News	News	PROPN
+hang	hang	VERB
+coast	coast	PROPN
+agencies received	received	VERB
+bridge moments	moments	NOUN
+collapse officials	officials	NOUN
+neared	neared	VERB
+Detective Niki Fennoy	Fennoy	PROPN
+Brandon Drenon	Drenon	PROPN
+missing men	missing	VERB
+received	received	VERB
+Middleton	Middleton	PROPN
+NBC4	NBC4	PROPN
+city collapses	collapses	VERB
+structure falling	falling	VERB
+partial bridge	bridge	NOUN
+topics	topics	NOUN
+helicopters	helicopters	NOUN
+China	China	PROPN
+gold	gold	NOUN
+Pete Buttigieg	Buttigieg	PROPN
+Kananaskis Country News	News	PROPN
+sending people	sending	VERB
+advertisement	advertisement	NOUN
+traffic alert	alert	NOUN
+roadway	roadway	NOUN
+Latest News Warriors	Warriors	NOUN
+believed missing	believed	VERB
+Lions	Lions	NOUN
+Vox Populi	Populi	PROPN
+main north	north	NOUN
+bodies removed	removed	VERB
+diminished visibility	diminished	VERB
+attack’ read	read	NOUN
+boat	boat	NOUN
+terror keywords	keywords	VERB
+wes	wes	NOUN
+indefinite closure	indefinite	VERB
+partners	partners	NOUN
+huge bond	bond	NOUN
+face	face	VERB
+Tarik Habte	Habte	PROPN
+audience advertising	advertising	NOUN
+USA	USA	PROPN
+uur	uur	ADJ
+water baltimore	baltimore	PROPN
+News Break	Break	PROPN
+CEO	CEO	NOUN
+governor wes	wes	NOUN
+collapse key	collapse	VERB
+calendar discover	discover	VERB
+rebuild baltimore	rebuild	VERB
+terrifying collapse	collapse	NOUN
+lift	lift	VERB
+navigation	navigation	NOUN
+Laura Coates	Coates	PROPN
+reportedly fallen	fallen	VERB
+Pasadena, Md	Pasadena	PROPN
+incident tuesday	incident	PROPN
+crew filling	filling	VERB
+barrelling	barrelling	VERB
+drop	drop	VERB
+chilly waters	waters	NOUN
+het water	water	NOUN
+offer	offer	VERB
+rapid	rapid	ADJ
+trade deficit	deficit	NOUN
+affected	affected	VERB
+sentdefender posted	posted	VERB
+lights	lights	NOUN
+bridge early	bridge	PROPN


### PR DESCRIPTION
## Why

Entity resolution is the make-or-break foundation of the graph substrate: today the KG's nodes are surface **mentions**, not entities (the Dali ≈ 8 nodes; ~half are verb-phrase fragments). Resolving them needs a syntactic **head** per mention — `Port of Baltimore` → `Port`, `ship crashed` → a verb-headed fragment to strip. This wires a real dependency parser into the engine as that foundation.

This is **Phase 1.1** of the entity-resolution roadmap (`shodh-vault/06-Engineering/Entity-Resolution-Plan.md`). It is the **frozen base** — nothing here learns at runtime; the learned matcher/coref/self-improving layers sit above it in later phases.

## What

- **`crates/spacy-rusty`** — vendored, pure-Rust reimplementation of spaCy's `en_core_web_sm` pipeline (tokenizer/tagger/parser/lemmatizer). Vendored (not a git/path dep to an external checkout) for sovereignty: deterministic, auditable, no external fetch. MIT/Apache; `NOTICE` carries the spaCy attribution.
  - Native `rlib` only (wasm bindings are `target_arch = "wasm32"`-gated and dropped from the default build).
  - `Rc<Vectors>` → `Arc<Vectors>` so **one** loaded pipeline is shared read-only across the async workers, instead of 15 MB per thread. Refcount primitive only — **zero change** to parse/tag/lemma output.
  - clippy allowed on the vendored crate: we track it to upstream and pin its behavior with parity tests, not our lint style.
- **`src/dep_parser.rs`** — the in-engine wrapper. Loads the bundle once (`SHODH_SPACY_MODEL_PATH`) into a `Send + Sync` `OnceLock`, exposes `parse` / `head_token` (POS + dependency head + lemma). The ~15 MB bundle is **not committed** — same asset convention as GLiNER/MiniLM. When the model is absent every entry point returns `None`, so the parser is **additive and never load-bearing** for a request. The env/global layer is split from a pure `load_from_dir` + `head_of` so tests never touch env or the `OnceLock`.

## Verification

- **Parity: 669/669.** In-engine heads reproduce Python spaCy `en_core_web_sm` exactly, through the real bundle-load + wrapper path (`tests/dep_parser_parity.rs`). `Port of Baltimore → Port`; `ship crashed → crashed/VERB`.
- **Model-free unit tests (CI-safe): 4/4** — head selection + graceful degradation, no model required.
- The parity test **skips cleanly** without the model (CI has no 15 MB asset yet — fetching it in CI is a follow-up; parity is proven locally and byte-identical to the upstream golden).
- `cargo check --tests` green across the workspace; clippy clean for the new code.

## Next

Task 1.2 (head-block resolver: span-clean + head-noun merge) consumes `dep_parser::head_token` to collapse mention nodes into canonical entities.
