### PR TITLE
fix(ci): pinned model assets for test jobs + pin 5 tests to shipped contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,108 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
+      # Real models, hermetically pinned — see recall.yml/batched-guard.yml for
+      # the pattern this mirrors. SHODH_OFFLINE=1 below only blocks auto-download
+      # of *missing* assets; ORT_DYLIB_PATH / SHODH_MODEL_PATH /
+      # SHODH_GLINER_MODEL_PATH are all read as explicit local paths first, so
+      # pre-supplying them keeps the run fully offline while using the real
+      # NER/embedder — never the silent fallback (SHODH_ALLOW_SIMPLIFIED_EMBEDDINGS
+      # is deliberately never set here).
+      - name: Determine pinned ONNX Runtime version
+        id: ort-version
+        run: |
+          VERSION=$(grep -oP 'ONNX_RUNTIME_VERSION: &str = "\K[0-9.]+' src/embeddings/downloader.rs)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract ONNX_RUNTIME_VERSION from src/embeddings/downloader.rs"
+            exit 1
+          fi
+          echo "Pinned ONNX Runtime version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Cache GLiNER typer assets
+        id: gliner-cache
+        uses: actions/cache@v4
+        with:
+          path: models/gliner-bi-edge
+          key: gliner-bi-edge-onnx-v1
+
+      - name: Fetch GLiNER typer assets
+        if: steps.gliner-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p models/gliner-bi-edge
+          gh release download gliner-bi-edge-onnx-v1 --repo "$GITHUB_REPOSITORY" --dir models/gliner-bi-edge
+          ls -la models/gliner-bi-edge
+
+      - name: Cache ONNX Runtime
+        id: ort-cache
+        uses: actions/cache@v4
+        with:
+          path: models/onnxruntime
+          key: onnxruntime-v${{ steps.ort-version.outputs.version }}-linux-x64
+
+      - name: Fetch ONNX Runtime
+        if: steps.ort-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          V="${{ steps.ort-version.outputs.version }}"
+          mkdir -p models/onnxruntime
+          curl -fL --retry 5 --retry-delay 5 --connect-timeout 30 -o /tmp/ort.tgz \
+            "https://github.com/microsoft/onnxruntime/releases/download/v${V}/onnxruntime-linux-x64-${V}.tgz"
+          tar -xzf /tmp/ort.tgz -C /tmp
+          # Pick the largest real (non-symlink) libonnxruntime.so* file, excluding
+          # libonnxruntime_providers_shared.so stubs — mirrors the selection logic
+          # in src/embeddings/downloader.rs::extract_onnx_runtime (fixes #223/#250:
+          # entry ordering and provider stubs must never clobber the real lib).
+          REAL=$(find "/tmp/onnxruntime-linux-x64-${V}/lib" -maxdepth 1 -type f -name 'libonnxruntime.so*' ! -name 'libonnxruntime_*' -printf '%s %p\n' | sort -rn | head -1 | cut -d' ' -f2-)
+          if [ -z "$REAL" ]; then
+            echo "::error::Could not find libonnxruntime.so in extracted archive"
+            exit 1
+          fi
+          cp "$REAL" models/onnxruntime/libonnxruntime.so
+          SIZE=$(stat -c%s models/onnxruntime/libonnxruntime.so)
+          if [ "$SIZE" -lt 1000000 ]; then
+            echo "::error::Extracted libonnxruntime.so is only $SIZE bytes — expected >1MB real runtime"
+            exit 1
+          fi
+          ls -la models/onnxruntime
+
+      - name: Cache MiniLM embedder weights
+        id: minilm-cache
+        uses: actions/cache@v4
+        with:
+          path: models/minilm-l6
+          key: minilm-l6-c9745ed1-v1
+
+      - name: Fetch MiniLM embedder weights
+        if: steps.minilm-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p models/minilm-l6
+          BASE="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf"
+          curl -fL --retry 5 --retry-delay 5 --connect-timeout 30 -o models/minilm-l6/model_quantized.onnx "$BASE/onnx/model_quint8_avx2.onnx"
+          curl -fL --retry 5 --retry-delay 5 --connect-timeout 30 -o models/minilm-l6/tokenizer.json "$BASE/tokenizer.json"
+          ls -la models/minilm-l6
+
+      - name: Verify model assets (hard gate — refuse to run on missing/degraded assets)
+        run: |
+          ORT_DYLIB_PATH="${{ github.workspace }}/models/onnxruntime/libonnxruntime.so"
+          SHODH_MODEL_PATH="${{ github.workspace }}/models/minilm-l6"
+          SHODH_GLINER_MODEL_PATH="${{ github.workspace }}/models/gliner-bi-edge"
+          test -s "$ORT_DYLIB_PATH" || { echo "::error::ONNX Runtime missing — embedder would hard-fail"; exit 1; }
+          test -s "$SHODH_MODEL_PATH/model_quantized.onnx" || { echo "::error::MiniLM weights missing"; exit 1; }
+          test -s "$SHODH_MODEL_PATH/tokenizer.json" || { echo "::error::MiniLM tokenizer missing"; exit 1; }
+          test -s "$SHODH_GLINER_MODEL_PATH/model.onnx" || { echo "::error::GLiNER model missing — refusing to run on fallback NER"; exit 1; }
+          test -s "$SHODH_GLINER_MODEL_PATH/tokenizer.json" || { echo "::error::GLiNER tokenizer missing"; exit 1; }
+          test -s "$SHODH_GLINER_MODEL_PATH/label_embeddings.bin" || { echo "::error::GLiNER label embeddings missing"; exit 1; }
+
       - name: Run unit tests
         env:
