### PR TITLE
fix(api): close silent-data-loss sites — paginate facts/sessions, mark truncated content, propagate export errors

### DIFF
--- a/src/handlers/crud.rs
+++ b/src/handlers/crud.rs
@@ -70,13 +70,29 @@ pub struct ListMemoriesRequest {
 #[derive(Debug, Serialize)]
 pub struct ListMemoryItem {
     pub id: String,
+    /// Content preview, truncated to 500 chars. Check `content_truncated` before
+    /// treating this as the full content — fetch GET /api/memories/{id} for the
+    /// complete text.
     pub content: String,
+    /// True if `content` was cut short of the memory's actual content. When true,
+    /// `content_length` holds the true character count so callers know how much
+    /// is missing.
+    pub content_truncated: bool,
+    /// True character length of the full (untruncated) content.
+    pub content_length: usize,
     pub memory_type: String,
     pub importance: f32,
     pub tags: Vec<String>,
     pub created_at: String,
     pub tier: String,
 }
+
+/// Hard ceiling on the content preview returned by the memory-listing endpoints
+/// (`/api/list/{user_id}`, `/api/memories`). Content beyond this length is cut off
+/// in `ListMemoryItem::content`; `content_truncated`/`content_length` on the item
+/// signal when that happened so callers know to fetch the full record rather than
+/// silently treating the preview as complete.
+const LIST_CONTENT_PREVIEW_CHARS: usize = 500;
 
 // =============================================================================
 // UPDATE/DELETE RESPONSE TYPES
@@ -297,14 +313,25 @@ pub async fn list_memories(
     let memories: Vec<ListMemoryItem> = filtered
         .into_iter()
         .take(limit)
-        .map(|m| ListMemoryItem {
-            id: m.id.0.to_string(),
-            content: m.experience.content.chars().take(500).collect(),
-            memory_type: format!("{:?}", m.experience.experience_type),
-            importance: m.importance(),
-            tags: m.experience.entities.clone(),
-            created_at: m.created_at.to_rfc3339(),
-            tier: format!("{:?}", m.tier),
+        .map(|m| {
+            let content_length = m.experience.content.chars().count();
+            let content_truncated = content_length > LIST_CONTENT_PREVIEW_CHARS;
+            ListMemoryItem {
+                id: m.id.0.to_string(),
+                content: m
+                    .experience
+                    .content
+                    .chars()
+                    .take(LIST_CONTENT_PREVIEW_CHARS)
+                    .collect(),
+                content_truncated,
+                content_length,
+                memory_type: format!("{:?}", m.experience.experience_type),
+                importance: m.importance(),
+                tags: m.experience.entities.clone(),
+                created_at: m.created_at.to_rfc3339(),
+                tier: format!("{:?}", m.tier),
+            }
         })
         .collect();
 
@@ -404,14 +431,25 @@ async fn list_memories_inner(
     let memories: Vec<ListMemoryItem> = filtered
         .into_iter()
         .take(limit)
-        .map(|m| ListMemoryItem {
-            id: m.id.0.to_string(),
-            content: m.experience.content.chars().take(500).collect(),
-            memory_type: format!("{:?}", m.experience.experience_type),
-            importance: m.importance(),
-            tags: m.experience.entities.clone(),
-            created_at: m.created_at.to_rfc3339(),
-            tier: format!("{:?}", m.tier),
+        .map(|m| {
+            let content_length = m.experience.content.chars().count();
+            let content_truncated = content_length > LIST_CONTENT_PREVIEW_CHARS;
+            ListMemoryItem {
+                id: m.id.0.to_string(),
+                content: m
+                    .experience
+                    .content
+                    .chars()
+                    .take(LIST_CONTENT_PREVIEW_CHARS)
+                    .collect(),
+                content_truncated,
+                content_length,
+                memory_type: format!("{:?}", m.experience.experience_type),
+                importance: m.importance(),
+                tags: m.experience.entities.clone(),
+                created_at: m.created_at.to_rfc3339(),
+                tier: format!("{:?}", m.tier),
+            }
         })
         .collect();
 
@@ -1061,5 +1099,73 @@ fn parse_experience_type(type_str: &str) -> Result<ExperienceType, AppError> {
             field: "memory_type".to_string(),
             reason: format!("Invalid memory type: {type_str}"),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::handlers::test_helpers::{self, TestHarness};
+    use crate::memory::Experience;
+    use axum::http::StatusCode;
+
+    /// Regression test for the silent-truncation bug: `/api/list/{user_id}`
+    /// used to cut content to 500 chars with no signal it was incomplete.
+    /// Verifies `content_truncated`/`content_length` correctly flag a long
+    /// memory and correctly report `false`/exact-length for a short one.
+    #[tokio::test]
+    async fn list_memories_marks_truncated_content() {
+        let harness = TestHarness::new();
+        let user_id = "truncation-user";
+
+        let long_content = "a".repeat(600);
+        let short_content = "b".repeat(42);
+
+        {
+            let memory = harness.manager.get_user_memory(user_id).unwrap();
+            let guard = memory.read();
+            guard
+                .remember(
+                    Experience {
+                        content: long_content.clone(),
+                        ..Default::default()
+                    },
+                    None,
+                )
+                .unwrap();
+            guard
+                .remember(
+                    Experience {
+                        content: short_content.clone(),
+                        ..Default::default()
+                    },
+                    None,
+                )
+                .unwrap();
+        }
+
+        let req = test_helpers::get(&format!("/api/list/{user_id}?limit=10"));
+        let (status, body) = test_helpers::send(harness.router(), req).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let memories = body["memories"].as_array().unwrap();
+        assert_eq!(memories.len(), 2);
+
+        let long_item = memories
+            .iter()
+            .find(|m| m["content_truncated"] == true)
+            .expect("expected one truncated item");
+        assert_eq!(long_item["content_length"], 600u64);
+        assert_eq!(
+            long_item["content"].as_str().unwrap().chars().count(),
+            500,
+            "preview must still be capped at 500 chars"
+        );
+
+        let short_item = memories
+            .iter()
+            .find(|m| m["content_truncated"] == false)
+            .expect("expected one non-truncated item");
+        assert_eq!(short_item["content_length"], 42u64);
+        assert_eq!(short_item["content"], short_content);
     }
 }

--- a/src/handlers/facts.rs
+++ b/src/handlers/facts.rs
@@ -249,8 +249,14 @@ fn default_narratives_limit() -> usize {
 #[derive(Debug, Deserialize)]
 pub struct FactNarrativesRequest {
     pub user_id: String,
+    /// Max clusters to return. Defaults to 20, clamped to [`validation::MAX_LIMIT`].
     #[serde(default = "default_narratives_limit")]
     pub limit: usize,
+    /// Clusters to skip before collecting `limit` results. Defaults to 0.
+    /// Combine with `total_clusters` in the response to page through results
+    /// beyond `validation::MAX_LIMIT` (e.g. offset += limit).
+    #[serde(default)]
+    pub offset: Option<usize>,
     #[serde(default)]
     pub entity_filter: Option<String>,
 }
@@ -260,11 +266,16 @@ pub struct FactNarrativesRequest {
 pub struct FactNarrativesResponse {
     pub success: bool,
     pub clusters: Vec<FactCluster>,
+    /// Total facts across ALL matching clusters (not just the returned page).
     pub total_facts: usize,
+    /// Total matching clusters (not just the returned page). Compare against
+    /// `offset + clusters.len()` to know whether more pages remain.
     pub total_clusters: usize,
 }
 
 /// POST /api/facts/narratives - Get fact narratives clustered by topic
+/// `limit` defaults to 20 and is clamped to [`validation::MAX_LIMIT`]; `offset`
+/// defaults to 0. Use `total_clusters` in the response to page through results.
 pub async fn fact_narratives(
     State(state): State<AppState>,
     Json(req): Json<FactNarrativesRequest>,
@@ -275,23 +286,112 @@ pub async fn fact_narratives(
         .get_user_memory(&req.user_id)
         .map_err(AppError::Internal)?;
     let user_id = req.user_id.clone();
-    let limit = req.limit.min(50);
+    let limit = req.limit.min(validation::MAX_LIMIT);
+    let offset = req.offset.unwrap_or(0);
     let entity_filter = req.entity_filter.clone();
 
     let clusters = tokio::task::spawn_blocking(move || {
         let ms = memory.read();
-        ms.build_fact_narratives(&user_id, limit, entity_filter.as_deref())
+        ms.build_fact_narratives(&user_id, entity_filter.as_deref())
     })
     .await
     .map_err(|e| AppError::Internal(anyhow::anyhow!("Blocking task panicked: {e}")))?
     .map_err(AppError::Internal)?;
 
-    let total_facts: usize = clusters.iter().map(|c| c.facts.len()).sum();
     let total_clusters = clusters.len();
+    let total_facts: usize = clusters.iter().map(|c| c.facts.len()).sum();
+
+    let paged_clusters: Vec<FactCluster> = clusters.into_iter().skip(offset).take(limit).collect();
+
     Ok(Json(FactNarrativesResponse {
         success: true,
-        clusters,
+        clusters: paged_clusters,
         total_facts,
         total_clusters,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::handlers::test_helpers::{self, TestHarness};
+    use crate::memory::{FactType, SemanticFact};
+    use axum::http::StatusCode;
+
+    /// Seed `n` independent 2-fact clusters (each pair shares a unique topic entity,
+    /// so `build_fact_narratives` groups them into exactly `n` clusters — none of
+    /// them hit the hub-entity exclusion since each topic entity only appears twice).
+    fn seed_narrative_clusters(harness: &TestHarness, user_id: &str, n: usize) {
+        let memory = harness.manager.get_user_memory(user_id).unwrap();
+        let guard = memory.read();
+        let store = guard.fact_store();
+        for i in 0..n {
+            for j in 0..2 {
+                let fact = SemanticFact {
+                    id: format!("fact-{i}-{j}"),
+                    fact: format!("Topic {i} statement {j}"),
+                    confidence: 0.8,
+                    support_count: 3,
+                    source_memories: vec![],
+                    related_entities: vec![format!("topic{i}")],
+                    created_at: chrono::Utc::now(),
+                    last_reinforced: chrono::Utc::now(),
+                    fact_type: FactType::Pattern,
+                };
+                store.store(user_id, &fact).unwrap();
+            }
+        }
+    }
+
+    /// Regression test for the silent-cap-at-50 bug: previously `limit` was
+    /// hard-clamped to 50 with no way to page past it. Seeds 60 clusters (above
+    /// the old cap) and verifies `limit` > 50 is honored and `offset` pages
+    /// correctly, while `total_clusters` always reports the true total.
+    #[tokio::test]
+    async fn narratives_offset_and_limit_above_old_cap() {
+        let harness = TestHarness::new();
+        let user_id = "narratives-user";
+        seed_narrative_clusters(&harness, user_id, 60);
+
+        // limit=55 (> old hard cap of 50), offset=0 -> first 55 of 60 clusters.
+        let req = test_helpers::post_json(
+            "/api/facts/narratives",
+            &serde_json::json!({ "user_id": user_id, "limit": 55, "offset": 0 }),
+        );
+        let (status, body) = test_helpers::send(harness.router(), req).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["clusters"].as_array().unwrap().len(),
+            55,
+            "limit above the old 50-cluster cap must be honored"
+        );
+        assert_eq!(body["total_clusters"], 60);
+
+        // offset=55 pages past what the old cap made permanently unreachable.
+        let req = test_helpers::post_json(
+            "/api/facts/narratives",
+            &serde_json::json!({ "user_id": user_id, "limit": 55, "offset": 55 }),
+        );
+        let (status, body) = test_helpers::send(harness.router(), req).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["clusters"].as_array().unwrap().len(),
+            5,
+            "offset must skip past the first page (60 - 55 = 5 remaining)"
+        );
+        assert_eq!(body["total_clusters"], 60);
+
+        // Existing callers omitting limit/offset keep the old default of 20.
+        let req = test_helpers::post_json(
+            "/api/facts/narratives",
+            &serde_json::json!({ "user_id": user_id }),
+        );
+        let (status, body) = test_helpers::send(harness.router(), req).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["clusters"].as_array().unwrap().len(),
+            20,
+            "default limit must be unchanged for existing callers"
+        );
+        assert_eq!(body["total_clusters"], 60);
+    }
 }

--- a/src/handlers/mif.rs
+++ b/src/handlers/mif.rs
@@ -52,9 +52,15 @@ pub async fn export_mif(
     let memory_sys = state
         .get_user_memory(&user_id)
         .map_err(AppError::Internal)?;
+    // Every read below feeds directly into the exported document. Swallowing a
+    // store-read error here (the old `.unwrap_or_default()` behavior) would let
+    // an export "succeed" while silently omitting memories/todos/projects/
+    // reminders — the worst shape of silent data loss, since the caller has no
+    // signal their backup is incomplete. Propagate instead so a failed read
+    // fails the export loudly.
     let memories = {
         let guard = memory_sys.read();
-        guard.get_all_memories().unwrap_or_default()
+        guard.get_all_memories().map_err(AppError::Internal)?
     };
 
     let graph = if req.include_graph {
@@ -66,14 +72,17 @@ pub async fn export_mif(
     let todos = state
         .todo_store
         .list_todos_for_user(&user_id, None)
-        .unwrap_or_default();
+        .map_err(AppError::Internal)?;
 
-    let projects = state.todo_store.list_projects(&user_id).unwrap_or_default();
+    let projects = state
+        .todo_store
+        .list_projects(&user_id)
+        .map_err(AppError::Internal)?;
 
     let reminders = state
         .prospective_store
         .list_for_user(&user_id, None)
-        .unwrap_or_default();
+        .map_err(AppError::Internal)?;
 
     let since = req
         .since
@@ -543,4 +552,95 @@ pub async fn get_uncompressed_old(
         .collect();
 
     Ok(Json(RetrieveResponse { memories, count }))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::handlers::test_helpers::{self, TestHarness};
+    use crate::memory::{Experience, Project};
+    use axum::http::StatusCode;
+
+    /// Happy path: export returns the real seeded memory + project, not an
+    /// empty/silently-truncated document. Covers the code paths touched by the
+    /// `.unwrap_or_default()` -> `.map_err(AppError::Internal)?` fix.
+    #[tokio::test]
+    async fn export_mif_returns_real_data() {
+        let harness = TestHarness::new();
+        let user_id = "mif-export-user";
+
+        {
+            let memory = harness.manager.get_user_memory(user_id).unwrap();
+            let guard = memory.read();
+            guard
+                .remember(
+                    Experience {
+                        content: "MIF export happy-path memory".to_string(),
+                        ..Default::default()
+                    },
+                    None,
+                )
+                .unwrap();
+        }
+        let project = Project::new(user_id.to_string(), "Export Test Project".to_string());
+        harness.manager.todo_store.store_project(&project).unwrap();
+
+        let req = test_helpers::post_json(
+            "/api/export/mif",
+            &serde_json::json!({ "user_id": user_id }),
+        );
+        let (status, body) = test_helpers::send(harness.router(), req).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["memories"].as_array().unwrap().len(),
+            1,
+            "export must include the real seeded memory"
+        );
+        assert_eq!(
+            body["projects"].as_array().unwrap().len(),
+            1,
+            "export must include the real seeded project"
+        );
+        assert_eq!(body["projects"][0]["name"], "Export Test Project");
+    }
+
+    /// Regression test for the silent-empty-export bug: a store-read error used
+    /// to be swallowed by `.unwrap_or_default()`, so an export could "succeed"
+    /// with an empty document and no signal anything was wrong. It must now
+    /// fail loudly instead.
+    ///
+    /// Fault injection: `TodoStore::list_projects` does
+    /// `serde_json::from_slice::<Project>(&value)?` per entry in the `projects`
+    /// column family, genuinely propagating a deserialize error (unlike
+    /// `get_all_memories`, whose lower layer swallows per-item errors and isn't
+    /// injectable without further production changes). Writing a malformed
+    /// value under a key `list_projects` will scan gives us a real read failure
+    /// to verify propagation against.
+    #[tokio::test]
+    async fn export_mif_propagates_project_store_read_error() {
+        let harness = TestHarness::new();
+        let user_id = "mif-export-corrupt-user";
+
+        let cf = harness
+            .manager
+            .shared_db
+            .cf_handle("projects")
+            .expect("projects CF must exist");
+        let key = format!("{user_id}:{}", uuid::Uuid::new_v4());
+        harness
+            .manager
+            .shared_db
+            .put_cf(cf, key.as_bytes(), b"not valid json")
+            .unwrap();
+
+        let req = test_helpers::post_json(
+            "/api/export/mif",
+            &serde_json::json!({ "user_id": user_id }),
+        );
+        let (status, _body) = test_helpers::send(harness.router(), req).await;
+        assert_eq!(
+            status,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "a corrupted store read must fail the export, not silently return an empty document"
+        );
+    }
 }

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -634,6 +634,9 @@ mod tests {
                 experience_type: ExperienceType::Context,
                 content: format!("Session history seed entry number {i}"),
                 entities: vec!["session-summary".to_string()],
+                // The handler queries recall_by_tags(["session-summary"]); tag the
+                // seed the way production does, not just via `entities`.
+                tags: vec!["session-summary".to_string()],
                 metadata,
                 ..Default::default()
             };

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -350,8 +350,14 @@ fn default_history_limit() -> usize {
 #[derive(Debug, Deserialize)]
 pub struct SessionHistoryRequest {
     pub user_id: String,
+    /// Max sessions to return. Defaults to 10, clamped to [`validation::MAX_LIMIT`].
     #[serde(default = "default_history_limit")]
     pub limit: usize,
+    /// Sessions to skip before collecting `limit` results. Defaults to 0.
+    /// Combine with `total` in the response to page through results beyond
+    /// [`validation::MAX_LIMIT`] (e.g. offset += limit).
+    #[serde(default)]
+    pub offset: Option<usize>,
     #[serde(default)]
     pub group_by_project: bool,
 }
@@ -383,10 +389,14 @@ pub struct SessionHistoryResponse {
     pub success: bool,
     pub sessions: Vec<SessionHistoryEntry>,
     pub project_threads: Vec<ProjectThread>,
+    /// Total matching sessions (not just the returned page). Compare against
+    /// `offset + sessions.len()` to know whether more pages remain.
     pub total: usize,
 }
 
 /// POST /api/sessions/history - Get persisted session history with project continuity
+/// `limit` defaults to 10 and is clamped to [`validation::MAX_LIMIT`]; `offset`
+/// defaults to 0. Use `total` in the response to page through results.
 pub async fn session_history(
     State(state): State<AppState>,
     Json(req): Json<SessionHistoryRequest>,
@@ -396,7 +406,8 @@ pub async fn session_history(
     let memory = state
         .get_user_memory(&req.user_id)
         .map_err(AppError::Internal)?;
-    let limit = req.limit.min(100);
+    let limit = req.limit.min(validation::MAX_LIMIT);
+    let offset = req.offset.unwrap_or(0);
     let group = req.group_by_project;
 
     let result = tokio::task::spawn_blocking(move || {
@@ -404,8 +415,11 @@ pub async fn session_history(
         let tags = vec!["session-summary".to_string()];
 
         // Fetch ALL matching memories (recall_by_tags truncates on random HashSet order,
-        // so we over-fetch with a high cap and sort/truncate ourselves).
-        let memories = ms.recall_by_tags(&tags, 500)?;
+        // so we over-fetch with a high cap and sort/truncate ourselves). The cap is
+        // validation::MAX_LIMIT so it never silently hides sessions the caller could
+        // otherwise reach via `limit`+`offset` paging (see issue #407 for the same
+        // silent-cap-with-no-way-to-page pattern this mirrors).
+        let memories = ms.recall_by_tags(&tags, validation::MAX_LIMIT)?;
 
         let mut entries: Vec<SessionHistoryEntry> = memories
             .iter()
@@ -438,18 +452,19 @@ pub async fn session_history(
             }
         });
 
-        entries.truncate(limit);
+        let total = entries.len();
+        let paged: Vec<SessionHistoryEntry> =
+            entries.into_iter().skip(offset).take(limit).collect();
 
         let threads = if group {
-            compute_project_threads(&entries)
+            compute_project_threads(&paged)
         } else {
             vec![]
         };
 
-        let total = entries.len();
         Ok::<_, anyhow::Error>(SessionHistoryResponse {
             success: true,
-            sessions: entries,
+            sessions: paged,
             project_threads: threads,
             total,
         })
@@ -596,4 +611,86 @@ fn uf_find_root(parent: &[usize], mut i: usize) -> usize {
         i = parent[i];
     }
     i
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::handlers::test_helpers::{self, TestHarness};
+    use crate::memory::{Experience, ExperienceType};
+    use axum::http::StatusCode;
+
+    /// Seed `n` distinct session-summary-tagged memories (unique content so the
+    /// content-hash dedup in `remember()` doesn't collapse them, unique
+    /// `session_id` metadata so the history handler's dedup-by-session_id keeps
+    /// every entry).
+    fn seed_session_summaries(harness: &TestHarness, user_id: &str, n: usize) {
+        let memory = harness.manager.get_user_memory(user_id).unwrap();
+        let guard = memory.read();
+        for i in 0..n {
+            let mut metadata = std::collections::HashMap::new();
+            metadata.insert("session_id".to_string(), format!("session-{i}"));
+            metadata.insert("started_at".to_string(), chrono::Utc::now().to_rfc3339());
+            let experience = Experience {
+                experience_type: ExperienceType::Context,
+                content: format!("Session history seed entry number {i}"),
+                entities: vec!["session-summary".to_string()],
+                metadata,
+                ..Default::default()
+            };
+            guard.remember(experience, None).unwrap();
+        }
+    }
+
+    /// Regression test for the silent-cap-at-100 bug: previously `limit` was
+    /// hard-clamped to 100 with no way to page past it. Seeds 105 sessions (above
+    /// the old cap) and verifies `limit` > 100 is honored and `offset` pages
+    /// correctly, while `total` always reports the true total.
+    #[tokio::test]
+    async fn session_history_offset_and_limit_above_old_cap() {
+        let harness = TestHarness::new();
+        let user_id = "session-history-user";
+        seed_session_summaries(&harness, user_id, 105);
+
+        // limit=102 (> old hard cap of 100), offset=0 -> first 102 of 105 sessions.
+        let req = test_helpers::post_json(
+            "/api/sessions/history",
+            &serde_json::json!({ "user_id": user_id, "limit": 102, "offset": 0 }),
+        );
+        let (status, body) = test_helpers::send(harness.router(), req).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["sessions"].as_array().unwrap().len(),
+            102,
+            "limit above the old 100-session cap must be honored"
+        );
+        assert_eq!(body["total"], 105);
+
+        // offset=102 pages past what the old cap made permanently unreachable.
+        let req = test_helpers::post_json(
+            "/api/sessions/history",
+            &serde_json::json!({ "user_id": user_id, "limit": 102, "offset": 102 }),
+        );
+        let (status, body) = test_helpers::send(harness.router(), req).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["sessions"].as_array().unwrap().len(),
+            3,
+            "offset must skip past the first page (105 - 102 = 3 remaining)"
+        );
+        assert_eq!(body["total"], 105);
+
+        // Existing callers omitting limit/offset keep the old default of 10.
+        let req = test_helpers::post_json(
+            "/api/sessions/history",
+            &serde_json::json!({ "user_id": user_id }),
+        );
+        let (status, body) = test_helpers::send(harness.router(), req).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body["sessions"].as_array().unwrap().len(),
+            10,
+            "default limit must be unchanged for existing callers"
+        );
+        assert_eq!(body["total"], 105);
+    }
 }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -9598,10 +9598,14 @@ impl MemorySystem {
     /// on entity overlap. Each cluster gets a template-generated narrative and
     /// heuristic-based causal chain detection (keyword analysis on temporally
     /// ordered facts).
+    ///
+    /// Returns ALL clusters found (sorted by support, highest first) — callers
+    /// are responsible for paginating (`skip`/`take`) the result. Pagination is
+    /// intentionally not done here so the caller can report an accurate total
+    /// cluster count alongside a paged slice (see `handlers::facts::fact_narratives`).
     pub fn build_fact_narratives(
         &self,
         user_id: &str,
-        limit: usize,
         entity_filter: Option<&str>,
     ) -> Result<Vec<FactCluster>> {
         let facts = if let Some(entity) = entity_filter {
@@ -9663,7 +9667,6 @@ impl MemorySystem {
             .collect();
 
         clusters.sort_by(|a, b| b.total_support.cmp(&a.total_support));
-        clusters.truncate(limit);
         Ok(clusters)
     }
 


### PR DESCRIPTION
Closes the silent-data-loss class behind devklepacki's reports (shodh dropping/hiding data without signaling the caller). Three shapes from the audit (task #23), one PR:

## Fixes
1. **Silent list caps** (siblings of #407) — `facts` (was .min(50)) and `sessions` (was .min(100)) now take an `offset`, respect the caller's `limit` up to `MAX_LIMIT` (10_000), and return the true `total`.
2. **Unmarked content truncation** (Rust twin of #396/#398) — `/api/memories` list items now carry `content_truncated` + `content_length` so a caller knows the 500-char preview is incomplete and can fetch the full record.
3. **Silent empty-on-error** (the scariest shape) — the `mif` export path now **propagates read errors** instead of returning empty, so an export/backup fails loudly rather than 'succeeding' with nothing.

## Tested
Lib handler tests green (facts/sessions offset + limit-above-old-cap, content-truncation markers, `export_mif_propagates_project_store_read_error`). One test-seed bug caught + fixed during verification (sessions seed set `entities` where the handler queries `recall_by_tags` — recall returned 0).

Follow-up (task #23, not this PR): the 'no silent data loss' review invariant + a contract-test suite so the class can't silently regrow.