### PR TITLE
Fix the first five minutes: shared API key, backend lifecycle, hook install

### DIFF
--- a/docs/agent-runs/2026-08-07-onboarding-first-five-minutes.md
+++ b/docs/agent-runs/2026-08-07-onboarding-first-five-minutes.md
@@ -1,0 +1,107 @@
+# Onboarding: the first five minutes (T14–T17)
+
+Branch: `fix/onboarding-first-five-minutes` · Date: 2026-08-07
+
+Fixes the four defects that make a fresh install fail — three of them silently.
+Work was done by a Fable agent (commits `0481a926`, `2e6af05f`, `f8d4e0ba`,
+`28e69683`) and then independently verified, which turned up three further
+defects fixed in `f10225e5` and `48feef30`.
+
+## Why this was the priority
+
+A locally-deployable memory that nobody successfully installs is
+indistinguishable from no product. Of the four defects, T15 and T16 share one
+root — the auto-generated API key was never persisted, so nothing else could
+learn it — and both end in capture 401ing forever while the user believes
+memory is working. That is worse than a crash: a crash gets reported.
+
+## The mechanism, chosen once
+
+A shared key file at `<data-root>/.api-key`, written by the MCP shim and read by
+the hooks. Zero IPC, works for `bash` hooks and the standalone `memory-hook.ts`
+alike, and collapses the concurrent-spawn race because both shims converge on
+the same key. Creation is atomic (temp file + hard link, `wx` fallback), so a
+concurrent reader can never observe a half-written key.
+
+`<data-root>` is `SHODH_MEMORY_PATH`, else the platform data dir. It is **not** a
+faithful mirror of the Rust `default_storage_path()` — see below.
+
+## What each commit does
+
+| Commit | Defect | Failure mode it removes |
+|---|---|---|
+| `0481a926` | T15 | Each shim generated its own key; the spawn-race loser 401'd all session |
+| `2e6af05f` | T14 | The shim that spawned the backend killed it on exit, cutting off every sibling client |
+| `f8d4e0ba` | T16 | Hooks defaulted to a dev key the server never accepts; capture died silently |
+| `28e69683` | T17 | Unquoted hook path broke every user whose home directory contains a space; matcher had the wrong shape |
+| `f10225e5` | — | Install-time hook removal would delete a developer's hand-written hooks |
+| `48feef30` | — | Env-supplied keys were never shared with hooks; a warming backend was misdiagnosed as a bad key |
+
+## Verified, and how
+
+Two of the three links in `shim persists → hook reads → server accepts` were
+executed for real against live processes, not stubs:
+
+- **Fresh install.** Shim run from a clean cwd with no key configured anywhere:
+  generated a key, persisted it, presented it to `/api/users`.
+- **Hook pickup.** A real `memory-hook.ts SessionStart` process with the same
+  data root presented the *same* key and completed all six briefing calls.
+- **Negative control.** The same hook without the shared root fell back to the
+  dev key, got 401, and printed the loud banner plus `systemMessage` and
+  `additionalContext`. The failure is loud, which was the point.
+- **The env-key case** (`48feef30`): with `SHODH_API_KEY` set only for the shim,
+  the hook presented `sk-shodh-dev-local-testing-key` before the fix and the
+  configured key after.
+
+The third link — the server accepting the key it was spawned with — is
+source-verified, not executed: `serverEnv["SHODH_DEV_API_KEY"] = API_KEY`
+(`mcp-server/index.ts`) feeds `configured_api_keys()` (`src/auth.rs`), which
+accepts `SHODH_DEV_API_KEY` outside production. No server binary was built, so
+this chain has not run against the real Rust server.
+
+`/api/users` was confirmed to be an authenticated route: `auth_middleware`
+exempts only `/health` and `/webhook/*`.
+
+### This machine cannot tell fixed from broken
+
+Three independent reasons the dev box works either way, all found during
+verification:
+
+1. `.mcp.json` pins `SHODH_API_KEY=sk-shodh-dev-local-testing-key`.
+2. The repo's `.env` sets the same key, and **Bun auto-loads `.env` from cwd** —
+   so even `env -u SHODH_API_KEY` does not clear it when running from the repo.
+3. The hook's legacy fallback is that same literal string.
+
+Any future test of this path must run from a directory with no `.env`.
+
+## Known limitations — not fixed, deliberately
+
+- **`SHODH_MEMORY_PATH` divergence.** If it is set in an MCP `env` block but not
+  in the shell, the shim and the hooks resolve different roots and the hook
+  falls back to the dev key. Now a loud 401 rather than silence, but not
+  working. Fixing it needs a location both sides agree on without shared env.
+- **`shodhDataRoot()` is not `default_storage_path()`.** The Rust function first
+  returns `./shodh_memory_data` if that directory exists in the server's cwd;
+  the TypeScript has no such branch. Harmless today — the server never reads the
+  key file, and shim and hooks agree with each other — and the comment now says
+  so instead of claiming parity.
+- **PID reuse.** A recycled pid in `.mcp-shims/` reads as a live sibling and can
+  pin a leaked backend. Costs a stray process, not data.
+- **macOS `.sh` search order** checks the XDG path before
+  `~/Library/Application Support`, unlike the TypeScript. Only bites if a stale
+  XDG key file exists on a Mac.
+- **`SessionStart` adds one sequential auth probe** before the parallel fetch.
+- Pre-existing: `src/auth.rs:143` comments a "built-in default" that the code
+  does not have; `hooks/memory-hook.test.ts` is stale and `bun test` segfaults
+  on this machine. Neither is in CI.
+
+## Test evidence
+
+173 vitest tests pass (45 added across the six commits); `bun run build` green.
+All tests ran under Node/vitest while the shim and hooks run under Bun — the
+one runtime-sensitive primitive, `Atomics.wait` on the main thread, was checked
+directly under Bun and works.
+
+`~/.claude/settings.json` was **not** modified by any of this work (mtime
+2026-08-05, no backup siblings); it was read to confirm the correct matcher
+shape, because the repo's own template had the wrong one.

--- a/hooks/claude-code-ingest.sh
+++ b/hooks/claude-code-ingest.sh
@@ -30,9 +30,22 @@ set -e
 API_URL="${SHODH_API_URL:-http://127.0.0.1:3030}"
 USER_ID="${SHODH_USER_ID:-claude-code}"
 
-# API Key - required (no hardcoded fallback for security)
+# API Key - env, else the shared key file persisted by the MCP server
+# (<data-root>/.api-key, see mcp-server/api-key-store.ts). No hardcoded fallback.
 if [ -z "$SHODH_API_KEY" ]; then
-    echo "ERROR: SHODH_API_KEY environment variable not set" >&2
+    for KEY_FILE in \
+        ${SHODH_MEMORY_PATH:+"$SHODH_MEMORY_PATH/.api-key"} \
+        "${XDG_DATA_HOME:-$HOME/.local/share}/shodh-memory/.api-key" \
+        "$HOME/Library/Application Support/shodh-memory/.api-key" \
+        ${APPDATA:+"$APPDATA/shodh-memory/.api-key"}; do
+        if [ -f "$KEY_FILE" ]; then
+            SHODH_API_KEY=$(tr -d '[:space:]' < "$KEY_FILE")
+            if [ -n "$SHODH_API_KEY" ]; then break; fi
+        fi
+    done
+fi
+if [ -z "$SHODH_API_KEY" ]; then
+    echo "ERROR: SHODH_API_KEY not set and no shared key file found (connect the shodh-memory MCP server once to create it)" >&2
     exit 1
 fi
 API_KEY="$SHODH_API_KEY"

--- a/hooks/claude-settings.json
+++ b/hooks/claude-settings.json
@@ -3,70 +3,62 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": {},
         "hooks": [
           {
             "type": "command",
-            "command": "bun run $SHODH_HOOKS_DIR/memory-hook.ts SessionStart"
+            "command": "bun run \"$SHODH_HOOKS_DIR/memory-hook.ts\" SessionStart"
           }
         ]
       }
     ],
     "UserPromptSubmit": [
       {
-        "matcher": {},
         "hooks": [
           {
             "type": "command",
-            "command": "bun run $SHODH_HOOKS_DIR/memory-hook.ts UserPromptSubmit"
+            "command": "bun run \"$SHODH_HOOKS_DIR/memory-hook.ts\" UserPromptSubmit"
           }
         ]
       }
     ],
     "Stop": [
       {
-        "matcher": {},
         "hooks": [
           {
             "type": "command",
-            "command": "bun run $SHODH_HOOKS_DIR/memory-hook.ts Stop"
+            "command": "bun run \"$SHODH_HOOKS_DIR/memory-hook.ts\" Stop"
           }
         ]
       }
     ],
     "PreToolUse": [
       {
-        "matcher": {
-          "tool_name": ["Edit", "Write", "Bash"]
-        },
+        "matcher": "Edit|Write|Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "bun run $SHODH_HOOKS_DIR/memory-hook.ts PreToolUse"
+            "command": "bun run \"$SHODH_HOOKS_DIR/memory-hook.ts\" PreToolUse"
           }
         ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": {
-          "tool_name": ["Edit", "Write", "Bash", "TodoWrite", "Read", "Task"]
-        },
+        "matcher": "Edit|Write|Bash|TodoWrite|Read|Task",
         "hooks": [
           {
             "type": "command",
-            "command": "bun run $SHODH_HOOKS_DIR/memory-hook.ts PostToolUse"
+            "command": "bun run \"$SHODH_HOOKS_DIR/memory-hook.ts\" PostToolUse"
           }
         ]
       }
     ],
     "SubagentStop": [
       {
-        "matcher": {},
         "hooks": [
           {
             "type": "command",
-            "command": "bun run $SHODH_HOOKS_DIR/memory-hook.ts SubagentStop"
+            "command": "bun run \"$SHODH_HOOKS_DIR/memory-hook.ts\" SubagentStop"
           }
         ]
       }

--- a/hooks/memory-hook.ts
+++ b/hooks/memory-hook.ts
@@ -16,7 +16,61 @@
 // ---------------------------------------------------------------------------
 
 const SHODH_API_URL = process.env.SHODH_API_URL || "http://127.0.0.1:3030";
-const SHODH_API_KEY = process.env.SHODH_API_KEY || "sk-shodh-dev-local-testing-key";
+
+/**
+ * API key resolution — MUST match the MCP shim's persistence scheme
+ * (mcp-server/api-key-store.ts; this file ships standalone and cannot import
+ * it). The auto-spawned server only accepts the key the shim generated, which
+ * the shim persists to `<data-root>/.api-key`. Resolution order:
+ *   1. SHODH_API_KEY env (explicit)
+ *   2. `<data-root>/.api-key` — the shared key persisted by the MCP shim
+ *      (data root = SHODH_MEMORY_PATH, else the platform data dir, mirroring
+ *      the Rust server's default_storage_path in src/config.rs)
+ *   3. Legacy dev key — only correct when the user started the server
+ *      manually with that key; SessionStart verifies auth and fails LOUDLY
+ *      instead of letting capture die silently on a 401.
+ */
+interface ResolvedApiKey {
+  key: string;
+  source: "env" | "shared-key-file" | "legacy-dev-fallback";
+  file?: string;
+}
+
+function resolveApiKey(): ResolvedApiKey {
+  if (process.env.SHODH_API_KEY) {
+    return { key: process.env.SHODH_API_KEY, source: "env" };
+  }
+  const fs = require("fs");
+  const path = require("path");
+  const os = require("os");
+
+  const roots: string[] = [];
+  if (process.env.SHODH_MEMORY_PATH) {
+    roots.push(process.env.SHODH_MEMORY_PATH);
+  }
+  const home = os.homedir();
+  if (process.platform === "win32") {
+    roots.push(path.join(process.env.APPDATA || path.join(home, "AppData", "Roaming"), "shodh-memory"));
+  } else if (process.platform === "darwin") {
+    roots.push(path.join(home, "Library", "Application Support", "shodh-memory"));
+  } else {
+    roots.push(path.join(process.env.XDG_DATA_HOME || path.join(home, ".local", "share"), "shodh-memory"));
+  }
+
+  for (const root of roots) {
+    const file = path.join(root, ".api-key");
+    try {
+      const raw = fs.readFileSync(file, "utf-8").trim();
+      if (raw) return { key: raw, source: "shared-key-file", file };
+    } catch {
+      // File absent or unreadable — try the next candidate.
+    }
+  }
+  return { key: "sk-shodh-dev-local-testing-key", source: "legacy-dev-fallback" };
+}
+
+const RESOLVED_API_KEY = resolveApiKey();
+const SHODH_API_KEY = RESOLVED_API_KEY.key;
 const SHODH_USER_ID = process.env.SHODH_USER_ID || "claude-code";
 const HOOK_TIMEOUT_MS = 5000;
 const CIRCUIT_BREAKER_THRESHOLD = 3;
@@ -281,6 +335,77 @@ async function callBrainGet(endpoint: string): Promise<unknown> {
     }
     return null;
   }
