### PR TITLE
seat: conversation harness on pi, with both learning loops

### DIFF
--- a/seat/.gitignore
+++ b/seat/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/seat/README.md
+++ b/seat/README.md
@@ -52,17 +52,47 @@ citations feed the reinforcement loop below.
 Both loops store and strengthen state through the same shodh-memory machinery.
 There is no second state store.
 
-**Loop 1 — memory-level (user scope).** After each turn, memories surfaced by
-recall are reinforced through the backend's existing Hebbian path
-(`POST /api/reinforce`):
+**Loop 1 — memory-level (user scope), two legs with strict ownership.**
+`/api/reinforce` moves importance, Hebbian associations, and entity salience —
+but **not** feedback momentum. The only backend path that writes momentum (the
+`feedback_multiplier` in score attribution) is `POST /api/proactive_context`
+(`src/handlers/recall.rs:1310-1720`). The seat drives both:
 
-- *helpful* — the response cited the memory (`[mem:id]`) or shares token
-  overlap ≥ 0.1 with it (mirrors `calculate_entity_overlap` and
-  `OVERLAP_WEAK_THRESHOLD` in `src/memory/feedback.rs`);
-- *neutral* — surfaced but unused (records access, mild strengthening);
-- *misleading* — the user's next message contains a correction/frustration
-  keyword (list copied verbatim from `NEGATIVE_KEYWORDS` in
-  `src/memory/feedback.rs`); applied to the previous turn's surfaced memories.
+- *Implicit/momentum leg* — every turn calls `proactive_context` with the new
+  user message as `context`, the previous assistant message as
+  `previous_response`, the new user message as `user_followup`, and the
+  previous run's tool actions (`ToolAction` shape from
+  `src/memory/feedback.rs`; native memory tools excluded — a recall cue
+  trivially overlaps memory content and would fake a usage signal). The
+  backend evaluates the previous turn's pending surfaced set (momentum,
+  context fingerprints, temporal credits) and applies its own
+  `reinforce_recall` + Hebbian pass for helpful/misleading classifications.
+  The memories it surfaces are all injected into the system prompt (surfaced
+  set == seen set, otherwise the implicit loop penalizes memories the model
+  never saw) and are **owned by this leg**. The `proactive_context` SSE event
+  exposes the surfaced set and the feedback outcome (reinforced/weakened ids).
+- *Explicit leg* — memories recalled by the `recall_memory` tool and **not**
+  proactive-surfaced that turn are reinforced through `POST /api/reinforce`:
+  - *helpful* — cited (`[mem:id]`) or token overlap ≥ 0.1 (mirrors
+    `calculate_entity_overlap` / `OVERLAP_WEAK_THRESHOLD`);
+  - *neutral* — surfaced but unused;
+  - *misleading* — negative follow-up keywords (verbatim `NEGATIVE_KEYWORDS`
+    list), applied to the previous turn's surfaced set minus proactive-owned
+    ids.
+
+The id-level ownership split is what prevents double-counting: a memory
+surfaced by both channels in one turn is reinforced exactly once (by the
+implicit leg). Known seam: tool-recalled-only memories get no momentum, because
+the backend ties momentum to its own pending-set lifecycle
+(`set_pending`/`take_pending`, single slot per `user_id`) — moving them would
+require a backend change, not a harness workaround. For the same reason the
+seat guards concurrent proactive calls per `user_id` in-process (feedback
+fields are skipped when a call is in flight, mirroring `mcp-server/index.ts`);
+a second process using the same `user_id` cannot be guarded from here.
+
+`auto_ingest` is explicitly `false` on every call: the backend default (true)
+silently ingests the previous response as memories, which would bypass the
+ledger. Seat writes stay deliberate and ledgered.
 
 **Loop 2 — harness-level (harness scope).** The harness gets better at its own
 job by storing operational lessons *as memories* in an isolated namespace,
@@ -114,8 +144,9 @@ Revert semantics are honest about what the backend supports:
 | POST | `/v1/learning/revert` | `{event_id}` |
 
 SSE event types: `turn_start`, `text_delta`, `thinking_delta`,