-          SHODH_OFFLINE: "1"   # no GLiNER auto-download in CI; smoke job fetches release assets
+          SHODH_OFFLINE: "1"   # hermetic: all model/runtime paths below are pre-supplied and verified, so offline mode costs nothing and guards against an accidental new auto-download dependency
+          ORT_DYLIB_PATH: ${{ github.workspace }}/models/onnxruntime/libonnxruntime.so
+          SHODH_MODEL_PATH: ${{ github.workspace }}/models/minilm-l6
+          SHODH_GLINER_MODEL_PATH: ${{ github.workspace }}/models/gliner-bi-edge
         run: |
           cargo test --lib --no-fail-fast 2>&1 | tee test-output.txt
 
@@ -195,9 +294,108 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
+      # Real models, hermetically pinned — see recall.yml/batched-guard.yml for
+      # the pattern this mirrors. SHODH_OFFLINE=1 below only blocks auto-download
+      # of *missing* assets; ORT_DYLIB_PATH / SHODH_MODEL_PATH /
+      # SHODH_GLINER_MODEL_PATH are all read as explicit local paths first, so
+      # pre-supplying them keeps the run fully offline while using the real
+      # NER/embedder — never the silent fallback (SHODH_ALLOW_SIMPLIFIED_EMBEDDINGS
+      # is deliberately never set here).
+      - name: Determine pinned ONNX Runtime version
+        id: ort-version
+        run: |
+          VERSION=$(grep -oP 'ONNX_RUNTIME_VERSION: &str = "\K[0-9.]+' src/embeddings/downloader.rs)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract ONNX_RUNTIME_VERSION from src/embeddings/downloader.rs"
+            exit 1
+          fi
+          echo "Pinned ONNX Runtime version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Cache GLiNER typer assets
+        id: gliner-cache
+        uses: actions/cache@v4
+        with:
+          path: models/gliner-bi-edge
+          key: gliner-bi-edge-onnx-v1
+
+      - name: Fetch GLiNER typer assets
+        if: steps.gliner-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p models/gliner-bi-edge
+          gh release download gliner-bi-edge-onnx-v1 --repo "$GITHUB_REPOSITORY" --dir models/gliner-bi-edge
+          ls -la models/gliner-bi-edge
+
+      - name: Cache ONNX Runtime
+        id: ort-cache
+        uses: actions/cache@v4
+        with:
+          path: models/onnxruntime
+          key: onnxruntime-v${{ steps.ort-version.outputs.version }}-linux-x64
+
+      - name: Fetch ONNX Runtime
+        if: steps.ort-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          V="${{ steps.ort-version.outputs.version }}"
+          mkdir -p models/onnxruntime
+          curl -fL --retry 5 --retry-delay 5 --connect-timeout 30 -o /tmp/ort.tgz \
+            "https://github.com/microsoft/onnxruntime/releases/download/v${V}/onnxruntime-linux-x64-${V}.tgz"
+          tar -xzf /tmp/ort.tgz -C /tmp
+          # Pick the largest real (non-symlink) libonnxruntime.so* file, excluding
+          # libonnxruntime_providers_shared.so stubs — mirrors the selection logic
+          # in src/embeddings/downloader.rs::extract_onnx_runtime (fixes #223/#250:
+          # entry ordering and provider stubs must never clobber the real lib).
+          REAL=$(find "/tmp/onnxruntime-linux-x64-${V}/lib" -maxdepth 1 -type f -name 'libonnxruntime.so*' ! -name 'libonnxruntime_*' -printf '%s %p\n' | sort -rn | head -1 | cut -d' ' -f2-)
+          if [ -z "$REAL" ]; then
+            echo "::error::Could not find libonnxruntime.so in extracted archive"
+            exit 1
+          fi
+          cp "$REAL" models/onnxruntime/libonnxruntime.so
+          SIZE=$(stat -c%s models/onnxruntime/libonnxruntime.so)
+          if [ "$SIZE" -lt 1000000 ]; then
+            echo "::error::Extracted libonnxruntime.so is only $SIZE bytes — expected >1MB real runtime"
+            exit 1
+          fi
+          ls -la models/onnxruntime
+
+      - name: Cache MiniLM embedder weights
+        id: minilm-cache
+        uses: actions/cache@v4
+        with:
+          path: models/minilm-l6
+          key: minilm-l6-c9745ed1-v1
+
+      - name: Fetch MiniLM embedder weights
+        if: steps.minilm-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p models/minilm-l6
+          BASE="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf"
+          curl -fL --retry 5 --retry-delay 5 --connect-timeout 30 -o models/minilm-l6/model_quantized.onnx "$BASE/onnx/model_quint8_avx2.onnx"
+          curl -fL --retry 5 --retry-delay 5 --connect-timeout 30 -o models/minilm-l6/tokenizer.json "$BASE/tokenizer.json"
+          ls -la models/minilm-l6
+
+      - name: Verify model assets (hard gate — refuse to run on missing/degraded assets)
+        run: |
+          ORT_DYLIB_PATH="${{ github.workspace }}/models/onnxruntime/libonnxruntime.so"
+          SHODH_MODEL_PATH="${{ github.workspace }}/models/minilm-l6"
+          SHODH_GLINER_MODEL_PATH="${{ github.workspace }}/models/gliner-bi-edge"
+          test -s "$ORT_DYLIB_PATH" || { echo "::error::ONNX Runtime missing — embedder would hard-fail"; exit 1; }
+          test -s "$SHODH_MODEL_PATH/model_quantized.onnx" || { echo "::error::MiniLM weights missing"; exit 1; }
+          test -s "$SHODH_MODEL_PATH/tokenizer.json" || { echo "::error::MiniLM tokenizer missing"; exit 1; }
+          test -s "$SHODH_GLINER_MODEL_PATH/model.onnx" || { echo "::error::GLiNER model missing — refusing to run on fallback NER"; exit 1; }
+          test -s "$SHODH_GLINER_MODEL_PATH/tokenizer.json" || { echo "::error::GLiNER tokenizer missing"; exit 1; }
+          test -s "$SHODH_GLINER_MODEL_PATH/label_embeddings.bin" || { echo "::error::GLiNER label embeddings missing"; exit 1; }
+
       - name: Run integration tests
         env:
