### PR TITLE
feat(ner): auto-resolve dependency parser bundle (causal spine on by default)

### DIFF
--- a/src/dep_parser.rs
+++ b/src/dep_parser.rs
@@ -82,15 +82,27 @@ fn load_from_dir(dir: &Path) -> Option<Arc<Pipeline>> {
     }
 }
 
-/// Resolve the bundle directory from `SHODH_SPACY_MODEL_PATH` and load it.
-fn load_from_env() -> Option<Arc<Pipeline>> {
-    let dir = std::env::var_os("SHODH_SPACY_MODEL_PATH")?;
-    load_from_dir(Path::new(&dir))
+/// Resolve the `en_core_web_sm` bundle and load it. Resolution order, so the
+/// causal spine is live by default when the bundle is present (no env required):
+///   1. `SHODH_SPACY_MODEL_PATH` — explicit override.
+///   2. the conventional cache dir (`~/.cache/shodh-memory/models/en_core_web_sm`),
+///      mirroring how GLiNER/MiniLM auto-resolve.
+///   3. a repo-relative `models/en_core_web_sm` — developer/eval convenience.
+fn load_bundle() -> Option<Arc<Pipeline>> {
+    if let Some(dir) = std::env::var_os("SHODH_SPACY_MODEL_PATH") {
+        if let Some(p) = load_from_dir(Path::new(&dir)) {
+            return Some(p);
+        }
+    }
+    if let Some(p) = load_from_dir(&crate::embeddings::downloader::get_spacy_models_dir()) {
+        return Some(p);
+    }
+    load_from_dir(Path::new("models/en_core_web_sm"))
 }
 
-/// The shared pipeline, or `None` when no model is configured/available.
+/// The shared pipeline, or `None` when no model is available.
 pub fn pipeline() -> Option<&'static Arc<Pipeline>> {
-    PIPELINE.get_or_init(load_from_env).as_ref()
+    PIPELINE.get_or_init(load_bundle).as_ref()
 }
 
 /// Whether the dependency parser is available in this process.

--- a/src/embeddings/downloader.rs
+++ b/src/embeddings/downloader.rs
@@ -159,6 +159,13 @@ pub fn get_ner_models_dir() -> PathBuf {
     get_cache_dir().join("models").join("bert-tiny-ner")
 }
 
+/// Get the bundle directory for the dependency parser (en_core_web_sm).
+/// Mirrors the other model dirs so the causal spine can auto-load from the
+/// conventional cache location without requiring `SHODH_SPACY_MODEL_PATH`.
+pub fn get_spacy_models_dir() -> PathBuf {
+    get_cache_dir().join("models").join("en_core_web_sm")
+}
+
 /// Get the cache directory for the GLiNER bi-edge typer assets.
 ///
 /// This is the first-run download target and is registered as a resolution


### PR DESCRIPTION
The causal spine (OpenIE + CATENA → `Causes`/`Precedes` edges) is fully wired and proven end-to-end (the `causal_spine_on_real_bridge_prose` live test passes with the parser), but it was **dormant by default**: `dep_parser` only loaded from `SHODH_SPACY_MODEL_PATH`, with no conventional-dir resolution — unlike GLiNER/MiniLM which resolve from `~/.cache/shodh-memory/`. So even though the bundle ships, the causal spine minted 0 edges unless you knew to set that env var.

## Change
- `downloader.rs`: add `get_spacy_models_dir()` = `get_cache_dir()/models/en_core_web_sm` (mirrors the MiniLM/bert-tiny dirs).
- `dep_parser.rs`: resolution order — `SHODH_SPACY_MODEL_PATH` → conventional cache dir → repo-relative `models/en_core_web_sm`. So the parser (and the causal spine) load without any env var when the bundle is present.

## Verification
- Live test `causal_spine_on_real_bridge_prose` already passes with the parser (extraction→edge pipeline proven). Its skip is gated on `dep_parser::is_available()`, so with this change it runs without the env var when the dev bundle is present.
- CI verifies compilation.

## Follow-up (not this PR)
Publish the en_core_web_sm bundle as a release asset + download-if-missing (mirror GLiNER's downloader) so a *fresh* environment auto-fetches it — the true 'on everywhere by default'. This PR closes the resolution gap; that closes the distribution gap.