-`tool_call_start`, `tool_call_end`, `memory_recall`, `memory_write`,
-`memory_reinforce`, `harness_learning_applied`, `model_changed`, `usage`
+`tool_call_start`, `tool_call_end`, `memory_recall`, `proactive_context`,
+`memory_write`, `memory_reinforce`, `harness_learning_applied`,
+`model_changed`, `usage`
 (per-call token counts and cost from pi's `Usage`), `turn_end`, `agent_end`,
 `error`. Payloads are defined in `src/events.ts`.
 

--- a/seat/README.md
+++ b/seat/README.md
@@ -1,0 +1,179 @@
+# seat — conversation harness
+
+Server-side agent harness for the shodh-memory conversation seat. It owns the
+agent loop, streams structured events to a client, and closes two learning
+loops against the Rust backend on every turn. Memory operations are never
+opaque: every recall carries ids, scores, and full per-memory
+`ScoreAttribution`; every learning update is a reviewable, revertible ledger
+event.
+
+Built on [`pi`](https://github.com/earendil-works/pi) (`@earendil-works/pi-agent-core`
+for the agent loop, `@earendil-works/pi-ai` for the unified multi-provider LLM
+API). Provider credentials resolve from environment variables inside this
+process and never reach a client.
+
+## Architecture
+
+```
+client (SSE) ──► SeatServer (node:http)
+                    │
+                    ├─ ModelRegistry ── pi builtin providers (env-key auth)
+                    │                └─ local providers: Ollama / LM Studio
+                    │                   (custom pi provider, openai-completions
+                    │                    API + per-model baseUrl)
+                    │
+                    ├─ Conversation ── pi Agent (loop, tools, streaming)
+                    │     ├─ memory tools (native HTTP → Rust backend)
+                    │     ├─ MCP bridge tools (stdio, any MCP server)
+                    │     └─ learning loops (see below)
+                    │
+                    ├─ ShodhBackend ── HTTP client for the Rust API
+                    │                  (X-API-Key, shapes transcribed from
+                    │                   src/handlers/*)
+                    └─ LearningLedger ── append-only JSONL, revert support
+```
+
+## Memory as a first-class tool
+
+`recall_memory` calls `POST /api/recall` with `debug: true`, so every result
+carries the backend's full score attribution (RRF base, graph/hybrid RRF,
+hebbian boost, importance/recency/arousal/credibility factors,
+`feedback_multiplier`, quality gate, final score, contributing sources). The
+tool returns a compact text rendering to the model and emits a
+`memory_recall` SSE event with the complete structured payload — retrieved
+ids, scores, attribution, related facts, todos, and lineage edges — for the UI
+to render as its own element.
+
+The system prompt asks the model to cite memories inline as `[mem:<id>]`;
+citations feed the reinforcement loop below.
+
+## Two learning loops, one substrate
+
+Both loops store and strengthen state through the same shodh-memory machinery.
+There is no second state store.
+
+**Loop 1 — memory-level (user scope).** After each turn, memories surfaced by
+recall are reinforced through the backend's existing Hebbian path
+(`POST /api/reinforce`):
+
+- *helpful* — the response cited the memory (`[mem:id]`) or shares token
+  overlap ≥ 0.1 with it (mirrors `calculate_entity_overlap` and
+  `OVERLAP_WEAK_THRESHOLD` in `src/memory/feedback.rs`);
+- *neutral* — surfaced but unused (records access, mild strengthening);
+- *misleading* — the user's next message contains a correction/frustration
+  keyword (list copied verbatim from `NEGATIVE_KEYWORDS` in
+  `src/memory/feedback.rs`); applied to the previous turn's surfaced memories.
+
+**Loop 2 — harness-level (harness scope).** The harness gets better at its own
+job by storing operational lessons *as memories* in an isolated namespace,
+`<user_id>.seat-harness`. Scope isolation uses the backend's existing
+per-`user_id` seam: memory store, knowledge graph, and feedback state are all
+keyed by `user_id` directory (`src/handlers/state.rs`), so the two scopes can
+never share retrieval, Hebbian co-activation, or feedback statistics.
+
+Harness learnings enter the scope three ways:
+
+- automatic capture of empty recalls (cue recorded with rephrasing advice);
+- automatic capture of tool failures;
+- the model's own `record_seat_learning` tool (operational lessons only).
+
+Before each turn the harness recalls from its scope with the user message as
+cue and injects strong matches (score ≥ 0.25, max 3) as a labeled
+system-prompt block for that turn only, emitting `harness_learning_applied`.
+Injected learnings are reinforced by the same rules as user memories — the
+loop is closed in both scopes.
+
+## Learning ledger
+
+Every update either loop makes is appended to a JSONL ledger
+(`<data-dir>/learning-ledger.jsonl`) *before* the conversation moves on:
+memory writes, every reinforcement (with per-memory overlap values and
+trigger), and reverts. Reverts are appended events referencing the original —
+nothing is mutated.
+
+Revert semantics are honest about what the backend supports:
+
+- memory writes revert exactly (`DELETE /api/memory/{id}`);
+- helpful/misleading reinforcements revert by a *compensating* opposite
+  outcome through the same `/api/reinforce` path — the backend's EMA-with-
+  inertia momentum update is not exactly invertible, and the revert event says
+  so;
+- neutral reinforcements record access only; nothing to compensate.
+
+## HTTP API
+
+| Method | Path | Body / notes |
+|---|---|---|
+| GET | `/healthz` | seat + backend health (unauthenticated) |
+| GET | `/v1/models?refresh=1` | available models; `refresh` re-probes local endpoints |
+| POST | `/v1/conversations` | `{user_id, provider, model, system_prompt?}` |
+| GET | `/v1/conversations/{id}` | state + transcript |
+| POST | `/v1/conversations/{id}/messages` | `{text}` → SSE stream of events |
+| PATCH | `/v1/conversations/{id}/model` | `{provider, model}` — swap model mid-conversation; transcript and retrieved evidence unchanged |
+| GET | `/v1/learning/events?limit&conversation_id` | ledger review |
+| POST | `/v1/learning/revert` | `{event_id}` |
+
+SSE event types: `turn_start`, `text_delta`, `thinking_delta`,
+`tool_call_start`, `tool_call_end`, `memory_recall`, `memory_write`,
+`memory_reinforce`, `harness_learning_applied`, `model_changed`, `usage`
+(per-call token counts and cost from pi's `Usage`), `turn_end`, `agent_end`,
+`error`. Payloads are defined in `src/events.ts`.
+
+## Local models
+
+pi ships no Ollama/LM Studio/vLLM provider, but every pi `Model` carries its
+own `baseUrl` and the `openai-completions` implementation dials it directly.
+The registry therefore registers two custom providers (`ollama`, `lmstudio`)
+built with `createProvider` + `openAICompletionsApi()`, keyless auth, and
+dynamic model discovery via `GET {baseUrl}/models`. Any other OpenAI-compatible
+endpoint works the same way.
+
+## MCP bridge
+
+pi has no MCP client (its README: "No MCP"), so `src/mcp.ts` bridges MCP
+servers into the agent loop: stdio transport, `listTools` → pi `AgentTool`s
+named `mcp__<server>__<tool>`, plain JSON Schema passed through (pi's
+validator handles non-TypeBox schemas). Configure with
+`SEAT_MCP_SERVERS=/path/to/servers.json`:
+
+```json
+{ "servers": [ { "name": "shodh-memory", "command": "node", "args": ["mcp-server/dist/index.js"] } ] }
+```
+
+The native memory tools remain the recall/remember path of record — they carry
+attribution that MCP text framing cannot.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `SHODH_API_URL` | `http://127.0.0.1:3030` | Rust backend (or `SHODH_HOST`/`SHODH_PORT`) |
+| `SHODH_API_KEY` | — (required) | backend `X-API-Key` (falls back to `SHODH_DEV_API_KEY`, `SHODH_API_KEYS`) |
+| `SEAT_HOST` / `SEAT_PORT` | `127.0.0.1` / `3141` | bind address |
+| `SEAT_AUTH_TOKEN` | — | bearer token; mandatory for non-loopback binds |
+| `SEAT_DATA_DIR` | `%LOCALAPPDATA%\shodh\seat-harness` (win) / XDG data dir | ledger location — deliberately outside watched/synced folders |
+| `OLLAMA_BASE_URL` | `http://127.0.0.1:11434/v1` | Ollama OpenAI-compat endpoint |
+| `LMSTUDIO_BASE_URL` | `http://127.0.0.1:1234/v1` | LM Studio endpoint |
+| `SEAT_LOCAL_CONTEXT_WINDOW` / `SEAT_LOCAL_MAX_TOKENS` | `32768` / `8192` | advertised limits for local models |
+| `SEAT_MCP_SERVERS` | — | path to MCP servers JSON |
+| Provider keys | — | pi's env conventions (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GROQ_API_KEY`, …) |
+
+## Build and run
+
+```
+npm install
+npm run build
+SHODH_API_KEY=... node dist/index.js
+```
+
+Requires Node ≥ 22.19 (pi's floor).
+
+## Deliberately not built
+
+- **Conversation persistence** — transcripts are in-memory per process. pi's
+  harness layer ships a session store (JSONL trees, branching, compaction);
+  adopting it is a product decision for the seat UI, not harness plumbing.
+- **Python/IPython kernel, installable skill packages, recursive sub-agents** —
+  external design choices that do not fit this product.
+- **A second store for harness behaviors** — harness learnings are memories in
+  an isolated scope, on purpose; see above.

--- a/seat/package.json
+++ b/seat/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@shodh/seat-harness",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Conversation seat harness: server-side agent loop over pi-agent-core with shodh-memory as a first-class, traceable memory substrate",
+  "type": "module",
+  "main": "./dist/index.js",
+  "engines": {
+    "node": ">=22.19.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@earendil-works/pi-agent-core": "^0.84.1",
+    "@earendil-works/pi-ai": "^0.84.1",
+    "@modelcontextprotocol/sdk": "^1.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.4",
+    "typescript": "^5.9.3"
+  }
+}

--- a/seat/src/backend.ts
+++ b/seat/src/backend.ts
@@ -1,0 +1,262 @@
+/**
+ * Typed HTTP client for the shodh-memory Rust backend.
+ *
+ * Every shape below is transcribed from the actual handler source
+ * (src/handlers/types.rs, src/handlers/recall.rs, src/handlers/remember.rs,
+ * src/handlers/crud.rs, src/memory/types.rs) — field names match the serde
+ * serialization exactly. Do not "fix" casing here without re-reading the Rust.
+ */
+
+/** src/memory/types.rs `ScoreAttribution` — present per memory when recall is called with debug:true. */
+export interface ScoreAttribution {
+	memory_id: string;
+	rrf_base: number;
+	graph_rrf: number;
+	hybrid_rrf: number;
+	hebbian_boost: number;
+	attribute_boost: number;
+	temporal_prefilter_boost: number;
+	temporal_fact_boost: number;
+	interference_adjustment: number;
+	prospective_boost: number;
+	fact_source_boost: number;
+	ontological_boost: number;
+	importance_factor: number;
+	recency_factor: number;
+	arousal_factor: number;
+	credibility_factor: number;
+	feedback_multiplier: number;
+	quality_gate: number;
+	final_score: number;
+	sources: string[];
+}
+
+/** src/handlers/types.rs `RecallExperience` */
+export interface RecallExperience {
+	content: string;
+	memory_type: string | null;
+	tags: string[];
+}
+
+/** src/handlers/types.rs `RecallMemory` */
+export interface RecallMemory {
+	id: string;
+	experience: RecallExperience;
+	importance: number;
+	created_at: string;
+	score: number;
+	tier: string;
+	score_attribution?: ScoreAttribution;
+}
+
+/** src/handlers/types.rs `RecallFact` */
+export interface RecallFact {
+	id: string;
+	fact: string;
+	confidence: number;
+	support_count: number;
+	related_entities: string[];
+}
+
+/** src/handlers/types.rs `RecallTodo` */
+export interface RecallTodo {
+	id: string;
+	short_id: string;
+	content: string;
+	status: string;
+	priority: string;
+	project: string | null;
+	due_date: string | null;
+	score: number;
+}
+
+/** src/handlers/types.rs `RecallLineageEdge` */
+export interface RecallLineageEdge {
+	from: string;
+	to: string;
+	relation: string;
+	confidence: number;
+}
+
+/** src/handlers/types.rs `RecallReminder` */
+export interface RecallReminder {
+	id: string;
+	content: string;
+	keywords: string[];
+	match_type: string;
+	priority: number;
+	created_at: string;
+}
+
+/** src/handlers/types.rs `RecallResponse` (vectors are skip_serializing_if empty → optional here). */
+export interface RecallResponse {
+	memories: RecallMemory[];
+	count: number;
+	retrieval_stats?: unknown;
+	todos?: RecallTodo[];
+	todo_count?: number;
+	facts?: RecallFact[];
+	fact_count?: number;
+	triggered_reminders?: RecallReminder[];
+	reminder_count?: number;
+	lineage?: RecallLineageEdge[];
+	lineage_count?: number;
+}
+
+/** Valid `mode` values, from src/handlers/recall.rs `parse_retrieval_mode`. */
+export type RecallMode =
+	| "hybrid"
+	| "semantic"
+	| "associative"
+	| "temporal"
+	| "causal"
+	| "spatial"
+	| "mission"
+	| "action_outcome";
+
+/** Valid memory types, from src/handlers/remember.rs `parse_experience_type`. */
+export type MemoryType =
+	| "observation"
+	| "decision"
+	| "learning"
+	| "error"
+	| "discovery"
+	| "pattern"
+	| "context"
+	| "task"
+	| "code_edit"
+	| "file_access"
+	| "search"
+	| "command"
+	| "conversation"
+	| "intention";
+
+/** src/handlers/recall.rs `reinforce_feedback` outcome strings. */
+export type ReinforceOutcome = "helpful" | "misleading" | "neutral";
+
+/** src/handlers/recall.rs `ReinforceFeedbackResponse` */
+export interface ReinforceStats {
+	memories_processed: number;
+	associations_strengthened: number;
+	importance_boosts: number;
+	importance_decays: number;
+}
+
+/** src/handlers/remember.rs `RememberResponse` */
+export interface RememberResponse {
+	id: string;
+	success: boolean;
+}
+
+export class ShodhBackendError extends Error {
+	readonly status: number;
+	readonly body: string;
+
+	constructor(message: string, status: number, body: string) {
+		super(message);
+		this.name = "ShodhBackendError";
+		this.status = status;
+		this.body = body;
+	}
+}
+
+export interface RecallParams {
+	userId: string;
+	query: string;
+	limit?: number;
+	mode?: RecallMode;
+	/** debug:true asks the pipeline for per-memory ScoreAttribution. */
+	debug?: boolean;
+}
+
+export interface RememberParams {
+	userId: string;
+	content: string;
+	memoryType?: MemoryType;
+	tags?: string[];
+	importance?: number;
+}
+
+export class ShodhBackend {
+	private readonly apiUrl: string;
+	private readonly apiKey: string;
+	private readonly timeoutMs: number;
+
+	constructor(apiUrl: string, apiKey: string, timeoutMs: number) {
+		this.apiUrl = apiUrl;
+		this.apiKey = apiKey;
+		this.timeoutMs = timeoutMs;
+	}
+
+	private async request<T>(method: "GET" | "POST" | "DELETE", pathname: string, body?: unknown): Promise<T> {
+		const url = `${this.apiUrl}${pathname}`;
+		let response: Response;
+		try {
+			response = await fetch(url, {
+				method,
+				headers: {
+					"Content-Type": "application/json",
+					"X-API-Key": this.apiKey,
+				},
+				body: body === undefined ? undefined : JSON.stringify(body),
+				signal: AbortSignal.timeout(this.timeoutMs),
+			});
+		} catch (error) {
+			const reason = error instanceof Error ? error.message : String(error);
+			throw new ShodhBackendError(`Backend unreachable (${method} ${pathname}): ${reason}`, 0, "");
+		}
+		const text = await response.text();
+		if (!response.ok) {
+			throw new ShodhBackendError(
+				`Backend error ${response.status} on ${method} ${pathname}`,
+				response.status,
+				text.slice(0, 2000),
+			);
+		}
+		return JSON.parse(text) as T;
+	}
+
+	/** POST /api/recall — src/handlers/recall.rs `recall`, request shape src/handlers/types.rs `RecallRequest`. */
+	recall(params: RecallParams): Promise<RecallResponse> {
+		return this.request<RecallResponse>("POST", "/api/recall", {
+			user_id: params.userId,
+			query: params.query,
+			limit: params.limit ?? 5,
+			mode: params.mode ?? "hybrid",
+			debug: params.debug ?? false,
+		});
+	}
+
+	/** POST /api/remember — src/handlers/remember.rs `remember` / `RememberRequest`. */
+	remember(params: RememberParams): Promise<RememberResponse> {
+		return this.request<RememberResponse>("POST", "/api/remember", {
+			user_id: params.userId,
+			content: params.content,
+			memory_type: params.memoryType,
+			tags: params.tags ?? [],
+			importance: params.importance,
+		});
+	}
+
+	/** POST /api/reinforce — src/handlers/recall.rs `reinforce_feedback` / `ReinforceFeedbackRequest`. */
+	reinforce(userId: string, ids: string[], outcome: ReinforceOutcome): Promise<ReinforceStats> {
+		return this.request<ReinforceStats>("POST", "/api/reinforce", {
+			user_id: userId,
+			ids,
+			outcome,
+		});
+	}
+
+	/** DELETE /api/memory/{id}?user_id=… — src/handlers/crud.rs `delete_memory`. */
+	deleteMemory(userId: string, memoryId: string): Promise<unknown> {
+		return this.request<unknown>(
+			"DELETE",
+			`/api/memory/${encodeURIComponent(memoryId)}?user_id=${encodeURIComponent(userId)}`,
+		);
+	}
+
+	/** GET /health — src/handlers/health.rs `health`. */
+	health(): Promise<{ status: string; version: string }> {
+		return this.request<{ status: string; version: string }>("GET", "/health");
+	}
+}

--- a/seat/src/backend.ts
+++ b/seat/src/backend.ts
@@ -148,6 +148,45 @@ export interface RememberResponse {
 	success: boolean;
 }
 
+/** src/memory/feedback.rs `ToolAction` — tool-aware feedback attribution input. */
+export interface ToolAction {
+	tool_name: string;
+	inputs: Record<string, string>;
+	success: boolean;
+	output_snippet?: string;
+}
+
+/** src/handlers/recall.rs `ProactiveSurfacedMemory` (embedding is #[serde(skip)] — never sent). */
+export interface ProactiveSurfacedMemory {
+	id: string;
+	content: string;
+	memory_type: string;
+	score: number;
+	importance: number;
+	created_at: string;
+	tags: string[];
+	tier: string;
+	relevance_reason: string;
+	matched_entities?: string[];
+}
+
+/** src/handlers/recall.rs `FeedbackProcessed` */
+export interface FeedbackProcessed {
+	memories_evaluated: number;
+	reinforced: string[];
+	weakened: string[];
+}
+
+/** src/handlers/recall.rs `ProactiveContextResponse` (fields the seat consumes; extras tolerated). */
+export interface ProactiveContextResponse {
+	memories: ProactiveSurfacedMemory[];
+	memory_count: number;
+	feedback_processed?: FeedbackProcessed;
+	temporal_credits_applied?: number;
+	latency_ms: number;
+	ingested_memory_id?: string;
+}
+
 export class ShodhBackendError extends Error {
 	readonly status: number;
 	readonly body: string;
@@ -175,6 +214,25 @@ export interface RememberParams {
 	memoryType?: MemoryType;
 	tags?: string[];
 	importance?: number;
+}
+
+export interface ProactiveContextParams {
+	userId: string;
+	context: string;
+	maxResults?: number;
+	semanticThreshold?: number;
+	/**
+	 * Required, no default: the backend defaults auto_ingest to TRUE
+	 * (src/handlers/recall.rs:172-174) and silently ingests the previous
+	 * response as memories. Callers must decide explicitly.
+	 */
+	autoIngest: boolean;
+	/** Previous assistant message — triggers implicit-feedback processing of the pending surfaced set. */
+	previousResponse?: string;
+	/** The user message following that response (negative-keyword detection). */
+	userFollowup?: string;
+	/** Tool actions performed since the pending set was surfaced (tool-aware attribution). */
+	toolActions?: ToolAction[];
 }
 
 export class ShodhBackend {
@@ -235,6 +293,30 @@ export class ShodhBackend {
 			memory_type: params.memoryType,
 			tags: params.tags ?? [],
 			importance: params.importance,
+		});
+	}
+
+	/**
+	 * POST /api/proactive_context — src/handlers/recall.rs `proactive_context`.
+	 *
+	 * This is the ONLY handler that writes feedback momentum (the
+	 * `feedback_multiplier` in ScoreAttribution): when `previous_response` is
+	 * present it consumes the pending surfaced set from the PREVIOUS call,
+	 * computes implicit-feedback signals, updates momentum, and internally
+	 * applies reinforce_recall + Hebbian edge strengthening for helpful and
+	 * misleading classifications (recall.rs:1670-1720). It then surfaces a new
+	 * set and stores it as pending for the next call.
+	 */
+	proactiveContext(params: ProactiveContextParams): Promise<ProactiveContextResponse> {
+		return this.request<ProactiveContextResponse>("POST", "/api/proactive_context", {
+			user_id: params.userId,
+			context: params.context,
+			max_results: params.maxResults ?? 5,
+			semantic_threshold: params.semanticThreshold ?? 0.6,
+			auto_ingest: params.autoIngest,
+			previous_response: params.previousResponse,
+			user_followup: params.userFollowup,
+			...(params.toolActions && params.toolActions.length > 0 ? { tool_actions: params.toolActions } : {}),
 		});
 	}
 

--- a/seat/src/config.ts
+++ b/seat/src/config.ts
@@ -1,0 +1,133 @@
+/**
+ * Seat harness configuration, resolved from environment variables.
+ *
+ * Backend resolution mirrors mcp-server/index.ts:
+ *   SHODH_API_URL > SHODH_HOST+SHODH_PORT > http://127.0.0.1:3030
+ * API key resolution mirrors mcp-server/index.ts:
+ *   SHODH_API_KEY > SHODH_DEV_API_KEY > first entry of SHODH_API_KEYS
+ * (No auto-generation here: unlike the MCP server, the seat does not spawn the
+ * backend, so a generated key would never match a running server.)
+ */
+
+import * as os from "node:os";
+import * as path from "node:path";
+
+export interface McpServerConfig {
+	/** Short identifier used in tool-name prefixes: [a-zA-Z0-9_-]+ */
+	name: string;
+	command: string;
+	args?: string[];
+	env?: Record<string, string>;
+	cwd?: string;
+}
+
+export interface SeatConfig {
+	/** shodh-memory Rust backend base URL (no trailing slash). */
+	apiUrl: string;
+	/** X-API-Key value for the backend. */
+	apiKey: string;
+	/** Bind host of the seat HTTP server. */
+	host: string;
+	/** Bind port of the seat HTTP server. */
+	port: number;
+	/** Bearer token required on seat endpoints. Mandatory for non-loopback binds. */
+	authToken?: string;
+	/** Directory for the learning ledger and other durable seat state. */
+	dataDir: string;
+	/** OpenAI-compatible base URL for Ollama (its /v1 endpoint). */
+	ollamaBaseUrl: string;
+	/** OpenAI-compatible base URL for LM Studio. */
+	lmStudioBaseUrl: string;
+	/** Context window advertised for locally served models (they do not report one). */
+	localContextWindow: number;
+	/** Max output tokens for locally served models. */
+	localMaxTokens: number;
+	/** Optional path to a JSON file: { "servers": McpServerConfig[] } */
+	mcpConfigPath?: string;
+	/** Backend request timeout in milliseconds. */
+	backendTimeoutMs: number;
+}
+
+function isLoopback(host: string): boolean {
+	return host === "127.0.0.1" || host === "localhost" || host === "::1";
+}
+
+function resolveApiUrl(env: NodeJS.ProcessEnv): string {
+	if (env.SHODH_API_URL) return env.SHODH_API_URL.replace(/\/+$/, "");
+	const host = env.SHODH_HOST;
+	const port = env.SHODH_PORT;
+	if (host) {
+		const scheme = port === "443" ? "https" : "http";
+		const portSuffix = port && port !== "443" && port !== "80" ? `:${port}` : "";
+		return `${scheme}://${host}${portSuffix}`;
+	}
+	if (port) return `http://127.0.0.1:${port}`;
+	return "http://127.0.0.1:3030";
+}
+
+function resolveApiKey(env: NodeJS.ProcessEnv): string {
+	if (env.SHODH_API_KEY) return env.SHODH_API_KEY;
+	if (env.SHODH_DEV_API_KEY) return env.SHODH_DEV_API_KEY;
+	const first = env.SHODH_API_KEYS?.split(",")[0]?.trim();
+	if (first) return first;
+	return "";
+}
+
+/**
+ * Default data directory. Deliberately NOT under the repository or any
+ * cloud-synced/user-watched folder: file watchers have been observed to
+ * corrupt append-heavy stores on this project (see
+ * finding-bm25-onedrive-silent-commit-loss). LOCALAPPDATA on Windows,
+ * XDG data dir elsewhere.
+ */
+function defaultDataDir(env: NodeJS.ProcessEnv): string {
+	if (process.platform === "win32") {
+		const base = env.LOCALAPPDATA ?? path.join(os.homedir(), "AppData", "Local");
+		return path.join(base, "shodh", "seat-harness");
+	}
+	const base = env.XDG_DATA_HOME ?? path.join(os.homedir(), ".local", "share");
+	return path.join(base, "shodh", "seat-harness");
+}
+
+function parseIntEnv(value: string | undefined, fallback: number, name: string): number {
+	if (value === undefined || value === "") return fallback;
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		throw new Error(`Invalid ${name}: "${value}" (expected a positive integer)`);
+	}
+	return parsed;
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): SeatConfig {
+	const apiKey = resolveApiKey(env);
+	if (!apiKey) {
+		throw new Error(
+			"No backend API key configured. Set SHODH_API_KEY (or SHODH_DEV_API_KEY / SHODH_API_KEYS) " +
+				"to the key the shodh-memory server accepts.",
+		);
+	}
+
+	const host = env.SEAT_HOST ?? "127.0.0.1";
+	const authToken = env.SEAT_AUTH_TOKEN?.trim() || undefined;
+	if (!isLoopback(host) && !authToken) {
+		throw new Error(
+			`SEAT_HOST=${host} is not loopback; refusing to start without SEAT_AUTH_TOKEN. ` +
+				"Provider credentials live in this process — never expose it unauthenticated.",
+		);
+	}
+
+	return {
+		apiUrl: resolveApiUrl(env),
+		apiKey,
+		host,
+		port: parseIntEnv(env.SEAT_PORT, 3141, "SEAT_PORT"),
+		authToken,
+		dataDir: env.SEAT_DATA_DIR ?? defaultDataDir(env),
+		ollamaBaseUrl: (env.OLLAMA_BASE_URL ?? "http://127.0.0.1:11434/v1").replace(/\/+$/, ""),
+		lmStudioBaseUrl: (env.LMSTUDIO_BASE_URL ?? "http://127.0.0.1:1234/v1").replace(/\/+$/, ""),
+		localContextWindow: parseIntEnv(env.SEAT_LOCAL_CONTEXT_WINDOW, 32768, "SEAT_LOCAL_CONTEXT_WINDOW"),
+		localMaxTokens: parseIntEnv(env.SEAT_LOCAL_MAX_TOKENS, 8192, "SEAT_LOCAL_MAX_TOKENS"),
+		mcpConfigPath: env.SEAT_MCP_SERVERS,
+		backendTimeoutMs: parseIntEnv(env.SEAT_BACKEND_TIMEOUT_MS, 30000, "SEAT_BACKEND_TIMEOUT_MS"),
+	};
+}

