### PR TITLE
style(ner): rustfmt hex-fragment rule (unbreak main Format Check)

### DIFF
--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -3974,7 +3974,9 @@ pub(crate) fn is_structural_non_entity(name: &str) -> bool {
     {
         let toks: Vec<&str> = name.split_whitespace().collect();
         if !toks.is_empty()
-            && toks.iter().all(|t| t.chars().all(|c| c.is_ascii_hexdigit()))
+            && toks
+                .iter()
+                .all(|t| t.chars().all(|c| c.is_ascii_hexdigit()))
             && name.chars().any(|c| c.is_ascii_digit())
         {
             return true;


### PR DESCRIPTION
Pure `cargo fmt` fix. #410 fixed the entity-hygiene test but its hex-fragment rule (inserted programmatically) wasn't rustfmt-formatted, so Format Check went red on main. This is exactly what `cargo fmt` produces — wraps the `.iter().all()` chain. No logic change.