+}
+
+/**
+ * Auth/reachability probe used at SessionStart. /health is public on the
+ * server, so a reachable server can still reject every capture call — probe
+ * an authenticated endpoint (/api/users, same one the MCP shim validates
+ * against) to distinguish "server down" from "key rejected".
+ */
+type AuthProbeResult =
+  | { status: "ok" }
+  | { status: "unauthorized"; httpStatus: number }
+  | { status: "unreachable"; detail: string };
+
+async function verifyServerAuth(): Promise<AuthProbeResult> {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), HOOK_TIMEOUT_MS);
+    const response = await fetch(`${SHODH_API_URL}/api/users`, {
+      headers: { "X-API-Key": SHODH_API_KEY },
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    if (response.status === 401 || response.status === 403) {
+      return { status: "unauthorized", httpStatus: response.status };
+    }
+    // Any other response (including 5xx) means the server is up and the key
+    // was not rejected — later calls will surface their own errors.
+    return { status: "ok" };
+  } catch (e) {
+    return { status: "unreachable", detail: e instanceof Error ? e.message : "unknown" };
+  }
+}
+
+/** Loud, actionable SessionStart failure: stderr block + user-visible systemMessage. */
+function reportAuthFailure(httpStatus: number): void {
+  const keyOrigin =
+    RESOLVED_API_KEY.source === "env"
+      ? "the SHODH_API_KEY environment variable"
+      : RESOLVED_API_KEY.source === "shared-key-file"
+        ? `the shared key file ${RESOLVED_API_KEY.file}`
+        : "the legacy dev key (no SHODH_API_KEY set and no shared key file found)";
+
+  const fixLines =
+    RESOLVED_API_KEY.source === "legacy-dev-fallback"
+      ? [
+          "Fix: connect the shodh-memory MCP server once (it persists a shared",
+          "key to <data-dir>/.api-key that hooks pick up automatically), or set",
+          "SHODH_API_KEY to the key your server was started with.",
+        ]
+      : [
+          "Fix: set SHODH_API_KEY to the key the server was started with, or",
+          "stop the server, delete the stale shared key file, and let the MCP",
+          "server re-create it on next connect.",
+        ];
+
+  console.error("[shodh] ============================================================");
+  console.error(`[shodh] MEMORY CAPTURE DISABLED — server rejected API key (${httpStatus})`);
+  console.error(`[shodh] Key came from ${keyOrigin}.`);
+  for (const line of fixLines) console.error(`[shodh] ${line}`);
+  console.error("[shodh] ============================================================");
+
+  console.log(
+    JSON.stringify({
+      systemMessage: `shodh-memory: capture DISABLED — the memory server rejected the hook's API key (${httpStatus}). Key source: ${keyOrigin}. ${fixLines.join(" ")}`,
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext:
+          "\n<shodh-memory>\nMemory capture is DISABLED this session: the memory server rejected the hook's API key. Do not rely on persistent memory until the user fixes the key configuration.\n</shodh-memory>",
+      },
+    })
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -910,6 +1035,19 @@ async function handleTaskUpdate(input: HookInput): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function handleSessionStart(input: HookInput): Promise<void> {
+  // Verify auth up front. A rejected key means EVERY capture call this session
+  // would silently 401 — the user must hear about it now, not never.
+  const probe = await verifyServerAuth();
+  if (probe.status === "unauthorized") {
+    reportAuthFailure(probe.httpStatus);
+    return;
+  }
+  if (probe.status === "unreachable") {
+    console.error(`[shodh] Memory server unreachable at ${SHODH_API_URL} (${probe.detail}) — no briefing this session.`);
+    console.error("[shodh] Later hook events will retry automatically once the server is up.");
+    return;
+  }
+
   const projectDir = process.env.CLAUDE_PROJECT_DIR || input.cwd || process.cwd();
   const projectName = projectDir.split(/[/\\]/).pop() || "unknown";
   const claudeDir = `${projectDir}/.claude`;

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -3,8 +3,26 @@
 # Loads proactive context at session start
 
 SHODH_API_URL="${SHODH_API_URL:-http://127.0.0.1:3030}"
-SHODH_API_KEY="${SHODH_API_KEY:-sk-shodh-dev-local-testing-key}"
 SHODH_USER_ID="${SHODH_USER_ID:-claude-code}"
+
+# Resolve API key: env > shared key file persisted by the MCP server > legacy dev key.
+# The shared file lives at <data-root>/.api-key (see mcp-server/api-key-store.ts);
+# the data root mirrors the Rust server's default_storage_path (src/config.rs).
+if [ -z "$SHODH_API_KEY" ]; then
+    for KEY_FILE in \
+        ${SHODH_MEMORY_PATH:+"$SHODH_MEMORY_PATH/.api-key"} \
+        "${XDG_DATA_HOME:-$HOME/.local/share}/shodh-memory/.api-key" \
+        "$HOME/Library/Application Support/shodh-memory/.api-key" \
+        ${APPDATA:+"$APPDATA/shodh-memory/.api-key"}; do
+        if [ -f "$KEY_FILE" ]; then
+            SHODH_API_KEY=$(tr -d '[:space:]' < "$KEY_FILE")
+            if [ -n "$SHODH_API_KEY" ]; then break; fi
+        fi
+    done
+fi
+# Last resort: legacy dev key (only valid when the server was started with it).
+# A wrong key is reported loudly below instead of failing silently.
+SHODH_API_KEY="${SHODH_API_KEY:-sk-shodh-dev-local-testing-key}"
 
 # Get project directory for context
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
@@ -19,8 +37,11 @@ if [ -d "$PROJECT_DIR/.git" ]; then
     fi
 fi
 
-# Query proactive context from brain
-RESPONSE=$(curl -s -X POST "$SHODH_API_URL/api/proactive_context" \
+# Query proactive context from brain, capturing the HTTP status so an auth
+# failure is reported LOUDLY instead of memory dying silently for the session.
+RESPONSE_FILE=$(mktemp)
+trap 'rm -f "$RESPONSE_FILE"' EXIT
+HTTP_CODE=$(curl -s -o "$RESPONSE_FILE" -w "%{http_code}" -X POST "$SHODH_API_URL/api/proactive_context" \
     -H "Content-Type: application/json" \
     -H "X-API-Key: $SHODH_API_KEY" \
     -d "{
@@ -29,6 +50,19 @@ RESPONSE=$(curl -s -X POST "$SHODH_API_URL/api/proactive_context" \
         \"max_results\": 5,
         \"auto_ingest\": false
     }" 2>/dev/null)
+
+if [ "$HTTP_CODE" = "401" ] || [ "$HTTP_CODE" = "403" ]; then
+    echo "[shodh] ============================================================" >&2
+    echo "[shodh] MEMORY CAPTURE DISABLED - server rejected API key ($HTTP_CODE)" >&2
+    echo "[shodh] Set SHODH_API_KEY to the key the server was started with, or" >&2
+    echo "[shodh] connect the shodh-memory MCP server once so it persists the" >&2
+    echo "[shodh] shared key file (<data-dir>/.api-key) that hooks read." >&2
+    echo "[shodh] ============================================================" >&2
+    echo "{\"systemMessage\": \"shodh-memory: capture DISABLED - the memory server rejected the hook's API key ($HTTP_CODE). Set SHODH_API_KEY or connect the MCP server once to create the shared key file.\"}"
+    exit 0
+fi
+
+RESPONSE=$(cat "$RESPONSE_FILE")
 
 # Extract memories if response is valid
 MEMORIES=$(echo "$RESPONSE" | jq -r '.memories[]? | "- [\(.memory_type)] \(.content | .[0:200])"' 2>/dev/null)

--- a/hooks/stop.sh
+++ b/hooks/stop.sh
@@ -3,8 +3,23 @@
 # Stores the interaction when Claude finishes responding
 
 SHODH_API_URL="${SHODH_API_URL:-http://127.0.0.1:3030}"
-SHODH_API_KEY="${SHODH_API_KEY:-sk-shodh-dev-local-testing-key}"
 SHODH_USER_ID="${SHODH_USER_ID:-claude-code}"
+
+# Resolve API key: env > shared key file persisted by the MCP server > legacy dev key.
+# (Shared file: <data-root>/.api-key, see mcp-server/api-key-store.ts.)
+if [ -z "$SHODH_API_KEY" ]; then
+    for KEY_FILE in \
+        ${SHODH_MEMORY_PATH:+"$SHODH_MEMORY_PATH/.api-key"} \
+        "${XDG_DATA_HOME:-$HOME/.local/share}/shodh-memory/.api-key" \
+        "$HOME/Library/Application Support/shodh-memory/.api-key" \
+        ${APPDATA:+"$APPDATA/shodh-memory/.api-key"}; do
+        if [ -f "$KEY_FILE" ]; then
+            SHODH_API_KEY=$(tr -d '[:space:]' < "$KEY_FILE")
+            if [ -n "$SHODH_API_KEY" ]; then break; fi
+        fi
+    done
+fi
+SHODH_API_KEY="${SHODH_API_KEY:-sk-shodh-dev-local-testing-key}"
 
 # Read hook input from stdin (JSON with stop_hook_active, etc.)
 INPUT=$(cat)

--- a/hooks/user-prompt.sh
+++ b/hooks/user-prompt.sh
@@ -3,8 +3,23 @@
 # Enriches context based on what user is asking
 
 SHODH_API_URL="${SHODH_API_URL:-http://127.0.0.1:3030}"
-SHODH_API_KEY="${SHODH_API_KEY:-sk-shodh-dev-local-testing-key}"
 SHODH_USER_ID="${SHODH_USER_ID:-claude-code}"
+
+# Resolve API key: env > shared key file persisted by the MCP server > legacy dev key.
+# (Shared file: <data-root>/.api-key, see mcp-server/api-key-store.ts.)
+if [ -z "$SHODH_API_KEY" ]; then
+    for KEY_FILE in \
+        ${SHODH_MEMORY_PATH:+"$SHODH_MEMORY_PATH/.api-key"} \
+        "${XDG_DATA_HOME:-$HOME/.local/share}/shodh-memory/.api-key" \
+        "$HOME/Library/Application Support/shodh-memory/.api-key" \
+        ${APPDATA:+"$APPDATA/shodh-memory/.api-key"}; do
+        if [ -f "$KEY_FILE" ]; then
+            SHODH_API_KEY=$(tr -d '[:space:]' < "$KEY_FILE")
+            if [ -n "$SHODH_API_KEY" ]; then break; fi
+        fi
+    done
+fi
+SHODH_API_KEY="${SHODH_API_KEY:-sk-shodh-dev-local-testing-key}"
 
 # Read hook input from stdin
 INPUT=$(cat)

--- a/mcp-server/api-key-store.ts
+++ b/mcp-server/api-key-store.ts
@@ -28,12 +28,21 @@ import * as path from "path";
 export const API_KEY_FILENAME = ".api-key";
 
 /**
- * Resolve the shodh-memory data root, mirroring the Rust server's
- * `default_storage_path()` (src/config.rs):
+ * Resolve the directory that holds the shared key and pidfiles:
  *   - SHODH_MEMORY_PATH when set
  *   - Windows: %APPDATA%\shodh-memory
  *   - macOS:   ~/Library/Application Support/shodh-memory
  *   - Linux:   $XDG_DATA_HOME/shodh-memory or ~/.local/share/shodh-memory
+ *
+ * This is NOT a faithful mirror of the Rust server's `default_storage_path()`
+ * (src/config.rs): that function first returns `./shodh_memory_data` when such
+ * a directory exists in the server's working directory, and this one has no
+ * equivalent branch. Harmless today — the server receives its key through the
+ * environment and never reads this file, and every reader (shim and hooks)
+ * resolves the root the same way, so they always agree with each other. It
+ * matters only if something later assumes the key file sits next to the
+ * database. Do not "fix" this by claiming parity in a comment; if real parity
+ * is ever needed, port the legacy branch and say so here.
  */
 export function shodhDataRoot(
   env: NodeJS.ProcessEnv = process.env,
@@ -116,6 +125,33 @@ function replaceAtomic(file: string, content: string): void {
   const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
   fs.writeFileSync(tmp, content, { mode: 0o600 });
   fs.renameSync(tmp, file);
+}
+
+/**
+ * Publish an already-resolved key (one that came from the environment) to the
+ * shared file so hooks can find it.
+ *
+ * Why this exists: an MCP client's `env` block — the normal way to configure
+ * SHODH_API_KEY — is visible only to the shim process. Claude Code hooks are
+ * spawned by Claude Code itself and never see it, so without this they fall
+ * back to the legacy dev key and get 401s. Auto-generated keys were already
+ * shared via loadOrCreatePersistedApiKey; this closes the same gap for the
+ * more common configured-key case.
+ *
+ * Callers MUST gate this on the backend being local — a remote/production key
+ * does not belong on disk just because a hook might want it.
+ *
+ * Returns true when the file was created or updated, false when it already
+ * held this key (the steady state, so the common path does no writes).
+ */
+export function publishSharedApiKey(rootDir: string, key: string): boolean {
+  const file = apiKeyFilePath(rootDir);
+  if (readPersistedApiKey(file) === key) return false;
+  fs.mkdirSync(rootDir, { recursive: true });
+  // Replace rather than create-exclusive: the configured key is authoritative,
+  // and rewriting it is how a stale key from an earlier config self-heals.
+  replaceAtomic(file, key + "\n");
+  return true;
 }
 
 export interface PersistedApiKey {

--- a/mcp-server/api-key-store.ts
+++ b/mcp-server/api-key-store.ts
@@ -1,0 +1,163 @@
+/**
+ * Persisted API key shared between every local shodh-memory client.
+ *
+ * Problem this solves: when no key is configured in the environment, each MCP
+ * shim used to generate its own random key in memory. Two shims starting
+ * concurrently would each generate a different key — whichever one lost the
+ * spawn race then received 401s for the rest of the session. Claude Code hooks
+ * (memory-hook.ts and the .sh hooks) had no way to learn the auto-generated
+ * key at all, so capture died silently on every fresh install.
+ *
+ * Mechanism: the first shim to need a key generates one and persists it to
+ * `<data-root>/.api-key`, created atomically so exactly one writer wins.
+ * Every other shim — and every hook — reads that file. The data root matches
+ * the Rust server's default storage path (`dirs::data_dir()/shodh-memory`,
+ * see src/config.rs::default_storage_path), or SHODH_MEMORY_PATH when set.
+ * The key file sits beside the server's subdirectories (`storage/`,
+ * `bm25_index/`) — never inside a RocksDB directory.
+ *
+ * NOTE: hooks/memory-hook.ts ships as a single self-contained file and cannot
+ * import this module. It duplicates the read-side path resolution — keep the
+ * two in sync (search for API_KEY_FILENAME there).
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+export const API_KEY_FILENAME = ".api-key";
+
+/**
+ * Resolve the shodh-memory data root, mirroring the Rust server's
+ * `default_storage_path()` (src/config.rs):
+ *   - SHODH_MEMORY_PATH when set
+ *   - Windows: %APPDATA%\shodh-memory
+ *   - macOS:   ~/Library/Application Support/shodh-memory
+ *   - Linux:   $XDG_DATA_HOME/shodh-memory or ~/.local/share/shodh-memory
+ */
+export function shodhDataRoot(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+  homeDir: string = os.homedir(),
+): string {
+  const explicit = env.SHODH_MEMORY_PATH?.trim();
+  if (explicit) return explicit;
+
+  if (platform === "win32") {
+    const appData = env.APPDATA?.trim() || path.join(homeDir, "AppData", "Roaming");
+    return path.join(appData, "shodh-memory");
+  }
+  if (platform === "darwin") {
+    return path.join(homeDir, "Library", "Application Support", "shodh-memory");
+  }
+  const xdg = env.XDG_DATA_HOME?.trim() || path.join(homeDir, ".local", "share");
+  return path.join(xdg, "shodh-memory");
+}
+
+export function apiKeyFilePath(rootDir: string): string {
+  return path.join(rootDir, API_KEY_FILENAME);
+}
+
+/** Read a persisted key. Returns null when the file is missing or empty. */
+export function readPersistedApiKey(file: string): string | null {
+  try {
+    const raw = fs.readFileSync(file, "utf-8").trim();
+    return raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Synchronous sleep without spinning the CPU (used only in a rare race window). */
+function sleepSync(ms: number): void {
+  const sab = new SharedArrayBuffer(4);
+  Atomics.wait(new Int32Array(sab), 0, 0, ms);
+}
+
+/**
+ * Create `file` with `content` if and only if it does not already exist.
+ * Returns true when this process created the file, false when it already
+ * existed (i.e. another process won the race).
+ *
+ * Primary strategy: write a private temp file, then hard-link it into place.
+ * link(2) fails with EEXIST if the target exists and — unlike open(O_EXCL) +
+ * write — makes the complete content appear atomically, so a concurrent
+ * reader can never observe a partially written key. Falls back to an
+ * exclusive write on filesystems without hard-link support.
+ */
+function createExclusive(file: string, content: string): boolean {
+  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmp, content, { mode: 0o600 });
+  try {
+    fs.linkSync(tmp, file);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EEXIST") return false;
+    // Hard links unsupported here — fall back to exclusive create.
+    try {
+      fs.writeFileSync(file, content, { flag: "wx", mode: 0o600 });
+      return true;
+    } catch (wxErr) {
+      if ((wxErr as NodeJS.ErrnoException).code === "EEXIST") return false;
+      throw wxErr;
+    }
+  } finally {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      // Best effort: tmp already gone or was renamed away.
+    }
+  }
+}
+
+/** Atomically replace `file` with `content` (used to heal an empty/corrupt key file). */
+function replaceAtomic(file: string, content: string): void {
+  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmp, content, { mode: 0o600 });
+  fs.renameSync(tmp, file);
+}
+
+export interface PersistedApiKey {
+  key: string;
+  file: string;
+  /** True when this call generated and persisted a new key. */
+  created: boolean;
+}
+
+/**
+ * Load the shared API key, generating and persisting one if none exists yet.
+ *
+ * Concurrency contract: any number of processes may call this at the same
+ * time; exactly one generates the key, and every caller returns the same
+ * value. Losers of the creation race read the winner's file (with a short
+ * bounded retry to cover the wx-fallback write window).
+ */
+export function loadOrCreatePersistedApiKey(
+  rootDir: string,
+  generate: () => string,
+): PersistedApiKey {
+  const file = apiKeyFilePath(rootDir);
+
+  const existing = readPersistedApiKey(file);
+  if (existing) return { key: existing, file, created: false };
+
+  fs.mkdirSync(rootDir, { recursive: true });
+
+  const candidate = generate();
+  if (createExclusive(file, candidate + "\n")) {
+    return { key: candidate, file, created: true };
+  }
+
+  // Another process created the file first — read the winner's key.
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const winner = readPersistedApiKey(file);
+    if (winner) return { key: winner, file, created: false };
+    sleepSync(25);
+  }
+
+  // The file exists but never became readable/non-empty: a writer crashed
+  // mid-create. Heal it by atomically installing our candidate.
+  replaceAtomic(file, candidate + "\n");
+  return { key: candidate, file, created: true };
+}

--- a/mcp-server/backend-lifecycle.ts
+++ b/mcp-server/backend-lifecycle.ts
@@ -1,0 +1,153 @@
+/**
+ * Shared-backend lifecycle bookkeeping for MCP shims.
+ *
+ * Problem this solves: the backend server is spawned detached and shared —
+ * several MCP shims (Claude Code, Claude Desktop, Cursor, ...) plus the
+ * Claude Code hooks all talk to the same process. The shim that happened to
+ * spawn it used to kill it on its own exit, yanking the backend out from
+ * under every other client mid-session.
+ *
+ * Mechanism: pidfiles under the shodh data root.
+ *   - `<root>/.mcp-shims/<pid>.pid` — one registration file per live shim.
+ *   - `<root>/.mcp-server.pid`      — the pid of an auto-spawned backend.
+ * On exit a shim unregisters itself, then kills the backend only when no
+ * other live shim remains AND the backend was auto-spawned (pidfile exists).
+ * Manually started servers never get a pidfile, so they are never killed.
+ *
+ * All functions are synchronous: the exit path runs inside process.on("exit")
+ * where async work is impossible. Stale registrations (crashed shims) are
+ * pruned by liveness-checking their pids.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+export const SERVER_PIDFILE = ".mcp-server.pid";
+export const SHIM_PID_DIR = ".mcp-shims";
+
+/** True when a process with this pid exists (EPERM means it exists but is not ours). */
+export function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function shimDir(rootDir: string): string {
+  return path.join(rootDir, SHIM_PID_DIR);
+}
+
+function shimFile(rootDir: string, pid: number): string {
+  return path.join(shimDir(rootDir), `${pid}.pid`);
+}
+
+/** Register this shim as a live user of the shared backend. Returns the pidfile path. */
+export function registerShim(rootDir: string, pid: number = process.pid): string {
+  const dir = shimDir(rootDir);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = shimFile(rootDir, pid);
+  fs.writeFileSync(file, `${pid}\n`, { mode: 0o600 });
+  return file;
+}
+
+/** Remove this shim's registration. Safe to call when never registered. */
+export function unregisterShim(rootDir: string, pid: number = process.pid): void {
+  try {
+    fs.unlinkSync(shimFile(rootDir, pid));
+  } catch {
+    // Already gone or never registered.
+  }
+}
+
+/**
+ * Pids of other shims that are still alive. Stale registrations (dead pids,
+ * unparseable filenames) are pruned as a side effect.
+ */
+export function liveSiblingShims(rootDir: string, selfPid: number = process.pid): number[] {
+  const dir = shimDir(rootDir);
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+
+  const alive: number[] = [];
+  for (const entry of entries) {
+    const match = /^(\d+)\.pid$/.exec(entry);
+    const pid = match ? parseInt(match[1], 10) : NaN;
+    if (!match || Number.isNaN(pid)) {
+      try {
+        fs.unlinkSync(path.join(dir, entry));
+      } catch {
+        // Best effort prune.
+      }
+      continue;
+    }
+    if (pid === selfPid) continue;
+    if (isPidAlive(pid)) {
+      alive.push(pid);
+    } else {
+      try {
+        fs.unlinkSync(path.join(dir, entry));
+      } catch {
+        // Best effort prune.
+      }
+    }
+  }
+  return alive;
+}
+
+/**
+ * Record the pid of an auto-spawned backend. Never clobbers the record of a
+ * backend that is still alive (e.g. a concurrent shim's spawn won the port);
+ * dead or missing records are replaced.
+ */
+export function recordSpawnedServer(rootDir: string, pid: number): void {
+  const file = path.join(rootDir, SERVER_PIDFILE);
+  const existing = readSpawnedServerPid(rootDir);
+  if (existing !== null && existing !== pid && isPidAlive(existing)) return;
+  fs.mkdirSync(rootDir, { recursive: true });
+  fs.writeFileSync(file, `${pid}\n`, { mode: 0o600 });
+}
+
+/** Pid of the auto-spawned backend, or null when none was recorded. */
+export function readSpawnedServerPid(rootDir: string): number | null {
+  try {
+    const raw = fs.readFileSync(path.join(rootDir, SERVER_PIDFILE), "utf-8").trim();
+    const pid = parseInt(raw, 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Remove the auto-spawned backend record. */
+export function clearSpawnedServer(rootDir: string): void {
+  try {
+    fs.unlinkSync(path.join(rootDir, SERVER_PIDFILE));
+  } catch {
+    // Already gone.
+  }
+}
+
+/**
+ * Decide whether the exiting shim should reap the auto-spawned backend.
+ * Call AFTER unregisterShim. Returns the backend pid to kill, or null when:
+ *   - other live shims still use the backend, or
+ *   - no auto-spawned backend was recorded (manually started servers), or
+ *   - the recorded backend is already dead (record is cleared).
+ */
+export function backendPidToReap(rootDir: string, selfPid: number = process.pid): number | null {
+  if (liveSiblingShims(rootDir, selfPid).length > 0) return null;
+  const pid = readSpawnedServerPid(rootDir);
+  if (pid === null) return null;
+  if (!isPidAlive(pid)) {
+    clearSpawnedServer(rootDir);
+    return null;
+  }
+  return pid;
+}

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -36,7 +36,12 @@ import { resolvePackageVersion } from "./version";
 import { renderContent, MEMORY_PREVIEW_MAX } from "./memory-format";
 import { ShodhIpcClient, type WindowsIpcHelper } from "./ipc-client";
 import { DrainController } from "./drain";
-import { shodhDataRoot, loadOrCreatePersistedApiKey } from "./api-key-store";
+import {
+  shodhDataRoot,
+  loadOrCreatePersistedApiKey,
+  publishSharedApiKey,
+  apiKeyFilePath,
+} from "./api-key-store";
 import {
   registerShim,
   unregisterShim,
@@ -155,6 +160,30 @@ if (!API_KEY) {
     process.exit(1);
   }
 }
+// Share an environment-supplied key with the hooks, for local backends only.
+// An MCP `env` block reaches this shim but NOT Claude Code's hooks, so without
+// this a user who configures SHODH_API_KEY in mcp.json gets a working shim and
+// hooks that 401 on every capture. Never done for remote backends: a
+// production key must not be written to disk to satisfy a local convenience.
+if (
+  API_KEY &&
+  apiKeyFile === null &&
+  apiKeySource !== "sandbox" &&
+  isLocalServer()
+) {
+  try {
+    const published = publishSharedApiKey(shodhDataRoot(), API_KEY);
+    apiKeyFile = apiKeyFilePath(shodhDataRoot());
+    if (published) {
+      console.error(`[shodh-memory] Shared this key with Claude Code hooks via ${apiKeyFile}.`);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[shodh-memory] WARNING: could not share the API key with hooks (${msg}).`);
+    console.error("[shodh-memory] Hook-based memory capture will fail unless SHODH_API_KEY is also set in your shell.");
+  }
+}
+
 // Log which source was used (without revealing the key itself).
 // Persisted/auto-generated/sandbox sources already logged their own message above.
 if (apiKeySource === "SHODH_DEV_API_KEY") {
@@ -4938,12 +4967,38 @@ async function waitForServer(maxAttempts: number = 30): Promise<boolean> {
   return false;
 }
 
-async function validateApiKey(): Promise<boolean> {
+// Outcome of an authenticated probe. "rejected" means the server answered and
+// refused the key; "inconclusive" means we never got an authoritative answer
+// (timeout, connection reset, 5xx). Collapsing the two would let a slow-starting
+// backend be reported as a bad key, sending users to delete a key file that was
+// never the problem.
+type KeyProbe = "accepted" | "rejected" | "inconclusive";
+
+/** Probe an authenticated endpoint — /health is public, so it proves nothing about auth. */
+async function probeApiKey(): Promise<KeyProbe> {
   try {
     await backendRequest("/api/users", "GET", undefined, 3000);
-    return true;
-  } catch {
-    return false;
+    return "accepted";
+  } catch (err) {
+    const status = /API error (\d+)/.exec(err instanceof Error ? err.message : String(err));
+    if (status) {
+      const code = parseInt(status[1], 10);
+      // Any answered status other than 401/403 means the key got past auth.
+      return code === 401 || code === 403 ? "rejected" : "accepted";
+    }
+    return "inconclusive";
+  }
+}
+
+/** Report a rejected key with the fix that matches how this shim got its key. */
+function reportKeyRejected(): void {
+  console.error("[shodh-memory] ERROR: the server rejected our API key (401/403).");
+  console.error("[shodh-memory] All memory operations will fail until this is fixed.");
+  if (apiKeyFile) {
+    console.error(`[shodh-memory] Fix: stop the server, delete ${apiKeyFile}, and reconnect,`);
+    console.error("[shodh-memory] or set SHODH_API_KEY to the key the server was started with.");
+  } else {
+    console.error("[shodh-memory] Fix: set SHODH_API_KEY to the key the server was started with.");
   }
 }
 
@@ -4955,16 +5010,9 @@ async function ensureServerRunning(): Promise<void> {
     // running server — /health is unauthenticated, so reachability alone
     // proves nothing about auth.
     if (!process.env.SHODH_API_KEY && isLocalServer()) {
-      const keyWorks = await validateApiKey();
-      if (!keyWorks) {
-        console.error("[shodh-memory] ERROR: API key rejected by the running server (401).");
+      if (await probeApiKey() === "rejected") {
         console.error("[shodh-memory] The server was started with a different API key.");
-        console.error("[shodh-memory] Fix: set SHODH_API_KEY to match the server's key, or stop the");
-        if (apiKeyFile) {
-          console.error(`[shodh-memory] server, delete ${apiKeyFile}, and reconnect to re-pair.`);
-        } else {
-          console.error("[shodh-memory] server and reconnect so a fresh shared key is negotiated.");
-        }
+        reportKeyRejected();
       }
     }
     return;
@@ -5064,16 +5112,8 @@ async function ensureServerRunning(): Promise<void> {
     // Validate auth against the freshly spawned server. /health is public, so
     // a healthy server can still reject our key (e.g. a concurrent shim's
     // spawn won the port with a different key, or a stale persisted key).
-    const keyWorks = await validateApiKey();
-    if (!keyWorks) {
-      console.error("[shodh-memory] ERROR: the running server rejected our API key (401).");
-      console.error("[shodh-memory] All memory operations will fail until this is fixed.");
-      if (apiKeyFile) {
-        console.error(`[shodh-memory] Fix: stop the server, delete ${apiKeyFile}, and reconnect,`);
-        console.error("[shodh-memory] or set SHODH_API_KEY to the key the server was started with.");
-      } else {
-        console.error("[shodh-memory] Fix: set SHODH_API_KEY to the key the server was started with.");
-      }
+    if (await probeApiKey() === "rejected") {
+      reportKeyRejected();
     }
   } else {
     console.error("[shodh-memory] Warning: Server may not have started properly");

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -160,17 +160,20 @@ if (!API_KEY) {
     process.exit(1);
   }
 }
-// Share an environment-supplied key with the hooks, for local backends only.
-// An MCP `env` block reaches this shim but NOT Claude Code's hooks, so without
-// this a user who configures SHODH_API_KEY in mcp.json gets a working shim and
-// hooks that 401 on every capture. Never done for remote backends: a
-// production key must not be written to disk to satisfy a local convenience.
-if (
-  API_KEY &&
-  apiKeyFile === null &&
-  apiKeySource !== "sandbox" &&
-  isLocalServer()
-) {
+// Share an environment-supplied key with the hooks. An MCP `env` block reaches
+// this shim but NOT Claude Code's hooks, so without this a user who configures
+// SHODH_API_KEY in mcp.json gets a working shim and hooks that 401 on every
+// capture.
+//
+// Two conditions, both needed. isLocalServer() checks the backend URL, which
+// alone is not enough: a loopback tunnel or local proxy in front of a remote
+// backend still looks local. So the key's own provenance is checked too, and
+// SHODH_API_KEYS is excluded — it is the production-shaped variable (the server
+// reads it as its full key list), and a production key must not be written to
+// disk to satisfy a local convenience.
+const KEY_SOURCE_IS_LOCAL_SHAPED =
+  apiKeySource === "SHODH_API_KEY" || apiKeySource === "SHODH_DEV_API_KEY";
+if (API_KEY && apiKeyFile === null && KEY_SOURCE_IS_LOCAL_SHAPED && isLocalServer()) {
   try {
     const published = publishSharedApiKey(shodhDataRoot(), API_KEY);
     apiKeyFile = apiKeyFilePath(shodhDataRoot());

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -36,6 +36,7 @@ import { resolvePackageVersion } from "./version";
 import { renderContent, MEMORY_PREVIEW_MAX } from "./memory-format";
 import { ShodhIpcClient, type WindowsIpcHelper } from "./ipc-client";
 import { DrainController } from "./drain";
+import { shodhDataRoot, loadOrCreatePersistedApiKey } from "./api-key-store";
 
 const __filename = (typeof import.meta !== "undefined" && import.meta.url) ? fileURLToPath(import.meta.url) : "";
 const __dirname = __filename ? path.dirname(__filename) : process.cwd();
@@ -87,10 +88,16 @@ const SANDBOX_MODE = process.env.SMITHERY_SANDBOX === "true";
 //   1. SHODH_API_KEY (explicit, preferred)
 //   2. SHODH_DEV_API_KEY (matches what the server accepts in dev mode)
 //   3. First key from SHODH_API_KEYS (matches server production config)
-//   4. Auto-generate for local servers (passed to server as SHODH_DEV_API_KEY)
+//   4. Shared persisted key at <data-root>/.api-key, auto-generated on first
+//      use for local servers (passed to the server as SHODH_DEV_API_KEY).
+//      Persisting it means concurrent shims and Claude Code hooks all use the
+//      SAME key — previously each shim generated its own in-memory key and
+//      whichever shim lost the spawn race got 401s for the whole session.
 //   5. Error for remote servers
 let API_KEY = "";
 let apiKeySource = "";
+// Path of the persisted shared key file, when one is in use (for diagnostics).
+let apiKeyFile: string | null = null;
 if (process.env.SHODH_API_KEY) {
   API_KEY = process.env.SHODH_API_KEY;
   apiKeySource = "SHODH_API_KEY";
@@ -106,10 +113,30 @@ if (process.env.SHODH_API_KEY) {
 }
 if (!API_KEY) {
   if (isLocalServer()) {
-    // Auto-generate a random key for local development — zero config
-    API_KEY = crypto.randomBytes(32).toString("hex");
-    apiKeySource = "auto-generated";
-    console.error("[shodh-memory] No API key set — auto-generated for local server.");
+    // Load (or generate once and persist) the shared local key — zero config.
+    try {
+      const persisted = loadOrCreatePersistedApiKey(shodhDataRoot(), () =>
+        crypto.randomBytes(32).toString("hex")
+      );
+      API_KEY = persisted.key;
+      apiKeyFile = persisted.file;
+      apiKeySource = persisted.created ? "auto-generated (persisted)" : "persisted key file";
+      if (persisted.created) {
+        console.error(`[shodh-memory] No API key set — generated one and saved it to ${persisted.file}`);
+        console.error("[shodh-memory] Hooks and other local MCP clients will share this key automatically.");
+      } else {
+        console.error(`[shodh-memory] API key loaded from ${persisted.file}.`);
+      }
+    } catch (err) {
+      // Persistence failed (e.g. read-only data dir) — fall back to an
+      // in-memory key so this shim still works, but say so loudly because
+      // hooks and sibling shims will NOT share it.
+      API_KEY = crypto.randomBytes(32).toString("hex");
+      apiKeySource = "auto-generated";
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[shodh-memory] WARNING: could not persist auto-generated API key (${msg}).`);
+      console.error("[shodh-memory] Hooks and other MCP clients will not share this key; set SHODH_API_KEY to fix.");
+    }
   } else {
     console.error("ERROR: SHODH_API_KEY is required for remote servers.");
     console.error("");
@@ -121,10 +148,11 @@ if (!API_KEY) {
     process.exit(1);
   }
 }
-// Log which source was used (without revealing the key itself)
+// Log which source was used (without revealing the key itself).
+// Persisted/auto-generated/sandbox sources already logged their own message above.
 if (apiKeySource === "SHODH_DEV_API_KEY") {
   console.error("[shodh-memory] WARNING: API key loaded from SHODH_DEV_API_KEY — this is a development key. Use SHODH_API_KEY for production.");
-} else if (apiKeySource && apiKeySource !== "auto-generated" && apiKeySource !== "sandbox") {
+} else if (apiKeySource === "SHODH_API_KEY" || apiKeySource === "SHODH_API_KEYS") {
   console.error(`[shodh-memory] API key loaded from ${apiKeySource}.`);
 }
 const IPC_CLIENT = IPC_ENDPOINT
@@ -4910,14 +4938,20 @@ async function ensureServerRunning(): Promise<void> {
   // Check if already running
   if (await isServerRunning()) {
     console.error("[shodh-memory] Backend server already running at", BACKEND_LOCATION);
-    // If we auto-generated a key, verify it works against the running server
+    // If our key wasn't explicitly configured, verify it works against the
+    // running server — /health is unauthenticated, so reachability alone
+    // proves nothing about auth.
     if (!process.env.SHODH_API_KEY && isLocalServer()) {
       const keyWorks = await validateApiKey();
       if (!keyWorks) {
-        console.error("[shodh-memory] WARNING: Auto-generated key rejected by running server.");
+        console.error("[shodh-memory] ERROR: API key rejected by the running server (401).");
         console.error("[shodh-memory] The server was started with a different API key.");
-        console.error("[shodh-memory] Set SHODH_API_KEY to match the server's key, or restart");
-        console.error("[shodh-memory] the server without SHODH_DEV_API_KEY to use auto-generated keys.");
+        console.error("[shodh-memory] Fix: set SHODH_API_KEY to match the server's key, or stop the");
+        if (apiKeyFile) {
+          console.error(`[shodh-memory] server, delete ${apiKeyFile}, and reconnect to re-pair.`);
+        } else {
+          console.error("[shodh-memory] server and reconnect so a fresh shared key is negotiated.");
+        }
       }
     }
     return;
@@ -5003,6 +5037,20 @@ async function ensureServerRunning(): Promise<void> {
 
   if (started) {
     console.error("[shodh-memory] Backend server started successfully");
+    // Validate auth against the freshly spawned server. /health is public, so
+    // a healthy server can still reject our key (e.g. a concurrent shim's
+    // spawn won the port with a different key, or a stale persisted key).
+    const keyWorks = await validateApiKey();
+    if (!keyWorks) {
+      console.error("[shodh-memory] ERROR: the running server rejected our API key (401).");
+      console.error("[shodh-memory] All memory operations will fail until this is fixed.");
+      if (apiKeyFile) {
+        console.error(`[shodh-memory] Fix: stop the server, delete ${apiKeyFile}, and reconnect,`);
+        console.error("[shodh-memory] or set SHODH_API_KEY to the key the server was started with.");
+      } else {
+        console.error("[shodh-memory] Fix: set SHODH_API_KEY to the key the server was started with.");
+      }
+    }
   } else {
     console.error("[shodh-memory] Warning: Server may not have started properly");
   }

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -37,6 +37,13 @@ import { renderContent, MEMORY_PREVIEW_MAX } from "./memory-format";
 import { ShodhIpcClient, type WindowsIpcHelper } from "./ipc-client";
 import { DrainController } from "./drain";
 import { shodhDataRoot, loadOrCreatePersistedApiKey } from "./api-key-store";
+import {
+  registerShim,
+  unregisterShim,
+  recordSpawnedServer,
+  clearSpawnedServer,
+  backendPidToReap,
+} from "./backend-lifecycle";
 
 const __filename = (typeof import.meta !== "undefined" && import.meta.url) ? fileURLToPath(import.meta.url) : "";
 const __dirname = __filename ? path.dirname(__filename) : process.cwd();
@@ -1735,14 +1742,20 @@ const handleCallTool = async (request: CallToolRequest) => {
   // Auto-capture context from tool arguments (non-blocking)
   autoStreamContext(name, args as Record<string, unknown>);
 
-  // Check server availability first
-  const serverUp = await isServerAvailable();
+  // Check server availability first. If the health check fails, try to bring
+  // the backend back (it may have crashed or been killed since we started)
+  // instead of failing every subsequent tool call for the rest of the session.
+  let serverUp = await isServerAvailable();
+  if (!serverUp) {
+    console.error("[shodh-memory] Backend health check failed — attempting to restart it...");
+    serverUp = await recoverBackend();
+  }
   if (!serverUp) {
     return {
       content: [
         {
           type: "text",
-          text: `Memory server unavailable at ${BACKEND_LOCATION}. Please ensure shodh-memory-server is running.\n\nTo start: shodh-memory-server`,
+          text: `Memory server unavailable at ${BACKEND_LOCATION}, and automatic restart did not bring it back. Please ensure shodh-memory-server is running.\n\nTo start: shodh-memory-server`,
         },
       ],
       isError: true,
@@ -5031,6 +5044,17 @@ async function ensureServerRunning(): Promise<void> {
 
   serverProcess.unref();
 
+  // Record the spawned backend's pid so whichever shim exits LAST can reap it.
+  // Recorded before the health wait: even a slow-starting backend must be
+  // reapable, and recordSpawnedServer never clobbers a live sibling's record.
+  if (serverProcess.pid) {
+    try {
+      recordSpawnedServer(shodhDataRoot(), serverProcess.pid);
+    } catch (err) {
+      console.error("[shodh-memory] Warning: could not record backend pidfile:", err instanceof Error ? err.message : err);
+    }
+  }
+
   // Wait for server to become available
   console.error("[shodh-memory] Waiting for server to start...");
   const started = await waitForServer();
@@ -5056,6 +5080,85 @@ async function ensureServerRunning(): Promise<void> {
   }
 }
 
+// -----------------------------------------------------------------------------
+// Backend recovery — re-run ensureServerRunning when a health check fails
+// -----------------------------------------------------------------------------
+// Concurrent tool calls share one in-flight recovery attempt, and a failed
+// attempt is not retried for a cooldown window so a dead backend doesn't cost
+// every tool call a full spawn-and-wait cycle.
+let recoveryInFlight: Promise<void> | null = null;
+let lastFailedRecoveryAt = 0;
+const RECOVERY_COOLDOWN_MS = 30_000;
+
+async function recoverBackend(): Promise<boolean> {
+  if (Date.now() - lastFailedRecoveryAt < RECOVERY_COOLDOWN_MS) return false;
+  if (!recoveryInFlight) {
+    recoveryInFlight = ensureServerRunning()
+      .catch((err) => {
+        console.error("[shodh-memory] Backend restart attempt failed:", err instanceof Error ? err.message : err);
+      })
+      .finally(() => {
+        recoveryInFlight = null;
+      });
+  }
+  await recoveryInFlight;
+  const up = await isServerAvailable();
+  if (!up) {
+    lastFailedRecoveryAt = Date.now();
+  }
+  return up;
+}
+
+// True once this shim registered itself in the shared shim pidfile directory.
+let shimRegistered = false;
+// Guard so the exit path releases the shared backend exactly once
+// (process.on("exit") and signal handlers can both invoke cleanup).
+let backendReleased = false;
+
+// Kill an auto-spawned backend by pid. On POSIX the backend was spawned
+// detached (its own process group, pgid == pid), so kill the group first.
+function killBackendPid(pid: number): void {
+  if (process.platform !== "win32") {
+    try {
+      process.kill(-pid, "SIGTERM");
+      return;
+    } catch (e) {
+      console.error("[Cleanup] Process group kill failed, falling back to direct kill:", e);
+    }
+  }
+  try { process.kill(pid, "SIGTERM"); } catch (_) { /* already gone */ }
+}
+
+// Release this shim's reference to the shared backend. The backend is only
+// killed when (a) it was auto-spawned by a shim (pidfile exists) and (b) no
+// other live shim remains — a shim exiting mid-session must never take the
+// backend away from siblings that are still using it.
+function releaseSharedBackend(): void {
+  if (backendReleased) return;
+  backendReleased = true;
+
+  try {
+    if (shimRegistered) {
+      unregisterShim(shodhDataRoot());
+      shimRegistered = false;
+    }
+    const pidToReap = backendPidToReap(shodhDataRoot());
+    if (pidToReap !== null) {
+      console.error(`[shodh-memory] Last shim exiting — stopping auto-spawned backend (pid ${pidToReap})`);
+      killBackendPid(pidToReap);
+      clearSpawnedServer(shodhDataRoot());
+    }
+  } catch (err) {
+    // Pidfile bookkeeping failed (e.g. data dir vanished). Fall back to the
+    // legacy behaviour for our own child only, so we never leak a process we
+    // spawned ourselves.
+    console.error("[Cleanup] Backend refcount failed, falling back to own-child kill:", err instanceof Error ? err.message : err);
+    if (serverProcess && !serverProcess.killed && serverProcess.pid) {
+      killBackendPid(serverProcess.pid);
+    }
+  }
+}
+
 // Graceful shutdown helper — tears down ALL event loop references
 function cleanupServer() {
   // 1. Stop WebSocket reconnect loop (prevents event loop from staying alive)
@@ -5071,21 +5174,8 @@ function cleanupServer() {
     streamSocket = null;
   }
 
-  // 3. Kill child process
-  if (serverProcess && !serverProcess.killed) {
-    // For detached processes, we need to kill the process group on Unix
-    if (process.platform !== "win32" && serverProcess.pid) {
-      try {
-        // Kill the process group (negative PID)
-        process.kill(-serverProcess.pid, "SIGTERM");
-      } catch (e) {
-        console.error("[Cleanup] Process group kill failed, falling back to direct kill:", e);
-        try { serverProcess.kill("SIGTERM"); } catch (_) { /* ignore */ }
-      }
-    } else {
-      try { serverProcess.kill(); } catch (_) { /* ignore */ }
-    }
-  }
+  // 3. Release the shared backend (kills it only if we are the last live shim)
+  releaseSharedBackend();
 }
 
 // Cleanup on exit
@@ -5160,6 +5250,15 @@ export function createSandboxServer() {
 // Start server
 async function main() {
   if (SANDBOX_MODE) return;
+
+  // Register this shim as a live user of the shared backend BEFORE any spawn,
+  // so a sibling shim exiting right now sees us and leaves the backend alive.
+  try {
+    registerShim(shodhDataRoot());
+    shimRegistered = true;
+  } catch (err) {
+    console.error("[shodh-memory] Warning: could not register shim pidfile:", err instanceof Error ? err.message : err);
+  }
 
   // Ensure backend is running
   await ensureServerRunning();

--- a/mcp-server/scripts/setup-hooks.cjs
+++ b/mcp-server/scripts/setup-hooks.cjs
@@ -171,10 +171,29 @@ function mergeHooks(existingSettings, newHooks) {
   return settings;
 }
 
+// Hooks we installed live under HOOKS_DEST (~/.claude/hooks/shodh-memory).
+// A developer running from a checkout may instead point hooks at the repo's
+// own hooks/memory-hook.ts — those commands also contain "shodh-memory" when
+// the clone directory is named that, but they are the user's, not ours.
+const MANAGED_HOOK_MARKER = HOOKS_DEST.replace(/\\/g, '/');
+
+function isShodhHookCommand(command, managedOnly) {
+  if (!command) return false;
+  const normalized = command.replace(/\\/g, '/');
+  return managedOnly
+    ? normalized.includes(MANAGED_HOOK_MARKER)
+    : normalized.includes('shodh-memory');
+}
+
 /**
- * Removes all shodh-memory hooks from settings.json.
+ * Removes shodh-memory hooks from settings.json.
+ *
+ * `managedOnly` restricts removal to hooks pointing at HOOKS_DEST. Install uses
+ * it so re-running setup-hooks repairs entries we wrote without deleting a
+ * developer's hand-written hooks that point at a checkout. Uninstall leaves it
+ * off, so "remove shodh hooks" removes all of them.
  */
-function removeHooks(existingSettings) {
+function removeHooks(existingSettings, { managedOnly = false } = {}) {
   const settings = JSON.parse(JSON.stringify(existingSettings));
   if (!settings.hooks) return settings;
 
@@ -182,7 +201,7 @@ function removeHooks(existingSettings) {
     if (!Array.isArray(entries)) continue;
     settings.hooks[event] = entries.filter((entry) => {
       if (!entry.hooks || !Array.isArray(entry.hooks)) return true;
-      return !entry.hooks.some((h) => h.command && h.command.includes('shodh-memory'));
+      return !entry.hooks.some((h) => isShodhHookCommand(h.command, managedOnly));
     });
     // Remove empty arrays
     if (settings.hooks[event].length === 0) {
@@ -304,11 +323,12 @@ async function main() {
     fs.copyFileSync(SETTINGS_PATH, backupPath);
   }
 
-  // Remove any stale shodh entries first (older installs wrote unquoted paths
-  // and object-shaped matchers), then merge the current config. This makes
-  // re-running setup-hooks an idempotent repair, not an accumulation.
+  // Remove stale entries we previously installed (older installs wrote unquoted
+  // paths and object-shaped matchers), then merge the current config. This makes
+  // re-running setup-hooks an idempotent repair, not an accumulation. Scoped to
+  // managed hooks so a developer's own repo-path hooks are left untouched.
   const hookConfig = buildHookConfig();
-  const merged = mergeHooks(removeHooks(settings), hookConfig);
+  const merged = mergeHooks(removeHooks(settings, { managedOnly: true }), hookConfig);
 
   if (!dryRun) {
     fs.writeFileSync(SETTINGS_PATH, JSON.stringify(merged, null, 2) + '\n');

--- a/mcp-server/scripts/setup-hooks.cjs
+++ b/mcp-server/scripts/setup-hooks.cjs
@@ -38,46 +38,49 @@ const HOOK_COMMAND_PREFIX = 'bun run';
 const HOOK_SCRIPT = path.join(HOOKS_DEST, 'memory-hook.ts');
 
 function makeCommand(event) {
-  // Use forward slashes for cross-platform compat in the command string
+  // Use forward slashes for cross-platform compat in the command string, and
+  // QUOTE the script path — hook commands run through a shell, so an unquoted
+  // path breaks for any user whose home directory contains a space
+  // (e.g. C:/Users/John Smith/...).
   const scriptPath = HOOK_SCRIPT.replace(/\\/g, '/');
-  return `${HOOK_COMMAND_PREFIX} ${scriptPath} ${event}`;
+  return `${HOOK_COMMAND_PREFIX} "${scriptPath}" ${event}`;
 }
 
+// Claude Code's hook schema: `matcher` is a STRING (a regex over tool names,
+// e.g. "Edit|Write|Bash") and only applies to PreToolUse/PostToolUse. Events
+// without a tool filter omit the field entirely. An object matcher like
+// { tool_name: [...] } does not match the schema and breaks hook dispatch.
 function buildHookConfig() {
   return {
     SessionStart: [
       {
-        matcher: {},
         hooks: [{ type: 'command', command: makeCommand('SessionStart') }],
       },
     ],
     UserPromptSubmit: [
       {
-        matcher: {},
         hooks: [{ type: 'command', command: makeCommand('UserPromptSubmit') }],
       },
     ],
     Stop: [
       {
-        matcher: {},
         hooks: [{ type: 'command', command: makeCommand('Stop') }],
       },
     ],
     PreToolUse: [
       {
-        matcher: { tool_name: ['Edit', 'Write', 'Bash'] },
+        matcher: 'Edit|Write|Bash',
         hooks: [{ type: 'command', command: makeCommand('PreToolUse') }],
       },
     ],
     PostToolUse: [
       {
-        matcher: { tool_name: ['Edit', 'Write', 'Bash', 'TodoWrite', 'Read', 'Task'] },
+        matcher: 'Edit|Write|Bash|TodoWrite|Read|Task',
         hooks: [{ type: 'command', command: makeCommand('PostToolUse') }],
       },
     ],
     SubagentStop: [
       {
-        matcher: {},
         hooks: [{ type: 'command', command: makeCommand('SubagentStop') }],
       },
     ],
@@ -301,8 +304,11 @@ async function main() {
     fs.copyFileSync(SETTINGS_PATH, backupPath);
   }
 
+  // Remove any stale shodh entries first (older installs wrote unquoted paths
+  // and object-shaped matchers), then merge the current config. This makes
+  // re-running setup-hooks an idempotent repair, not an accumulation.
   const hookConfig = buildHookConfig();
-  const merged = mergeHooks(settings, hookConfig);
+  const merged = mergeHooks(removeHooks(settings), hookConfig);
 
   if (!dryRun) {
     fs.writeFileSync(SETTINGS_PATH, JSON.stringify(merged, null, 2) + '\n');
@@ -328,7 +334,12 @@ async function main() {
   process.stderr.write('\n');
 }
 
-main().catch((err) => {
-  process.stderr.write(`\n  \u2717 Setup failed: ${err.message}\n\n`);
-  process.exit(1);
-});
+// Exported for tests; the CLI entrypoint only runs when executed directly.
+module.exports = { makeCommand, buildHookConfig, mergeHooks, removeHooks, HOOK_SCRIPT };
+
+if (require.main === module) {
+  main().catch((err) => {
+    process.stderr.write(`\n  \u2717 Setup failed: ${err.message}\n\n`);
+    process.exit(1);
+  });
+}

--- a/mcp-server/tests/api-key-store.test.ts
+++ b/mcp-server/tests/api-key-store.test.ts
@@ -6,6 +6,7 @@ import {
   API_KEY_FILENAME,
   apiKeyFilePath,
   loadOrCreatePersistedApiKey,
+  publishSharedApiKey,
   readPersistedApiKey,
   shodhDataRoot,
 } from "../api-key-store";
@@ -114,5 +115,42 @@ describe("readPersistedApiKey", () => {
     expect(readPersistedApiKey(file)).toBeNull();
     fs.writeFileSync(file, "  the-key \n");
     expect(readPersistedApiKey(file)).toBe("the-key");
+  });
+});
+
+describe("publishSharedApiKey — sharing an environment-supplied key with hooks", () => {
+  it("writes the key so a hook reading the same root finds it", () => {
+    // The gap this closes: an MCP client's `env` block reaches the shim but not
+    // Claude Code's hooks, which then fall back to the dev key and get 401s.
+    expect(publishSharedApiKey(tmpRoot, "sk-from-mcp-json")).toBe(true);
+    expect(readPersistedApiKey(apiKeyFilePath(tmpRoot))).toBe("sk-from-mcp-json");
+  });
+
+  it("creates the root directory when it does not exist yet", () => {
+    const nested = path.join(tmpRoot, "does", "not", "exist");
+    expect(publishSharedApiKey(nested, "sk-nested")).toBe(true);
+    expect(readPersistedApiKey(apiKeyFilePath(nested))).toBe("sk-nested");
+  });
+
+  it("reports no write when the file already holds this key", () => {
+    publishSharedApiKey(tmpRoot, "sk-same");
+    expect(publishSharedApiKey(tmpRoot, "sk-same")).toBe(false);
+  });
+
+  it("overwrites a stale key so a changed config self-heals", () => {
+    // Unlike first-time generation, a configured key is authoritative: if the
+    // user edits SHODH_API_KEY, the file must follow or hooks keep 401ing.
+    publishSharedApiKey(tmpRoot, "sk-old");
+    expect(publishSharedApiKey(tmpRoot, "sk-new")).toBe(true);
+    expect(readPersistedApiKey(apiKeyFilePath(tmpRoot))).toBe("sk-new");
+  });
+
+  it("leaves a published key readable by loadOrCreatePersistedApiKey", () => {
+    // A sibling shim with no key configured must adopt the published key
+    // rather than generating a second one.
+    publishSharedApiKey(tmpRoot, "sk-published");
+    const loaded = loadOrCreatePersistedApiKey(tmpRoot, () => "sk-should-not-be-used");
+    expect(loaded.key).toBe("sk-published");
+    expect(loaded.created).toBe(false);
   });
 });

--- a/mcp-server/tests/api-key-store.test.ts
+++ b/mcp-server/tests/api-key-store.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  API_KEY_FILENAME,
+  apiKeyFilePath,
+  loadOrCreatePersistedApiKey,
+  readPersistedApiKey,
+  shodhDataRoot,
+} from "../api-key-store";
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "shodh-key-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("shodhDataRoot", () => {
+  it("prefers SHODH_MEMORY_PATH when set", () => {
+    const root = shodhDataRoot({ SHODH_MEMORY_PATH: "/custom/data" } as NodeJS.ProcessEnv, "linux", "/home/u");
+    expect(root).toBe("/custom/data");
+  });
+
+  it("uses %APPDATA%/shodh-memory on Windows (matches Rust dirs::data_dir)", () => {
+    const root = shodhDataRoot(
+      { APPDATA: "C:\\Users\\John Smith\\AppData\\Roaming" } as NodeJS.ProcessEnv,
+      "win32",
+      "C:\\Users\\John Smith",
+    );
+    expect(root).toBe(path.join("C:\\Users\\John Smith\\AppData\\Roaming", "shodh-memory"));
+  });
+
+  it("falls back to <home>/AppData/Roaming when APPDATA is unset on Windows", () => {
+    const root = shodhDataRoot({} as NodeJS.ProcessEnv, "win32", "C:\\Users\\John Smith");
+    expect(root).toBe(path.join("C:\\Users\\John Smith", "AppData", "Roaming", "shodh-memory"));
+  });
+
+  it("uses Application Support on macOS", () => {
+    const root = shodhDataRoot({} as NodeJS.ProcessEnv, "darwin", "/Users/u");
+    expect(root).toBe(path.join("/Users/u", "Library", "Application Support", "shodh-memory"));
+  });
+
+  it("respects XDG_DATA_HOME on Linux, defaulting to ~/.local/share", () => {
+    expect(shodhDataRoot({ XDG_DATA_HOME: "/xdg" } as NodeJS.ProcessEnv, "linux", "/home/u")).toBe(
+      path.join("/xdg", "shodh-memory"),
+    );
+    expect(shodhDataRoot({} as NodeJS.ProcessEnv, "linux", "/home/u")).toBe(
+      path.join("/home/u", ".local", "share", "shodh-memory"),
+    );
+  });
+});
+
+describe("loadOrCreatePersistedApiKey", () => {
+  it("generates and persists a key when none exists", () => {
+    const result = loadOrCreatePersistedApiKey(tmpRoot, () => "generated-key-1");
+    expect(result.created).toBe(true);
+    expect(result.key).toBe("generated-key-1");
+    expect(result.file).toBe(path.join(tmpRoot, API_KEY_FILENAME));
+    expect(fs.readFileSync(result.file, "utf-8").trim()).toBe("generated-key-1");
+  });
+
+  it("returns the SAME key on subsequent calls instead of regenerating (the T15 race fix)", () => {
+    const first = loadOrCreatePersistedApiKey(tmpRoot, () => "first-shim-key");
+    // A second shim with a different generator must get the first shim's key.
+    const second = loadOrCreatePersistedApiKey(tmpRoot, () => "second-shim-key");
+    expect(first.key).toBe("first-shim-key");
+    expect(second.key).toBe("first-shim-key");
+    expect(second.created).toBe(false);
+  });
+
+  it("never invokes the generator when a key is already persisted", () => {
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    fs.writeFileSync(path.join(tmpRoot, API_KEY_FILENAME), "existing-key\n");
+    const result = loadOrCreatePersistedApiKey(tmpRoot, () => {
+      throw new Error("generator must not be called when a key exists");
+    });
+    expect(result.key).toBe("existing-key");
+    expect(result.created).toBe(false);
+  });
+
+  it("creates the data root directory when missing", () => {
+    const nested = path.join(tmpRoot, "deep", "nested", "root");
+    const result = loadOrCreatePersistedApiKey(nested, () => "k");
+    expect(result.created).toBe(true);
+    expect(readPersistedApiKey(apiKeyFilePath(nested))).toBe("k");
+  });
+
+  it("heals an empty key file left by a crashed writer", () => {
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    fs.writeFileSync(path.join(tmpRoot, API_KEY_FILENAME), "");
+    const result = loadOrCreatePersistedApiKey(tmpRoot, () => "healed-key");
+    expect(result.key).toBe("healed-key");
+    expect(readPersistedApiKey(apiKeyFilePath(tmpRoot))).toBe("healed-key");
+  });
+
+  it("restricts key file permissions on POSIX", () => {
+    if (process.platform === "win32") return; // mode bits are not meaningful on Windows
+    const result = loadOrCreatePersistedApiKey(tmpRoot, () => "k");
+    const mode = fs.statSync(result.file).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+});
+
+describe("readPersistedApiKey", () => {
+  it("returns null for missing or empty files, trimmed content otherwise", () => {
+    const file = path.join(tmpRoot, API_KEY_FILENAME);
+    expect(readPersistedApiKey(file)).toBeNull();
+    fs.writeFileSync(file, "   \n");
+    expect(readPersistedApiKey(file)).toBeNull();
+    fs.writeFileSync(file, "  the-key \n");
+    expect(readPersistedApiKey(file)).toBe("the-key");
+  });
+});

--- a/mcp-server/tests/backend-lifecycle.test.ts
+++ b/mcp-server/tests/backend-lifecycle.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, beforeEach, afterEach, beforeAll } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { spawnSync } from "child_process";
+import {
+  SERVER_PIDFILE,
+  SHIM_PID_DIR,
+  backendPidToReap,
+  clearSpawnedServer,
+  isPidAlive,
+  liveSiblingShims,
+  readSpawnedServerPid,
+  recordSpawnedServer,
+  registerShim,
+  unregisterShim,
+} from "../backend-lifecycle";
+
+let tmpRoot: string;
+// A pid that definitely existed and is definitely dead now (short-lived child).
+let deadPid: number;
+
+beforeAll(() => {
+  const child = spawnSync(process.execPath, ["-e", ""], { stdio: "ignore" });
+  if (child.pid === undefined) throw new Error("failed to spawn probe child");
+  deadPid = child.pid;
+});
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "shodh-lifecycle-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("isPidAlive", () => {
+  it("is true for the current process and false for a dead pid", () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+    expect(isPidAlive(deadPid)).toBe(false);
+  });
+
+  it("rejects garbage pids", () => {
+    expect(isPidAlive(0)).toBe(false);
+    expect(isPidAlive(-5)).toBe(false);
+    expect(isPidAlive(1.5)).toBe(false);
+  });
+});
+
+describe("shim registration", () => {
+  it("registers and unregisters a pidfile", () => {
+    const file = registerShim(tmpRoot, process.pid);
+    expect(file).toBe(path.join(tmpRoot, SHIM_PID_DIR, `${process.pid}.pid`));
+    expect(fs.existsSync(file)).toBe(true);
+    unregisterShim(tmpRoot, process.pid);
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
+  it("unregister is safe when never registered", () => {
+    expect(() => unregisterShim(tmpRoot, 12345)).not.toThrow();
+  });
+});
+
+describe("liveSiblingShims", () => {
+  it("excludes self and prunes dead registrations", () => {
+    registerShim(tmpRoot, process.pid); // self
+    registerShim(tmpRoot, deadPid); // crashed shim
+    const siblings = liveSiblingShims(tmpRoot, process.pid);
+    expect(siblings).toEqual([]);
+    // The dead shim's stale file must have been pruned.
+    expect(fs.existsSync(path.join(tmpRoot, SHIM_PID_DIR, `${deadPid}.pid`))).toBe(false);
+  });
+
+  it("reports a live sibling", () => {
+    // Register our own (live) pid, then ask from the perspective of another shim.
+    registerShim(tmpRoot, process.pid);
+    const siblings = liveSiblingShims(tmpRoot, deadPid);
+    expect(siblings).toEqual([process.pid]);
+  });
+
+  it("returns empty when the directory does not exist", () => {
+    expect(liveSiblingShims(tmpRoot, process.pid)).toEqual([]);
+  });
+
+  it("prunes unparseable entries", () => {
+    fs.mkdirSync(path.join(tmpRoot, SHIM_PID_DIR), { recursive: true });
+    fs.writeFileSync(path.join(tmpRoot, SHIM_PID_DIR, "garbage.txt"), "x");
+    expect(liveSiblingShims(tmpRoot, process.pid)).toEqual([]);
+    expect(fs.existsSync(path.join(tmpRoot, SHIM_PID_DIR, "garbage.txt"))).toBe(false);
+  });
+});
+
+describe("spawned server record", () => {
+  it("records and reads the backend pid", () => {
+    recordSpawnedServer(tmpRoot, 4242);
+    expect(readSpawnedServerPid(tmpRoot)).toBe(4242);
+    clearSpawnedServer(tmpRoot);
+    expect(readSpawnedServerPid(tmpRoot)).toBeNull();
+  });
+
+  it("does not clobber a live backend's record (concurrent-spawn loser)", () => {
+    recordSpawnedServer(tmpRoot, process.pid); // "live" backend
+    recordSpawnedServer(tmpRoot, 99999999); // loser tries to record its dead child
+    expect(readSpawnedServerPid(tmpRoot)).toBe(process.pid);
+  });
+
+  it("replaces a dead backend's record", () => {
+    recordSpawnedServer(tmpRoot, deadPid);
+    recordSpawnedServer(tmpRoot, process.pid);
+    expect(readSpawnedServerPid(tmpRoot)).toBe(process.pid);
+  });
+
+  it("readSpawnedServerPid rejects garbage content", () => {
+    fs.writeFileSync(path.join(tmpRoot, SERVER_PIDFILE), "not-a-pid\n");
+    expect(readSpawnedServerPid(tmpRoot)).toBeNull();
+  });
+});
+
+describe("backendPidToReap — the T14 kill decision", () => {
+  it("never kills while another live shim is registered", () => {
+    recordSpawnedServer(tmpRoot, process.pid); // pretend backend is alive
+    registerShim(tmpRoot, process.pid); // a live sibling (our own pid, seen from selfPid=deadPid)
+    expect(backendPidToReap(tmpRoot, deadPid)).toBeNull();
+  });
+
+  it("returns the backend pid when this is the last shim", () => {
+    recordSpawnedServer(tmpRoot, process.pid);
+    expect(backendPidToReap(tmpRoot, process.pid)).toBe(process.pid);
+  });
+
+  it("returns null when no backend was auto-spawned (manual servers are never killed)", () => {
+    expect(backendPidToReap(tmpRoot, process.pid)).toBeNull();
+  });
+
+  it("clears the record and returns null when the backend already died", () => {
+    recordSpawnedServer(tmpRoot, deadPid);
+    expect(backendPidToReap(tmpRoot, process.pid)).toBeNull();
+    expect(readSpawnedServerPid(tmpRoot)).toBeNull();
+  });
+
+  it("ignores stale registrations from crashed shims", () => {
+    recordSpawnedServer(tmpRoot, process.pid);
+    registerShim(tmpRoot, deadPid); // crashed shim never unregistered
+    expect(backendPidToReap(tmpRoot, process.pid)).toBe(process.pid);
+  });
+});

--- a/mcp-server/tests/setup-hooks.test.ts
+++ b/mcp-server/tests/setup-hooks.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+// Requiring the CLI module must NOT execute its main() (guarded by require.main).
+const setupHooks = require("../scripts/setup-hooks.cjs") as {
+  makeCommand: (event: string) => string;
+  buildHookConfig: () => Record<string, Array<{ matcher?: unknown; hooks: Array<{ type: string; command: string }> }>>;
+  mergeHooks: (settings: Record<string, unknown>, hooks: Record<string, unknown>) => { hooks: Record<string, unknown> };
+  removeHooks: (settings: Record<string, unknown>) => { hooks?: Record<string, unknown> };
+  HOOK_SCRIPT: string;
+};
+
+const { makeCommand, buildHookConfig, mergeHooks, removeHooks, HOOK_SCRIPT } = setupHooks;
+
+describe("makeCommand — T17 path quoting", () => {
+  it("quotes the script path so paths containing spaces survive shell parsing", () => {
+    const cmd = makeCommand("SessionStart");
+    const scriptPath = HOOK_SCRIPT.replace(/\\/g, "/");
+    expect(cmd).toBe(`bun run "${scriptPath}" SessionStart`);
+  });
+
+  it("produces a parseable command even when the home directory contains spaces", () => {
+    const cmd = makeCommand("Stop");
+    // The path segment must be wrapped in double quotes: exactly one quoted
+    // region between the runner prefix and the event argument.
+    const match = /^bun run "([^"]+)" Stop$/.exec(cmd);
+    expect(match).not.toBeNull();
+    expect(match![1].endsWith("memory-hook.ts")).toBe(true);
+  });
+});
+
+describe("buildHookConfig — T17 matcher shape", () => {
+  const config = buildHookConfig();
+
+  it("uses Claude Code's string matcher for tool events", () => {
+    expect(config.PreToolUse[0].matcher).toBe("Edit|Write|Bash");
+    expect(config.PostToolUse[0].matcher).toBe("Edit|Write|Bash|TodoWrite|Read|Task");
+  });
+
+  it("omits matcher entirely for non-tool events", () => {
+    for (const event of ["SessionStart", "UserPromptSubmit", "Stop", "SubagentStop"]) {
+      expect(Object.prototype.hasOwnProperty.call(config[event][0], "matcher")).toBe(false);
+    }
+  });
+
+  it("never emits the legacy object matcher shape", () => {
+    for (const entries of Object.values(config)) {
+      for (const entry of entries) {
+        if (entry.matcher !== undefined) {
+          expect(typeof entry.matcher).toBe("string");
+        }
+      }
+    }
+  });
+});
+
+describe("mergeHooks / removeHooks", () => {
+  it("merge is idempotent (same command not appended twice)", () => {
+    const config = buildHookConfig();
+    const once = mergeHooks({}, config);
+    const twice = mergeHooks(once, config);
+    expect(twice).toEqual(once);
+  });
+
+  it("preserves unrelated hooks", () => {
+    const settings = {
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: "echo other-tool" }] }],
+      },
+    };
+    const merged = mergeHooks(settings, buildHookConfig());
+    const stopEntries = merged.hooks.Stop as Array<{ hooks: Array<{ command: string }> }>;
+    expect(stopEntries.some((e) => e.hooks[0].command === "echo other-tool")).toBe(true);
+    expect(stopEntries.some((e) => e.hooks[0].command.includes("memory-hook.ts"))).toBe(true);
+  });
+
+  it("removeHooks strips legacy broken entries (unquoted path, object matcher)", () => {
+    const legacy = {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: { tool_name: ["Edit", "Write"] },
+            hooks: [{ type: "command", command: "bun run C:/Users/John Smith/.claude/hooks/shodh-memory/memory-hook.ts PostToolUse" }],
+          },
+          { matcher: "Edit", hooks: [{ type: "command", command: "echo keep-me" }] },
+        ],
+      },
+    };
+    const cleaned = removeHooks(legacy);
+    const entries = cleaned.hooks!.PostToolUse as Array<{ hooks: Array<{ command: string }> }>;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].hooks[0].command).toBe("echo keep-me");
+  });
+
+  it("upgrade path: removeHooks + mergeHooks replaces a broken install with the fixed shape", () => {
+    const legacy = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: { tool_name: ["Edit", "Write", "Bash"] },
+            hooks: [{ type: "command", command: "bun run C:/Users/John Smith/.claude/hooks/shodh-memory/memory-hook.ts PreToolUse" }],
+          },
+        ],
+      },
+    };
+    const repaired = mergeHooks(removeHooks(legacy), buildHookConfig());
+    const entries = repaired.hooks.PreToolUse as Array<{ matcher?: unknown; hooks: Array<{ command: string }> }>;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].matcher).toBe("Edit|Write|Bash");
+    expect(entries[0].hooks[0].command).toMatch(/^bun run "/);
+  });
+});

--- a/mcp-server/tests/setup-hooks.test.ts
+++ b/mcp-server/tests/setup-hooks.test.ts
@@ -7,11 +7,23 @@ const setupHooks = require("../scripts/setup-hooks.cjs") as {
   makeCommand: (event: string) => string;
   buildHookConfig: () => Record<string, Array<{ matcher?: unknown; hooks: Array<{ type: string; command: string }> }>>;
   mergeHooks: (settings: Record<string, unknown>, hooks: Record<string, unknown>) => { hooks: Record<string, unknown> };
-  removeHooks: (settings: Record<string, unknown>) => { hooks?: Record<string, unknown> };
+  removeHooks: (
+    settings: Record<string, unknown>,
+    opts?: { managedOnly?: boolean },
+  ) => { hooks?: Record<string, unknown> };
   HOOK_SCRIPT: string;
 };
 
 const { makeCommand, buildHookConfig, mergeHooks, removeHooks, HOOK_SCRIPT } = setupHooks;
+
+// A command as older installs wrote it: same managed script, unquoted path.
+const MANAGED_SCRIPT = HOOK_SCRIPT.replace(/\\/g, "/");
+const legacyManagedCommand = (event: string) => `bun run ${MANAGED_SCRIPT} ${event}`;
+// A hook a developer wrote by hand, pointing at a checkout rather than the
+// managed install directory. Contains "shodh-memory" because the clone is
+// named that — install must not treat it as ours to delete.
+const REPO_HOOK_COMMAND =
+  'bun run "C:/src/shodh-memory/hooks/memory-hook.ts" SessionStart';
 
 describe("makeCommand — T17 path quoting", () => {
   it("quotes the script path so paths containing spaces survive shell parsing", () => {
@@ -81,7 +93,7 @@ describe("mergeHooks / removeHooks", () => {
         PostToolUse: [
           {
             matcher: { tool_name: ["Edit", "Write"] },
-            hooks: [{ type: "command", command: "bun run C:/Users/John Smith/.claude/hooks/shodh-memory/memory-hook.ts PostToolUse" }],
+            hooks: [{ type: "command", command: legacyManagedCommand("PostToolUse") }],
           },
           { matcher: "Edit", hooks: [{ type: "command", command: "echo keep-me" }] },
         ],
@@ -99,15 +111,49 @@ describe("mergeHooks / removeHooks", () => {
         PreToolUse: [
           {
             matcher: { tool_name: ["Edit", "Write", "Bash"] },
-            hooks: [{ type: "command", command: "bun run C:/Users/John Smith/.claude/hooks/shodh-memory/memory-hook.ts PreToolUse" }],
+            hooks: [{ type: "command", command: legacyManagedCommand("PreToolUse") }],
           },
         ],
       },
     };
-    const repaired = mergeHooks(removeHooks(legacy), buildHookConfig());
+    const repaired = mergeHooks(
+      removeHooks(legacy, { managedOnly: true }),
+      buildHookConfig(),
+    );
     const entries = repaired.hooks.PreToolUse as Array<{ matcher?: unknown; hooks: Array<{ command: string }> }>;
     expect(entries).toHaveLength(1);
     expect(entries[0].matcher).toBe("Edit|Write|Bash");
     expect(entries[0].hooks[0].command).toMatch(/^bun run "/);
+  });
+
+  it("install-time removal keeps a developer's hand-written repo-path hook", () => {
+    const settings = {
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: "command", command: legacyManagedCommand("SessionStart") }] },
+          { hooks: [{ type: "command", command: REPO_HOOK_COMMAND }] },
+        ],
+      },
+    };
+    const cleaned = removeHooks(settings, { managedOnly: true });
+    const entries = cleaned.hooks!.SessionStart as Array<{ hooks: Array<{ command: string }> }>;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].hooks[0].command).toBe(REPO_HOOK_COMMAND);
+  });
+
+  it("uninstall removes every shodh hook, including repo-path ones", () => {
+    const settings = {
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: "command", command: legacyManagedCommand("SessionStart") }] },
+          { hooks: [{ type: "command", command: REPO_HOOK_COMMAND }] },
+          { hooks: [{ type: "command", command: "echo unrelated" }] },
+        ],
+      },
+    };
+    const cleaned = removeHooks(settings);
+    const entries = cleaned.hooks!.SessionStart as Array<{ hooks: Array<{ command: string }> }>;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].hooks[0].command).toBe("echo unrelated");
   });
 });


