### PR TITLE
fix(llm-parser): repair the stale call site; gate optional features in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,53 @@ jobs:
           echo "| Warnings | $WARNINGS |" >> $GITHUB_STEP_SUMMARY
           echo "| Status | $WARNINGS warning(s) — non-blocking (-W mode) |" >> $GITHUB_STEP_SUMMARY
 
+  feature-gates:
+    name: Optional Features Compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install LLVM
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm-dev libclang-dev clang
+
+      # Optional features are compiled by nothing else in this workflow, so code
+      # behind a #[cfg(feature = ...)] gate can stop compiling and no PR will
+      # ever show it. Not hypothetical: the zenoh transport accrued four compile
+      # errors that way (repaired in #417), and llm-parser two (repaired here).
+      # 'python' is excluded deliberately: it needs a maturin/PyO3 toolchain and
+      # is already built on every release by pypi.yml.
+      - name: cargo check each optional feature
+        run: |
+          set -o pipefail
+          FAILED=""
+          for feature in zenoh llm-parser telemetry; do
+            echo "::group::cargo check --features $feature"
+            if cargo check --features "$feature" --all-targets; then
+              echo "OK: $feature"
+            else
+              echo "FAILED: $feature"
+              FAILED="$FAILED $feature"
+            fi
+            echo "::endgroup::"
+          done
+          {
+            echo "### Optional Feature Compilation"
+            echo ""
+            if [ -n "$FAILED" ]; then
+              echo "Broken:$FAILED"
+            else
+              echo "All optional features compile."
+            fi
+          } >> $GITHUB_STEP_SUMMARY
+          if [ -n "$FAILED" ]; then
+            echo "Optional features failed to compile:$FAILED" >&2
+            exit 1
+          fi
+
   build:
     name: Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/src/query_parsing/mod.rs
+++ b/src/query_parsing/mod.rs
@@ -40,25 +40,31 @@ pub enum ParserType {
 }
 
 /// Configuration for the query parser
+///
+/// `LlmParser` loads no weights of its own — it calls an OpenAI-compatible or
+/// Ollama HTTP endpoint. The fields below describe that endpoint. They replaced
+/// `llm_model_path`, `llm_threads` and `llm_context_size`, which described an
+/// in-process model loader this parser has not used since it became an HTTP
+/// client; thread and context-size knobs belong to the server now, not to us.
 #[derive(Debug, Clone)]
 pub struct ParserConfig {
     /// Which parser implementation to use
     pub parser_type: ParserType,
-    /// Path to LLM model (only used if parser_type is Llm)
-    pub llm_model_path: Option<String>,
-    /// Number of threads for LLM inference
-    pub llm_threads: usize,
-    /// Context size for LLM
-    pub llm_context_size: usize,
+    /// Base URL of the inference server (only used if parser_type is Llm)
+    pub llm_endpoint: String,
+    /// Model name as the server knows it (only used if parser_type is Llm)
+    pub llm_model: String,
 }
 
 impl Default for ParserConfig {
     fn default() -> Self {
         Self {
             parser_type: ParserType::RuleBased,
-            llm_model_path: None,
-            llm_threads: 4,
-            llm_context_size: 2048,
+            // Ollama's default bind address, and a small instruct model — this
+            // parser classifies queries rather than generating prose, so the
+            // smallest capable model is the right default.
+            llm_endpoint: "http://localhost:11434".to_string(),
+            llm_model: "qwen2.5:1.5b".to_string(),
         }
     }
 }
@@ -69,12 +75,12 @@ impl ParserConfig {
         Self::default()
     }
 
-    /// Create config for LLM parser
-    pub fn llm(model_path: impl Into<String>) -> Self {
+    /// Create config for LLM parser against a given endpoint and model.
+    pub fn llm(endpoint: impl Into<String>, model: impl Into<String>) -> Self {
         Self {
             parser_type: ParserType::Llm,
-            llm_model_path: Some(model_path.into()),
-            ..Default::default()
+            llm_endpoint: endpoint.into(),
+            llm_model: model.into(),
         }
     }
 }
@@ -85,13 +91,11 @@ pub fn create_parser(config: ParserConfig) -> Arc<dyn QueryParser> {
         ParserType::RuleBased => Arc::new(RuleBasedParser::new()),
         #[cfg(feature = "llm-parser")]
         ParserType::Llm => {
-            let model_path = config
-                .llm_model_path
-                .expect("LLM model path required for LLM parser");
-            Arc::new(
-                LlmParser::new(&model_path, config.llm_threads, config.llm_context_size)
-                    .expect("Failed to load LLM model"),
-            )
+            // `LlmParser::new` is infallible and connects lazily — there is no
+            // model to load and therefore nothing here that can fail. The
+            // previous `.expect("Failed to load LLM model")` panicked the
+            // process on a construction that no longer returns a Result.
+            Arc::new(LlmParser::new(&config.llm_endpoint, &config.llm_model))
         }
         #[cfg(not(feature = "llm-parser"))]
         ParserType::Llm => {


### PR DESCRIPTION
Rebuilt on current main: this branch originally also repaired the zenoh feature, but #417 merged an equivalent repair first — that half is dropped, and what survives is the value main still lacks.

### llm-parser (2 errors, fixed)

`LlmParser` was refactored from an in-process model loader into an HTTP client for Ollama/OpenAI-compatible servers; the call site was left behind. `ParserConfig` still carried `llm_model_path`/`llm_threads`/`llm_context_size` — fields describing a loader that no longer exists, and knobs that now belong to the server. Replaced with `llm_endpoint` + `llm_model`. No other call sites existed and the feature has not compiled, so nothing depended on the old shape. The stale `.expect("Failed to load LLM model")` is gone: `new()` is infallible and connects lazily, so that expect would have panicked the process on a construction that cannot fail.

### Root fix: CI gate

A new **Optional Features Compile** job `cargo check`s `zenoh`, `llm-parser` and `telemetry` with `--all-targets` and fails on any of them. Nothing in `ci.yml` compiled optional features before — which is exactly how both this rot and the zenoh rot (independently repaired in #417) stayed invisible to every PR that caused them. `python` is excluded deliberately: maturin/PyO3 toolchain, already built on every release by `pypi.yml`.

This PR's own CI run is the live proof of the gate: it must come back green on all three features against current main.