### PR TITLE
fix(mcp): drain in-flight tool calls on stdin EOF before shutdown (closes #405)

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -280,6 +280,11 @@ Based on Cowan's working memory model:
 3. **Connect**: MCP client connects to this MCP server via stdio; backend requests
    use local IPC when `SHODH_IPC_ENDPOINT` is set, otherwise HTTP
 4. **Ready**: Start using `remember` and `recall` tools
+5. **Session end**: when the host closes stdin (e.g. a Claude Desktop thread
+   switch), the shim finishes any in-flight tool call and writes its response to
+   the still-open stdout before exiting, so a mid-flight request is never
+   silently dropped. Draining is bounded by a grace window; if it elapses the
+   caller receives an explicit error instead of waiting out the host timeout.
 
 The backend server runs locally and stores all data on your machine. No cloud dependency.
 

--- a/mcp-server/drain.ts
+++ b/mcp-server/drain.ts
@@ -1,0 +1,201 @@
+/**
+ * Drain controller — keeps the MCP shim alive long enough to finish in-flight
+ * tool calls when the host closes stdin on a thread switch (issue #405).
+ *
+ * Background: MCP hosts such as Claude Desktop close the shim's *stdin* when the
+ * user switches threads, but leave *stdout* open. The stdio server transport
+ * (`@modelcontextprotocol/sdk`) never listens to stdin "end"/"close"; it writes
+ * responses to stdout whenever a request handler's promise resolves. So a tool
+ * call that is mid-flight when stdin EOFs can still be answered — as long as the
+ * process does not exit first. Previously the shim called `gracefulShutdown` on
+ * the stdin "end"/"close" events and exited ~100ms later, abandoning the pending
+ * `await` and leaving the caller to eat the host's ~4-minute call timeout.
+ *
+ * This controller sits between the stdin lifecycle events and shutdown:
+ *   - It counts in-flight tool calls (via {@link track}).
+ *   - On stdin EOF with nothing in flight, it shuts down immediately (no change).
+ *   - On stdin EOF with work in flight, it delays shutdown until every call has
+ *     settled and its response has been written, bounded by a grace window so it
+ *     can never hang forever.
+ *   - If the grace window expires (or stdout is gone), it resolves the abandoned
+ *     calls with an explicit error result — written to the still-open stdout —
+ *     so the caller gets a prompt error instead of a silent drop, then exits.
+ *
+ * The controller is transport-agnostic and fully injectable so it can be unit
+ * tested without a live process, transport, or backend.
+ */
+
+export type TimerHandle = ReturnType<typeof setTimeout>;
+
+export interface DrainControllerOptions<R> {
+  /**
+   * Upper bound (ms) on how long to wait for in-flight tool calls to settle
+   * after stdin EOF before abandoning them. Must exceed the longest a single
+   * tool handler can legitimately take, so a slow-but-progressing backend call
+   * is never truncated — yet stay well under the host's call timeout so the
+   * caller still receives a response (real or {@link abandonResult}).
+   */
+  graceMs: number;
+  /**
+   * Result handed to any tool call still in flight when the grace window
+   * expires (or stdout is lost). Written to stdout by the normal handler-return
+   * path so the caller gets an error rather than nothing.
+   */
+  abandonResult: R;
+  /**
+   * Whether the output stream (stdout) can still be written. When false the host
+   * is fully gone and no response can be delivered, so draining is pointless and
+   * the controller shuts down immediately.
+   */
+  isOutputWritable: () => boolean;
+  /** Perform the real teardown + process exit. Idempotent on the caller's side. */
+  shutdown: (reason: string) => void;
+  /** Structured log sink; defaults to {@link console.error}. */
+  log?: (message: string) => void;
+  /** Timer scheduler; injectable for deterministic tests. Defaults to setTimeout. */
+  setTimer?: (fn: () => void, ms: number) => TimerHandle;
+  /** Timer canceller; injectable for deterministic tests. Defaults to clearTimeout. */
+  clearTimer?: (handle: TimerHandle) => void;
+}
+
+export class DrainController<R> {
+  private inFlight = 0;
+  private stdinClosed = false;
+  private completed = false;
+  private forceAbandon = false;
+  private graceTimer: TimerHandle | null = null;
+
+  private readonly graceMs: number;
+  private readonly abandonResult: R;
+  private readonly isOutputWritable: () => boolean;
+  private readonly doShutdown: (reason: string) => void;
+  private readonly log: (message: string) => void;
+  private readonly setTimer: (fn: () => void, ms: number) => TimerHandle;
+  private readonly clearTimer: (handle: TimerHandle) => void;
+
+  // Signal that unblocks every in-flight `track()` race, resolving each one with
+  // the abandon result. Triggered exactly once, on forced drain.
+  private readonly abandonSignal: Promise<void>;
+  private triggerAbandon!: () => void;
+
+  constructor(options: DrainControllerOptions<R>) {
+    this.graceMs = options.graceMs;
+    this.abandonResult = options.abandonResult;
+    this.isOutputWritable = options.isOutputWritable;
+    this.doShutdown = options.shutdown;
+    this.log = options.log ?? ((message: string) => console.error(message));
+    this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle));
+    this.abandonSignal = new Promise<void>((resolve) => {
+      this.triggerAbandon = resolve;
+    });
+  }
+
+  /** Number of tool calls currently in flight. */
+  get inFlightCount(): number {
+    return this.inFlight;
+  }
+
+  /** True once stdin has closed and a drain is (or was) pending. */
+  get isDraining(): boolean {
+    return this.stdinClosed && !this.completed;
+  }
+
+  /**
+   * Run a tool call under drain tracking. The in-flight count is incremented for
+   * the duration and decremented once the work settles (success OR error). If a
+   * forced drain occurs while the work is still pending, the returned promise
+   * resolves with {@link abandonResult} so the caller is answered promptly; the
+   * underlying work is left to finish on its own as the process exits.
+   */
+  async track<T extends R>(work: () => Promise<T>): Promise<T> {
+    this.inFlight++;
+    try {
+      if (this.forceAbandon) {
+        // Grace window already expired before this call even started.
+        return this.abandonResult as T;
+      }
+      // Kick off the work but race it against the abandon signal so a forced
+      // drain can pre-empt a hung backend call with a written error result.
+      const workPromise = work();
+      return await Promise.race([
+        workPromise,
+        this.abandonSignal.then(() => this.abandonResult as T),
+      ]);
+    } finally {
+      this.inFlight--;
+      this.onSettled();
+    }
+  }
+
+  /**
+   * Handle a stdin "end"/"close" event (both fire; the first wins). Decides
+   * between immediate shutdown and a bounded drain of in-flight tool calls.
+   */
+  onStdinClose(reason: string): void {
+    if (this.stdinClosed) return; // double-fire guard: end + close both fire
+    this.stdinClosed = true;
+
+    if (this.inFlight === 0) {
+      // Nothing in flight — behave exactly as before this fix.
+      this.shutdown(reason);
+      return;
+    }
+
+    if (!this.isOutputWritable()) {
+      // Host is fully gone; we could not deliver a response even if we waited.
+      this.shutdown(
+        `${reason} (output stream not writable — cannot deliver ${this.inFlight} in-flight response(s))`,
+      );
+      return;
+    }
+
+    this.log(
+      `[shodh-memory] stdin closed with ${this.inFlight} in-flight tool call(s); draining before shutdown (grace ${this.graceMs}ms)...`,
+    );
+    this.graceTimer = this.setTimer(() => {
+      this.forceDrain(
+        `drain grace window (${this.graceMs}ms) expired — abandoning ${this.inFlight} in-flight tool call(s) and shutting down`,
+      );
+    }, this.graceMs);
+  }
+
+  /**
+   * Handle loss of the output stream (stdout "error"/"close") while draining.
+   * Without stdout there is nothing to drain toward, so abandon and exit.
+   */
+  onOutputLost(reason: string): void {
+    if (!this.stdinClosed || this.completed) return;
+    this.forceDrain(reason);
+  }
+
+  private shutdown(reason: string): void {
+    if (this.completed) return;
+    this.completed = true;
+    if (this.graceTimer !== null) {
+      this.clearTimer(this.graceTimer);
+      this.graceTimer = null;
+    }
+    this.doShutdown(reason);
+  }
+
+  private onSettled(): void {
+    if (this.stdinClosed && this.inFlight === 0) {
+      // Last in-flight call finished after stdin EOF. Its response has resolved
+      // and will be flushed to stdout by shutdown's own grace period.
+      this.shutdown("in-flight tool call(s) drained after stdin EOF — shutting down");
+    }
+  }
+
+  private forceDrain(reason: string): void {
+    this.forceAbandon = true;
+    // Unblock in-flight races so each resolves with the abandon result. Only
+    // worth attempting if stdout can still carry the error to the caller.
+    // Idempotent: triggerAbandon resolves a promise (a no-op if re-called).
+    if (this.isOutputWritable()) {
+      this.triggerAbandon();
+    }
+    // `shutdown` is the single completion gate — guards against double-exit.
+    this.shutdown(reason);
+  }
+}

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -16,6 +16,7 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
+  type CallToolRequest,
   ListToolsRequestSchema,
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
@@ -34,6 +35,7 @@ import { TokenTracker } from "./token-tracking";
 import { resolvePackageVersion } from "./version";
 import { renderContent, MEMORY_PREVIEW_MAX } from "./memory-format";
 import { ShodhIpcClient, type WindowsIpcHelper } from "./ipc-client";