### PR DESCRIPTION
Fixes the four defects that make a fresh install fail — three of them silently. Relates to #12.

On a clean machine today: the shim generates an API key it never writes down, so hooks cannot learn it and every capture call 401s while the user believes memory is working. Closing one client kills the backend out from under the others. And `setup-hooks` writes a command that does not execute at all for users whose home directory contains a space.

## Changes

| Commit | Defect | Failure mode removed |
|---|---|---|
| `0481a926` | T15 | Each shim generated its own key; the spawn-race loser 401'd all session |
| `2e6af05f` | T14 | The shim that spawned the backend killed it on exit, cutting off sibling clients |
| `f8d4e0ba` | T16 | Hooks defaulted to a dev key the server never accepts; capture died silently |
| `28e69683` | T17 | Unquoted hook path broke on spaced home directories; matcher had the wrong shape |
| `f10225e5` | — | Install-time hook removal would delete a developer's hand-written hooks |
| `48feef30` | — | Env-supplied keys were never shared with hooks; a warming backend was misdiagnosed as a bad key |

The key-sharing mechanism is chosen once and used by both T15 and T16: a shared file at `<data-root>/.api-key`, written atomically by the shim, read by the hooks. Backend lifecycle is refcounted through pidfiles — last live shim out reaps, and a manually started server is never touched.