--- a/seat/src/conversation.ts
+++ b/seat/src/conversation.ts
@@ -2,11 +2,20 @@
  * A conversation: one pi Agent wired to shodh-memory, with two learning loops
  * closing at every turn.
  *
- * Loop 1 — memory-level (user scope): memories recalled during a turn are
- * reinforced through the backend's existing Hebbian path (POST /api/reinforce)
- * according to whether the response actually used them (citation or token
- * overlap, mirroring src/memory/feedback.rs semantics). A negative follow-up
- * from the user penalizes the previous turn's surfaced memories.
+ * Loop 1 — memory-level (user scope), two legs with strict ownership:
+ *
+ * - Implicit/momentum leg: each turn calls POST /api/proactive_context — the
+ *   only backend path that writes feedback momentum (feedback_multiplier).
+ *   It evaluates the previous turn's proactive-surfaced set against the
+ *   previous response, the current user message (followup), and the previous
+ *   run's tool actions; it also applies its own reinforce_recall + Hebbian
+ *   pass internally (src/handlers/recall.rs:1670-1720). Memories surfaced by
+ *   this channel are OWNED by it.
+ * - Explicit leg: memories recalled by the recall_memory tool (and not also
+ *   proactive-surfaced) are reinforced through POST /api/reinforce according
+ *   to citation or token overlap (mirroring src/memory/feedback.rs), with
+ *   negative-followup penalties for the previous turn. This leg moves
+ *   importance/Hebbian but NOT momentum — a backend seam, not a seat choice.
  *
  * Loop 2 — harness-level (harness scope): operational lessons about retrieval
  * and tool use are stored AS MEMORIES in an isolated namespace
@@ -23,7 +32,7 @@
 import * as crypto from "node:crypto";
 import { Agent, type AgentEvent, type AgentTool } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
-import type { RecallMemory, ReinforceOutcome, ShodhBackend } from "./backend.js";
+import type { RecallMemory, ReinforceOutcome, ShodhBackend, ToolAction } from "./backend.js";
 import type { MemoryScope, ModelRef, ReinforceTrigger, SeatEvent, SeatEventSink, UsagePayload } from "./events.js";
 import {
 	detectNegativeKeywords,
@@ -46,6 +55,29 @@ const HARNESS_INJECT_LIMIT = 3;
 /** Caps on automatic harness captures, per conversation. */
 const MAX_EMPTY_RECALL_CAPTURES = 5;
 const MAX_TOOL_ERROR_CAPTURES = 5;
+
+/** How many proactive memories to surface and inject per turn. Kept equal so
+ * the backend's pending-feedback set contains only memories the model actually
+ * saw — otherwise the implicit loop penalizes memories that were never shown. */
+const PROACTIVE_MAX_RESULTS = 3;
+/** Matches the thresholds the existing callers use (mcp-server/index.ts, hooks/memory-hook.ts). */
+const PROACTIVE_SEMANTIC_THRESHOLD = 0.6;
+
+/** Native memory tools are excluded from tool-usage attribution: their inputs
+ * (the recall cue) trivially overlap surfaced memory content, which would turn
+ * the act of recalling into a fake "usage" signal. */
+const MEMORY_TOOL_NAMES = new Set(["recall_memory", "remember_memory", "record_seat_learning"]);
+
+/**
+ * The backend keeps ONE pending-feedback slot per user_id (set_pending
+ * overwrites, take_pending consumes — src/memory/feedback.rs). Concurrent
+ * proactive calls for the same user would corrupt each other's feedback, so
+ * feedback fields are skipped when another call for that user is in flight —
+ * the same guard mcp-server/index.ts uses (proactiveCallInFlight). This
+ * protects seat-internal concurrency only; a separate process (e.g. a Claude
+ * Code session on the same user_id) cannot be guarded from here.
+ */
+const proactiveFeedbackInFlight = new Set<string>();
 
 const BASE_SYSTEM_PROMPT = `You are the shodh-memory conversation seat: an assistant whose persistent memory is visible and inspectable by the user.
 
@@ -145,6 +177,18 @@ export class Conversation {
 	private surfaced = new Map<string, SurfacedMemory>();
 	/** Memories surfaced during the previous run (target of negative-followup penalties). */
 	private prevSurfaced = new Map<string, SurfacedMemory>();
+	/** Ids surfaced by proactive_context this run — owned by the backend's
+	 * implicit-feedback loop, excluded from the seat's explicit reinforcement. */
+	private proactiveIds = new Set<string>();
+	/** Previous run's proactive ids — excluded from explicit negative-followup
+	 * penalties because the implicit loop applies its own followup penalty. */
+	private prevProactiveIds = new Set<string>();
+	/** Final assistant text of the previous run — previous_response for the next proactive call. */
+	private lastAssistantText: string | undefined;
+	/** Tool actions since the last consumed pending set (feedback attribution window). */
+	private pendingToolActions: ToolAction[] = [];
+	/** Args captured at tool_execution_start (the end event does not carry them). */
+	private toolArgsByCallId = new Map<string, unknown>();
 	private emptyRecallQueries: string[] = [];
 	private toolErrors: { toolName: string; message: string }[] = [];
 	private assistantTexts: string[] = [];
@@ -243,6 +287,8 @@ export class Conversation {
 					tool_name: event.toolName,
 					args: event.args,
 				});
+				// tool_execution_end does not carry args; keep them for attribution.
+				this.toolArgsByCallId.set(event.toolCallId, event.args);
 				break;
 			case "tool_execution_end": {
 				this.emit({
@@ -256,6 +302,9 @@ export class Conversation {
 						typeof event.result === "string" ? event.result : JSON.stringify(event.result)?.slice(0, 500);
 					this.toolErrors.push({ toolName: event.toolName, message: message ?? "unknown error" });
 				}
+				const args = this.toolArgsByCallId.get(event.toolCallId);
+				this.toolArgsByCallId.delete(event.toolCallId);
+				this.recordToolAction(event.toolName, args, event.result, event.isError);
 				break;
 			}
 			default:
@@ -274,6 +323,8 @@ export class Conversation {
 
 		// Reset per-run state.
 		this.surfaced = new Map();
+		this.prevProactiveIds = this.proactiveIds;
+		this.proactiveIds = new Set();
 		this.emptyRecallQueries = [];
 		this.toolErrors = [];
 		this.assistantTexts = [];
@@ -287,11 +338,16 @@ export class Conversation {
 			this.emit({ type: "turn_start", turn: this.turn });
 
 			await this.applyNegativeFollowupPenalty(text);
-			await this.injectHarnessLearnings(text);
+			const proactiveBlock = await this.runProactivePass(text);
+			const harnessBlock = await this.buildHarnessLearningsBlock(text);
+			this.agent.state.systemPrompt = [this.baseSystemPrompt, proactiveBlock, harnessBlock]
+				.filter((block): block is string => Boolean(block))
+				.join("\n\n");
 
 			await this.agent.prompt(text);
 
 			await this.closeLearningLoops();
+			this.lastAssistantText = this.assistantTexts.join("\n") || undefined;
 
 			this.emit({
 				type: "turn_end",
@@ -303,6 +359,118 @@ export class Conversation {
 		} finally {
 			this.prevSurfaced = this.surfaced;
 			this.currentSink = undefined;
+		}
+	}
+
+	/** Map a finished tool call into the backend's ToolAction shape for feedback attribution. */
+	private recordToolAction(toolName: string, args: unknown, result: unknown, isError: boolean): void {
+		if (MEMORY_TOOL_NAMES.has(toolName)) return;
+		const inputs: Record<string, string> = {};
+		if (args && typeof args === "object") {
+			for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
+				inputs[key] = (typeof value === "string" ? value : JSON.stringify(value) ?? "").slice(0, 500);
+			}
+		}
+		let outputSnippet: string | undefined;
+		if (result && typeof result === "object" && "content" in result) {
+			const content = (result as { content?: unknown }).content;
+			if (Array.isArray(content)) {
+				outputSnippet = content
+					.filter(
+						(block): block is { type: "text"; text: string } =>
+							typeof block === "object" &&
+							block !== null &&
+							(block as { type?: string }).type === "text" &&
+							typeof (block as { text?: unknown }).text === "string",
+					)
+					.map((block) => block.text)
+					.join(" ")
+					.slice(0, 200);
+			}
+		} else if (typeof result === "string") {
+			outputSnippet = result.slice(0, 200);
+		}
+		this.pendingToolActions.push({
+			tool_name: toolName,
+			inputs,
+			success: !isError,
+			...(outputSnippet ? { output_snippet: outputSnippet } : {}),
+		});
+	}
+
+	/**
+	 * The momentum leg of the memory-level loop. POST /api/proactive_context is
+	 * the only backend path that writes feedback momentum (feedback_multiplier);
+	 * /api/reinforce does not. This call:
+	 *
+	 * 1. Delivers the previous assistant response (+ this user message as the
+	 *    followup, + tool actions from the previous run) so the backend
+	 *    evaluates the pending surfaced set: momentum, context fingerprints,
+	 *    temporal credits, AND its own reinforce_recall/Hebbian pass
+	 *    (recall.rs:1670-1720).
+	 * 2. Surfaces a new set for this turn, which the backend stores as pending.
+	 *    Every surfaced memory is injected into the system prompt — the pending
+	 *    set must only contain memories the model actually saw, or the implicit
+	 *    loop penalizes memories that never had a chance to be used.
+	 *
+	 * Ownership rule (prevents double-counting): memories surfaced here belong
+	 * to the implicit loop; the seat's explicit /api/reinforce never touches
+	 * them (closeLearningLoops and the negative-followup pass filter them out).
+	 *
+	 * auto_ingest is explicitly false: the backend would otherwise silently
+	 * ingest the previous response as memories (its default is true), bypassing
+	 * the ledger. Seat writes stay deliberate and ledgered.
+	 */
+	private async runProactivePass(userText: string): Promise<string | undefined> {
+		const feedbackAllowed = !proactiveFeedbackInFlight.has(this.userId);
+		if (feedbackAllowed) proactiveFeedbackInFlight.add(this.userId);
+		const sendFeedback = feedbackAllowed && this.lastAssistantText !== undefined;
+		const toolActions = sendFeedback ? this.pendingToolActions.splice(0, this.pendingToolActions.length) : [];
+
+		try {
+			const startedAt = Date.now();
+			const response = await this.deps.backend.proactiveContext({
+				userId: this.userId,
+				context: userText,
+				maxResults: PROACTIVE_MAX_RESULTS,
+				semanticThreshold: PROACTIVE_SEMANTIC_THRESHOLD,
+				autoIngest: false,
+				previousResponse: sendFeedback ? this.lastAssistantText : undefined,
+				userFollowup: sendFeedback ? userText : undefined,
+				toolActions,
+			});
+
+			for (const memory of response.memories) {
+				this.proactiveIds.add(memory.id);
+			}
+			this.emit({
+				type: "proactive_context",
+				scope: "user",
+				query: userText,
+				memories: response.memories,
+				injected_memory_ids: response.memories.map((memory) => memory.id),
+				feedback: response.feedback_processed ?? null,
+				temporal_credits_applied: response.temporal_credits_applied ?? null,
+				took_ms: Date.now() - startedAt,
+			});
+
+			if (response.memories.length === 0) return undefined;
+			const lines = response.memories.map(
+				(memory) =>
+					`- [mem:${memoryShortId(memory.id)}] (${memory.memory_type}) ${memory.content.slice(0, 400)}`,
+			);
+			return `## Possibly relevant memories (auto-surfaced — cite [mem:id] if used)\n${lines.join("\n")}`;
+		} catch (error) {
+			// Momentum loop is an enhancement; its failure must not block the turn.
+			// Un-drained tool actions stay queued for the next attempt.
+			if (toolActions.length > 0) this.pendingToolActions.unshift(...toolActions);
+			this.emit({
+				type: "error",
+				message: `Proactive context failed: ${error instanceof Error ? error.message : String(error)}`,
+			});
+			return undefined;
+		} finally {
+			if (feedbackAllowed) proactiveFeedbackInFlight.delete(this.userId);
 		}
 	}
 