+import { DrainController } from "./drain";
 
 const __filename = (typeof import.meta !== "undefined" && import.meta.url) ? fileURLToPath(import.meta.url) : "";
 const __dirname = __filename ? path.dirname(__filename) : process.cwd();
@@ -136,6 +138,60 @@ const REQUEST_TIMEOUT_MS = 10000;
 // persists data before post-processing (graph, lineage, temporal facts).
 // Issue #109: 10s was too short, causing retries that created duplicate memories.
 const WRITE_TIMEOUT_MS = 30000;
+
+// -----------------------------------------------------------------------------
+// In-flight drain on stdin EOF (issue #405)
+// -----------------------------------------------------------------------------
+// MCP hosts (e.g. Claude Desktop) close the shim's stdin on a thread switch but
+// leave stdout open. A tool call mid-flight when stdin EOFs can still be
+// answered over stdout — provided the process does not exit first. The drain
+// controller keeps us alive until in-flight calls settle, bounded by a grace
+// window, then delivers an error for anything still stuck so the caller never
+// eats the host's ~4-minute call timeout.
+
+// Shape any tool response can take (mirrors the handler's return union).
+type CallToolResult = {
+  content: { type: string; text: string }[];
+  isError?: boolean;
+  _meta?: unknown;
+};
+
+// Grace window for draining in-flight tool calls after stdin EOF. Derived from
+// the request budget so a slow-but-progressing backend call is never truncated:
+// a retried idempotent GET can take up to RETRY_ATTEMPTS * REQUEST_TIMEOUT_MS of
+// timeouts, and a write up to WRITE_TIMEOUT_MS — 3*10s + 30s = 60s covers a
+// handler that chains both. Still far below the host's ~240s call timeout, so
+// the caller always gets a response (real, or an abandon error) well in time.
+const DRAIN_GRACE_MS = RETRY_ATTEMPTS * REQUEST_TIMEOUT_MS + WRITE_TIMEOUT_MS;
+
+// Result returned to a tool call still in flight when the grace window expires.
+const DRAIN_ABANDON_RESULT: CallToolResult = {
+  content: [
+    {
+      type: "text",
+      text:
+        "Error: the MCP session ended (host closed stdin) before this tool call finished, " +
+        "and the shim's drain grace window elapsed while the backend was still working. " +
+        "The request was abandoned during shutdown; the backend may have already applied the change. " +
+        "Re-check state or retry in a new session.",
+    },
+  ],
+  isError: true,
+};
+
+// True while stdout can still carry a response back to the host.
+function isStdoutWritable(): boolean {
+  const out = process.stdout;
+  return Boolean(out) && out.writable !== false && !out.writableEnded && !out.destroyed;
+}
+
+// Constructed here; `gracefulShutdown` is a hoisted function declaration below.
+const drain = new DrainController<CallToolResult>({
+  graceMs: DRAIN_GRACE_MS,
+  abandonResult: DRAIN_ABANDON_RESULT,
+  isOutputWritable: isStdoutWritable,
+  shutdown: (reason) => gracefulShutdown(reason),
+});
 
 // Warn if non-localhost URL uses HTTP (security risk)
 if ((!IPC_ENDPOINT || IPC_WEBSOCKET_STREAM_ENABLED)
@@ -1637,7 +1693,7 @@ function autoStreamContext(toolName: string, args: Record<string, unknown>): voi
 }
 
 // Handle tool calls
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
+const handleCallTool = async (request: CallToolRequest) => {
   const { name, arguments: args } = request.params;
 
   // Ensure streaming is connected (lazy reconnect on tool calls)
@@ -4148,7 +4204,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       isError: true,
     };
   }
