### PR TITLE
test(graph): pin coactivation contract to shipped strengthen-only semantics

### DIFF
--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -9019,6 +9019,77 @@ mod tests {
         assert_eq!(origins[0].0, a);
     }
 
+    // ------------------------------------------------------------------
+    // record_memory_coactivation_impl: strengthen-only contract (2026-07-10,
+    // f6b730ee). The both-modes contract (mint on strengthen_only=false;
+    // strengthen-not-mint on strengthen_only=true given a prior edge; mint
+    // nothing on strengthen_only=true given no prior edge) is already
+    // pinned by the pre-existing `coactivation_strengthen_only_creates_no_new_edges`
+    // and `coactivation_strengthen_only_still_strengthens_existing` tests
+    // above/below in this module. Neither of those, however, verifies that
+    // "strengthen" actually mutates the edge — only that the impl's return
+    // count matches. That gap is what the test below fills. Together, these
+    // three are the mode-contract holder that
+    // tests/brutal_stress_tests.rs::test_brutal_dense_graph now points back
+    // to instead of asserting a specific pair count itself.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn coactivation_strengthen_only_actually_increments_activation_and_strength() {
+        // Complements `coactivation_strengthen_only_still_strengthens_existing`,
+        // which only checks the impl's returned count (3). This test checks
+        // the actual edge mutation: activation_count increments and strength
+        // increases (Hebbian `RelationshipEdge::strengthen()`), and that
+        // relationship_count does NOT grow across the strengthen-only pass
+        // (no edge minted on top of the seeded ones).
+        let temp_dir = tempfile::tempdir().unwrap();
+        let graph = GraphMemory::new(temp_dir.path(), None).unwrap();
+        let ids: Vec<Uuid> = (0..3).map(|_| Uuid::new_v4()).collect(); // 3 pairs
+
+        // Seed pre-existing edges via strengthen_only=false (the only way to
+        // populate the `mem_edge:` index `find_edge_between_entities` reads —
+        // see the diagnosis's "Flagged finding": nothing else writes it).
+        let minted = graph.record_memory_coactivation_impl(&ids, false).unwrap();
+        assert_eq!(minted, 3, "seed step should mint all 3 pairs");
+        let seeded_count = graph.get_stats().unwrap().relationship_count;
+        assert_eq!(seeded_count, 3);
+
+        let (a, b) = (ids[0], ids[1]);
+        let before = graph
+            .find_edge_between_entities(&a, &b)
+            .unwrap()
+            .expect("edge must exist after seeding");
+        assert_eq!(before.activation_count, 1);
+
+        // Re-run co-activation for the same pairs under the DEFAULT gate.
+        let strengthened = graph.record_memory_coactivation_impl(&ids, true).unwrap();
+
+        assert_eq!(
+            strengthened, 3,
+            "all 3 pre-existing edges should be strengthened, none skipped"
+        );
+        assert_eq!(
+            graph.get_stats().unwrap().relationship_count,
+            seeded_count,
+            "strengthen_only=true must NOT mint any new edge on top of the seeded ones"
+        );
+
+        let after = graph
+            .find_edge_between_entities(&a, &b)
+            .unwrap()
+            .expect("edge must still exist");
+        assert_eq!(
+            after.activation_count, 2,
+            "the pre-existing edge must be strengthened (activation_count incremented)"
+        );
+        assert!(
+            after.strength > before.strength,
+            "Hebbian strengthening must increase edge strength: before={}, after={}",
+            before.strength,
+            after.strength
+        );
+    }
+
     #[test]
     fn typed_neighbors_respects_relation_and_direction() {
         let temp_dir = tempfile::tempdir().unwrap();

--- a/tests/brutal_stress_tests.rs
+++ b/tests/brutal_stress_tests.rs
@@ -613,22 +613,50 @@ fn test_brutal_dense_graph() {
         ids.push(system.remember(exp, None).expect("Failed"));
     }
 
-    // Create full mesh - every pair of memories associated
-    // This creates 50*49/2 = 1225 edges
+    // Reinforce co-retrieval across all 50 memories under load. Before
+    // 2026-07-10 this unconditionally minted an all-pairs CoRetrieved edge
+    // for every co-retrieved pair (capped by MAX_COACTIVATION_SIZE=20 ->
+    // 20*19/2 = 190 edges), which this test used to assert (edge_count >=
+    // 150). `f6b730ee` (2026-07-10) flipped `SHODH_COACT_STRENGTHEN_ONLY`
+    // to default-ON: `record_memory_coactivation` now only STRENGTHENS an
+    // edge that already exists between a co-active memory pair; it no
+    // longer mints a new one ("strengthen-not-create", to stop the
+    // CoRetrieved edge explosion that was ~80% of the graph). These 50
+    // memories have no pre-existing memory-to-memory edges between them, so
+    // under the shipped default there is nothing to strengthen and
+    // reinforce_recall must mint zero NEW edges — this is the current,
+    // intentional contract, not a bug. Asserted as a delta (edge_count
+    // before vs. after) rather than an absolute total, since `edge_count`
+    // is the whole-graph relationship count (memory/mod.rs maps it from
+    // GraphMemory::get_stats().relationship_count) and this test does not
+    // control what, if anything, entity-level ingest already put in the
+    // graph for these 50 plain-content memories. The full both-modes
+    // contract (mint when strengthen_only=false, strengthen-not-mint when
+    // strengthen_only=true and a prior edge exists, mint nothing when
+    // strengthen_only=true and no prior edge exists) is pinned by the unit
+    // tests in src/graph_memory.rs: coactivation_strengthen_only_creates_no_new_edges,
+    // coactivation_strengthen_only_still_strengthens_existing, and
+    // coactivation_strengthen_only_actually_increments_activation_and_strength
+    // (the last of which verifies the strengthen path actually mutates the
+    // edge, not just that the impl's return count matches). This brutal
+    // test only needs to confirm the shipped default doesn't crash or
+    // explode edges at n=50 (> MAX_COACTIVATION_SIZE=20).
+    let edges_before = system.graph_stats().edge_count;
     system
         .reinforce_recall(&ids, RetrievalOutcome::Helpful)
         .expect("Failed");
 
-    let stats = system.graph_stats();
-    // Due to MAX_COACTIVATION_SIZE=20 cap in record_coactivation (O(n²) protection),
-    // only first 20 memories get edges: 20*19/2 = 190 edges max
-    assert!(
-        stats.edge_count >= 150,
-        "Should have many edges (capped by MAX_COACTIVATION_SIZE): {}",
-        stats.edge_count
+    let edges_after = system.graph_stats().edge_count;
+    println!("dense_graph edge_count: before={edges_before} after={edges_after}");
+    assert_eq!(
+        edges_after, edges_before,
+        "strengthen-only default (SHODH_COACT_STRENGTHEN_ONLY, default-on since f6b730ee, \
+         2026-07-10) must mint zero NEW CoRetrieved edges for co-retrieved memories with no \
+         prior edges between them: before={}, after={}",
+        edges_before, edges_after
     );
 
-    // Verify graph maintenance doesn't crash
+    // Verify graph maintenance doesn't crash even with zero coactivation edges minted
     system.graph_maintenance();
 }
 


### PR DESCRIPTION
Fixes the known-failing `test_brutal_dense_graph`: it asserted the pre-2026-07-10 legacy behavior (unconditional all-pairs CoRetrieved minting) that f6b730ee deliberately disabled via `SHODH_COACT_STRENGTHEN_ONLY=true` (the strengthen-not-create policy). Rewritten to assert shipped semantics; the mode contract now lives in unit tests, including a new assertion that strengthen actually mutates activation/strength (the one gap in existing coverage — prior tests only checked return counts).

Assertion verified to have teeth: with `SHODH_COACT_STRENGTHEN_ONLY=0` the rewritten test correctly fails with the legacy 190-edge flood.

Diagnosed side-finding, tracked separately (NOT fixed here): the strengthen-only default leaves the memory-to-memory Hebbian layer inert in production — nothing writes the `mem_edge:` index outside the disabled branch, so there is never anything to strengthen. Remove-vs-revive is a pending design decision backed by the L5-Hebbian ablation evidence.

Unblocks the honest CI from #421 on this known failure.