### PR TITLE
fix(api): paginate /api/memories — add offset, lift hard 1000 cap, return total (closes #407)

### DIFF
--- a/src/handlers/crud.rs
+++ b/src/handlers/crud.rs
@@ -40,10 +40,26 @@ pub struct MemoryWithHierarchy {
 // LIST MEMORIES TYPES
 // =============================================================================
 
+/// Hard ceiling on `limit` for the memory-listing endpoints (`/api/list/{user_id}`,
+/// `/api/memories`). Callers may request any `limit`, but it is always clamped to
+/// this value to bound per-request memory use (each returned item clones up to
+/// 500 chars of content plus tags/metadata) and RocksDB scan cost. Large exports
+/// should page through with repeated `offset`-advancing requests rather than
+/// requesting everything in one call.
+///
+/// See issue #407: the previous hard cap of 1000 (with no way to page past it)
+/// made records beyond the first 1000 permanently unreachable via this API.
+const MAX_LIST_LIMIT: usize = 10_000;
+
 /// Query parameters for listing memories
 #[derive(Debug, Deserialize)]
 pub struct ListQuery {
+    /// Max items to return. Defaults to 100, clamped to [`MAX_LIST_LIMIT`].
     pub limit: Option<usize>,
+    /// Items to skip before collecting `limit` results. Defaults to 0.
+    /// Combine with `total` in the response to page through results beyond
+    /// `MAX_LIST_LIMIT` (e.g. offset=10000, offset=20000, ...).
+    pub offset: Option<usize>,
     #[serde(rename = "type")]
     pub memory_type: Option<String>,
     /// Text search query - filters by content or tags (case-insensitive)
@@ -54,6 +70,9 @@ pub struct ListQuery {
 #[derive(Debug, Serialize)]
 pub struct ListResponse {
     pub memories: Vec<ListMemoryItem>,
+    /// Total number of memories matching the filters (`type`/`query`), independent
+    /// of `limit`/`offset`. Callers can compare `memories.len() + offset` against
+    /// `total` to know whether more pages remain.
     pub total: usize,
 }
 
@@ -61,7 +80,10 @@ pub struct ListResponse {
 #[derive(Debug, Deserialize)]
 pub struct ListMemoriesRequest {
     pub user_id: String,
+    /// Max items to return. Defaults to 100, clamped to [`MAX_LIST_LIMIT`].
     pub limit: Option<usize>,
+    /// Items to skip before collecting `limit` results. Defaults to 0.
+    pub offset: Option<usize>,
     #[serde(rename = "type")]
     pub memory_type: Option<String>,
     pub query: Option<String>,
@@ -238,7 +260,9 @@ pub async fn get_memory(
 // =============================================================================
 
 /// GET /api/list/{user_id} - List all memories for a user
-/// Query params: ?limit=100&type=Decision
+/// Query params: ?limit=100&offset=0&type=Decision
+/// `limit` defaults to 100 and is clamped to [`MAX_LIST_LIMIT`]; `offset` defaults
+/// to 0. Use `total` in the response to page through results (offset += limit).
 #[tracing::instrument(skip(state), fields(user_id = %user_id))]
 pub async fn list_memories(
     State(state): State<AppState>,
@@ -292,10 +316,12 @@ pub async fn list_memories(
     }
 
     let total = filtered.len();
-    let limit = query.limit.unwrap_or(100).min(1000);
+    let limit = query.limit.unwrap_or(100).min(MAX_LIST_LIMIT);
+    let offset = query.offset.unwrap_or(0);
 
     let memories: Vec<ListMemoryItem> = filtered
         .into_iter()
+        .skip(offset)
         .take(limit)
         .map(|m| ListMemoryItem {
             id: m.id.0.to_string(),
@@ -325,13 +351,16 @@ pub async fn list_memories_post(
 #[derive(Debug, Deserialize)]
 pub struct ListMemoriesQuery {
     pub user_id: String,
+    /// Max items to return. Defaults to 100, clamped to [`MAX_LIST_LIMIT`].
     pub limit: Option<usize>,
+    /// Items to skip before collecting `limit` results. Defaults to 0.
+    pub offset: Option<usize>,
     #[serde(rename = "type")]
     pub memory_type: Option<String>,
     pub query: Option<String>,
 }
 
-/// GET /api/memories?user_id=...&limit=... - List memories via query params
+/// GET /api/memories?user_id=...&limit=...&offset=... - List memories via query params
 /// Cloudflare Worker compatibility alias for POST /api/memories
 #[tracing::instrument(skip(state), fields(user_id = %params.user_id))]
 pub async fn list_memories_get(
@@ -341,6 +370,7 @@ pub async fn list_memories_get(
     let req = ListMemoriesRequest {
         user_id: params.user_id,
         limit: params.limit,
+        offset: params.offset,
         memory_type: params.memory_type,
         query: params.query,
     };
@@ -399,10 +429,12 @@ async fn list_memories_inner(
     }
 
     let total = filtered.len();
-    let limit = req.limit.unwrap_or(100).min(1000);
+    let limit = req.limit.unwrap_or(100).min(MAX_LIST_LIMIT);
+    let offset = req.offset.unwrap_or(0);
 
     let memories: Vec<ListMemoryItem> = filtered
         .into_iter()
+        .skip(offset)
         .take(limit)
         .map(|m| ListMemoryItem {
             id: m.id.0.to_string(),

--- a/tests/handler_tests.rs
+++ b/tests/handler_tests.rs
@@ -24,6 +24,7 @@ use shodh_memory::{
     handlers::{
         build_probe_routes, build_protected_routes, build_public_routes, MultiUserMemoryManager,
     },
+    memory::types::{Experience, ExperienceType},
 };
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -74,6 +75,27 @@ impl Harness {
             shodh_memory::auth::auth_middleware,
         ));
         Router::new().merge(probe).merge(public).merge(protected)
+    }
+
+    /// Seed `count` distinct memories for `user_id` directly through the memory
+    /// system, bypassing HTTP and the real embedder (a canned 384-dim vector is
+    /// supplied so `remember()` skips embedding generation). This is the same
+    /// direct-call pattern `brutal_stress_tests.rs` uses for bulk seeding, and is
+    /// necessary here to seed 1000+ records without paying ~300-500ms/record of
+    /// real embedding-generation cost per the timing measured in
+    /// `test_brutal_timing_record`.
+    fn seed_memories(&self, user_id: &str, count: usize) {
+        let memory = self.mgr.get_user_memory(user_id).expect("get_user_memory");
+        let guard = memory.read();
+        for i in 0..count {
+            let exp = Experience {
+                experience_type: ExperienceType::Learning,
+                content: format!("pagination-seed-{user_id}-{i:06}"),
+                embeddings: Some(vec![0.01_f32; 384]),
+                ..Default::default()
+            };
+            guard.remember(exp, None).expect("seed remember");
+        }
     }
 }
 
@@ -549,6 +571,206 @@ async fn list_memories_post_empty() {
     )
     .await;
     assert!(status.is_success());
+}
+
+// ── Issue #407: offset/limit pagination on the list endpoints ──
+
+/// GET /api/list/{user_id} (list_memories): offset actually skips records rather
+/// than being silently ignored. Pages of 10, chunked from a known-good full
+/// listing, must match the corresponding slice — proving `.skip(offset)` lines
+/// up with the same ordering `get_all_memories()` produces.
+#[tokio::test]
+async fn list_memories_get_offset_paginates_distinct_pages() {
+    let h = Harness::new();
+    h.seed_memories("offset-user", 30);
+
+    let (status, full_body) = json_of(h.app(), authed_get("/api/list/offset-user?limit=30")).await;
+    assert_eq!(status, StatusCode::OK);
+    let full_ids: Vec<String> = full_body["memories"]
+        .as_array()
+        .expect("memories array")
+        .iter()
+        .map(|m| m["id"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(full_ids.len(), 30, "expected all 30 seeded memories");
+
+    for (page_index, expected_chunk) in full_ids.chunks(10).enumerate() {
+        let offset = page_index * 10;
+        let (status, body) = json_of(
+            h.app(),
+            authed_get(&format!("/api/list/offset-user?limit=10&offset={offset}")),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let page_ids: Vec<String> = body["memories"]
+            .as_array()
+            .expect("memories array")
+            .iter()
+            .map(|m| m["id"].as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(
+            page_ids, expected_chunk,
+            "page at offset={offset} should equal slice [{offset}..{offset}+10] of the full list"
+        );
+    }
+
+    // Past-the-end offset returns an empty page, not an error.
+    let (status, body) = json_of(
+        h.app(),
+        authed_get("/api/list/offset-user?limit=10&offset=1000"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["memories"].as_array().unwrap().is_empty());
+}
+
+/// POST /api/memories (list_memories_inner via list_memories_post): offset in the
+/// request body composes with limit to walk distinct, non-overlapping pages.
+#[tokio::test]
+async fn list_memories_post_offset_paginates_distinct_pages() {
+    let h = Harness::new();
+    h.seed_memories("post-offset-user", 12);
+
+    let (status, page0) = json_of(
+        h.app(),
+        authed_post(
+            "/api/memories",
+            json!({"user_id": "post-offset-user", "limit": 5, "offset": 0}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, page1) = json_of(
+        h.app(),
+        authed_post(
+            "/api/memories",
+            json!({"user_id": "post-offset-user", "limit": 5, "offset": 5}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let ids0: std::collections::HashSet<String> = page0["memories"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m["id"].as_str().unwrap().to_string())
+        .collect();
+    let ids1: std::collections::HashSet<String> = page1["memories"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m["id"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(ids0.len(), 5);
+    assert_eq!(ids1.len(), 5);
+    assert!(
+        ids0.is_disjoint(&ids1),
+        "offset=0 and offset=5 pages must not overlap: {ids0:?} vs {ids1:?}"
+    );
+}
+
+/// GET /api/memories?...&offset=... (list_memories_get -> list_memories_inner):
+/// confirms `offset` is threaded from `ListMemoriesQuery` into `ListMemoriesRequest`
+/// rather than being dropped on the query-param path.
+#[tokio::test]
+async fn list_memories_get_query_offset_is_threaded() {
+    let h = Harness::new();
+    h.seed_memories("get-query-offset-user", 12);
+
+    let (status, page0) = json_of(
+        h.app(),
+        authed_get("/api/memories?user_id=get-query-offset-user&limit=5&offset=0"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, page1) = json_of(
+        h.app(),
+        authed_get("/api/memories?user_id=get-query-offset-user&limit=5&offset=5"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let ids0: std::collections::HashSet<String> = page0["memories"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m["id"].as_str().unwrap().to_string())
+        .collect();
+    let ids1: std::collections::HashSet<String> = page1["memories"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m["id"].as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        ids0.is_disjoint(&ids1),
+        "offset must be threaded through the GET query-param path, not ignored"
+    );
+}
+
+/// A `limit` above the old hard-coded 1000 cap must actually return more than
+/// 1000 records when the store has more — the core regression from #407.
+#[tokio::test]
+async fn list_memories_limit_above_1000_returns_more_than_1000() {
+    let h = Harness::new();
+    let seeded: usize = 1200;
+    h.seed_memories("big-user", seeded);
+
+    let (status, body) = json_of(h.app(), authed_get("/api/list/big-user?limit=2000")).await;
+    assert_eq!(status, StatusCode::OK);
+    let memories = body["memories"].as_array().expect("memories array");
+    assert!(
+        memories.len() > 1000,
+        "limit=2000 over {seeded} stored memories must exceed the old hard cap of 1000, got {}",
+        memories.len()
+    );
+    assert_eq!(
+        memories.len(),
+        seeded,
+        "all {seeded} seeded memories should be returned under the new MAX_LIST_LIMIT ceiling"
+    );
+    assert_eq!(body["total"].as_u64().unwrap(), seeded as u64);
+}
+
+/// `total` must reflect the full filtered count, not the page size — so callers
+/// can tell whether they've received everything.
+#[tokio::test]
+async fn list_memories_total_reflects_full_count_not_page_size() {
+    let h = Harness::new();
+    let seeded: usize = 15;
+    h.seed_memories("total-user", seeded);
+
+    let (status, body) =
+        json_of(h.app(), authed_get("/api/list/total-user?limit=3&offset=5")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["memories"].as_array().unwrap().len(),
+        3,
+        "page size should honor limit=3"
+    );
+    assert_eq!(
+        body["total"].as_u64().unwrap(),
+        seeded as u64,
+        "total must reflect the full filtered count, independent of limit/offset"
+    );
+}
+
+/// Callers that don't pass offset/limit keep the pre-#407 defaults: limit=100,
+/// offset=0 (i.e. from the start).
+#[tokio::test]
+async fn list_memories_default_limit_and_offset_unchanged() {
+    let h = Harness::new();
+    h.seed_memories("defaults-user", 5);
+
+    let (status, body) = json_of(h.app(), authed_get("/api/list/defaults-user")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["memories"].as_array().unwrap().len(),
+        5,
+        "default limit=100 should return all 5 seeded memories"
+    );
+    assert_eq!(body["total"].as_u64().unwrap(), 5);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #407. The list endpoint silently capped at 1000 with no offset/pagination, so records past 1000 were unreachable and the caller got no signal it was incomplete (same silent-data-loss class as #391/#396).

## Fix (`src/handlers/crud.rs`, both GET + POST handlers)
- **Added `offset`** to `ListMemoriesQuery`/`ListMemoriesRequest`, threaded through, with `.skip(offset)` before `.take(limit)`.
- **Lifted the hard 1000 cap** → `MAX_LIST_LIMIT = 10_000` (matches existing bulk-batch constants; respects the caller's limit, bounds per-request clone cost). Documented in the handler doc-comments.
- **Returns the true `total`** so callers know whether they received everything.
- Defaults unchanged (limit 100, offset 0) — existing callers unaffected.

## Tested
8/8 (6 new pagination tests: offset skips correctly, limit >1000 returns >1000 when the store has more, total reflects full count); `cargo check` + `cargo fmt --check` clean.

Note: the >1000 test seeds 1200 records and runs ~150-200s (RocksDB write-bound) — slowest in `handler_tests.rs`, flagged for CI-budget awareness. devklepacki's 5th daily-use report.