-});
+};
+
+// Register the tool handler under drain tracking (issue #405): the in-flight
+// count drives whether a stdin EOF shuts down immediately or drains first.
+server.setRequestHandler(CallToolRequestSchema, (request) =>
+  drain.track(() => handleCallTool(request)),
+);
 
 // List resources (static commands + dynamic memories)
 server.setRequestHandler(ListResourcesRequestSchema, async () => {
@@ -5010,8 +5072,25 @@ function gracefulShutdown(reason: string, code: number = 0) {
 // stdin "end" fires when EOF is read (host closed write end of pipe).
 // stdin "close" fires when the underlying resource is freed.
 // Both are terminal — the host is gone, there's no session to evict.
-process.stdin.on("end", () => gracefulShutdown("stdin closed (MCP session ended), shutting down..."));
-process.stdin.on("close", () => gracefulShutdown("stdin pipe closed, shutting down..."));
+// Issue #405: hosts close stdin (not stdout) on a thread switch. Route the EOF
+// through the drain controller so any in-flight tool call finishes and its
+// response is written to the still-open stdout before we exit.
+process.stdin.on("end", () => drain.onStdinClose("stdin closed (MCP session ended), shutting down..."));
+process.stdin.on("close", () => drain.onStdinClose("stdin pipe closed, shutting down..."));
+
+// If stdout dies while we are mid-drain there is nothing left to deliver to —
+// abandon in-flight calls and exit instead of waiting out the grace window.
+// Outside a drain, a stdout error means the host is gone: preserve the prior
+// uncaught-EPIPE behaviour (log + exit) rather than silently swallowing it.
+process.stdout.on("error", (err) => {
+  if (drain.isDraining) {
+    drain.onOutputLost("stdout errored during drain, shutting down...");
+  } else {
+    console.error("[shodh-memory] stdout error:", err);
+    gracefulShutdown("stdout errored, shutting down...", 1);
+  }
+});
+process.stdout.on("close", () => drain.onOutputLost("stdout closed during drain, shutting down..."));
 
 // Catch unhandled errors to ensure cleanup runs
 process.on("uncaughtException", (err) => {

--- a/mcp-server/tests/drain.test.ts
+++ b/mcp-server/tests/drain.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DrainController, type TimerHandle } from "../drain";
+
+type Result = { content: { type: string; text: string }[]; isError?: boolean };
+
+const ABANDON: Result = {
+  content: [{ type: "text", text: "ABANDONED" }],
+  isError: true,
+};
+
+function real(text: string): Result {
+  return { content: [{ type: "text", text }] };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+interface FakeTimer {
+  fn: () => void;
+  ms: number;
+  handle: number;
+  cleared: boolean;
+}
+
+function makeHarness(opts?: { graceMs?: number; writable?: boolean }) {
+  const graceMs = opts?.graceMs ?? 60_000;
+  const shutdownCalls: string[] = [];
+  const logs: string[] = [];
+  const state = { writable: opts?.writable ?? true };
+  const timers: FakeTimer[] = [];
+  let nextHandle = 1;
+
+  const controller = new DrainController<Result>({
+    graceMs,
+    abandonResult: ABANDON,
+    isOutputWritable: () => state.writable,
+    shutdown: (reason) => shutdownCalls.push(reason),
+    log: (message) => logs.push(message),
+    setTimer: (fn, ms) => {
+      const handle = nextHandle++;
+      timers.push({ fn, ms, handle, cleared: false });
+      return handle as unknown as TimerHandle;
+    },
+    clearTimer: (handle) => {
+      const timer = timers.find((t) => t.handle === (handle as unknown as number));
+      if (timer) timer.cleared = true;
+    },
+  });
+
+  return {
+    controller,
+    shutdownCalls,
+    logs,
+    state,
+    timers,
+    activeTimers: () => timers.filter((t) => !t.cleared),
+    fireGraceTimer: () => {
+      const active = timers.filter((t) => !t.cleared);
+      if (active.length === 0) throw new Error("no active grace timer to fire");
+      active[0].fn();
+    },
+  };
+}
+
+describe("DrainController — nothing in flight", () => {
+  it("shuts down immediately on stdin EOF and schedules no grace timer", () => {
+    const h = makeHarness();
+    expect(h.controller.isDraining).toBe(false);
+    h.controller.onStdinClose("eof");
+    expect(h.shutdownCalls).toEqual(["eof"]);
+    expect(h.timers).toHaveLength(0);
+  });
+
+  it("shuts down exactly once when both stdin end and close fire (double-fire guard)", () => {
+    const h = makeHarness();
+    h.controller.onStdinClose("end-fired");
+    h.controller.onStdinClose("close-fired");
+    expect(h.shutdownCalls).toEqual(["end-fired"]);
+  });
+});
+
+describe("DrainController — draining in-flight calls", () => {
+  it("delivers the real in-flight response before exiting on stdin EOF", async () => {
+    const h = makeHarness();
+    const work = deferred<Result>();
+    const tracked = h.controller.track(() => work.promise);
+    expect(h.controller.inFlightCount).toBe(1);
+
+    // Host closes stdin mid-flight: must NOT exit yet, must arm the grace timer.
+    h.controller.onStdinClose("eof");
+    expect(h.controller.isDraining).toBe(true);
+    expect(h.shutdownCalls).toHaveLength(0);
+    expect(h.activeTimers()).toHaveLength(1);
+    expect(h.logs.some((l) => l.includes("draining before shutdown"))).toBe(true);
+
+    // Backend finishes: caller gets the REAL result, not the abandon result.
+    work.resolve(real("REAL"));
+    await expect(tracked).resolves.toEqual(real("REAL"));
+
+    // Only now do we shut down, and the grace timer is cleared.
+    expect(h.shutdownCalls).toHaveLength(1);
+    expect(h.timers[0].cleared).toBe(true);
+    expect(h.controller.inFlightCount).toBe(0);
+
+    // A late output-loss signal after completion is a harmless no-op.
+    h.controller.onOutputLost("late");
+    expect(h.shutdownCalls).toHaveLength(1);
+  });
+
+  it("waits for ALL in-flight calls before shutting down", async () => {
+    const h = makeHarness();
+    const w1 = deferred<Result>();
+    const w2 = deferred<Result>();
+    const t1 = h.controller.track(() => w1.promise);
+    const t2 = h.controller.track(() => w2.promise);
+    expect(h.controller.inFlightCount).toBe(2);
+
+    h.controller.onStdinClose("eof");
+
+    w1.resolve(real("a"));
+    await expect(t1).resolves.toEqual(real("a"));
+    expect(h.shutdownCalls).toHaveLength(0); // one still in flight
+    expect(h.controller.inFlightCount).toBe(1);
+
+    w2.resolve(real("b"));
+    await expect(t2).resolves.toEqual(real("b"));
+    expect(h.shutdownCalls).toHaveLength(1);
+  });
+
+  it("decrements the in-flight count even when the tool call throws", async () => {
+    const h = makeHarness();
+    const tracked = h.controller.track(async () => {
+      throw new Error("boom");
+    });
+    await expect(tracked).rejects.toThrow("boom");
+    expect(h.controller.inFlightCount).toBe(0);
+  });
+
+  it("does not shut down when a call settles before any stdin EOF", async () => {
+    const h = makeHarness();
+    await expect(h.controller.track(async () => real("ok"))).resolves.toEqual(real("ok"));
+    expect(h.shutdownCalls).toHaveLength(0);
+    expect(h.controller.isDraining).toBe(false);
+  });
+});
+
+describe("DrainController — grace window expiry", () => {
+  it("abandons a hung in-flight call with an error result, then exits", async () => {
+    const h = makeHarness();
+    const work = deferred<Result>(); // backend never responds
+    const tracked = h.controller.track(() => work.promise);
+
+    h.controller.onStdinClose("eof");
+    expect(h.shutdownCalls).toHaveLength(0);
+
+    // Grace window elapses.
+    h.fireGraceTimer();
+    await expect(tracked).resolves.toEqual(ABANDON);
+    expect(h.shutdownCalls).toHaveLength(1);
+    expect(h.shutdownCalls[0]).toContain("grace window");
+  });
+
+  it("returns the abandon result immediately for calls that start after expiry", async () => {
+    const h = makeHarness();
+    const work = deferred<Result>();
+    const t1 = h.controller.track(() => work.promise);
+    h.controller.onStdinClose("eof");
+    h.fireGraceTimer();
+    await expect(t1).resolves.toEqual(ABANDON);
+
+    const t2 = h.controller.track(async () => real("late"));
+    await expect(t2).resolves.toEqual(ABANDON);
+  });
+});
+
+describe("DrainController — output stream gone", () => {
+  it("shuts down immediately if stdout is already unwritable when stdin closes mid-flight", () => {
+    const h = makeHarness({ writable: false });
+    const work = deferred<Result>();
+    void h.controller.track(() => work.promise);
+
+    h.controller.onStdinClose("eof");
+    expect(h.shutdownCalls).toHaveLength(1);
+    expect(h.shutdownCalls[0]).toContain("not writable");
+    expect(h.timers).toHaveLength(0); // no drain attempted
+  });
+
+  it("abandons and exits if stdout dies during the drain window", async () => {
+    const h = makeHarness();
+    const work = deferred<Result>();
+    const tracked = h.controller.track(() => work.promise);
+    h.controller.onStdinClose("eof");
+    expect(h.shutdownCalls).toHaveLength(0);
+
+    // stdout dies mid-drain: cannot deliver, so exit now (no abandon write).
+    h.state.writable = false;
+    h.controller.onOutputLost("stdout gone");
+    expect(h.shutdownCalls).toEqual(["stdout gone"]);
+
+    // The underlying work still resolves to its real value; process is exiting.
+    work.resolve(real("late"));
+    await expect(tracked).resolves.toEqual(real("late"));
+  });
+
+  it("ignores output loss when not draining", () => {
+    const h = makeHarness();
+    h.controller.onOutputLost("noise");
+    expect(h.shutdownCalls).toHaveLength(0);
+  });
+});
+
+describe("DrainController — default wiring (no injected log/timers)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("uses console.error and real timers, clearing the timer on a normal drain", async () => {
+    vi.useFakeTimers();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const shutdownCalls: string[] = [];
+    const controller = new DrainController<Result>({
+      graceMs: 5_000,
+      abandonResult: ABANDON,
+      isOutputWritable: () => true,
+      shutdown: (reason) => shutdownCalls.push(reason),
+    });
+
+    const work = deferred<Result>();
+    const tracked = controller.track(() => work.promise);
+    controller.onStdinClose("eof");
+    expect(errSpy).toHaveBeenCalled(); // default log sink
+
+    work.resolve(real("ok"));
+    await expect(tracked).resolves.toEqual(real("ok"));
+    expect(shutdownCalls).toHaveLength(1);
+
+    // The real grace timer was cleared, so advancing time triggers nothing more.
+    vi.advanceTimersByTime(10_000);
+    expect(shutdownCalls).toHaveLength(1);
+  });
+
+  it("fires the default real timer on grace expiry", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const shutdownCalls: string[] = [];
+    const controller = new DrainController<Result>({
+      graceMs: 5_000,
+      abandonResult: ABANDON,
+      isOutputWritable: () => true,
+      shutdown: (reason) => shutdownCalls.push(reason),
+    });
+
+    const work = deferred<Result>(); // hung
+    const tracked = controller.track(() => work.promise);
+    controller.onStdinClose("eof");
+
+    vi.advanceTimersByTime(5_000);
+    await expect(tracked).resolves.toEqual(ABANDON);
+    expect(shutdownCalls).toHaveLength(1);
+  });
+});

--- a/mcp-server/vitest.config.ts
+++ b/mcp-server/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     include: ["tests/**/*.test.ts"],
     coverage: {
       provider: "v8",
-      include: ["security-utils.ts", "string-utils.ts", "token-tracking.ts", "memory-format.ts"],
+      include: ["security-utils.ts", "string-utils.ts", "token-tracking.ts", "memory-format.ts", "drain.ts"],
       reporter: ["text", "lcov"],
       thresholds: {
         statements: 100,


### PR DESCRIPTION
Closes #405. When Claude Desktop closes the shim's stdin on a thread switch, in-flight tool calls were abandoned — the caller got nothing and ate the host's ~4-minute timeout, even though the backend on :3030 finished the work.

## Root cause
`stdin.on("end")` → `gracefulShutdown` → exit, with no in-flight tracking. Only *stdin* closes on a thread switch; *stdout* stays open — so the response could still be delivered if the process didn't exit first.

## Fix
New injectable `DrainController` (`mcp-server/drain.ts`) sits between the stdin lifecycle and shutdown:
- Tracks in-flight tool calls (`CallToolRequest` handler wrapped in `drain.track()`).
- **Nothing in flight** → shuts down immediately (unchanged behavior).
- **Work in flight** → delays shutdown until every call settles and its response is written, then exits — draining promptly the instant the last call finishes, not for the full window.
- **Bounded** by a 60s grace window (= `RETRY_ATTEMPTS×REQUEST_TIMEOUT + WRITE_TIMEOUT`, derived from the file's own request budget — never truncates a slow-but-progressing call, well under the host's ~240s call timeout). On expiry, each pending call resolves with an explicit **error result written to stdout** so the caller gets a prompt error instead of a silent drop.
- **stdout gone** (host fully departed) → shuts down immediately; `onOutputLost` covers stdout dying mid-drain.
- **Signals (SIGINT/SIGTERM) bypass the drain** — a real shutdown exits promptly.

Fills the gap #218 left (shutdown hygiene, but not the in-flight path).

## Verified
- SDK viability confirmed: the shipped stdio transport listens only to stdin `data`/`error` (never `end`/`close`) and `send()` writes to stdout independently — response-after-stdin-close is fully supported.
- `npm test` 128 pass (new `drain.ts` at 100% coverage, incl. in-flight-delivered, prompt-when-idle, grace-expiry-error, stdout-gone cases); `bun run build` clean.
- Caught + fixed a latent type bug (an explicit `Promise<CallToolResult>` annotation broke SDK `ServerResult` assignability).

devklepacki's 4th daily-use report; contained TS-only change.