### PR TITLE
fix(ner): reject hex-id/UUID fragments (unbreak main — #381 regression)

### DIFF
--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -3967,6 +3967,20 @@ pub(crate) fn is_structural_non_entity(name: &str) -> bool {
         return true;
     }
 
+    // Hex-id / UUID fragments where an incidental 3+ letter run (e.g. "8dea",
+    // "1cdb") slips the letter-run rule below: every whitespace token is hex and
+    // the string carries a digit. Spares real hex-letter words ("cafe"/"face" have
+    // no digit) and multi-word names ("The Dali" tokens are not all hex).
+    {
+        let toks: Vec<&str> = name.split_whitespace().collect();
+        if !toks.is_empty()
+            && toks.iter().all(|t| t.chars().all(|c| c.is_ascii_hexdigit()))
+            && name.chars().any(|c| c.is_ascii_digit())
+        {
+            return true;
+        }
+    }
+
     // No run of 3+ consecutive letters -> not a word/name. Kills hex-id and code
     // fragments ("46ec 53a6", "1cdb0c73c b8") from URL slugs and article ids.
     let mut run = 0usize;


### PR DESCRIPTION
**Unbreaks main.** #381's entity-hygiene test `structural_non_entities_are_rejected` is red on ubuntu/macos: `is_structural_non_entity("46ec 53a6 8dea")` returns false because "8dea" contains "dea" — a 3-letter run that slips the `max_run < 3` hex rule ("1cdb0c73c b8" likewise via "cdb").

Fix: strengthen the impl (not weaken the test — these strings ARE junk that should be rejected). Add a rule — reject when **every whitespace token is all hex digits AND the string contains a decimal digit**. Verified against the survive-list (none are all-hex; none contain digits → all spared). Both `structural_non_entities_are_rejected` and `real_named_entities_survive` pass locally (2/2).

Deterministic pure-function change; the earlier windows-pass was a stale rust-cache.