@@ -318,6 +486,11 @@ export class Conversation {
 
 		const byScope = new Map<MemoryScope, string[]>();
 		for (const [memoryId, memory] of this.prevSurfaced) {
+			// Ownership: memories the proactive channel surfaced last turn get
+			// their followup penalty from the backend's implicit loop (this
+			// turn's proactive call carries user_followup) — penalizing them
+			// here too would double-count.
+			if (this.prevProactiveIds.has(memoryId)) continue;
 			const ids = byScope.get(memory.scope) ?? [];
 			ids.push(memoryId);
 			byScope.set(memory.scope, ids);
@@ -332,10 +505,10 @@ export class Conversation {
 
 	/**
 	 * Harness-level learning, read side: recall operational lessons from the
-	 * harness scope with the user message as cue and inject strong matches as
+	 * harness scope with the user message as cue and return strong matches as
 	 * a labeled system-prompt block for this run only.
 	 */
-	private async injectHarnessLearnings(userText: string): Promise<void> {
+	private async buildHarnessLearningsBlock(userText: string): Promise<string | undefined> {
 		let memories: RecallMemory[] = [];
 		try {
 			const startedAt = Date.now();
@@ -368,16 +541,12 @@ export class Conversation {
 			});
 		}
 
-		if (memories.length === 0) {
-			this.agent.state.systemPrompt = this.baseSystemPrompt;
-			return;
-		}
+		if (memories.length === 0) return undefined;
 
 		for (const memory of memories) {
 			this.surfaced.set(memory.id, { scope: "harness", content: memory.experience.content });
 		}
 		const lines = memories.map((memory) => `- ${memory.experience.content}`);
-		this.agent.state.systemPrompt = `${this.baseSystemPrompt}\n\n## Learned operating notes (from previous sessions of this assistant)\n${lines.join("\n")}`;
 		this.emit({
 			type: "harness_learning_applied",
 			memories: memories.map((memory) => ({
@@ -386,6 +555,7 @@ export class Conversation {
 				score: memory.score,
 			})),
 		});
+		return `## Learned operating notes (from previous sessions of this assistant)\n${lines.join("\n")}`;
 	}
 
 	/** Reinforce + ledger + emit, with failures surfaced as error events. */
@@ -440,6 +610,12 @@ export class Conversation {
 				{ scope: MemoryScope; outcome: ReinforceOutcome; ids: string[]; overlaps: Record<string, number>; cited: string[] }
 			>();
 			for (const [memoryId, memory] of this.surfaced) {
+				// Ownership: memories the proactive channel surfaced this turn
+				// are evaluated by the backend's implicit loop on the NEXT
+				// proactive call (which itself applies reinforce_recall +
+				// Hebbian strengthening, recall.rs:1670-1720). Reinforcing them
+				// here too would double importance and association updates.
+				if (this.proactiveIds.has(memoryId)) continue;
 				const cited = citations.has(memoryShortId(memoryId));
 				const overlap = memoryOverlap(memory.content, responseTokens);
 				const outcome: ReinforceOutcome = cited || overlap >= OVERLAP_USED_THRESHOLD ? "helpful" : "neutral";

--- a/seat/src/conversation.ts
+++ b/seat/src/conversation.ts
@@ -1,0 +1,566 @@
+/**
+ * A conversation: one pi Agent wired to shodh-memory, with two learning loops
+ * closing at every turn.
+ *
+ * Loop 1 — memory-level (user scope): memories recalled during a turn are
+ * reinforced through the backend's existing Hebbian path (POST /api/reinforce)
+ * according to whether the response actually used them (citation or token
+ * overlap, mirroring src/memory/feedback.rs semantics). A negative follow-up
+ * from the user penalizes the previous turn's surfaced memories.
+ *
+ * Loop 2 — harness-level (harness scope): operational lessons about retrieval
+ * and tool use are stored AS MEMORIES in an isolated namespace
+ * (`<user_id>.seat-harness`), surfaced by the same recall machinery before
+ * each turn, injected as a labeled system-prompt block, and reinforced by the
+ * same rules. One substrate, two scopes; the scopes never share retrieval
+ * because the backend keys every store (RocksDB, graph, feedback) by user_id
+ * (src/handlers/state.rs get_user_memory / get_user_graph).
+ *
+ * Every update either loop makes is recorded in the LearningLedger before the
+ * conversation continues — reviewable and revertible from the start.
+ */
+
+import * as crypto from "node:crypto";
+import { Agent, type AgentEvent, type AgentTool } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type { RecallMemory, ReinforceOutcome, ShodhBackend } from "./backend.js";
+import type { MemoryScope, ModelRef, ReinforceTrigger, SeatEvent, SeatEventSink, UsagePayload } from "./events.js";
+import {
+	detectNegativeKeywords,
+	extractCitations,
+	extractTokens,
+	memoryOverlap,
+	OVERLAP_USED_THRESHOLD,
+} from "./feedback.js";
+import type { LearningLedger } from "./ledger.js";
+import { createMemoryTools } from "./memory-tools.js";
+import type { ModelRegistry } from "./models-registry.js";
+
+const HARNESS_SUFFIX = ".seat-harness";
+/** Backend limit: src/validation.rs MAX_USER_ID_LENGTH = 128. */
+const MAX_USER_ID_LENGTH = 128;
+const USER_ID_PATTERN = /^[A-Za-z0-9@._-]+$/;
+/** Minimum normalized recall score for a harness learning to be injected. */
+const HARNESS_INJECT_MIN_SCORE = 0.25;
+const HARNESS_INJECT_LIMIT = 3;
+/** Caps on automatic harness captures, per conversation. */
+const MAX_EMPTY_RECALL_CAPTURES = 5;
+const MAX_TOOL_ERROR_CAPTURES = 5;
+
+const BASE_SYSTEM_PROMPT = `You are the shodh-memory conversation seat: an assistant whose persistent memory is visible and inspectable by the user.
+
+Memory discipline:
+- Use recall_memory when the user refers to past work, decisions, people, or preferences, or when prior context would materially improve the answer.
+- When a recalled memory informs your answer, cite it inline as [mem:<id>] using the id shown in the recall result.
+- Use remember_memory sparingly: durable facts, decisions, and learnings only.
+- Use record_seat_learning only for operational lessons about retrieval or tool strategy — never for user content.`;
+
+export class ConversationBusyError extends Error {
+	constructor() {
+		super("Conversation is currently processing a message");
+		this.name = "ConversationBusyError";
+	}
+}
+
+export class UnknownModelError extends Error {
+	constructor(provider: string, id: string) {
+		super(`Unknown or unavailable model: ${provider}/${id}`);
+		this.name = "UnknownModelError";
+	}
+}
+
+export interface ConversationDeps {
+	backend: ShodhBackend;
+	registry: ModelRegistry;
+	ledger: LearningLedger;
+	mcpTools: AgentTool<any>[];
+}
+
+export interface ConversationOptions {
+	userId: string;
+	model: Model<Api>;
+	systemPrompt?: string;
+}
+
+interface SurfacedMemory {
+	scope: MemoryScope;
+	content: string;
+}
+
+export function deriveHarnessUserId(userId: string): string {
+	const derived = `${userId}${HARNESS_SUFFIX}`;
+	if (!USER_ID_PATTERN.test(userId) || userId.includes("..") || userId.startsWith(".")) {
+		throw new Error(`Invalid user_id "${userId}" (allowed: alphanumeric, -, _, @, .)`);
+	}
+	if (derived.length > MAX_USER_ID_LENGTH) {
+		throw new Error(`user_id too long: harness namespace "${derived}" exceeds ${MAX_USER_ID_LENGTH} chars`);
+	}
+	return derived;
+}
+
+function modelRef(model: Model<Api>): ModelRef {
+	return { provider: model.provider, id: model.id, name: model.name };
+}
+
+function usagePayload(usage: {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	reasoning?: number;
+	totalTokens: number;
+	cost: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
+}): UsagePayload {
+	return {
+		input: usage.input,
+		output: usage.output,
+		cacheRead: usage.cacheRead,
+		cacheWrite: usage.cacheWrite,
+		reasoning: usage.reasoning,
+		totalTokens: usage.totalTokens,
+		cost: { ...usage.cost },
+	};
+}
+
+function memoryShortId(memoryId: string): string {
+	return memoryId.replace(/-/g, "").slice(0, 8).toLowerCase();
+}
+
+export class Conversation {
+	readonly id: string;
+	readonly userId: string;
+	readonly harnessUserId: string;
+	readonly createdAt: Date;
+
+	private readonly deps: ConversationDeps;
+	private readonly agent: Agent;
+	private readonly baseSystemPrompt: string;
+
+	private turn = 0;
+	private currentSink?: SeatEventSink;
+	/** Events raised outside an active run (e.g. model change), flushed on the next run. */
+	private pendingEvents: SeatEvent[] = [];
+
+	/** Memories surfaced during the current run, keyed by memory id. */
+	private surfaced = new Map<string, SurfacedMemory>();
+	/** Memories surfaced during the previous run (target of negative-followup penalties). */
+	private prevSurfaced = new Map<string, SurfacedMemory>();
+	private emptyRecallQueries: string[] = [];
+	private toolErrors: { toolName: string; message: string }[] = [];
+	private assistantTexts: string[] = [];
+	private lastStopReason = "stop";
+	private lastErrorMessage: string | undefined;
+
+	/** Per-conversation dedupe for automatic harness captures. */
+	private capturedEmptyRecalls = new Set<string>();
+	private capturedToolErrors = new Set<string>();
+
+	constructor(deps: ConversationDeps, options: ConversationOptions) {
+		this.id = crypto.randomUUID();
+		this.userId = options.userId;
+		this.harnessUserId = deriveHarnessUserId(options.userId);
+		this.createdAt = new Date();
+		this.deps = deps;
+		this.baseSystemPrompt = options.systemPrompt?.trim()
+			? `${BASE_SYSTEM_PROMPT}\n\n${options.systemPrompt.trim()}`
+			: BASE_SYSTEM_PROMPT;
+
+		const memoryTools = createMemoryTools({
+			backend: deps.backend,
+			userId: this.userId,
+			harnessUserId: this.harnessUserId,
+			conversationId: this.id,
+			getTurn: () => this.turn,
+			emit: (event) => this.emit(event),
+			onSurfaced: (scope, memories) => {
+				for (const memory of memories) {
+					this.surfaced.set(memory.id, { scope, content: memory.content });
+				}
+			},
+			onEmptyRecall: (query) => {
+				this.emptyRecallQueries.push(query);
+			},
+			ledger: deps.ledger,
+		});
+
+		this.agent = new Agent({
+			initialState: {
+				systemPrompt: this.baseSystemPrompt,
+				model: options.model,
+				thinkingLevel: "off",
+				tools: [...memoryTools, ...deps.mcpTools],
+			},
+			streamFn: (model, context, streamOptions) => deps.registry.models.streamSimple(model, context, streamOptions),
+		});
+		this.agent.subscribe((event) => this.onAgentEvent(event));
+	}
+
+	get model(): ModelRef {
+		return modelRef(this.agent.state.model);
+	}
+
+	get isStreaming(): boolean {
+		return this.agent.state.isStreaming;
+	}
+
+	private emit(event: SeatEvent): void {
+		if (this.currentSink) {
+			this.currentSink(event);
+		} else {
+			this.pendingEvents.push(event);
+		}
+	}
+
+	private onAgentEvent(event: AgentEvent): void {
+		switch (event.type) {
+			case "message_update": {
+				const streamEvent = event.assistantMessageEvent;
+				if (streamEvent.type === "text_delta") {
+					this.emit({ type: "text_delta", delta: streamEvent.delta });
+				} else if (streamEvent.type === "thinking_delta") {
+					this.emit({ type: "thinking_delta", delta: streamEvent.delta });
+				}
+				break;
+			}
+			case "message_end": {
+				const message = event.message;
+				if (typeof message === "object" && message !== null && "role" in message && message.role === "assistant") {
+					this.lastStopReason = message.stopReason;
+					this.lastErrorMessage = message.errorMessage;
+					const text = message.content
+						.filter((block): block is { type: "text"; text: string } => block.type === "text")
+						.map((block) => block.text)
+						.join("");
+					if (text) this.assistantTexts.push(text);
+					this.emit({ type: "usage", model: this.model, usage: usagePayload(message.usage) });
+				}
+				break;
+			}
+			case "tool_execution_start":
+				this.emit({
+					type: "tool_call_start",
+					tool_call_id: event.toolCallId,
+					tool_name: event.toolName,
+					args: event.args,
+				});
+				break;
+			case "tool_execution_end": {
+				this.emit({
+					type: "tool_call_end",
+					tool_call_id: event.toolCallId,
+					tool_name: event.toolName,
+					is_error: event.isError,
+				});
+				if (event.isError) {
+					const message =
+						typeof event.result === "string" ? event.result : JSON.stringify(event.result)?.slice(0, 500);
+					this.toolErrors.push({ toolName: event.toolName, message: message ?? "unknown error" });
+				}
+				break;
+			}
+			default:
+				break;
+		}
+	}
+
+	/**
+	 * Run one user message through the agent, streaming SeatEvents to `sink`.
+	 * Resolves after the run AND the learning loops have completed.
+	 */
+	async sendMessage(text: string, sink: SeatEventSink): Promise<void> {
+		if (this.agent.state.isStreaming || this.currentSink) throw new ConversationBusyError();
+		this.currentSink = sink;
+		this.turn += 1;
+
+		// Reset per-run state.
+		this.surfaced = new Map();
+		this.emptyRecallQueries = [];
+		this.toolErrors = [];
+		this.assistantTexts = [];
+		this.lastStopReason = "stop";
+		this.lastErrorMessage = undefined;
+
+		try {
+			for (const pending of this.pendingEvents) sink(pending);
+			this.pendingEvents = [];
+
+			this.emit({ type: "turn_start", turn: this.turn });
+
+			await this.applyNegativeFollowupPenalty(text);
+			await this.injectHarnessLearnings(text);
+
+			await this.agent.prompt(text);
+
+			await this.closeLearningLoops();
+
+			this.emit({
+				type: "turn_end",
+				turn: this.turn,
+				stop_reason: this.lastStopReason,
+				error_message: this.lastErrorMessage,
+			});
+			this.emit({ type: "agent_end" });
+		} finally {
+			this.prevSurfaced = this.surfaced;
+			this.currentSink = undefined;
+		}
+	}
+
+	/**
+	 * Mirror of the backend's user_followup penalty (src/memory/feedback.rs):
+	 * a correction/frustration message penalizes the memories surfaced on the
+	 * previous turn.
+	 */
+	private async applyNegativeFollowupPenalty(userText: string): Promise<void> {
+		if (this.prevSurfaced.size === 0) return;
+		const keywords = detectNegativeKeywords(userText);
+		if (keywords.length === 0) return;
+
+		const byScope = new Map<MemoryScope, string[]>();
+		for (const [memoryId, memory] of this.prevSurfaced) {
+			const ids = byScope.get(memory.scope) ?? [];
+			ids.push(memoryId);
+			byScope.set(memory.scope, ids);
+		}
+		for (const [scope, ids] of byScope) {
+			await this.reinforceAndRecord(scope, ids, "misleading", {
+				kind: "negative_followup",
+				keywords,
+			});
+		}
+	}
+
+	/**
+	 * Harness-level learning, read side: recall operational lessons from the
+	 * harness scope with the user message as cue and inject strong matches as
+	 * a labeled system-prompt block for this run only.
+	 */
+	private async injectHarnessLearnings(userText: string): Promise<void> {
+		let memories: RecallMemory[] = [];
+		try {
+			const startedAt = Date.now();
+			const response = await this.deps.backend.recall({
+				userId: this.harnessUserId,
+				query: userText,
+				limit: HARNESS_INJECT_LIMIT,
+				mode: "hybrid",
+				debug: true,
+			});
+			memories = response.memories.filter((memory) => memory.score >= HARNESS_INJECT_MIN_SCORE);
+			if (memories.length > 0) {
+				this.emit({
+					type: "memory_recall",
+					scope: "harness",
+					query: userText,
+					mode: "hybrid",
+					memories,
+					facts: [],
+					todos: [],
+					lineage: [],
+					took_ms: Date.now() - startedAt,
+				});
+			}
+		} catch (error) {
+			// Harness recall is an enhancement; its failure must not block the turn.
+			this.emit({
+				type: "error",
+				message: `Harness-scope recall failed: ${error instanceof Error ? error.message : String(error)}`,
+			});
+		}
+
+		if (memories.length === 0) {
+			this.agent.state.systemPrompt = this.baseSystemPrompt;
+			return;
+		}
+
+		for (const memory of memories) {
+			this.surfaced.set(memory.id, { scope: "harness", content: memory.experience.content });
+		}
+		const lines = memories.map((memory) => `- ${memory.experience.content}`);
+		this.agent.state.systemPrompt = `${this.baseSystemPrompt}\n\n## Learned operating notes (from previous sessions of this assistant)\n${lines.join("\n")}`;
+		this.emit({
+			type: "harness_learning_applied",
+			memories: memories.map((memory) => ({
+				id: memory.id,
+				content: memory.experience.content,
+				score: memory.score,
+			})),
+		});
+	}
+
+	/** Reinforce + ledger + emit, with failures surfaced as error events. */
+	private async reinforceAndRecord(
+		scope: MemoryScope,
+		memoryIds: string[],
+		outcome: ReinforceOutcome,
+		trigger: ReinforceTrigger,
+	): Promise<void> {
+		if (memoryIds.length === 0) return;
+		const scopeUserId = scope === "user" ? this.userId : this.harnessUserId;
+		try {
+			const stats = await this.deps.backend.reinforce(scopeUserId, memoryIds, outcome);
+			const ledgerEntry = await this.deps.ledger.append("reinforce", scope, scopeUserId, this.id, this.turn, {
+				outcome,
+				memory_ids: memoryIds,
+				trigger,
+				stats,
+			});
+			this.emit({
+				type: "memory_reinforce",
+				scope,
+				outcome,
+				memory_ids: memoryIds,
+				stats,
+				trigger,
+				ledger_event_id: ledgerEntry.id,
+			});
+		} catch (error) {
+			this.emit({
+				type: "error",
+				message: `Reinforcement (${outcome}) failed for ${scope} scope: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			});
+		}
+	}
+
+	/**
+	 * Close both learning loops for the finished run:
+	 * 1. Reinforce surfaced memories by usage (citation or token overlap).
+	 * 2. Capture deterministic harness learnings (empty recalls, tool errors).
+	 */
+	private async closeLearningLoops(): Promise<void> {
+		const responseText = this.assistantTexts.join("\n");
+		if (this.surfaced.size > 0 && responseText.length > 0) {
+			const responseTokens = extractTokens(responseText);
+			const citations = extractCitations(responseText);
+
+			const groups = new Map<
+				string,
+				{ scope: MemoryScope; outcome: ReinforceOutcome; ids: string[]; overlaps: Record<string, number>; cited: string[] }
+			>();
+			for (const [memoryId, memory] of this.surfaced) {
+				const cited = citations.has(memoryShortId(memoryId));
+				const overlap = memoryOverlap(memory.content, responseTokens);
+				const outcome: ReinforceOutcome = cited || overlap >= OVERLAP_USED_THRESHOLD ? "helpful" : "neutral";
+				const key = `${memory.scope}:${outcome}`;
+				const group =
+					groups.get(key) ??
+					({ scope: memory.scope, outcome, ids: [], overlaps: {}, cited: [] } as {
+						scope: MemoryScope;
+						outcome: ReinforceOutcome;
+						ids: string[];
+						overlaps: Record<string, number>;
+						cited: string[];
+					});
+				group.ids.push(memoryId);
+				group.overlaps[memoryId] = Number(overlap.toFixed(4));
+				if (cited) group.cited.push(memoryId);
+				groups.set(key, group);
+			}
+
+			for (const group of groups.values()) {
+				const trigger =
+					group.cited.length > 0
+						? ({ kind: "citation", cited: group.cited } as const)
+						: ({ kind: "response_overlap", overlaps: group.overlaps, threshold: OVERLAP_USED_THRESHOLD } as const);
+				await this.reinforceAndRecord(group.scope, group.ids, group.outcome, trigger);
+			}
+		}
+
+		await this.captureHarnessLearnings();
+	}
+
+	/** Deterministic write side of the harness loop, with per-conversation dedupe and caps. */
+	private async captureHarnessLearnings(): Promise<void> {
+		for (const query of this.emptyRecallQueries) {
+			if (this.capturedEmptyRecalls.size >= MAX_EMPTY_RECALL_CAPTURES) break;
+			const normalized = query.trim().toLowerCase();
+			if (this.capturedEmptyRecalls.has(normalized)) continue;
+			this.capturedEmptyRecalls.add(normalized);
+			await this.writeHarnessCapture(
+				`Recall returned no results for cue "${query.slice(0, 200)}". Rephrase with concrete entity names or broaden the cue before answering without memory.`,
+				"learning",
+				["seat-harness", "retrieval", "empty-recall"],
+				"empty_recall_capture",
+			);
+		}
+
+		for (const toolError of this.toolErrors) {
+			if (this.capturedToolErrors.size >= MAX_TOOL_ERROR_CAPTURES) break;
+			if (this.capturedToolErrors.has(toolError.toolName)) continue;
+			this.capturedToolErrors.add(toolError.toolName);
+			await this.writeHarnessCapture(
+				`Tool ${toolError.toolName} failed: ${toolError.message.slice(0, 300)}. Verify arguments and tool availability before relying on it.`,
+				"error",
+				["seat-harness", "tool-error", toolError.toolName],
+				"tool_error_capture",
+			);
+		}
+	}
+
+	private async writeHarnessCapture(
+		content: string,
+		memoryType: "learning" | "error",
+		tags: string[],
+		trigger: "empty_recall_capture" | "tool_error_capture",
+	): Promise<void> {
+		try {
+			const response = await this.deps.backend.remember({
+				userId: this.harnessUserId,
+				content,
+				memoryType,
+				tags,
+			});
+			const ledgerEntry = await this.deps.ledger.append(
+				"memory_write",
+				"harness",
+				this.harnessUserId,
+				this.id,
+				this.turn,
+				{
+					memory_id: response.id,
+					memory_type: memoryType,
+					content_preview: content.slice(0, 200),
+					trigger,
+				},
+			);
+			this.emit({
+				type: "memory_write",
+				scope: "harness",
+				memory_id: response.id,
+				memory_type: memoryType,
+				content_preview: content.slice(0, 200),
+				ledger_event_id: ledgerEntry.id,
+			});
+		} catch (error) {
+			this.emit({
+				type: "error",
+				message: `Harness learning capture failed: ${error instanceof Error ? error.message : String(error)}`,
+			});
+		}
+	}
+
+	/**
+	 * Swap the model for future turns. The transcript and all retrieved
+	 * evidence stay exactly as they are — only the model producing the next
+	 * turn changes.
+	 */
+	setModel(provider: string, id: string): ModelRef {
+		if (this.agent.state.isStreaming) throw new ConversationBusyError();
+		const model = this.deps.registry.resolve(provider, id);
+		if (!model) throw new UnknownModelError(provider, id);
+		this.agent.state.model = model;
+		const ref = modelRef(model);
+		this.emit({ type: "model_changed", model: ref });
+		return ref;
+	}
+
+	abort(): void {
+		this.agent.abort();
+	}
+
+	transcript(): unknown[] {
+		return this.agent.state.messages.map((message) => message as unknown);
+	}
+}

--- a/seat/src/events.ts
+++ b/seat/src/events.ts
@@ -8,6 +8,8 @@
  */
 
 import type {
+	FeedbackProcessed,
+	ProactiveSurfacedMemory,
 	RecallFact,
 	RecallLineageEdge,
 	RecallMemory,
@@ -82,6 +84,23 @@ export type SeatEvent =
 			stats: ReinforceStats;
 			trigger: ReinforceTrigger;
 			ledger_event_id: string;
+	  }
+	| {
+			/**
+			 * One proactive_context round-trip: the memories the backend
+			 * auto-surfaced for this turn, plus the implicit-feedback outcome
+			 * for the PREVIOUS turn's surfaced set (momentum reinforced /
+			 * weakened ids), so the momentum loop is as inspectable as the
+			 * explicit one.
+			 */
+			type: "proactive_context";
+			scope: "user";
+			query: string;
+			memories: ProactiveSurfacedMemory[];
+			injected_memory_ids: string[];
+			feedback: FeedbackProcessed | null;
+			temporal_credits_applied: number | null;
+			took_ms: number;
 	  }
 	| { type: "harness_learning_applied"; memories: { id: string; content: string; score: number }[] }
 	| { type: "model_changed"; model: ModelRef }

--- a/seat/src/events.ts
+++ b/seat/src/events.ts
@@ -1,0 +1,93 @@
+/**
+ * Structured events streamed to the client over SSE.
+ *
+ * The traceability surface is the product: memory operations are never opaque.
+ * Every recall carries ids, scores, and full ScoreAttribution; every learning
+ * update (write or reinforcement) carries its ledger event id so the UI can
+ * review and revert it.
+ */
+
+import type {
+	RecallFact,
+	RecallLineageEdge,
+	RecallMemory,
+	RecallTodo,
+	ReinforceOutcome,
+	ReinforceStats,
+} from "./backend.js";
+
+/** Which memory namespace an operation touched. */
+export type MemoryScope = "user" | "harness";
+
+export interface ModelRef {
+	provider: string;
+	id: string;
+	name: string;
+}
+
+export interface UsagePayload {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	reasoning?: number;
+	totalTokens: number;
+	cost: {
+		input: number;
+		output: number;
+		cacheRead: number;
+		cacheWrite: number;
+		total: number;
+	};
+}
+
+export type ReinforceTrigger =
+	| { kind: "response_overlap"; overlaps: Record<string, number>; threshold: number }
+	| { kind: "citation"; cited: string[] }
+	| { kind: "negative_followup"; keywords: string[] }
+	| { kind: "revert"; of: string };
+
+export type SeatEvent =
+	| { type: "conversation_created"; conversation_id: string; user_id: string; model: ModelRef }
+	| { type: "turn_start"; turn: number }
+	| { type: "text_delta"; delta: string }
+	| { type: "thinking_delta"; delta: string }
+	| { type: "tool_call_start"; tool_call_id: string; tool_name: string; args: unknown }
+	| { type: "tool_call_end"; tool_call_id: string; tool_name: string; is_error: boolean }
+	| {
+			type: "memory_recall";
+			scope: MemoryScope;
+			tool_call_id?: string;
+			query: string;
+			mode: string;
+			memories: RecallMemory[];
+			facts: RecallFact[];
+			todos: RecallTodo[];
+			lineage: RecallLineageEdge[];
+			took_ms: number;
+	  }
+	| {
+			type: "memory_write";
+			scope: MemoryScope;
+			memory_id: string;
+			memory_type: string;
+			content_preview: string;
+			ledger_event_id: string;
+	  }
+	| {
+			type: "memory_reinforce";
+			scope: MemoryScope;
+			outcome: ReinforceOutcome;
+			memory_ids: string[];
+			stats: ReinforceStats;
+			trigger: ReinforceTrigger;
+			ledger_event_id: string;
+	  }
+	| { type: "harness_learning_applied"; memories: { id: string; content: string; score: number }[] }
+	| { type: "model_changed"; model: ModelRef }
+	| { type: "usage"; model: ModelRef; usage: UsagePayload }
+	| { type: "turn_end"; turn: number; stop_reason: string; error_message?: string }
+	| { type: "agent_end" }
+	| { type: "error"; message: string };
+
+export type SeatEventSink = (event: SeatEvent) => void;

--- a/seat/src/feedback.ts
+++ b/seat/src/feedback.ts
@@ -1,0 +1,95 @@
+/**
+ * Client-side mirror of the backend's implicit-feedback heuristics.
+ *
+ * The backend owns the learning mechanics (EMA momentum, inertia, Hebbian
+ * strengthening — src/memory/feedback.rs, applied through POST /api/reinforce).
+ * The harness only needs to decide WHICH surfaced memories a response actually
+ * used, and it deliberately reuses the backend's own published semantics
+ * rather than inventing parallel ones:
+ *
+ * - Token extraction mirrors feedback.rs `extract_entities_simple`
+ *   (lowercase, split on non-alphanumeric except '_', keep length > 2).
+ * - Usage overlap mirrors `calculate_entity_overlap`
+ *   (|memory ∩ response| / |memory|), with the same weak threshold (0.1,
+ *   `OVERLAP_WEAK_THRESHOLD` after FBK-4).
+ * - The negative-keyword list is copied verbatim from feedback.rs
+ *   `NEGATIVE_KEYWORDS`.
+ */
+
+/** feedback.rs OVERLAP_WEAK_THRESHOLD — at/above this a surfaced memory counts as used. */
+export const OVERLAP_USED_THRESHOLD = 0.1;
+
+/** Copied verbatim from src/memory/feedback.rs `NEGATIVE_KEYWORDS`. */
+export const NEGATIVE_KEYWORDS: readonly string[] = [
+	"wrong",
+	"incorrect",
+	"not correct",
+	"nope",
+	"not what i meant",
+	"that's not right",
+	"that's wrong",
+	"i already said",
+	"i told you",
+	"i already told",
+	"already mentioned",
+	"not helpful",
+	"not relevant",
+	"not useful",
+	"irrelevant",
+	"useless",
+	"doesn't help",
+	"didn't help",
+	"not related",
+	"doesn't work",
+	"didn't work",
+	"broken",
+	"still broken",
+	"that failed",
+	"forget that",
+	"ignore that",
+	"disregard",
+	"stop suggesting",
+	"don't show",
+];
+
+/** Mirror of feedback.rs `extract_entities_simple`. */
+export function extractTokens(text: string): Set<string> {
+	const tokens = new Set<string>();
+	for (const word of text.toLowerCase().split(/[^\p{L}\p{N}_]+/u)) {
+		if (word.length > 2) tokens.add(word);
+	}
+	return tokens;
+}
+
+/** Mirror of feedback.rs `calculate_entity_overlap`: |memory ∩ response| / |memory|. */
+export function memoryOverlap(memoryContent: string, responseTokens: Set<string>): number {
+	const memoryTokens = extractTokens(memoryContent);
+	if (memoryTokens.size === 0) return 0;
+	let intersection = 0;
+	for (const token of memoryTokens) {
+		if (responseTokens.has(token)) intersection += 1;
+	}
+	return intersection / memoryTokens.size;
+}
+
+/** Mirror of feedback.rs `detect_negative_keywords` (contains-match on lowercased text). */
+export function detectNegativeKeywords(text: string): string[] {
+	const lower = text.toLowerCase();
+	return NEGATIVE_KEYWORDS.filter((keyword) => lower.includes(keyword));
+}
+
+/**
+ * Inline citations the system prompt asks the model to emit when a recalled
+ * memory informs the answer: [mem:<first 8 hex chars of the id>].
+ */
+const CITATION_PATTERN = /\[mem:([0-9a-fA-F]{8})\]/g;
+
+/** Extract cited memory-id prefixes from a response. */
+export function extractCitations(text: string): Set<string> {
+	const cited = new Set<string>();
+	for (const match of text.matchAll(CITATION_PATTERN)) {
+		const prefix = match[1];
+		if (prefix) cited.add(prefix.toLowerCase());
+	}
+	return cited;
+}

--- a/seat/src/index.ts
+++ b/seat/src/index.ts
@@ -1,0 +1,79 @@
+/**
+ * Seat harness entry point.
+ */
+
+import * as fsp from "node:fs/promises";
+import { ShodhBackend } from "./backend.js";
+import { loadConfig, type McpServerConfig } from "./config.js";
+import { LearningLedger } from "./ledger.js";
+import { McpHost } from "./mcp.js";
+import { ModelRegistry } from "./models-registry.js";
+import { SeatServer } from "./server.js";
+
+async function loadMcpServers(configPath: string | undefined): Promise<McpServerConfig[]> {
+	if (!configPath) return [];
+	const raw = await fsp.readFile(configPath, "utf8");
+	const parsed = JSON.parse(raw) as { servers?: McpServerConfig[] };
+	if (!Array.isArray(parsed.servers)) {
+		throw new Error(`${configPath}: expected { "servers": [ { name, command, args?, env?, cwd? } ] }`);
+	}
+	for (const server of parsed.servers) {
+		if (!server.name || !server.command) {
+			throw new Error(`${configPath}: every server needs "name" and "command"`);
+		}
+	}
+	return parsed.servers;
+}
+
+async function main(): Promise<void> {
+	const config = loadConfig();
+	const backend = new ShodhBackend(config.apiUrl, config.apiKey, config.backendTimeoutMs);
+	const registry = new ModelRegistry(config);
+	const ledger = new LearningLedger(config.dataDir);
+	const mcpHost = new McpHost();
+
+	try {
+		const health = await backend.health();
+		console.log(`[seat] backend ${config.apiUrl} reachable (status: ${health.status})`);
+	} catch (error) {
+		console.warn(
+			`[seat] WARNING: backend ${config.apiUrl} not reachable yet — memory tools will fail until it is up. ` +
+				`(${error instanceof Error ? error.message : String(error)})`,
+		);
+	}
+
+	const localErrors = await registry.refreshLocal();
+	for (const [provider, message] of Object.entries(localErrors)) {
+		console.log(`[seat] local provider ${provider} offline: ${message}`);
+	}
+
+	const mcpServers = await loadMcpServers(config.mcpConfigPath);
+	if (mcpServers.length > 0) {
+		const mcpErrors = await mcpHost.connect(mcpServers);
+		for (const server of mcpHost.listServers()) {
+			console.log(`[seat] MCP server "${server.name}": ${server.tool_count} tools bridged`);
+		}
+		for (const [name, message] of Object.entries(mcpErrors)) {
+			console.warn(`[seat] MCP server "${name}" failed to connect: ${message}`);
+		}
+	}
+
+	const server = new SeatServer({ config, backend, registry, ledger, mcpHost });
+	await server.listen();
+	console.log(`[seat] listening on http://${config.host}:${config.port}`);
+	console.log(`[seat] learning ledger: ${ledger.file}`);
+
+	const shutdown = async (signal: string): Promise<void> => {
+		console.log(`[seat] ${signal} received, shutting down`);
+		await server.close();
+		await mcpHost.close();
+		process.exit(0);
+	};
+	process.on("SIGINT", () => void shutdown("SIGINT"));
+	process.on("SIGTERM", () => void shutdown("SIGTERM"));
+}
+
+main().catch((error) => {
+	console.error(`[seat] fatal: ${error instanceof Error ? error.message : String(error)}`);
+	process.exit(1);
+});

--- a/seat/src/ledger.ts
+++ b/seat/src/ledger.ts
@@ -1,0 +1,209 @@
+/**
+ * Learning ledger: every update the learning loops make to shodh-memory state
+ * is recorded as an append-only, reviewable, revertible event BEFORE the UI or
+ * anyone else has to ask "what changed and why".
+ *
+ * Design:
+ * - Append-only JSONL. Reverts are themselves appended events referencing the
+ *   original (`kind: "revert"`, data.of = original id); nothing is mutated.
+ * - Revert semantics are honest about what the backend supports:
+ *   - memory writes revert exactly (DELETE /api/memory/{id}).
+ *   - "helpful"/"misleading" reinforcements revert by applying the opposite
+ *     outcome through the same /api/reinforce path. The backend's momentum
+ *     update (EMA with inertia, src/memory/feedback.rs) is not exactly
+ *     invertible, so this is a compensating action, not a bitwise undo —
+ *     recorded as such in the revert event.
+ *   - "neutral" reinforcements record access only; there is nothing to
+ *     compensate, and the revert event says so.
+ */
+
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import type { ReinforceOutcome, ReinforceStats, ShodhBackend } from "./backend.js";
+import type { MemoryScope, ReinforceTrigger } from "./events.js";
+
+export interface MemoryWriteData {
+	memory_id: string;
+	memory_type: string;
+	content_preview: string;
+	trigger: "model_tool_call" | "empty_recall_capture" | "tool_error_capture";
+}
+
+export interface ReinforceData {
+	outcome: ReinforceOutcome;
+	memory_ids: string[];
+	trigger: ReinforceTrigger;
+	stats: ReinforceStats;
+}
+
+export interface RevertData {
+	of: string;
+	compensation:
+		| { kind: "memory_delete"; memory_id: string }
+		| { kind: "counter_reinforce"; outcome: ReinforceOutcome; memory_ids: string[]; stats: ReinforceStats }
+		| { kind: "none" };
+	note: string;
+}
+
+export type LedgerEntry =
+	| LedgerEntryBase<"memory_write", MemoryWriteData>
+	| LedgerEntryBase<"reinforce", ReinforceData>
+	| LedgerEntryBase<"revert", RevertData>;
+
+interface LedgerEntryBase<K extends string, D> {
+	id: string;
+	ts: string;
+	kind: K;
+	scope: MemoryScope;
+	/** The actual backend user_id the operation ran against (harness scope uses the derived namespace). */
+	user_id: string;
+	conversation_id: string;
+	turn: number;
+	data: D;
+}
+
+export interface LedgerEntryView {
+	entry: LedgerEntry;
+	reverted_by?: string;
+}
+
+export class LedgerError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "LedgerError";
+	}
+}
+
+export class LearningLedger {
+	private readonly filePath: string;
+	/** Serializes appends so entries never interleave. */
+	private writeChain: Promise<void> = Promise.resolve();
+
+	constructor(dataDir: string) {
+		fs.mkdirSync(dataDir, { recursive: true });
+		this.filePath = path.join(dataDir, "learning-ledger.jsonl");
+	}
+
+	get file(): string {
+		return this.filePath;
+	}
+
+	async append<K extends LedgerEntry["kind"]>(
+		kind: K,
+		scope: MemoryScope,
+		userId: string,
+		conversationId: string,
+		turn: number,
+		data: Extract<LedgerEntry, { kind: K }>["data"],
+	): Promise<LedgerEntry> {
+		const entry = {
+			id: crypto.randomUUID(),
+			ts: new Date().toISOString(),
+			kind,
+			scope,
+			user_id: userId,
+			conversation_id: conversationId,
+			turn,
+			data,
+		} as LedgerEntry;
+
+		const write = this.writeChain.then(() => fsp.appendFile(this.filePath, `${JSON.stringify(entry)}\n`, "utf8"));
+		// Keep the chain alive even if a write fails; the failure surfaces to the caller.
+		this.writeChain = write.catch(() => {});
+		await write;
+		return entry;
+	}
+
+	private async readAll(): Promise<LedgerEntry[]> {
+		let raw: string;
+		try {
+			raw = await fsp.readFile(this.filePath, "utf8");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+			throw error;
+		}
+		const entries: LedgerEntry[] = [];
+		for (const line of raw.split("\n")) {
+			const trimmed = line.trim();
+			if (!trimmed) continue;
+			try {
+				entries.push(JSON.parse(trimmed) as LedgerEntry);
+			} catch {
+				// A torn trailing line (crash mid-append) is skipped; everything
+				// before it is intact because appends are serialized.
+			}
+		}
+		return entries;
+	}
+
+	async list(options: { limit?: number; conversationId?: string } = {}): Promise<LedgerEntryView[]> {
+		const limit = options.limit ?? 100;
+		const entries = await this.readAll();
+		const revertedBy = new Map<string, string>();
+		for (const entry of entries) {
+			if (entry.kind === "revert") revertedBy.set(entry.data.of, entry.id);
+		}
+		const filtered = options.conversationId
+			? entries.filter((entry) => entry.conversation_id === options.conversationId)
+			: entries;
+		return filtered
+			.slice(-limit)
+			.reverse()
+			.map((entry) => ({
+				entry,
+				reverted_by: revertedBy.get(entry.id),
+			}));
+	}
+
+	async get(id: string): Promise<LedgerEntryView | undefined> {
+		const entries = await this.readAll();
+		const entry = entries.find((candidate) => candidate.id === id);
+		if (!entry) return undefined;
+		const revert = entries.find(
+			(candidate) => candidate.kind === "revert" && candidate.data.of === id,
+		);
+		return { entry, reverted_by: revert?.id };
+	}
+
+	/**
+	 * Revert a learning event by applying its compensating action through the
+	 * backend, then recording the revert as a new ledger event.
+	 */
+	async revert(id: string, backend: ShodhBackend): Promise<LedgerEntry> {
+		const view = await this.get(id);
+		if (!view) throw new LedgerError(`Unknown ledger event: ${id}`);
+		if (view.reverted_by) throw new LedgerError(`Event ${id} was already reverted by ${view.reverted_by}`);
+		const original = view.entry;
+		if (original.kind === "revert") throw new LedgerError("Revert events cannot be reverted");
+
+		let compensation: RevertData["compensation"];
+		let note: string;
+
+		if (original.kind === "memory_write") {
+			await backend.deleteMemory(original.user_id, original.data.memory_id);
+			compensation = { kind: "memory_delete", memory_id: original.data.memory_id };
+			note = "Exact revert: the written memory was deleted.";
+		} else {
+			const outcome = original.data.outcome;
+			if (outcome === "neutral") {
+				compensation = { kind: "none" };
+				note = "Neutral reinforcement records access only; no compensating action exists.";
+			} else {
+				const inverse: ReinforceOutcome = outcome === "helpful" ? "misleading" : "helpful";
+				const stats = await backend.reinforce(original.user_id, original.data.memory_ids, inverse);
+				compensation = { kind: "counter_reinforce", outcome: inverse, memory_ids: original.data.memory_ids, stats };
+				note =
+					"Compensating action: opposite outcome applied via /api/reinforce. " +
+					"The backend momentum update (EMA with inertia) is not exactly invertible.";
+			}
+		}
+
+		return this.append("revert", original.scope, original.user_id, original.conversation_id, original.turn, {
+			of: original.id,
+			compensation,
+			note,
+		});
+	}
+}

--- a/seat/src/mcp.ts
+++ b/seat/src/mcp.ts
@@ -1,0 +1,138 @@
+/**
+ * MCP → agent-loop bridge.
+ *
+ * pi has no MCP client (packages/agent/src contains none; pi's README states
+ * "No MCP" explicitly), so this bridge is ours: it connects to MCP servers
+ * over stdio and exposes their tools as pi `AgentTool`s.
+ *
+ * Schema note: MCP tools publish plain JSON Schema. pi's tool-argument
+ * validation handles non-TypeBox schemas explicitly
+ * (packages/ai/src/utils/validation.ts `validateToolArguments`, TYPEBOX_KIND
+ * branch), so the inputSchema passes through unchanged.
+ *
+ * Tool names follow the mcp__<server>__<tool> convention used across this
+ * repository's tooling.
+ */
+
+import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
+import type { TSchema } from "@earendil-works/pi-ai";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { getDefaultEnvironment, StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
+import type { McpServerConfig } from "./config.js";
+
+interface ConnectedServer {
+	name: string;
+	client: Client;
+	tools: AgentTool<any>[];
+}
+
+const NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const CALL_TIMEOUT_MS = 120_000;
+
+function mapContent(content: unknown): (TextContent | ImageContent)[] {
+	if (!Array.isArray(content)) return [{ type: "text", text: "" }];
+	const mapped: (TextContent | ImageContent)[] = [];
+	for (const block of content) {
+		if (block && typeof block === "object" && "type" in block) {
+			const typed = block as { type: string; text?: string; data?: string; mimeType?: string };
+			if (typed.type === "text" && typeof typed.text === "string") {
+				mapped.push({ type: "text", text: typed.text });
+				continue;
+			}
+			if (typed.type === "image" && typeof typed.data === "string" && typeof typed.mimeType === "string") {
+				mapped.push({ type: "image", data: typed.data, mimeType: typed.mimeType });
+				continue;
+			}
+		}
+		mapped.push({ type: "text", text: JSON.stringify(block) });
+	}
+	return mapped.length > 0 ? mapped : [{ type: "text", text: "" }];
+}
+
+function toAgentTool(serverName: string, client: Client, tool: {
+	name: string;
+	description?: string;
+	inputSchema: unknown;
+	title?: string;
+}): AgentTool<any> {
+	return {
+		name: `mcp__${serverName}__${tool.name}`,
+		label: tool.title ?? tool.name,
+		description: tool.description ?? `${tool.name} (MCP tool from ${serverName})`,
+		// Plain JSON Schema; pi validates it via its non-TypeBox branch.
+		parameters: (tool.inputSchema ?? { type: "object", properties: {} }) as TSchema,
+		execute: async (_toolCallId, params, signal): Promise<AgentToolResult<unknown>> => {
+			const result = await client.callTool(
+				{ name: tool.name, arguments: (params ?? {}) as Record<string, unknown> },
+				undefined,
+				{ timeout: CALL_TIMEOUT_MS, signal },
+			);
+			const content = mapContent(result.content);
+			if (result.isError) {
+				const text = content
+					.map((block) => (block.type === "text" ? block.text : "<image>"))
+					.join("\n")
+					.trim();
+				throw new Error(text || `MCP tool ${tool.name} failed`);
+			}
+			return {
+				content,
+				details: result.structuredContent ?? undefined,
+			};
+		},
+	};
+}
+
+export class McpHost {
+	private servers: ConnectedServer[] = [];
+
+	/**
+	 * Connect to each configured server. Per-server failures are collected and
+	 * reported, not fatal: one broken server must not take the seat down.
+	 */
+	async connect(configs: McpServerConfig[]): Promise<Record<string, string>> {
+		const errors: Record<string, string> = {};
+		for (const config of configs) {
+			if (!NAME_PATTERN.test(config.name)) {
+				errors[config.name] = `Invalid server name "${config.name}" (allowed: [a-zA-Z0-9_-]+)`;
+				continue;
+			}
+			if (this.servers.some((server) => server.name === config.name)) {
+				errors[config.name] = "Duplicate server name";
+				continue;
+			}
+			try {
+				const client = new Client({ name: "shodh-seat-harness", version: "0.1.0" });
+				const transport = new StdioClientTransport({
+					command: config.command,
+					args: config.args ?? [],
+					env: { ...getDefaultEnvironment(), ...(config.env ?? {}) },
+					cwd: config.cwd,
+					stderr: "ignore",
+				});
+				await client.connect(transport);
+				const listed = await client.listTools();
+				const tools = listed.tools.map((tool) => toAgentTool(config.name, client, tool));
+				this.servers.push({ name: config.name, client, tools });
+			} catch (error) {
+				errors[config.name] = error instanceof Error ? error.message : String(error);
+			}
+		}
+		return errors;
+	}
+
+	/** All bridged tools across connected servers. */
+	getTools(): AgentTool<any>[] {
+		return this.servers.flatMap((server) => server.tools);
+	}
+
+	listServers(): { name: string; tool_count: number }[] {
+		return this.servers.map((server) => ({ name: server.name, tool_count: server.tools.length }));
+	}
+
+	async close(): Promise<void> {
+		await Promise.allSettled(this.servers.map((server) => server.client.close()));
+		this.servers = [];
+	}
+}

--- a/seat/src/memory-tools.ts
+++ b/seat/src/memory-tools.ts
@@ -1,0 +1,248 @@
+/**
+ * shodh-memory as first-class agent tools.
+ *
+ * These are native tools over the Rust backend's HTTP API (not MCP-framed
+ * text): recall runs with debug:true so every result carries per-memory
+ * ScoreAttribution, and every operation is emitted as a structured SeatEvent
+ * the UI renders as its own element. Memory operations are never opaque.
+ */
+
+import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
+import { Type } from "@earendil-works/pi-ai";
+import type { MemoryType, RecallMemory, RecallMode, ShodhBackend } from "./backend.js";
+import type { MemoryScope, SeatEvent } from "./events.js";
+import type { LearningLedger } from "./ledger.js";
+
+export interface MemoryToolContext {
+	backend: ShodhBackend;
+	/** The person's memory namespace. */
+	userId: string;
+	/** The harness's own isolated namespace (separate RocksDB + graph per user_id). */
+	harnessUserId: string;
+	conversationId: string;
+	getTurn(): number;
+	emit(event: SeatEvent): void;
+	/** Register memories surfaced this turn so the turn-end loop can reinforce them. */
+	onSurfaced(scope: MemoryScope, memories: { id: string; content: string }[]): void;
+	/** A recall came back empty — candidate harness learning. */
+	onEmptyRecall(query: string): void;
+	ledger: LearningLedger;
+}
+
+const RECALL_MODES: RecallMode[] = [
+	"hybrid",
+	"semantic",
+	"associative",
+	"temporal",
+	"causal",
+	"spatial",
+];
+
+const recallParameters = Type.Object({
+	query: Type.String({
+		minLength: 1,
+		maxLength: 2000,
+		description: "Natural-language cue. Entity names and concrete terms retrieve better than abstractions.",
+	}),
+	limit: Type.Optional(
+		Type.Integer({ minimum: 1, maximum: 20, description: "Maximum memories to retrieve (default 5)." }),
+	),
+	mode: Type.Optional(
+		Type.Union(
+			RECALL_MODES.map((mode) => Type.Literal(mode)),
+			{ description: "Retrieval mode (default hybrid: vector + BM25 + graph fusion)." },
+		),
+	),
+});
+
+const rememberParameters = Type.Object({
+	content: Type.String({ minLength: 3, maxLength: 10000, description: "The content to remember." }),
+	memory_type: Type.Optional(
+		Type.Union(
+			(["observation", "decision", "learning", "error", "discovery", "pattern", "context", "task"] as const).map(
+				(memoryType) => Type.Literal(memoryType),
+			),
+			{ description: "Memory type (default observation)." },
+		),
+	),
+	tags: Type.Optional(Type.Array(Type.String({ minLength: 1, maxLength: 100 }), { maxItems: 10 })),
+});
+
+const seatLearningParameters = Type.Object({
+	learning: Type.String({
+		minLength: 10,
+		maxLength: 2000,
+		description: "The operational lesson, stated so it is actionable the next time the situation recurs.",
+	}),
+	kind: Type.Optional(
+		Type.Union([Type.Literal("learning"), Type.Literal("pattern"), Type.Literal("error")], {
+			description: "Lesson category (default learning).",
+		}),
+	),
+	tags: Type.Optional(Type.Array(Type.String({ minLength: 1, maxLength: 100 }), { maxItems: 8 })),
+});
+
+function shortId(memoryId: string): string {
+	return memoryId.replace(/-/g, "").slice(0, 8);
+}
+
+function formatMemoryForModel(memory: RecallMemory, index: number): string {
+	const memoryType = memory.experience.memory_type ?? "Observation";
+	const content =
+		memory.experience.content.length > 600
+			? `${memory.experience.content.slice(0, 600)}…`
+			: memory.experience.content;
+	return `${index + 1}. [mem:${shortId(memory.id)}] (${memoryType}, score ${memory.score.toFixed(2)}) ${content}`;
+}
+
+function textResult<T>(text: string, details: T): AgentToolResult<T> {
+	return { content: [{ type: "text", text }], details };
+}
+
+export function createMemoryTools(context: MemoryToolContext): AgentTool<any>[] {
+	const recallTool: AgentTool<typeof recallParameters> = {
+		name: "recall_memory",
+		label: "Recall memory",
+		description:
+			"Search the user's persistent memory (vector + BM25 + knowledge-graph fusion). " +
+			"Returns memories with ids and scores, plus related facts and todos. " +
+			"When a recalled memory informs your answer, cite it inline as [mem:<id>] using the id shown.",
+		parameters: recallParameters,
+		execute: async (toolCallId, params) => {
+			const startedAt = Date.now();
+			const mode = params.mode ?? "hybrid";
+			const response = await context.backend.recall({
+				userId: context.userId,
+				query: params.query,
+				limit: params.limit ?? 5,
+				mode,
+				debug: true,
+			});
+			const tookMs = Date.now() - startedAt;
+
+			context.onSurfaced(
+				"user",
+				response.memories.map((memory) => ({ id: memory.id, content: memory.experience.content })),
+			);
+			context.emit({
+				type: "memory_recall",
+				scope: "user",
+				tool_call_id: toolCallId,
+				query: params.query,
+				mode,
+				memories: response.memories,
+				facts: response.facts ?? [],
+				todos: response.todos ?? [],
+				lineage: response.lineage ?? [],
+				took_ms: tookMs,
+			});
+
+			if (response.memories.length === 0) {
+				context.onEmptyRecall(params.query);
+				return textResult(
+					"No memories matched this cue. Consider retrying with concrete entity names or a broader phrasing.",
+					response,
+				);
+			}
+
+			const lines: string[] = [`Found ${response.memories.length} memories:`];
+			response.memories.forEach((memory, index) => lines.push(formatMemoryForModel(memory, index)));
+			if (response.facts && response.facts.length > 0) {
+				lines.push("Related facts:");
+				for (const fact of response.facts.slice(0, 5)) {
+					lines.push(`- ${fact.fact} (confidence ${fact.confidence.toFixed(2)})`);
+				}
+			}
+			if (response.todos && response.todos.length > 0) {
+				lines.push("Related todos:");
+				for (const todo of response.todos.slice(0, 5)) {
+					lines.push(`- [${todo.status}] ${todo.content}`);
+				}
+			}
+			return textResult(lines.join("\n"), response);
+		},
+	};
+
+	const rememberTool: AgentTool<typeof rememberParameters> = {
+		name: "remember_memory",
+		label: "Remember",
+		description:
+			"Store a durable memory for the user. Use sparingly, for high-value facts, decisions, and learnings — " +
+			"not for conversational filler.",
+		parameters: rememberParameters,
+		execute: async (_toolCallId, params) => {
+			const memoryType = (params.memory_type ?? "observation") as MemoryType;
+			const response = await context.backend.remember({
+				userId: context.userId,
+				content: params.content,
+				memoryType,
+				tags: params.tags ?? [],
+			});
+			const ledgerEntry = await context.ledger.append(
+				"memory_write",
+				"user",
+				context.userId,
+				context.conversationId,
+				context.getTurn(),
+				{
+					memory_id: response.id,
+					memory_type: memoryType,
+					content_preview: params.content.slice(0, 200),
+					trigger: "model_tool_call",
+				},
+			);
+			context.emit({
+				type: "memory_write",
+				scope: "user",
+				memory_id: response.id,
+				memory_type: memoryType,
+				content_preview: params.content.slice(0, 200),
+				ledger_event_id: ledgerEntry.id,
+			});
+			return textResult(`Remembered as [mem:${shortId(response.id)}].`, { memory_id: response.id });
+		},
+	};
+
+	const seatLearningTool: AgentTool<typeof seatLearningParameters> = {
+		name: "record_seat_learning",
+		label: "Record seat learning",
+		description:
+			"Record an operational lesson about how this assistant should retrieve, phrase cues, or use tools — " +
+			"stored in the harness's own memory scope, never in the user's. " +
+			"Never store user content or conversation facts here; use remember_memory for those.",
+		parameters: seatLearningParameters,
+		execute: async (_toolCallId, params) => {
+			const memoryType = (params.kind ?? "learning") as MemoryType;
+			const response = await context.backend.remember({
+				userId: context.harnessUserId,
+				content: params.learning,
+				memoryType,
+				tags: ["seat-harness", ...(params.tags ?? [])],
+			});
+			const ledgerEntry = await context.ledger.append(
+				"memory_write",
+				"harness",
+				context.harnessUserId,
+				context.conversationId,
+				context.getTurn(),
+				{
+					memory_id: response.id,
+					memory_type: memoryType,
+					content_preview: params.learning.slice(0, 200),
+					trigger: "model_tool_call",
+				},
+			);
+			context.emit({
+				type: "memory_write",
+				scope: "harness",
+				memory_id: response.id,
+				memory_type: memoryType,
+				content_preview: params.learning.slice(0, 200),
+				ledger_event_id: ledgerEntry.id,
+			});
+			return textResult("Seat learning recorded.", { memory_id: response.id });
+		},
+	};
+
+	return [recallTool, rememberTool, seatLearningTool];
+}

--- a/seat/src/models-registry.ts
+++ b/seat/src/models-registry.ts
@@ -1,0 +1,160 @@
+/**
+ * Model registry: pi's full built-in provider catalog plus local
+ * OpenAI-compatible endpoints (Ollama, LM Studio) as first-class providers.
+ *
+ * pi ships no local-model provider (packages/ai/src/providers/ has none), but
+ * every `Model` carries its own `baseUrl` (packages/ai/src/types.ts) and the
+ * openai-completions API implementation uses it directly
+ * (packages/ai/src/api/openai-completions.ts → `baseURL: model.baseUrl`), so a
+ * local endpoint is just a custom provider built with `createProvider` +
+ * `openAICompletionsApi()` and dynamic model discovery via GET {baseUrl}/models.
+ *
+ * Provider API keys resolve from environment variables inside this process
+ * (pi's env auth). They are never sent to, or readable by, any client.
+ */
+
+import {
+	type Api,
+	createProvider,
+	type Model,
+	type MutableModels,
+	type Provider,
+	type RefreshModelsContext,
+} from "@earendil-works/pi-ai";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+import { builtinModels } from "@earendil-works/pi-ai/providers/all";
+import type { SeatConfig } from "./config.js";
+
+export interface ModelInfo {
+	provider: string;
+	id: string;
+	name: string;
+	context_window: number;
+	max_tokens: number;
+	reasoning: boolean;
+	local: boolean;
+}
+
+const LOCAL_PROVIDER_IDS = ["ollama", "lmstudio"] as const;
+
+interface LocalProviderOptions {
+	id: (typeof LOCAL_PROVIDER_IDS)[number];
+	name: string;
+	baseUrl: string;
+	contextWindow: number;
+	maxTokens: number;
+}
+
+/** Response shape of the OpenAI-compatible model listing endpoint (GET /v1/models). */
+interface OpenAiModelList {
+	data?: { id?: unknown }[];
+}
+
+function localModel(options: LocalProviderOptions, id: string): Model<"openai-completions"> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: options.id,
+		baseUrl: options.baseUrl,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: options.contextWindow,
+		maxTokens: options.maxTokens,
+	};
+}
+
+async function fetchLocalModels(
+	options: LocalProviderOptions,
+	context: RefreshModelsContext,
+): Promise<readonly Model<"openai-completions">[]> {
+	const response = await fetch(`${options.baseUrl}/models`, {
+		signal: AbortSignal.any([context.signal, AbortSignal.timeout(5000)]),
+	});
+	if (!response.ok) {
+		throw new Error(`${options.name} model listing failed: HTTP ${response.status}`);
+	}
+	const payload = (await response.json()) as OpenAiModelList;
+	const ids = (payload.data ?? [])
+		.map((entry) => entry.id)
+		.filter((id): id is string => typeof id === "string" && id.length > 0);
+	return ids.map((id) => localModel(options, id));
+}
+
+function localProvider(options: LocalProviderOptions): Provider<"openai-completions"> {
+	return createProvider<"openai-completions">({
+		id: options.id,
+		name: options.name,
+		baseUrl: options.baseUrl,
+		auth: {
+			// Keyless local endpoint: resolve always succeeds so the provider is
+			// "configured"; the placeholder key satisfies clients that require
+			// a bearer token (Ollama and LM Studio both ignore it).
+			apiKey: {
+				name: `${options.name} endpoint`,
+				resolve: async () => ({ auth: { apiKey: "local" }, source: "local endpoint (keyless)" }),
+			},
+		},
+		models: [],
+		fetchModels: (context) => fetchLocalModels(options, context),
+		api: openAICompletionsApi(),
+	});
+}
+
+export class ModelRegistry {
+	readonly models: MutableModels;
+
+	constructor(config: SeatConfig) {
+		this.models = builtinModels();
+		this.models.setProvider(
+			localProvider({
+				id: "ollama",
+				name: "Ollama",
+				baseUrl: config.ollamaBaseUrl,
+				contextWindow: config.localContextWindow,
+				maxTokens: config.localMaxTokens,
+			}),
+		);
+		this.models.setProvider(
+			localProvider({
+				id: "lmstudio",
+				name: "LM Studio",
+				baseUrl: config.lmStudioBaseUrl,
+				contextWindow: config.localContextWindow,
+				maxTokens: config.localMaxTokens,
+			}),
+		);
+	}
+
+	/**
+	 * Refresh local-endpoint model listings. Errors are returned, not thrown:
+	 * an offline Ollama must not take the seat down.
+	 */
+	async refreshLocal(): Promise<Record<string, string>> {
+		const result = await this.models.refresh({ providers: [...LOCAL_PROVIDER_IDS] });
+		const errors: Record<string, string> = {};
+		for (const [provider, error] of result.errors) {
+			errors[provider] = error.message;
+		}
+		return errors;
+	}
+
+	/** Models whose providers have working auth (env keys present, or local). */
+	async listAvailable(): Promise<ModelInfo[]> {
+		const available = await this.models.getAvailable();
+		return available.map((model) => ({
+			provider: model.provider,
+			id: model.id,
+			name: model.name,
+			context_window: model.contextWindow,
+			max_tokens: model.maxTokens,
+			reasoning: model.reasoning,
+			local: (LOCAL_PROVIDER_IDS as readonly string[]).includes(model.provider),
+		}));
+	}
+
+	resolve(provider: string, id: string): Model<Api> | undefined {
+		return this.models.getModel(provider, id);
+	}
+}

--- a/seat/src/server.ts
+++ b/seat/src/server.ts
@@ -1,0 +1,349 @@
+/**
+ * Seat HTTP server (node:http, no framework).
+ *
+ * Endpoints:
+ *   GET    /healthz
+ *   GET    /v1/models[?refresh=1]
+ *   POST   /v1/conversations                      { user_id, provider, model, system_prompt? }
+ *   GET    /v1/conversations/{id}
+ *   POST   /v1/conversations/{id}/messages        { text }  → SSE stream of SeatEvents
+ *   PATCH  /v1/conversations/{id}/model           { provider, model }
+ *   GET    /v1/learning/events[?limit&conversation_id]
+ *   POST   /v1/learning/revert                    { event_id }
+ *
+ * Auth: optional bearer token (mandatory for non-loopback binds, enforced at
+ * config load). Provider credentials never appear in any response or event.
+ */
+
+import * as http from "node:http";
+import type { ShodhBackend } from "./backend.js";
+import type { SeatConfig } from "./config.js";
+import { Conversation, ConversationBusyError, type ConversationDeps, UnknownModelError } from "./conversation.js";
+import type { SeatEvent } from "./events.js";
+import { LedgerError, type LearningLedger } from "./ledger.js";
+import type { McpHost } from "./mcp.js";
+import type { ModelRegistry } from "./models-registry.js";
+
+const MAX_BODY_BYTES = 1_048_576;
+const SSE_HEARTBEAT_MS = 15_000;
+
+interface CreateConversationBody {
+	user_id?: string;
+	provider?: string;
+	model?: string;
+	system_prompt?: string;
+}
+
+class HttpError extends Error {
+	readonly status: number;
+
+	constructor(status: number, message: string) {
+		super(message);
+		this.status = status;
+	}
+}
+
+function readBody(request: http.IncomingMessage): Promise<string> {
+	return new Promise((resolve, reject) => {
+		let size = 0;
+		const chunks: Buffer[] = [];
+		request.on("data", (chunk: Buffer) => {
+			size += chunk.length;
+			if (size > MAX_BODY_BYTES) {
+				reject(new HttpError(413, "Request body too large"));
+				request.destroy();
+				return;
+			}
+			chunks.push(chunk);
+		});
+		request.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+		request.on("error", reject);
+	});
+}
+
+function parseJson<T>(raw: string): T {
+	if (!raw.trim()) throw new HttpError(400, "Empty request body");
+	try {
+		return JSON.parse(raw) as T;
+	} catch {
+		throw new HttpError(400, "Invalid JSON body");
+	}
+}
+
+function sendJson(response: http.ServerResponse, status: number, payload: unknown): void {
+	const body = JSON.stringify(payload);
+	response.writeHead(status, {
+		"Content-Type": "application/json; charset=utf-8",
+		"Content-Length": Buffer.byteLength(body),
+	});
+	response.end(body);
+}
+
+export interface SeatServerDeps {
+	config: SeatConfig;
+	backend: ShodhBackend;
+	registry: ModelRegistry;
+	ledger: LearningLedger;
+	mcpHost: McpHost;
+}
+
+export class SeatServer {
+	private readonly deps: SeatServerDeps;
+	private readonly conversations = new Map<string, Conversation>();
+	private readonly server: http.Server;
+
+	constructor(deps: SeatServerDeps) {
+		this.deps = deps;
+		this.server = http.createServer((request, response) => {
+			this.route(request, response).catch((error) => {
+				const status = error instanceof HttpError ? error.status : 500;
+				const message = error instanceof Error ? error.message : String(error);
+				if (!response.headersSent) {
+					sendJson(response, status, { error: message });
+				} else {
+					response.end();
+				}
+			});
+		});
+	}
+
+	listen(): Promise<void> {
+		return new Promise((resolve, reject) => {
+			this.server.once("error", reject);
+			this.server.listen(this.deps.config.port, this.deps.config.host, () => resolve());
+		});
+	}
+
+	close(): Promise<void> {
+		return new Promise((resolve) => {
+			for (const conversation of this.conversations.values()) conversation.abort();
+			this.server.close(() => resolve());
+		});
+	}
+
+	private authorize(request: http.IncomingMessage): void {
+		const token = this.deps.config.authToken;
+		if (!token) return;
+		const header = request.headers.authorization ?? "";
+		if (header !== `Bearer ${token}`) throw new HttpError(401, "Unauthorized");
+	}
+
+	private conversation(id: string): Conversation {
+		const conversation = this.conversations.get(id);
+		if (!conversation) throw new HttpError(404, `Unknown conversation: ${id}`);
+		return conversation;
+	}
+
+	private async route(request: http.IncomingMessage, response: http.ServerResponse): Promise<void> {
+		const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`);
+		const method = request.method ?? "GET";
+		const segments = url.pathname.split("/").filter(Boolean);
+
+		if (method === "GET" && url.pathname === "/healthz") {
+			await this.handleHealth(response);
+			return;
+		}
+
+		this.authorize(request);
+
+		if (method === "GET" && url.pathname === "/v1/models") {
+			await this.handleModels(url, response);
+			return;
+		}
+		if (method === "POST" && url.pathname === "/v1/conversations") {
+			await this.handleCreateConversation(request, response);
+			return;
+		}
+		if (segments[0] === "v1" && segments[1] === "conversations" && segments[2]) {
+			const conversation = this.conversation(segments[2]);
+			if (method === "GET" && segments.length === 3) {
+				sendJson(response, 200, {
+					conversation_id: conversation.id,
+					user_id: conversation.userId,
+					harness_user_id: conversation.harnessUserId,
+					model: conversation.model,
+					created_at: conversation.createdAt.toISOString(),
+					busy: conversation.isStreaming,
+					messages: conversation.transcript(),
+				});
+				return;
+			}
+			if (method === "POST" && segments[3] === "messages" && segments.length === 4) {
+				await this.handleMessage(conversation, request, response);
+				return;
+			}
+			if (method === "PATCH" && segments[3] === "model" && segments.length === 4) {
+				await this.handleModelChange(conversation, request, response);
+				return;
+			}
+		}
+		if (method === "GET" && url.pathname === "/v1/learning/events") {
+			const limitParam = url.searchParams.get("limit");
+			const limit = limitParam ? Number.parseInt(limitParam, 10) : 100;
+			if (!Number.isFinite(limit) || limit <= 0 || limit > 1000) {
+				throw new HttpError(400, "limit must be an integer in [1, 1000]");
+			}
+			const events = await this.deps.ledger.list({
+				limit,
+				conversationId: url.searchParams.get("conversation_id") ?? undefined,
+			});
+			sendJson(response, 200, { events });
+			return;
+		}
+		if (method === "POST" && url.pathname === "/v1/learning/revert") {
+			await this.handleRevert(request, response);
+			return;
+		}
+
+		throw new HttpError(404, `No route: ${method} ${url.pathname}`);
+	}
+
+	private async handleHealth(response: http.ServerResponse): Promise<void> {
+		let backend: { ok: boolean; detail: string };
+		try {
+			const health = await this.deps.backend.health();
+			backend = { ok: health.status === "ok" || health.status === "healthy", detail: health.status };
+		} catch (error) {
+			backend = { ok: false, detail: error instanceof Error ? error.message : String(error) };
+		}
+		sendJson(response, backend.ok ? 200 : 503, {
+			seat: "ok",
+			backend,
+			conversations: this.conversations.size,
+			mcp_servers: this.deps.mcpHost.listServers(),
+		});
+	}
+
+	private async handleModels(url: URL, response: http.ServerResponse): Promise<void> {
+		let localErrors: Record<string, string> = {};
+		if (url.searchParams.get("refresh")) {
+			localErrors = await this.deps.registry.refreshLocal();
+		}
+		const models = await this.deps.registry.listAvailable();
+		sendJson(response, 200, { models, local_errors: localErrors });
+	}
+
+	private async handleCreateConversation(
+		request: http.IncomingMessage,
+		response: http.ServerResponse,
+	): Promise<void> {
+		const body = parseJson<CreateConversationBody>(await readBody(request));
+		if (!body.user_id || typeof body.user_id !== "string") throw new HttpError(400, "user_id is required");
+		if (!body.provider || typeof body.provider !== "string") throw new HttpError(400, "provider is required");
+		if (!body.model || typeof body.model !== "string") throw new HttpError(400, "model is required");
+
+		const model = this.deps.registry.resolve(body.provider, body.model);
+		if (!model) throw new HttpError(400, `Unknown model: ${body.provider}/${body.model}`);
+
+		const deps: ConversationDeps = {
+			backend: this.deps.backend,
+			registry: this.deps.registry,
+			ledger: this.deps.ledger,
+			mcpTools: this.deps.mcpHost.getTools(),
+		};
+		let conversation: Conversation;
+		try {
+			conversation = new Conversation(deps, {
+				userId: body.user_id,
+				model,
+				systemPrompt: typeof body.system_prompt === "string" ? body.system_prompt : undefined,
+			});
+		} catch (error) {
+			throw new HttpError(400, error instanceof Error ? error.message : String(error));
+		}
+		this.conversations.set(conversation.id, conversation);
+		sendJson(response, 201, {
+			conversation_id: conversation.id,
+			user_id: conversation.userId,
+			harness_user_id: conversation.harnessUserId,
+			model: conversation.model,
+		});
+	}
+
+	private async handleMessage(
+		conversation: Conversation,
+		request: http.IncomingMessage,
+		response: http.ServerResponse,
+	): Promise<void> {
+		const body = parseJson<{ text?: string }>(await readBody(request));
+		if (!body.text || typeof body.text !== "string" || !body.text.trim()) {
+			throw new HttpError(400, "text is required");
+		}
+		if (conversation.isStreaming) throw new HttpError(409, "Conversation is busy");
+
+		response.writeHead(200, {
+			"Content-Type": "text/event-stream; charset=utf-8",
+			"Cache-Control": "no-cache, no-transform",
+			Connection: "keep-alive",
+			"X-Accel-Buffering": "no",
+		});
+		response.write("retry: 5000\n\n");
+
+		const heartbeat = setInterval(() => {
+			if (!response.writableEnded) response.write(": ping\n\n");
+		}, SSE_HEARTBEAT_MS);
+
+		// A destroyed response must never take the agent loop down: writes are
+		// guarded and stream errors are absorbed (the disconnect handler below
+		// aborts the run).
+		response.on("error", () => {});
+		const sink = (event: SeatEvent): void => {
+			if (response.writableEnded || response.destroyed) return;
+			try {
+				response.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+			} catch {
+				// Socket torn down mid-write; the close handler aborts the run.
+			}
+		};
+
+		let clientGone = false;
+		request.on("close", () => {
+			if (!response.writableEnded) {
+				clientGone = true;
+				conversation.abort();
+			}
+		});
+
+		try {
+			await conversation.sendMessage(body.text, sink);
+		} catch (error) {
+			if (error instanceof ConversationBusyError) {
+				sink({ type: "error", message: error.message });
+			} else if (!clientGone) {
+				sink({ type: "error", message: error instanceof Error ? error.message : String(error) });
+			}
+		} finally {
+			clearInterval(heartbeat);
+			if (!response.writableEnded) response.end();
+		}
+	}
+
+	private async handleModelChange(
+		conversation: Conversation,
+		request: http.IncomingMessage,
+		response: http.ServerResponse,
+	): Promise<void> {
+		const body = parseJson<{ provider?: string; model?: string }>(await readBody(request));
+		if (!body.provider || !body.model) throw new HttpError(400, "provider and model are required");
+		try {
+			const model = conversation.setModel(body.provider, body.model);
+			sendJson(response, 200, { model });
+		} catch (error) {
+			if (error instanceof UnknownModelError) throw new HttpError(400, error.message);
+			if (error instanceof ConversationBusyError) throw new HttpError(409, error.message);
+			throw error;
+		}
+	}
+
+	private async handleRevert(request: http.IncomingMessage, response: http.ServerResponse): Promise<void> {
+		const body = parseJson<{ event_id?: string }>(await readBody(request));
+		if (!body.event_id || typeof body.event_id !== "string") throw new HttpError(400, "event_id is required");
+		try {
+			const revertEntry = await this.deps.ledger.revert(body.event_id, this.deps.backend);
+			sendJson(response, 200, { revert: revertEntry });
+		} catch (error) {
+			if (error instanceof LedgerError) throw new HttpError(409, error.message);
+			throw error;
+		}
+	}
+}

--- a/seat/tsconfig.json
+++ b/seat/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
A TypeScript service (`seat/`) that owns the agent loop, built on `@earendil-works/pi-agent-core` and `@earendil-works/pi-ai`.

### Verified about pi before building (file:line in the report, not assumed)

- **Local models work without a fork.** `baseUrl` is a required field on every `Model` (`packages/ai/src/types.ts:790`), dialled directly by the OpenAI-compat implementation. Ollama and LM Studio are registered as custom providers with keyless auth and discovery via `GET {baseUrl}/models`.
- **pi has no MCP client, deliberately** — its README says so outright. The bridge is `seat/src/mcp.ts`. pi's tool-argument validator handles plain JSON Schema, so MCP `inputSchema` passes through unmodified.
- **Streaming is first-class**, with token usage and cost on every assistant message — no separate telemetry dependency needed.
- pi ships ~40 providers, not the handful an alphabetically-truncated listing suggested.

### Memory operations are first-class, not opaque

Recall runs with `debug:true` and emits a `memory_recall` SSE event carrying ids, scores, full `ScoreAttribution`, facts, todos and lineage. The system prompt asks for inline `[mem:id]` citations. This is the point of the service: memory operations must be renderable as their own UI element, never buried in an `execute` cell.

### Two learning loops

**Memory-level** — surfaced memories reinforced through the existing `POST /api/reinforce`, with outcome decided by citation or entity overlap mirroring `src/memory/feedback.rs`. Momentum additionally moves via `POST /api/proactive_context`, which is the only handler that writes it.

**Harness-level** — lessons stored **as memories** in a `<user_id>.seat-harness` scope, recalled before each turn and injected. One substrate, two scopes. Isolation is by `user_id` namespacing because `get_user_memory` keys every store — RocksDB, knowledge graph, feedback state — by a per-user directory, so harness writes cannot pollute a user's co-activation weights.

### Care taken around the feedback path

- `auto_ingest` is explicitly `false` and **required** on the client type: auto-ingest writes memories with no ledger entry, which would violate the invariant that every learning update is reviewable and revertible.
- Double-counting avoided by id-level signal ownership — `proactive_context` itself calls `reinforce_recall`, so it is a full second reinforcement caller, not a momentum-only path.
- The implicit loop penalises surfaced-but-unused memories, so every proactive-surfaced memory is injected: the pending set equals the seen set. Otherwise memories that were never shown would be punished for not being used.

### Ledger

Append-only JSONL; every write and reinforcement recorded before the turn completes, with a revert endpoint. Honest semantics: writes revert exactly, reinforcements are EMA-with-inertia and therefore **not invertible**, so revert compensates with an opposite signal and the event says so.

### Known limitation

Memories surfaced only by the `recall_memory` tool still receive no momentum — the backend ties momentum exclusively to its own pending-set lifecycle. Closing that is a Rust change; forcing it from the harness would corrupt the single pending slot.

### Not built

Conversation persistence (transcripts are in-memory per process), no Python kernel, no package-style skills, no recursive sub-agents.

### Verification

Typecheck and build clean; server boots; SSE pipeline, model registry, ledger and error paths exercised live. **Not tested against a running backend or with real provider credentials.**

Also flags a likely off-by-one in `mcp-server/index.ts:2844`: it sends the *previous* user message as `user_followup`, but that field means the message *after* the agent response and feeds negative-keyword detection. Not touched here — separate fix.