### PR TITLE
feat(workbench): map and recall open onto the corpus, not onto an instruction

### DIFF
--- a/front/ui/src/features/geo/GeoMap.tsx
+++ b/front/ui/src/features/geo/GeoMap.tsx
@@ -97,7 +97,17 @@ function hexA(hex: string, a: number): string {
 
 const HIT_RADIUS_PX = 9;
 
-export function GeoMap({ memories, types }: { memories: RecallMemory[]; types: string[] }) {
+export function GeoMap({
+  memories,
+  types,
+  dimmed,
+}: {
+  memories: RecallMemory[];
+  types: string[];
+  /** Ids drawn as quiet context — present on the map, visibly not part of the
+   *  current answer. Absent set = every point is a first-class result. */
+  dimmed?: Set<string>;
+}) {
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const selectedId = useSession((s) => s.selectedMemoryId);
@@ -231,23 +241,29 @@ export function GeoMap({ memories, types }: { memories: RecallMemory[]; types: s
 
       for (const { point, x, y } of screen) {
         const isSelected = point.id === sel;
+        // Selection outranks dimming: a person who clicked a context point is
+        // asking about it, and the map must answer at full strength.
+        const isDim = !isSelected && (dimmed?.has(point.id) ?? false);
         // Coordinates are DATA, so a point takes a category hue. The accent is
         // reserved for focus — the selected point and nothing else.
         const hue = isSelected ? tokens.active : hueFor(point.type);
-        const r = 4 + Math.sqrt(Math.max(0, point.score)) * 3;
+        const r = isDim ? 2.5 : 4 + Math.sqrt(Math.max(0, point.score)) * 3;
 
-        // A soft halo so a single point on an empty ocean is still findable.
-        ctx!.beginPath();
-        ctx!.arc(x, y, r + (isSelected ? 7 : 4), 0, 2 * Math.PI);
-        ctx!.fillStyle = hexA(hue, isSelected ? 0.28 : 0.14);
-        ctx!.fill();
+        if (!isDim) {
+          // A soft halo so a single point on an empty ocean is still findable.
+          // Context points get none — a halo is a claim on attention.
+          ctx!.beginPath();
+          ctx!.arc(x, y, r + (isSelected ? 7 : 4), 0, 2 * Math.PI);
+          ctx!.fillStyle = hexA(hue, isSelected ? 0.28 : 0.14);
+          ctx!.fill();
+        }
 
         ctx!.beginPath();
         ctx!.arc(x, y, r, 0, 2 * Math.PI);
-        ctx!.fillStyle = hexA(hue, 0.9);
+        ctx!.fillStyle = hexA(hue, isDim ? 0.35 : 0.9);
         ctx!.fill();
-        ctx!.lineWidth = isSelected ? 2 : 1;
-        ctx!.strokeStyle = isSelected ? tokens.active : hexA(hue, 1);
+        ctx!.lineWidth = isSelected ? 2 : isDim ? 0.75 : 1;
+        ctx!.strokeStyle = isSelected ? tokens.active : hexA(hue, isDim ? 0.45 : 1);
         ctx!.stroke();
       }
     }
@@ -275,7 +291,7 @@ export function GeoMap({ memories, types }: { memories: RecallMemory[]; types: s
       observer.disconnect();
       sel.on(".zoom", null);
     };
-  }, [points, types]);
+  }, [points, types, dimmed]);
 
   const pointAt = useCallback((sx: number, sy: number) => {
     let hit: { point: GeoPoint; x: number; y: number } | null = null;

--- a/front/ui/src/features/geo/GeoView.tsx
+++ b/front/ui/src/features/geo/GeoView.tsx
@@ -1,37 +1,61 @@
+import { useMemo } from "react";
 import type { Reachability } from "@/lib/api";
+import { corpusToRecallMemory, useCorpus } from "@/lib/api/corpus";
 import { EmptyState } from "@/components/ui/empty-state";
 import { useRecall } from "@/features/recall/useRecall";
 import { useMemoryTypes } from "@/features/recall/GraphCanvas";
 import { GeoMap } from "./GeoMap";
 
 /**
- * Geo — where the current recall result set happened.
+ * Geo — everywhere this profile's memory happened, with the current recall
+ * result highlighted on top of it.
  *
- * It plots the SAME result set the Recall destination lists, read from the same
- * react-query cache entry (see useRecall), so this is a second view of one
- * retrieval rather than a second retrieval. Selecting a point selects the
- * memory, which is the same global selection the result list and the graph
- * canvas drive, and it opens in the same Inspector.
+ * The map is populated the moment the destination opens: every located memory
+ * in the corpus is drawn as a quiet context point, because "where do I have
+ * memory?" is a question with an answer before any search is typed. Running a
+ * search does not swap the map out — it turns the matching points up and the
+ * rest down, so a result is always seen against the corpus it came from.
  *
- * The empty states carry most of this screen's honesty budget. Most memories
- * have no coordinates, and that is a property of how they were written rather
- * than a failure of this view — saying so plainly is the difference between a
- * user concluding "the map is broken" and "this corpus is not geotagged".
+ * Both data sources are shared cache entries (useCorpus, useRecall): this view
+ * issues no retrieval of its own.
  */
 
 export function GeoView({ reach }: { reach: Reachability }) {
+  const corpus = useCorpus(reach);
   const { data, error, isFetching, profile, query } = useRecall(reach);
-  const memories = data?.memories ?? [];
-  const types = useMemoryTypes(memories);
 
-  const located = memories.filter((m) => m.experience.geo_location);
+  const hasQuery = query.trim().length > 0;
+  const results = useMemo(() => (hasQuery ? (data?.memories ?? []) : []), [hasQuery, data]);
+
+  // The plotted set: recall results first (they carry scores and therefore
+  // size), then every located corpus memory that is not already a result.
+  const { plotted, dimmed } = useMemo(() => {
+    const resultIds = new Set(results.map((m) => m.id));
+    const context = (corpus.data?.memories ?? [])
+      .filter((m) => m.geo_location)
+      .filter((m) => !resultIds.has(m.id))
+      .map(corpusToRecallMemory);
+    if (!hasQuery || results.length === 0) {
+      // No active answer: the corpus IS the map. Nothing is dimmed — these
+      // points are not losing to anything.
+      return { plotted: context, dimmed: undefined };
+    }
+    return {
+      plotted: [...results, ...context],
+      dimmed: new Set(context.map((m) => m.id)),
+    };
+  }, [corpus.data, results, hasQuery]);
+
+  const types = useMemoryTypes(plotted);
+  const located = plotted.filter((m) => m.experience.geo_location);
+  const matched = results.filter((m) => m.experience.geo_location);
 
   if (reach.state !== "online") {
     return (
       <EmptyState
         size="page"
         title="Not connected"
-        body="The map draws from a recall result, which needs the memory server running."
+        body="The map draws from memory, which needs the memory server running."
       />
     );
   }
@@ -40,77 +64,43 @@ export function GeoView({ reach }: { reach: Reachability }) {
     return (
       <EmptyState
         size="page"
-        title="No profile to search"
-        body="Geo plots the results of a recall, and recall needs a profile that already exists."
+        title="No profile selected"
+        body="The map shows where a profile's memory happened, so it needs a profile that already exists."
       />
     );
   }
 
-  if (!query.trim()) {
-    return (
-      <EmptyState
-        size="page"
-        title="Search to place results on the map"
-        body="Geo shows where the current recall result happened. Run a search and any memory carrying coordinates appears here."
-      />
-    );
-  }
-
-  if (error) {
-    return (
-      <EmptyState
-        size="page"
-        title="Recall failed"
-        body="The map plots a recall result, and that query did not complete."
-      />
-    );
-  }
-
-  if (isFetching && !data) {
-    return <EmptyState size="page" title="Searching" body="Placing results as they arrive." />;
-  }
-
-  if (memories.length === 0) {
-    return (
-      <EmptyState
-        size="page"
-        title="Nothing surfaced"
-        body="No memory in this profile activated strongly enough for that cue, so there is nothing to place."
-      />
-    );
+  if (corpus.isFetching && !corpus.data) {
+    return <EmptyState size="page" title="Loading corpus" body="Placing every located memory." />;
   }
 
   if (located.length === 0) {
     return (
-      // Factual, not apologetic. The reason is a property of the data and the
-      // sentence says which data would behave differently, so it is actionable
-      // rather than a shrug.
+      // Factual, not apologetic: the reason is a property of the data.
       <EmptyState
         size="page"
-        title="No coordinates in these results"
-        body={`All ${memories.length} results came back without coordinates. A memory only carries them when whatever wrote it supplied them — imported corpora like GDELT do, session captures do not.`}
+        title="No coordinates in this corpus"
+        body="A memory only carries coordinates when whatever wrote it supplied them — imported corpora like GDELT do, session captures do not. Once one does, it appears here without any search."
       />
     );
   }
 
   return (
-    // `h-full`, not `flex-1`. GraphStage can use `flex-1` because RecallView
-    // wraps it in a flex row; this view is a direct child of `main`, which is
-    // not a flex container, so `flex-1` resolves to nothing and the section
-    // collapses to the height of its content — which is zero, since the map
-    // and every overlay inside it are absolutely positioned. That renders a
-    // blank destination with no error anywhere.
+    // `h-full`, not `flex-1` — this view is a direct child of `main`, which is
+    // not a flex container (see the history of this comment in git blame).
     <section className="relative h-full min-h-0 min-w-0 overflow-hidden">
       <div aria-hidden="true" className="graticule pointer-events-none absolute inset-0" />
 
-      <GeoMap memories={memories} types={types} />
+      <GeoMap memories={plotted} types={types} dimmed={dimmed} />
 
       <div className="text-muted-foreground pointer-events-none absolute top-3 left-4 z-10 text-[12px]">
-        Where this happened
+        {hasQuery ? "Where this answer happened" : "Where this profile's memory happened"}
       </div>
 
-      <div className="pointer-events-none absolute inset-x-4 bottom-3 z-10 flex flex-wrap items-center justify-between gap-x-6 gap-y-2"
-      style={{ paddingRight: "var(--overlay-dock-inset, 0px)" }}>
+      <div
+        className="pointer-events-none absolute inset-x-4 bottom-3 z-10 flex flex-wrap items-center justify-between gap-x-6 gap-y-2"
+        style={{ paddingRight: "var(--overlay-dock-inset, 0px)" }}
+      >
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
           {types.map((t, i) => (
             <span key={t} className="text-muted-foreground flex items-center gap-1.5 text-[11px]">
@@ -123,11 +113,14 @@ export function GeoView({ reach }: { reach: Reachability }) {
           ))}
         </div>
         <span className="text-muted-foreground/70 text-[11px]">
-          {/* State the ratio, not just the count. "12 placed" alone invites the
-              reading that the other 13 failed to draw; naming both makes the
-              gap a fact about the corpus. */}
-          {located.length} of {memories.length} carry coordinates · scroll to zoom · drag to pan ·
-          click a point to inspect
+          {hasQuery
+            ? error
+              ? "That search did not complete — showing the corpus"
+              : isFetching && !data
+                ? "Searching…"
+                : `${matched.length} matched of ${located.length} placed`
+            : `${located.length} located ${located.length === 1 ? "memory" : "memories"}`}
+          {" · scroll to zoom · drag to pan · click a point to inspect"}
         </span>
       </div>
     </section>

--- a/front/ui/src/features/recall/RecallView.tsx
+++ b/front/ui/src/features/recall/RecallView.tsx
@@ -1,4 +1,6 @@
+import { useMemo } from "react";
 import { ApiError, NetworkError, type Reachability } from "@/lib/api";
+import { corpusToRecallMemory, useCorpus } from "@/lib/api/corpus";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ResultList, ResultListSkeleton } from "./ResultList";
 import { GraphStage } from "./GraphStage";
@@ -18,6 +20,19 @@ function ResultPane({ reach }: { reach: Reachability }) {
   // The query itself lives in `useRecall` — the graph stage renders the same
   // result set and must not issue a second retrieval to get it.
   const { data, error, isFetching, profile, query } = useRecall(reach);
+  const corpus = useCorpus(reach);
+
+  // The pre-query listing: newest first. The corpus endpoint already returns
+  // newest-first, but sorting here keeps the promise in the heading true even
+  // if that ordering ever changes server-side.
+  const recent = useMemo(
+    () =>
+      [...(corpus.data?.memories ?? [])]
+        .sort((a, b) => b.created_at.localeCompare(a.created_at))
+        .slice(0, 50)
+        .map(corpusToRecallMemory),
+    [corpus.data],
+  );
 
   if (reach.state !== "online") {
     return (
@@ -38,11 +53,25 @@ function ResultPane({ reach }: { reach: Reachability }) {
   }
 
   if (!query.trim()) {
+    // No query yet: open onto the corpus, newest first, instead of onto an
+    // instruction. The list IS the invitation — it shows what there is to
+    // search, and selecting a row inspects it like any result.
+    if (corpus.isFetching && !corpus.data) return <ResultListSkeleton />;
+    if (recent.length === 0) {
+      return (
+        <EmptyState
+          title="Nothing remembered yet"
+          body="Once this profile holds memory, the newest entries appear here before any search."
+        />
+      );
+    }
     return (
-      <EmptyState
-        title="Search memory"
-        body="A few words are enough. Recall starts from meaning, not from matching the words that were stored."
-      />
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="text-muted-foreground border-border shrink-0 border-b px-4 py-2 text-[11px]">
+          Newest memories — search above to rank by relevance
+        </div>
+        <ResultList memories={recent} />
+      </div>
     );
   }
 

--- a/front/ui/src/lib/api/corpus.ts
+++ b/front/ui/src/lib/api/corpus.ts
@@ -1,0 +1,83 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "./client";
+import type { Reachability } from "./health";
+import type { RecallMemory } from "./types";
+import { useSession } from "@/stores/session";
+
+/**
+ * The corpus listing — every memory in the active profile, newest first.
+ *
+ * Two surfaces want a view of the store BEFORE any query exists: Geo plots
+ * every located memory as ambient context, and Recall shows the newest
+ * memories so the destination opens onto the corpus rather than onto an
+ * instruction. Both read this one cache entry.
+ *
+ * `GET /api/list/{user_id}` returns previews (content capped at 500 chars),
+ * which is exactly right here: these rows are orientation, and selecting one
+ * routes through the Inspector, which fetches the full record.
+ */
+
+/** `ListMemoryItem` — src/handlers/crud.rs */
+export interface CorpusMemory {
+  id: string;
+  content: string;
+  content_truncated: boolean;
+  content_length: number;
+  memory_type: string;
+  importance: number;
+  tags: string[];
+  created_at: string;
+  tier: string;
+  /** `[lat, lon, alt]` when the memory carries coordinates. */
+  geo_location?: [number, number, number];
+}
+
+interface ListResponse {
+  memories: CorpusMemory[];
+  total: number;
+}
+
+const CORPUS_LIMIT = 500;
+
+export function corpusKey(profile: string | null) {
+  return ["corpus", profile] as const;
+}
+
+/**
+ * Adapt a corpus row to the `RecallMemory` shape the result/geo surfaces
+ * render. `score: 0` is a statement, not a placeholder — an unqueried corpus
+ * row has no retrieval evidence, and every consumer that sizes or ranks by
+ * score treats zero as the quiet baseline.
+ */
+export function corpusToRecallMemory(m: CorpusMemory): RecallMemory {
+  return {
+    id: m.id,
+    experience: {
+      content: m.content,
+      memory_type: m.memory_type,
+      tags: m.tags,
+      geo_location: m.geo_location,
+    },
+    importance: m.importance,
+    created_at: m.created_at,
+    score: 0,
+    tier: m.tier,
+  };
+}
+
+export function useCorpus(reach: Reachability) {
+  const profile = useSession((s) => s.profile);
+  const enabled = reach.state === "online" && profile !== null;
+
+  const { data, error, isFetching } = useQuery({
+    queryKey: corpusKey(profile),
+    queryFn: ({ signal }) =>
+      api.get<ListResponse>(
+        `/api/list/${encodeURIComponent(profile!)}?limit=${CORPUS_LIMIT}`,
+        signal,
+      ),
+    enabled,
+  });
+
+  return { data, error, isFetching, enabled, profile };
+}

--- a/src/handlers/crud.rs
+++ b/src/handlers/crud.rs
@@ -107,6 +107,10 @@ pub struct ListMemoryItem {
     pub tags: Vec<String>,
     pub created_at: String,
     pub tier: String,
+    /// `[lat, lon, alt]` when the memory carries coordinates; `None` otherwise.
+    /// Lets map surfaces plot the corpus without a per-memory fetch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub geo_location: Option<[f64; 3]>,
 }
 
 /// Hard ceiling on the content preview returned by the memory-listing endpoints
@@ -357,6 +361,7 @@ pub async fn list_memories(
                 tags: m.experience.entities.clone(),
                 created_at: m.created_at.to_rfc3339(),
                 tier: format!("{:?}", m.tier),
+                geo_location: m.experience.geo_location,
             }
         })
         .collect();
@@ -481,6 +486,7 @@ async fn list_memories_inner(
                 tags: m.experience.entities.clone(),
                 created_at: m.created_at.to_rfc3339(),
                 tier: format!("{:?}", m.tier),
+                geo_location: m.experience.geo_location,
             }
         })
         .collect();


### PR DESCRIPTION
Both destinations were empty until someone typed a query, which read as broken rather than empty. Now:

- **Geo** plots every located memory the moment it opens (36 of 74 in the demo corpus). Searching dims the non-matching points instead of replacing the map, so a result is always seen against its corpus.
- **Recall** lists the newest 50 memories until a query exists.
- **API**: `GET /api/list/{user_id}` returns `geo_location` (omitted when absent) so the map needs one request, not one per memory.

Verified against the live seeded store: list returns 36 located of 74; typecheck clean.