## Verification

Two of the three links in `shim persists → hook reads → server accepts` were executed against live processes, not stubs. A real shim on a fresh root generated and persisted a key; a real `memory-hook.ts SessionStart` process with the same root presented that key and completed all six briefing calls. Without the shared root it fell back to the dev key, got 401, and printed the loud banner — the failure is loud, which was the point.

The third link is source-verified rather than executed: `serverEnv["SHODH_DEV_API_KEY"] = API_KEY` feeds `configured_api_keys()` in `src/auth.rs`, which accepts that variable outside production. No server binary was built.

173 vitest tests pass (45 added); `bun run build` green.

**This machine cannot distinguish fixed from broken**, for three independent reasons found during verification: `.mcp.json` pins the dev key, the repo's `.env` sets the same key and Bun auto-loads `.env` from cwd, and the hook's legacy fallback is that same literal. Any future test of this path must run from a directory with no `.env`.

## Known limitations, deliberately not fixed

- If `SHODH_MEMORY_PATH` is set in an MCP `env` block but not in the shell, shim and hooks resolve different roots and the hook falls back to the dev key. Loud 401 rather than silence, but not working.
- `shodhDataRoot()` omits the Rust `default_storage_path()` legacy `./shodh_memory_data` branch. Harmless — the server never reads the key file — and the comment now says so instead of claiming parity.
- A recycled pid in `.mcp-shims/` reads as a live sibling and can pin a leaked backend. Costs a stray process, not data.

Full reasoning, evidence and unproved claims: `docs/agent-runs/2026-08-07-onboarding-first-five-minutes.md`.