-          SHODH_OFFLINE: "1"   # no GLiNER auto-download in CI; smoke job fetches release assets
+          SHODH_OFFLINE: "1"   # hermetic: all model/runtime paths below are pre-supplied and verified, so offline mode costs nothing and guards against an accidental new auto-download dependency
+          ORT_DYLIB_PATH: ${{ github.workspace }}/models/onnxruntime/libonnxruntime.so
+          SHODH_MODEL_PATH: ${{ github.workspace }}/models/minilm-l6
+          SHODH_GLINER_MODEL_PATH: ${{ github.workspace }}/models/gliner-bi-edge
         run: |
           cargo test \
             --test adaptive_memory_tests \

--- a/tests/graph_memory_tests.rs
+++ b/tests/graph_memory_tests.rs
@@ -929,6 +929,39 @@ fn test_long_term_potentiation_threshold() {
     );
 }
 
+// =============================================================================
+// DECAY TESTS — pinned to the SHIPPED Wixted hybrid model (SHO-103, bee3915b).
+//
+// `RelationshipEdge::decay_at` (src/graph_memory.rs) routes L2Episodic and
+// L3Semantic edges through `crate::decay::hybrid_decay_factor`, NOT through
+// `tier_decay_factor`'s simple-exponential L2 branch (λ=0.031/day) — that branch
+// is now reachable only for L1Working. The tests below therefore derive their
+// expected values from the hybrid model's own parameters:
+//
+//   DECAY_LAMBDA_CONSOLIDATION = 0.693   (src/constants.rs)
+//   DECAY_CROSSOVER_DAYS       = 3.0
+//   POWERLAW_BETA              = 0.5     (non-potentiated)
+//   L2_PRUNE_THRESHOLD         = 0.2
+//   LTP_MIN_STRENGTH           = 0.01    (post-decay floor)
+//
+//   t <  3 days:  f(t) = exp(-0.693 · t)                        [consolidation]
+//   t >= 3 days:  f(t) = exp(-0.693 · 3) · (t / 3)^(-0.5)       [power-law tail]
+//
+// Anchor value used repeatedly below:
+//   A_cross = exp(-0.693 × 3) = exp(-2.079) = 0.12505519
+//
+// `create_relationship_with_plasticity(..., potentiated = false, ...)` builds an
+// L2Episodic edge with LtpStatus::None and endpoint_selectivity = None, so
+// `ltp_factor` = 1.0 and `is_potentiated` (ltp_factor <= 0.5) is FALSE — the
+// non-potentiated β=0.5 branch above is the one exercised.
+//
+// Expected values are written as literals (not recomputed via
+// `shodh_memory::decay::hybrid_decay_factor`) on purpose: recomputing the model
+// inside the assertion would make the test tautological and silently absorb any
+// change to the constants above. The derivation is shown so the literal is
+// auditable rather than a record of whatever the code last printed.
+// =============================================================================
+
 #[test]
 fn test_decay_reduces_strength() {
     let entity_a = Uuid::new_v4();
@@ -953,9 +986,57 @@ fn test_decay_reduces_strength() {
         edge.strength < initial_strength,
         "Strength should decrease after decay"
     );
+
+    // Derivation (power-law tail, t = 30 days >= crossover 3):
+    //   f(30) = A_cross × (30/3)^(-0.5)
+    //         = 0.12505519 × 10^(-0.5)
+    //         = 0.12505519 × 0.31622777
+    //         = 0.03954777
+    //   strength = 0.8 × 0.03954777 = 0.03163822
+    // Well above LTP_MIN_STRENGTH (0.01), so no floor clamp applies and this is
+    // the raw product.
+    let expected = 0.031_638_22_f32;
     assert!(
-        !should_prune,
-        "Edge with strength 0.8 should not be pruned after 30 days"
+        (edge.strength - expected).abs() < 1e-4,
+        "30-day Wixted decay of a 0.8 L2 edge should give ~{expected}, got {}",
+        edge.strength
+    );
+
+    // Shipped prune semantics: `decay_at`'s final ladder prunes a non-potentiated,
+    // non-corroborated edge once `strength <= tier.prune_threshold()`. At 0.0316
+    // the edge is far below L2_PRUNE_THRESHOLD (0.2), so it IS prune-eligible.
+    // (Only the returned bool is asserted — at exactly 30 days the *age* branch
+    // sits on its `hours_elapsed > 720.0` boundary and may or may not fire first
+    // depending on sub-second timing, but both branches return true.)
+    assert!(
+        should_prune,
+        "a 30-day-stale L2 edge decays to {} <= L2_PRUNE_THRESHOLD (0.2) and is prune-eligible",
+        edge.strength
+    );
+
+    // Complement — the "a strong edge survives" intent, checked where it actually
+    // holds under the shipped model. Consolidation phase, t = 1 day < crossover:
+    //   f(1) = exp(-0.693 × 1) = 0.50007360
+    //   strength = 0.8 × 0.50007360 = 0.40005888  >  0.2
+    let one_day_ago = Utc::now() - Duration::days(1);
+    let mut fresh = create_relationship_with_plasticity(
+        entity_a,
+        entity_b,
+        RelationType::Knows,
+        0.8,
+        5,
+        false,
+        one_day_ago,
+    );
+    let fresh_prune = fresh.decay();
+    assert!(
+        (fresh.strength - 0.400_058_88_f32).abs() < 1e-4,
+        "1-day Wixted decay of a 0.8 L2 edge should give ~0.40005888, got {}",
+        fresh.strength
+    );
+    assert!(
+        !fresh_prune,
+        "an edge active 1 day ago is still above the L2 prune threshold"
     );
 }
 
