### PR TITLE
feat(workbench): consolidation-tier encoding on recall graph nodes

### DIFF
--- a/front/ui/src/features/inspector/Inspector.tsx
+++ b/front/ui/src/features/inspector/Inspector.tsx
@@ -5,6 +5,7 @@ import { ScoreBreakdown } from "./ScoreBreakdown";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { relName } from "@/features/recall/relation";
+import { memoryTier, MEMORY_TIER_LABEL, MEMORY_TIER_MEANING } from "@/features/recall/tier";
 import { recallKey } from "@/features/recall/useRecall";
 import { EntityDetail } from "./EntityDetail";
 
@@ -138,8 +139,20 @@ export function Inspector() {
                 </Field>
               ) : null}
 
-              <Field label="Tier">
-                <p className="mono text-[11px]">{memory.tier}</p>
+              {/* The same consolidation step the graph canvas encodes as node
+                  presence, named here in words. `memory.tier` is a Rust Debug
+                  rendering — `LongTerm` — and putting an identifier on screen
+                  asks the reader to know the enum. This is the one surface with
+                  room to say what the step MEANS, and it costs nothing here
+                  because it is shown for one selected memory rather than on
+                  every hover. */}
+              <Field label="Consolidation">
+                <p className="mono text-[11px]">
+                  {MEMORY_TIER_LABEL[memoryTier(memory.tier)]}
+                </p>
+                <p className="text-muted-foreground/70 mt-0.5 text-[11px]">
+                  {MEMORY_TIER_MEANING[memoryTier(memory.tier)]}
+                </p>
               </Field>
             </div>
 

--- a/front/ui/src/features/recall/GraphCanvas.tsx
+++ b/front/ui/src/features/recall/GraphCanvas.tsx
@@ -18,6 +18,14 @@ import {
 import type { RecallMemory, RecallLineageEdge } from "@/lib/api";
 import { useSession } from "@/stores/session";
 import { relClass, relName, type RelationClass } from "./relation";
+import {
+  memoryTier,
+  MEMORY_TIER_LABEL,
+  MEMORY_TIER_MARK,
+  MEMORY_TIER_SELECTED_FILL,
+  MEMORY_TIER_SELECTED_RING,
+  type MemoryTier,
+} from "./tier";
 
 /**
  * The knowledge-graph canvas.
@@ -58,6 +66,14 @@ import { relClass, relName, type RelationClass } from "./relation";
  * sizing (:894-899), squared-distance hit-testing (:1552-1559) and the
  * drag-vs-click threshold (:1568).
  *
+ * CONSOLIDATION is drawn, not just listed. Every node carries `RecallMemory.tier`
+ * (src/handlers/types.rs:249, `format!("{:?}", m.tier)` at src/handlers/recall.rs:830),
+ * and until now that reached the screen only as a text field in the Inspector —
+ * one memory at a time, which is the one form in which it answers nothing. The
+ * useful question is comparative ("is this cluster settled knowledge or this
+ * morning's context?"), so it is encoded on the mark itself as how PRESENT the
+ * node is drawn. ./tier.ts holds the ramp and the argument for that channel.
+ *
  * PROVENANCE is the point. An edge is never just a line: hovering or selecting
  * surfaces the relation type and the confidence the server actually returned,
  * because "why is this connected" is the question a hairball cannot answer.
@@ -74,6 +90,9 @@ interface GraphNode extends SimulationNodeDatum {
   r: number;
   color: string;
   degree: number;
+  /** Consolidation tier, normalised from `RecallMemory.tier`. Encoded as how
+   *  PRESENT the node is drawn — see ./tier.ts for why it is not a hue. */
+  tier: MemoryTier;
 }
 
 interface GraphLink extends SimulationLinkDatum<GraphNode> {
@@ -201,6 +220,7 @@ export function GraphCanvas({
         r: 6 + Math.sqrt(Math.max(0, m.score)) * 7,
         color: typeIndex >= 0 ? `chart:${typeIndex}` : "muted",
         degree: deg,
+        tier: memoryTier(m.tier),
       };
     });
 
