### PR TITLE
ci(recall): hermetic MiniLM provisioning — close the last HF-download flake in the recall gate

### DIFF
--- a/.github/workflows/recall.yml
+++ b/.github/workflows/recall.yml
@@ -100,6 +100,40 @@ jobs:
           gh release download gliner-bi-edge-onnx-v1 --repo "$GITHUB_REPOSITORY" --dir models/gliner-bi-edge
           ls -la models/gliner-bi-edge
 
+      # Pre-supply the MiniLM embedder the same way ci.yml's Build job does
+      # (shared cache keys — a warm cache means neither workflow touches
+      # HuggingFace). Without this the eval binary downloads MiniLM at runtime,
+      # and one HF hiccup fails the gate as `infrastructure` — which is exactly
+      # how run 31227613424 went red on a PR whose quality deltas were +0.0000.
+      # SHODH_ALLOW_SIMPLIFIED_EMBEDDINGS is never set here: degrading the
+      # embedder would make the recall numbers meaningless.
+      - name: Cache MiniLM embedder weights
+        id: minilm-cache
+        uses: actions/cache@v4
+        with:
+          path: models/minilm-l6
+          key: minilm-l6-c9745ed1-v1
+
+      - name: Fetch MiniLM embedder weights
+        if: steps.minilm-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p models/minilm-l6
+          BASE="https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/c9745ed1d9f207416be6d2e6f8de32d1f16199bf"
+          curl -fL --retry 5 --retry-delay 5 --connect-timeout 30 -o models/minilm-l6/model_quantized.onnx "$BASE/onnx/model_quint8_avx2.onnx"
+          curl -fL --retry 5 --retry-delay 5 --connect-timeout 30 -o models/minilm-l6/tokenizer.json "$BASE/tokenizer.json"
+          ls -la models/minilm-l6
+
+      - name: Verify model assets (hard gate — refuse to run on missing/degraded assets)
+        run: |
+          SHODH_MODEL_PATH="${{ github.workspace }}/models/minilm-l6"
+          SHODH_GLINER_MODEL_PATH="${{ github.workspace }}/models/gliner-bi-edge"
+          test -s "$SHODH_MODEL_PATH/model_quantized.onnx" || { echo "::error::MiniLM weights missing"; exit 1; }
+          test -s "$SHODH_MODEL_PATH/tokenizer.json" || { echo "::error::MiniLM tokenizer missing"; exit 1; }
+          test -s "$SHODH_GLINER_MODEL_PATH/model.onnx" || { echo "::error::GLiNER model missing — refusing to measure fallback NER"; exit 1; }
+          test -s "$SHODH_GLINER_MODEL_PATH/tokenizer.json" || { echo "::error::GLiNER tokenizer missing"; exit 1; }
+          test -s "$SHODH_GLINER_MODEL_PATH/label_embeddings.bin" || { echo "::error::GLiNER label embeddings missing"; exit 1; }
+
       - name: Verify baseline is checked in
         run: |
           if [ ! -f tests/recall/locomo-gate-baseline.json ]; then
@@ -118,6 +152,7 @@ jobs:
       - name: Run L1 smoke suite vs. baseline
         id: run_eval
         env:
+          SHODH_MODEL_PATH: ${{ github.workspace }}/models/minilm-l6
           SHODH_GLINER_MODEL_PATH: ${{ github.workspace }}/models/gliner-bi-edge
         run: |
           set +e


### PR DESCRIPTION
## Problem

Recall gate run 31227613424 (#442) failed with `Recall harness infrastructure failure` on a PR whose gated metrics were all **+0.0000 / ✅ No regressions**. The emitted error:

> Failed to initialize MiniLM embedder (ONNX model): Failed to download models: Failed to download from https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/...

`recall.yml` pre-supplies GLiNER assets but left MiniLM to a runtime HuggingFace download — the same flake class that hit CI on #443 and was fixed hermetically there (ci.yml Build job). This closes the remaining gap.

## Change (workflow-only)

- **Cache + fetch MiniLM** pinned to revision `c9745ed1`, cache key `minilm-l6-c9745ed1-v1` — deliberately shared with ci.yml so a warm cache means neither workflow touches HF.
- **Verify model assets** hard gate before the eval run (same step as ci.yml): missing weights fail loudly instead of downloading or degrading.
- **`SHODH_MODEL_PATH` exported** to the eval step, making the download branch unreachable.

`SHODH_ALLOW_SIMPLIFIED_EMBEDDINGS` is never set; tolerance untouched.