@@ -964,11 +1045,42 @@ fn test_decay_half_life() {
     let entity_a = Uuid::new_v4();
     let entity_b = Uuid::new_v4();
 
-    // L2 decay rate: λ = 0.031/day (exponential)
-    // Half-life = ln(2)/0.031 ≈ 22.36 days
-    // After 14 days: e^(-0.031 × 14) = e^(-0.434) ≈ 0.648
+    // --- Half-life, consolidation phase -------------------------------------
+    // The hybrid model's exponential leg uses λ = DECAY_LAMBDA_CONSOLIDATION =
+    // 0.693, i.e. ln(2) to three decimals, so the half-life is
+    //   t½ = ln(2)/λ = 0.6931472 / 0.693 = 1.0002125 days  (≈ 1 day, by design).
+    // At exactly t = 1 day:
+    //   f(1) = exp(-0.693) = 0.50007360
+    // λ is 0.693 and not ln(2) exactly, so this is 0.500074 rather than 0.5 —
+    // hence a 1e-3 tolerance rather than an equality check.
+    let one_day_ago = Utc::now() - Duration::days(1);
+    let mut edge_1d = create_relationship_with_plasticity(
+        entity_a,
+        entity_b,
+        RelationType::Knows,
+        1.0,
+        1,
+        false,
+        one_day_ago,
+    );
+    edge_1d.decay();
+    assert!(
+        (edge_1d.strength - 0.500_073_6_f32).abs() < 1e-3,
+        "L2 consolidation half-life is ~1 day: strength should halve to ~0.500074, got {}",
+        edge_1d.strength
+    );
+
+    // --- Power-law tail ------------------------------------------------------
+    // Past the 3-day crossover the model is power-law, so 14 days is NOT four
+    // more exponential half-lives — the heavy tail is the whole point of SHO-103.
+    //   f(14) = A_cross × (14/3)^(-0.5)
+    //         = 0.12505519 × (4.6666667)^(-0.5)
+    //         = 0.12505519 × 0.46291005
+    //         = 0.05788933
+    // Starting strength 1.0 ⇒ strength = 0.05788933 (above LTP_MIN_STRENGTH 0.01,
+    // so no floor clamp).
     let fourteen_days_ago = Utc::now() - Duration::days(14);
-    let mut edge = create_relationship_with_plasticity(
+    let mut edge_14d = create_relationship_with_plasticity(
         entity_a,
         entity_b,
         RelationType::Knows,
@@ -977,18 +1089,19 @@ fn test_decay_half_life() {
         false,
         fourteen_days_ago,
     );
+    edge_14d.decay();
 
-    edge.decay();
-
-    // After 14 days with L2 exponential decay (λ=0.031/day), expect ~0.648
-    let expected = 0.648;
-    let tolerance = 0.05;
+    let expected = 0.057_889_33_f32;
     assert!(
-        (edge.strength - expected).abs() < tolerance,
-        "After 14 days with L2 decay (λ=0.031/day), strength should be ~{}, got {}",
-        expected,
-        edge.strength
+        (edge_14d.strength - expected).abs() < 1e-4,
+        "After 14 days of Wixted hybrid decay, strength should be ~{expected}, got {}",
+        edge_14d.strength
     );
+
+    // Ordering sanity: the tail must retain strictly less than the 1-day value
+    // but stay strictly positive — a power law decays, it does not truncate.
+    assert!(edge_14d.strength < edge_1d.strength);
+    assert!(edge_14d.strength > 0.0);
 }
 
 #[test]
@@ -1164,7 +1277,7 @@ fn test_decay_synapse_persists() {
 
     // Create edge with old activation timestamp
     let thirty_days_ago = Utc::now() - Duration::days(30);
-    let mut edge = create_relationship_with_plasticity(
+    let edge = create_relationship_with_plasticity(
         id1,
         id2,
         RelationType::Knows,
@@ -1174,22 +1287,63 @@ fn test_decay_synapse_persists() {
         thirty_days_ago,
     );
 
-    // Note: add_relationship sets last_activated to now, so we test the method call works
     let edge_id = graph.add_relationship(edge).expect("Failed");
 
-    // Apply decay via the GraphMemory method
-    // For a fresh edge, decay will be minimal but the method should work
+    // The 30-day derivation below is only valid if the insert path round-trips
+    // `strength` and `last_activated` untouched, so pin that first rather than
+    // assume it.
+    let stored = graph
+        .get_relationship(&edge_id)
+        .expect("Failed")
+        .expect("Edge should exist after insert");
+    assert!(
+        (stored.strength - 0.8).abs() < 1e-6,
+        "add_relationship must persist strength verbatim, got {}",
+        stored.strength
+    );
+    assert!(
+        (stored.last_activated - thirty_days_ago).num_seconds().abs() <= 1,
+        "add_relationship must preserve last_activated (30 days ago), got {}",
+        stored.last_activated
+    );
+
+    // Apply decay through the GraphMemory method (read-modify-write under lock).
     let should_prune = graph.decay_synapse(&edge_id).expect("Failed");
 
-    // Verify decay was applied
     let decayed_edge = graph
         .get_relationship(&edge_id)
         .expect("Failed")
         .expect("Edge should exist");
 
-    // The strength should have decreased (though the exact amount depends on timing)
-    // Since we can't easily mock time in the DB, we just verify the method works
-    assert!(!should_prune, "Edge with 0.8 strength should not be pruned");
+    // Same derivation as `test_decay_reduces_strength` — L2Episodic, not
+    // potentiated, t = 30 days (power-law tail):
+    //   f(30) = A_cross × (30/3)^(-0.5) = 0.12505519 × 0.31622777 = 0.03954777
+    //   strength = 0.8 × 0.03954777 = 0.03163822
+    // This is what must have been WRITTEN BACK to storage — the point of the
+    // test is that decay_synapse persists its result, not merely that it runs.
+    assert!(
+        (decayed_edge.strength - 0.031_638_22_f32).abs() < 1e-4,
+        "decay_synapse must persist the Wixted-decayed strength (~0.03163822), got {}",
+        decayed_edge.strength
+    );
+    assert!(
+        decayed_edge.strength < stored.strength,
+        "persisted strength should be lower than the pre-decay stored value"
+    );
+    // decay_at also writes `last_activated = now` to prevent double-decay; that
+    // update must survive the round-trip too, otherwise every pass would re-apply
+    // 30 days of decay.
+    assert!(
+        (Utc::now() - decayed_edge.last_activated).num_seconds() < 60,
+        "decay_synapse must persist the refreshed last_activated, got {}",
+        decayed_edge.last_activated
+    );
+
+    // Shipped prune semantics: 0.0316 <= L2_PRUNE_THRESHOLD (0.2) ⇒ prune-eligible.
+    assert!(
+        should_prune,
+        "a 30-day-stale L2 edge decays below the L2 prune threshold and is prune-eligible"
+    );
 }
 
 #[test]

--- a/tests/graph_memory_tests.rs
+++ b/tests/graph_memory_tests.rs
@@ -1302,7 +1302,10 @@ fn test_decay_synapse_persists() {
         stored.strength
     );
     assert!(
-        (stored.last_activated - thirty_days_ago).num_seconds().abs() <= 1,
+        (stored.last_activated - thirty_days_ago)
+            .num_seconds()
+            .abs()
+            <= 1,
         "add_relationship must preserve last_activated (30 days ago), got {}",
         stored.last_activated
     );

--- a/tests/integration_webhook_tests.rs
+++ b/tests/integration_webhook_tests.rs
@@ -94,8 +94,15 @@ mod linear_tests {
     #[test]
     fn test_linear_webhook_creation() {
         let webhook = LinearWebhook::new(Some("test-secret".to_string()));
-        // Invalid hex should return error
-        assert!(webhook.verify_signature(b"test", "sha256=invalid").is_err());
+        // A malformed (non-hex) signature is an invalid signature, not a server
+        // error — #284 (c1098786) hardened `verify_signature` to reject it via
+        // `Ok(false)` so the HTTP caller responds 400, not 500.
+        let result = webhook.verify_signature(b"test", "sha256=invalid");
+        assert!(result.is_ok());
+        assert!(
+            !result.unwrap(),
+            "malformed (non-hex) signature should be rejected, not errored"
+        );
 
         let webhook_no_secret = LinearWebhook::new(None);
         let result = webhook_no_secret.verify_signature(b"test", "any");
@@ -413,8 +420,15 @@ mod github_tests {
     #[test]
     fn test_github_webhook_creation() {
         let webhook = GitHubWebhook::new(Some("test-secret".to_string()));
-        // Invalid hex should return error
-        assert!(webhook.verify_signature(b"test", "sha256=invalid").is_err());
+        // A malformed (non-hex) signature is an invalid signature, not a server
+        // error — #284 (c1098786) hardened `verify_signature` to reject it via
+        // `Ok(false)` so the HTTP caller responds 400, not 500.
+        let result = webhook.verify_signature(b"test", "sha256=invalid");
+        assert!(result.is_ok());
+        assert!(
+            !result.unwrap(),
+            "malformed (non-hex) signature should be rejected, not errored"
+        );
 
         let webhook_no_secret = GitHubWebhook::new(None);
         let result = webhook_no_secret.verify_signature(b"test", "any");


### PR DESCRIPTION
Companion to #421 — makes the restored-honesty CI green for the right reasons.

## Part 1 — model assets for test jobs
The first honest CI run (#421) failed 343 of 348 test failures for one reason: unit/integration jobs run with SHODH_OFFLINE=1 and no models, so every NER/embedder-dependent test family (all written in the last ~2.5 months, never once executed in CI) ran on fallback NER. Per the ratified never-measure-on-fallback-NER rule, the fix provides real pinned assets, not test skips: cache+fetch+hard-verify for GLiNER, ONNX Runtime dylib, and MiniLM weights (same pattern as recall.yml/batched-guard.yml), with SHODH_OFFLINE=1 kept (blocks auto-download only — hermetic and pinned). Verification gates refuse to run on missing assets.

## Part 2 — the 5 genuinely rotted tests
All five assert deliberately-superseded contracts (same disease as the #422 fix):
- decay trio: asserted the pre-2025-12-19 simple-exponential L2 model; rewritten against the shipped Wixted hybrid with parameter-derived literal expectations (derivations in comments; tolerance tightened 0.05 → 1e-4 — the old tolerance was 86% of the true value and would have passed almost anything)
- webhook pair: asserted pre-#284 `is_err()`; now assert the deliberate `Ok(false)` hardening contract

## Flagged for follow-up (not touched here)
Decay-calibration suspicion: `L2_MAX_AGE_DAYS = 30` and the λ comment describe the dead exponential branch — under shipped Wixted parameters a 0.8-strength edge is prune-eligible at ~2 days, and `decay_at`'s `last_activated` reset at production cadence may keep edges perpetually in the exponential leg. Needs its own investigation.

Tests: decay 5/5, webhook 2/2, whole-file regressions 42/42 + 30/30, cargo check clean. First end-to-end green is expected on #421's re-run after this merges.