@@ -321,12 +341,25 @@ export function GraphCanvas({
         const isSelected = n.id === sel;
         ctx!.globalAlpha = isLit ? 1 : 0.1;
 
+        // Consolidation tier, as presence. A working memory is a faint outline
+        // and a long-term one is filled and firmly ringed, so "how settled is
+        // this?" is answerable without reading the legend. Selection ADDS to
+        // the tier's step rather than overwriting it — the accent stroke is
+        // what makes a selection unmistakable, so the tier survives being
+        // clicked. Rationale and the ramp itself live in ./tier.ts.
+        const mark = MEMORY_TIER_MARK[n.tier];
+
         ctx!.beginPath();
         ctx!.arc(n.x, n.y, n.r, 0, 2 * Math.PI);
-        ctx!.fillStyle = hexA(hue(n), isSelected ? 0.5 : 0.28);
+        ctx!.fillStyle = hexA(
+          hue(n),
+          isSelected ? Math.min(1, mark.fill + MEMORY_TIER_SELECTED_FILL) : mark.fill,
+        );
         ctx!.fill();
-        ctx!.lineWidth = (isSelected ? 2.4 : 1.3) / transformRef.current.k;
-        ctx!.strokeStyle = isSelected ? tokens.active : hexA(hue(n), 0.95);
+        ctx!.lineWidth =
+          (isSelected ? mark.ring + MEMORY_TIER_SELECTED_RING : mark.ring) /
+          transformRef.current.k;
+        ctx!.strokeStyle = isSelected ? tokens.active : hexA(hue(n), mark.ringAlpha);
         ctx!.stroke();
 
         // An isolated memory is a real finding, not a rendering gap: it means
@@ -518,7 +551,11 @@ function GraphTooltip({ hover, links }: { hover: Hover; links: GraphLink[] }) {
     >
       <p className="line-clamp-3 text-[12px] leading-relaxed">{node.label}</p>
       <p className="text-muted-foreground mono mt-1.5 text-[10px]">
-        {node.type ?? "untyped"} · score {node.score.toFixed(3)}
+        {/* The tier is named as well as drawn. The ramp answers "is this
+            settled?" at a glance across the whole canvas; a reader who has
+            singled one node out wants the step by name, not by comparison. */}
+        {node.type ?? "untyped"} · {MEMORY_TIER_LABEL[node.tier]} · score{" "}
+        {node.score.toFixed(3)}
       </p>
 
       {shown.length > 0 ? (

--- a/front/ui/src/features/recall/GraphStage.tsx
+++ b/front/ui/src/features/recall/GraphStage.tsx
@@ -1,8 +1,16 @@
+import { useMemo } from "react";
 import { cn } from "@/lib/utils";
 import type { Reachability } from "@/lib/api";
 import { RecallDiagram } from "./RecallDiagram";
 import { GraphCanvas, useMemoryTypes } from "./GraphCanvas";
 import { useRecall } from "./useRecall";
+import {
+  memoryTier,
+  MEMORY_TIER_LABEL,
+  MEMORY_TIER_ORDER,
+  memoryTierSwatch,
+  type MemoryTier,
+} from "./tier";
 
 /**
  * The graph stage.
@@ -29,6 +37,15 @@ export function GraphStage({ reach }: { reach: Reachability }) {
   const hasGraph = memories.length > 0;
 
   const edgeCount = lineage.length;
+
+  /** Tier populations over the memories actually drawn. Counted here from the
+   *  same `memoryTier` normaliser the canvas uses, so the key and the picture
+   *  cannot disagree about which step a node is on. */
+  const tierCounts = useMemo(() => {
+    const counts: Record<MemoryTier, number> = { Working: 0, Session: 0, LongTerm: 0 };
+    for (const m of memories) counts[memoryTier(m.tier)] += 1;
+    return counts;
+  }, [memories]);
 
   return (
     // `min-w-0`: a flex item's default min-width is its content's intrinsic
@@ -77,25 +94,65 @@ export function GraphStage({ reach }: { reach: Reachability }) {
           )}
           style={{ paddingRight: "var(--overlay-dock-inset, 0px)" }}
         >
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
-            {/* The legend is the memory types actually present, in the order
-                the canvas assigns hues in. The server's set is closed — 14
-                Debug-rendered enum variants — but a fixed legend would name
-                eleven categories this result set does not contain, and 14
-                categories cannot map onto 5 chart hues without arbitrary
-                collisions. Listing what is present keeps the key honest. */}
-            {types.map((t, i) => (
-              <span
-                key={t}
-                className="text-muted-foreground flex items-center gap-1.5 text-[11px]"
-              >
+          {/* Two encodings, two rows. Node HUE is memory type; node PRESENCE —
+              fill and ring weight — is consolidation tier. They are kept on
+              separate palettes on purpose: categorical colour belongs to the
+              type, and the tier is a progression, so it climbs in weight rather
+              than changing hue. The same split governs the entity graph
+              (features/graph/GraphView.tsx:215-219). */}
+          <div className="flex flex-col gap-1.5">
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
+              {/* The legend is the memory types actually present, in the order
+                  the canvas assigns hues in. The server's set is closed — 14
+                  Debug-rendered enum variants — but a fixed legend would name
+                  eleven categories this result set does not contain, and 14
+                  categories cannot map onto 5 chart hues without arbitrary
+                  collisions. Listing what is present keeps the key honest. */}
+              {types.map((t, i) => (
                 <span
-                  className="size-2 rounded-full"
-                  style={{ background: `var(--chart-${(i % 5) + 1})` }}
-                />
-                {t}
-              </span>
-            ))}
+                  key={t}
+                  className="text-muted-foreground flex items-center gap-1.5 text-[11px]"
+                >
+                  <span
+                    className="size-2 rounded-full"
+                    style={{ background: `var(--chart-${(i % 5) + 1})` }}
+                  />
+                  {t}
+                </span>
+              ))}
+            </div>
+
+            {/* All three tiers, always, counts included — unlike the memory-type
+                row above. There are only three and they are a fixed ladder, so
+                a zero beside "Long-term" is a finding about this result set
+                (nothing here has consolidated yet) rather than a category the
+                legend had no business naming. */}
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
+              {/* This row is named and the one above is not, because the one
+                  above needs no name: coloured dots beside a graph read as
+                  categories on sight. Three rings labelled Working / Session /
+                  Long-term do not say what dimension they are three steps OF
+                  until someone is told, and a legend that has to be puzzled out
+                  has already failed. */}
+              <span className="text-muted-foreground/50 text-[11px]">Consolidation</span>
+              {MEMORY_TIER_ORDER.map((t) => (
+                <span
+                  key={t}
+                  className="text-muted-foreground flex items-center gap-1.5 text-[11px]"
+                >
+                  {/* A ring, not a bar: these describe nodes, and matching the
+                      mark to what it describes is what makes the key readable
+                      beside the type dots above. Neutral, because tier is not a
+                      hue on this canvas — it is how filled-in a node is. 12px
+                      rather than the type dots' 8px, because this swatch encodes
+                      ring WEIGHT and a 2.2px ring on an 8px circle leaves too
+                      little middle for the fill step to read. */}
+                  <span className="size-3 rounded-full" style={memoryTierSwatch(t)} />
+                  {MEMORY_TIER_LABEL[t]}
+                  <span className="text-muted-foreground/60">{tierCounts[t]}</span>
+                </span>
+              ))}
+            </div>
           </div>
           <span className="text-muted-foreground/70 text-[11px]">
             {/* Say what the edges ARE, not just how to move the camera. Zero

--- a/front/ui/src/features/recall/tier.ts
+++ b/front/ui/src/features/recall/tier.ts
@@ -1,0 +1,150 @@
+import type { CSSProperties } from "react";
+
+/**
+ * Memory consolidation tiers, and how a memory node wears one.
+ *
+ * WHAT THE WIRE CARRIES. `RecallMemory.tier` is a plain `String`
+ * (src/handlers/types.rs:249, no `skip_serializing_if`), populated as
+ * `format!("{:?}", m.tier)` at every construction site of that struct —
+ * src/handlers/recall.rs:830, :3172 and :3581. So the values are the *Debug*
+ * renderings of `MemoryTier` (src/memory/types.rs:1047-1076): `Working`,
+ * `Session`, `LongTerm`, and the retired `Archive`.
+ *
+ * This is a genuine progression, not a set of kinds. A memory starts in
+ * `Working` — immediate context, dense and volatile — is promoted to `Session`
+ * once it earns it, and reaches `LongTerm`, the terminal tier, only after the
+ * age and importance thresholds are met (the ladder is documented at
+ * src/memory/mod.rs:6226-6233). "How settled is this?" is therefore an ordinal
+ * question, and the encoding below answers it as one.
+ *
+ * `Archive` is deliberately NOT given a step. src/memory/types.rs:1056-1075 is
+ * explicit that nothing assigns it and nothing should — the variant survives
+ * only because `MemoryTier` is positionally encoded inside `MemoryFlat` and
+ * deleting discriminant 3 would bet live user data on a negative-existence
+ * proof. Drawing a fourth step for a tier the server cannot emit would put a
+ * key on screen that no memory can ever match.
+ */
+
+/** The three tiers the ladder actually produces. */
+export type MemoryTier = "Working" | "Session" | "LongTerm";
+
+/** Least- to most-consolidated. The order the legend reads in, and the order
+ *  the visual ramp climbs. */
+export const MEMORY_TIER_ORDER: MemoryTier[] = ["Working", "Session", "LongTerm"];
+
+/**
+ * Normalise the wire string.
+ *
+ * Anything unrecognised — a future variant, or the inert `Archive` — falls back
+ * to `Working`, the LEAST consolidated step. That direction is the honest one:
+ * the encoding is a claim about how durable a memory is, and understating
+ * durability for a value this client does not understand is safe, whereas
+ * drawing an unknown tier as `LongTerm` would assert consolidation the client
+ * cannot vouch for. It mirrors what the canvas already does with an absent
+ * `memory_type`, which falls back to the muted hue rather than guessing a
+ * category (GraphCanvas.tsx).
+ */
+export function memoryTier(raw: string | null | undefined): MemoryTier {
+  return raw === "LongTerm" || raw === "Session" ? raw : "Working";
+}
+
+/**
+ * Legend and tooltip copy.
+ *
+ * Plain English, not the enum. `LongTerm` is how Rust spells an identifier;
+ * "Long-term" is how a person reads one, and an analyst surface should not make
+ * someone learn a variant name to read a chart. Mirrors `TIER_LABEL` in
+ * features/graph/universe.ts, which does the same job for edge tiers.
+ */
+export const MEMORY_TIER_LABEL: Record<MemoryTier, string> = {
+  Working: "Working",
+  Session: "Session",
+  LongTerm: "Long-term",
+};
+
+/**
+ * One-line explanation of what a tier means.
+ *
+ * For the Inspector, not the hover tooltip. The canvas shows one memory's
+ * tooltip per pointer position and a repeat user reads that dozens of times a
+ * session, so a sentence they learned on day one becomes noise there; the
+ * Inspector shows a single selected memory deliberately, and has the room.
+ */
+export const MEMORY_TIER_MEANING: Record<MemoryTier, string> = {
+  Working: "immediate context, not yet consolidated",
+  Session: "promoted out of working memory",
+  LongTerm: "consolidated and durable",
+};
+
+/**
+ * The visual step for each tier.
+ *
+ * WHY NOT COLOUR. Edge tiers get their own hue ramp (`--edge-l1/l2/l3`,
+ * index.css:153-171) because nothing else on the canvas claims edge colour.
+ * Memory nodes have no such freedom: node hue is already `memory_type`
+ * (GraphCanvas.tsx `readTokens`), and the rule the graph legend states outright
+ * — categorical colour belongs to nodes, the tier ramp is a progression and the
+ * two never share a palette (features/graph/GraphView.tsx:215-219) — forbids
+ * spending hue twice on one mark. Tier therefore takes the one channel still
+ * free on a node: how PRESENT it is.
+ *
+ * The ramp direction follows the edge ramp's, for the same stated reason: the
+ * ground is near-black (#08090a), so on this canvas "settled and solid" means
+ * more present, not darker. A working memory is a faint outline; a long-term
+ * one is filled and firmly ringed. That reads at a glance, before anyone looks
+ * at a legend, which is the test this encoding has to pass.
+ *
+ * `Session` is deliberately today's appearance (fill 0.28, ring 1.3px): the
+ * middle of a new ramp should be the look the canvas already had, so this adds
+ * a distinction rather than restyling every node.
+ *
+ * Channels NOT used, because they are already spoken for on this canvas:
+ * radius (retrieval score), hue (memory_type), a dashed outer ring (a memory
+ * nothing in the result set connects to), stroke colour and globalAlpha
+ * (selection and focus dimming).
+ */
+export interface MemoryTierMark {
+  /** Alpha for the node's fill, over its `memory_type` hue. */
+  fill: number;
+  /** Ring width in CSS pixels, before the zoom transform divides it. */
+  ring: number;
+  /** Alpha for the ring, over the same hue. */
+  ringAlpha: number;
+}
+
+export const MEMORY_TIER_MARK: Record<MemoryTier, MemoryTierMark> = {
+  Working: { fill: 0.11, ring: 1.0, ringAlpha: 0.55 },
+  Session: { fill: 0.28, ring: 1.3, ringAlpha: 0.8 },
+  LongTerm: { fill: 0.5, ring: 2.2, ringAlpha: 1.0 },
+};
+
+/** Selection adds to the tier's own step rather than replacing it, so a
+ *  selected node still says which tier it is. The accent stroke colour is what
+ *  makes selection unmistakable; these only stop the selected node from being
+ *  the faintest thing on screen when it happens to be a working memory. */
+export const MEMORY_TIER_SELECTED_FILL = 0.2;
+export const MEMORY_TIER_SELECTED_RING = 1.2;
+
+/**
+ * The legend swatch, as CSS.
+ *
+ * Drawn in `--muted-foreground` rather than any data hue, because that is
+ * exactly what the encoding claims: tier is not a colour here, it is weight and
+ * presence, and a coloured key would imply a hue mapping that the canvas does
+ * not have. A ring, not a bar — the graph legend uses a bar for edge tiers
+ * because edges are lines (features/graph/GraphView.tsx:240-246); these describe
+ * nodes, so they are round.
+ */
+export function memoryTierSwatch(tier: MemoryTier): CSSProperties {
+  const mark = MEMORY_TIER_MARK[tier];
+  return {
+    borderWidth: `${mark.ring}px`,
+    borderStyle: "solid",
+    borderColor: `color-mix(in srgb, var(--muted-foreground) ${Math.round(
+      mark.ringAlpha * 100,
+    )}%, transparent)`,
+    background: `color-mix(in srgb, var(--muted-foreground) ${Math.round(
+      mark.fill * 100,
+    )}%, transparent)`,
+  };
+}

--- a/front/ui/src/lib/api/types.ts
+++ b/front/ui/src/lib/api/types.ts
@@ -58,6 +58,17 @@ export interface RecallMemory {
   importance: number;
   created_at: string;
   score: number;
+  /** Consolidation tier. `format!("{:?}", m.tier)` — the Debug rendering of
+   *  `MemoryTier` (src/memory/types.rs:1047-1076), so the values are `Working`,
+   *  `Session` and `LongTerm`, plus the retired-but-undeletable `Archive`.
+   *  Populated at every `RecallMemory` construction site (src/handlers/recall.rs:830,
+   *  :3172, :3581) and carries no `skip_serializing_if` (src/handlers/types.rs:249),
+   *  so it is always present.
+   *
+   *  Typed as `string` rather than a union for the same reason `memory_type` is:
+   *  the wire type is a `String`, and a union here would turn a server-side enum
+   *  addition into a client compile error. `memoryTier()` in
+   *  features/recall/tier.ts narrows it. */
   tier: string;
   score_attribution?: ScoreAttribution;
 }

--- a/tests/pipeline_integration_tests.rs
+++ b/tests/pipeline_integration_tests.rs
@@ -423,6 +423,76 @@ mod roundtrip_tests {
         );
     }
 
+    /// Every recalled memory states its consolidation tier, spelled the way the
+    /// UI reads it.
+    ///
+    /// This pins a wire contract that now has a VISUAL consumer. The analyst
+    /// workbench draws `tier` on each memory node as how present the node is —
+    /// a faint outline for working memory through to a filled, firmly-ringed
+    /// long-term one (front/ui/src/features/recall/tier.ts). That encoding is
+    /// only readable while the three strings on the wire stay exactly these
+    /// three, so the assertion is on the literal values rather than on mere
+    /// presence.
+    ///
+    /// The values are Debug renderings of `MemoryTier` (src/memory/types.rs),
+    /// produced by `format!("{:?}", m.tier)` at every `RecallMemory` site
+    /// (src/handlers/recall.rs). Renaming a variant, or switching the field to a
+    /// serde `rename_all`, would silently retune every node on that canvas to the
+    /// least-consolidated step, because the client falls back that way for
+    /// strings it does not recognise. That is a safe failure but an invisible
+    /// one, which is exactly why it needs a test rather than a reviewer.
+    ///
+    /// `Archive` is excluded deliberately: src/memory/types.rs documents it as
+    /// retired, with nothing assigning it. If it ever appears here, the ladder
+    /// grew an arrow it is not supposed to fire and the workbench legend is
+    /// short a step.
+    #[tokio::test]
+    async fn recall_memories_carry_consolidation_tier() {
+        const LIVE_TIERS: [&str; 3] = ["Working", "Session", "LongTerm"];
+
+        let h = Harness::new();
+        for i in 0..3 {
+            store_memory(
+                &h,
+                "test-user",
+                &format!("Consolidation ladder note {i} about tier promotion thresholds"),
+            )
+            .await;
+        }
+        wait_for_indexing().await;
+
+        let (status, body) = recall(&h, "test-user", "consolidation ladder tier promotion").await;
+        assert_eq!(status, StatusCode::OK, "recall failed: {body}");
+
+        let memories = body["memories"].as_array().expect("memories array");
+        assert!(
+            !memories.is_empty(),
+            "seeded memories should be recallable: {body}"
+        );
+
+        for m in memories {
+            let tier = m["tier"]
+                .as_str()
+                .unwrap_or_else(|| panic!("recalled memory has no string `tier` field: {m}"));
+            assert!(
+                LIVE_TIERS.contains(&tier),
+                "tier {tier:?} is not one of the three live tiers {LIVE_TIERS:?}; \
+                 the workbench node encoding and its legend are built on exactly these"
+            );
+        }
+
+        // Freshly written memories have not aged or been reinforced, so they are
+        // still at the bottom of the ladder. Asserting the START of the ladder —
+        // rather than only that the value parses — is what shows the field is
+        // read from the record rather than defaulted somewhere downstream.
+        assert!(
+            memories
+                .iter()
+                .all(|m| m["tier"].as_str() == Some("Working")),
+            "newly written memories should still be Working: {body}"
+        );
+    }
+
     #[tokio::test]
     async fn recall_memory_type_preserved() {
         let h = Harness::new();


### PR DESCRIPTION
Memory nodes on the recall lineage canvas now encode their consolidation tier (Working / Session / Long-term) as visual presence — fill alpha + ring width/alpha ramping toward consolidation — rather than hue, which is already spent on memory_type. Selection adds to the tier step instead of replacing it. Legend row labelled "Consolidation"; unrecognised tier strings fall back to the least-consolidated step so the client never overstates durability.

The `tier` field was already on the recall wire (handlers/types.rs, populated at all three recall sites) — this is a frontend-only change plus one pinned-contract test (`recall_memories_carry_consolidation_tier`, 57/57 file green locally).

Originally built against the consolidation branch; cherry-picked to main cleanly — no dependency on #442.