### PR TITLE
feat(workbench): say what each screen is, why a result surfaced, and where to start

### DIFF
--- a/front/ui/WORKFLOWS.md
+++ b/front/ui/WORKFLOWS.md
@@ -73,6 +73,25 @@ selects the same memory, so the list and the canvas are two views of one
 selection. From the other end, the Graph destination starts at an entity and
 walks back to the memories it was extracted from.
 
+*Chain 1 starts before the query.* Recall opens onto the corpus, newest first,
+and those rows select into the same Inspector — which reads the corpus cache as
+well as the recall one, because a listing whose rows invite a click and whose
+clicks answer "search first" is a dead end in the one place a stranger begins.
+The head above that listing offers the first move: cues taken verbatim from the
+tags extraction wrote, ranked by how often they appear, so they are a reading of
+this corpus rather than a promise about somebody else's.
+
+**Why a result is a result is on the row.** Which legs reached it, and how many
+of the other results it is causally linked to — one muted line, and absent
+rather than blank when the server attributed nothing. The full attribution stays
+in the Inspector; the row carries the sentence, because nobody opens a panel to
+audit a list they have already read as a black box. Once a query has run the
+head states what was searched, the server's own retrieval time, and the claim
+that distinguishes this from any other ranked list: nothing on screen was
+written. That claim is deliberately about *generation*, not about models —
+retrieval embeds the query with a local encoder, and the copy must never grow
+into saying otherwise.
+
 **Two graphs, two questions — neither replaces the other.**
 
 - *Lineage* (on `/recall`) — "how do these recalled memories cause each other".

--- a/front/ui/src/components/layout/SearchField.tsx
+++ b/front/ui/src/components/layout/SearchField.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
-import { Input } from "@/components/ui/input";
+import { useEffect, useRef, useState } from "react";
+import { Search } from "lucide-react";
+import { cn } from "@/lib/utils";
 import type { Reachability } from "@/lib/api";
 import { useSession } from "@/stores/session";
 
@@ -14,19 +15,72 @@ import { useSession } from "@/stores/session";
  * genuinely different things: the draft is what someone is typing, the
  * committed query is what the results on screen are an answer to. Keeping them
  * as one value makes the result list contradict its own heading mid-word.
+ *
+ * WHY IT IS THIS BIG. Searching is the primary verb of this product and this is
+ * the only control that performs it, and as a bare 280px input at the right
+ * edge of a 48px bar it was missed outright — by the person who built it, on a
+ * screen whose whole left column was captioned "search above". Size, a leading
+ * glyph and a stated shortcut are what make a control read as the thing to use
+ * rather than as chrome. It is still one input in the header: this is a
+ * workbench, and a hero search box would claim the screen the results need.
+ *
+ * The keyboard hint is not decoration — it is the shortcut's only discovery
+ * surface, and it doubles as the strongest "this is a search field" signal at a
+ * glance. It hides while the field has focus, where it would be advice on how
+ * to reach somewhere you already are.
  */
+
+/** Focus keys. `/` is the convention every reading surface uses; ⌘/Ctrl-K is the
+ *  convention every command surface uses. Supporting both costs one branch. */
+function isFocusKey(e: KeyboardEvent): boolean {
+  if (e.key === "k" && (e.metaKey || e.ctrlKey)) return true;
+  return e.key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey;
+}
+
+/** Typing must never be stolen. The conversation composer is mounted on every
+ *  destination (ConversationOverlay), so "/" inside it has to stay a slash. */
+function isTyping(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el || !el.tagName) return false;
+  const tag = el.tagName.toLowerCase();
+  return tag === "input" || tag === "textarea" || tag === "select" || el.isContentEditable;
+}
+
 export function SearchField({ reach }: { reach: Reachability }) {
   const profile = useSession((s) => s.profile);
   const activeQuery = useSession((s) => s.activeQuery);
   const setActiveQuery = useSession((s) => s.setActiveQuery);
   const [draft, setDraft] = useState(activeQuery);
+  const [focused, setFocused] = useState(false);
+  const input = useRef<HTMLInputElement>(null);
 
-  // Switching profile switches corpus, so a query committed against the old one
-  // is no longer what is on screen. Clearing the draft with it avoids offering
-  // to re-run a search whose results would silently be from elsewhere.
-  useEffect(() => setDraft(""), [profile]);
+  // The committed query can now be set from outside this component — a cue chip
+  // on the empty Recall state commits one directly. Without this the field would
+  // sit empty while the list below it showed that query's results, which is the
+  // same "heading contradicts its own list" failure the draft/committed split
+  // exists to prevent, only inverted.
+  //
+  // This replaces an unconditional clear on profile change. That clear was aimed
+  // at the right problem and solved the wrong half of it: `setProfile` does not
+  // touch `activeQuery` (stores/session.ts:65-71), so the committed query
+  // survives the switch and re-runs against the new corpus — emptying the field
+  // hid a search that was still on screen. Re-seeding from the committed value
+  // states what the results actually are, on both paths.
+  useEffect(() => setDraft(activeQuery), [activeQuery, profile]);
 
   const usable = reach.state === "online" && profile !== null;
+
+  useEffect(() => {
+    if (!usable) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (!isFocusKey(e) || isTyping(e.target)) return;
+      e.preventDefault();
+      input.current?.focus();
+      input.current?.select();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [usable]);
 
   return (
     <form
@@ -34,21 +88,63 @@ export function SearchField({ reach }: { reach: Reachability }) {
       onSubmit={(e) => {
         e.preventDefault();
         setActiveQuery(draft.trim());
+        // Committing is the end of the typing task. Blurring hands the keyboard
+        // back to the page so the results can be reached without a Tab out of
+        // a field that has already done its job.
+        input.current?.blur();
       }}
       className="flex min-w-0 flex-1 justify-end"
     >
-      <Input
-        type="search"
-        name="q"
-        value={draft}
-        onChange={(e) => setDraft(e.target.value)}
-        disabled={!usable}
-        placeholder={usable ? "Search memory…" : "Search unavailable"}
-        aria-label="Search memory"
-        // Shrinks rather than pushing the title off. A fixed 280px crowded
-        // the heading out of the bar below ~480px.
-        className="max-w-[280px]"
-      />
+      {/* The wrapper, not the input, carries the frame: the icon and the hint
+          sit inside the field's box, so the box has to be the thing that draws
+          it. `focus-within` puts the ring on the same box, which is what makes
+          the whole control read as focused rather than just its text area. */}
+      <div
+        className={cn(
+          "border-input bg-input/30 flex h-8 w-full max-w-[420px] min-w-0 items-center gap-2",
+          "rounded-md border pr-2 pl-2.5 transition-colors duration-100",
+          focused ? "border-ring ring-ring/50 ring-[3px]" : "hover:border-ring/40",
+          !usable && "opacity-50",
+        )}
+      >
+        <Search
+          aria-hidden="true"
+          className="text-muted-foreground size-[15px] shrink-0"
+          strokeWidth={1.8}
+        />
+        <input
+          ref={input}
+          type="search"
+          name="q"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          onKeyDown={(e) => {
+            // Escape leaves the field without committing. A search box that
+            // traps the keyboard is the reason people reach for the mouse.
+            if (e.key === "Escape") input.current?.blur();
+          }}
+          disabled={!usable}
+          placeholder={usable ? "Search this memory…" : "Search unavailable"}
+          aria-label="Search memory"
+          className={cn(
+            "placeholder:text-muted-foreground min-w-0 flex-1 bg-transparent text-[13px]",
+            "outline-none disabled:cursor-not-allowed",
+            // Chrome draws its own clear affordance on type=search, in its own
+            // colours, on a surface it knows nothing about.
+            "[&::-webkit-search-cancel-button]:appearance-none",
+          )}
+        />
+        {usable && !focused ? (
+          <kbd
+            aria-hidden="true"
+            className="border-border text-muted-foreground/70 mono shrink-0 rounded border px-1 text-[10px] leading-[16px]"
+          >
+            /
+          </kbd>
+        ) : null}
+      </div>
     </form>
   );
 }

--- a/front/ui/src/components/layout/Sidebar.tsx
+++ b/front/ui/src/components/layout/Sidebar.tsx
@@ -48,55 +48,75 @@ import shodhMark from "@/assets/shodh-mark.png";
  * transition to 0.01ms — this component needs no separate branch for it.
  */
 
+/**
+ * The destinations, and the one line each of them is.
+ *
+ * A caption is not a tooltip and not a tagline. It is the sentence someone
+ * needs in order to know what they are looking at the moment they arrive, so it
+ * says what the DATA on that screen is, in the words a person would use. Three
+ * rules it is held to, all of them learned from copy that failed them:
+ *
+ *  - No subsystem words. "corpus", "session store", "spreading activation" name
+ *    parts of this program, not things a reader has.
+ *  - True of the screen as it opens, not of the screen after work. Geo used to
+ *    promise "the current results" and then opened onto the whole map, which
+ *    reads as the wrong screen rather than as a fuller one.
+ *  - It labels; it does not sell. No adjective that the screen cannot be
+ *    checked against.
+ *
+ * Read in two places — the rail (`Placeholder`, for destinations with nothing
+ * behind them yet) and the header, next to the title (TopBar.tsx). Both read it
+ * from here so the app cannot describe one destination two ways.
+ */
 export const DESTINATIONS = [
   {
     id: "chat",
     path: "/chat",
     label: "Conversations",
     icon: MessageSquare,
-    caption: "Converse with memory on the table",
+    caption: "Ask a model that can read this memory",
   },
   {
     id: "recall",
     path: "/recall",
     label: "Recall",
     icon: Search,
-    caption: "Search memory and see what connects",
+    caption: "Search this memory, and see what connects to what",
   },
   {
     id: "graph",
     path: "/graph",
     label: "Graph",
     icon: Share2,
-    caption: "The entities this corpus knows and how they relate",
+    caption: "The things this memory knows about, and how they relate",
   },
   {
     id: "geo",
     path: "/geo",
     label: "Geo",
     icon: Globe,
-    caption: "Where the current results happened",
+    caption: "Where this memory happened, on a map",
   },
   {
     id: "anomalies",
     path: "/anomalies",
     label: "Anomalies",
     icon: TriangleAlert,
-    caption: "What deviates from this user's baseline",
+    caption: "What stands out against this profile's own normal",
   },
   {
     id: "tasks",
     path: "/tasks",
     label: "Tasks",
     icon: ListChecks,
-    caption: "Open work captured from sessions",
+    caption: "Open work picked up from what was recorded",
   },
   {
     id: "providers",
     path: "/providers",
     label: "Providers",
     icon: KeyRound,
-    caption: "Model endpoints and credentials",
+    caption: "Where models run, and the keys they need",
   },
 ] as const;
 

--- a/front/ui/src/components/layout/TopBar.tsx
+++ b/front/ui/src/components/layout/TopBar.tsx
@@ -1,13 +1,36 @@
 import type { ReactNode } from "react";
+import { useLocation } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import type { Reachability } from "@/lib/api";
 import { StatusStrip } from "./StatusStrip";
+import { DESTINATIONS } from "./Sidebar";
 
 /** Collapsed rail width, as the offset every fixed element reserves. The rail's
  *  *expanded* width is deliberately never reserved: doing so would make the
  *  expansion push content, which is the one thing it must not do. */
 export const RAIL_OFFSET = "pl-14";
 
+/**
+ * The header — and the one place every destination says what it is.
+ *
+ * A name is not an explanation. "Geo" tells someone which button they pressed;
+ * it does not tell them that the points are memories and that the map is the
+ * whole corpus until they search. Arriving somewhere and not knowing what the
+ * data means was the single most repeated reaction to this app, and the fix has
+ * to be visible without hovering, because a tooltip only pays out to someone who
+ * already suspected there was something to learn.
+ *
+ * The caption is read from `DESTINATIONS` rather than passed in, so the rail and
+ * the header cannot describe the same destination two different ways, and a new
+ * destination gets its line by existing rather than by remembering to wire one.
+ * The `title` prop still comes from the shell, and still wins: it is what the
+ * router decided is on screen, and this component is not the place to disagree
+ * with it.
+ *
+ * One line, not a stacked title and subtitle: the bar is 48px, and a two-line
+ * block inside it is cramped everywhere and clipped at the sizes where the
+ * status strip is also fighting for room.
+ */
 export function TopBar({
   title,
   reach,
@@ -17,6 +40,9 @@ export function TopBar({
   reach: Reachability;
   children?: ReactNode;
 }) {
+  const { pathname } = useLocation();
+  const caption = DESTINATIONS.find((d) => d.path === pathname)?.caption;
+
   return (
     <header
       className={cn(
@@ -29,9 +55,19 @@ export function TopBar({
           from the left, so anything in its first 224px gets occluded on hover
           — and a status strip sliced mid-word reads as a rendering fault. The
           title is the one thing that can afford to go: while the rail is open
-          it is showing its own header, which names the product anyway. */}
-      <h1 className="shrink-0 text-[13px] font-medium tracking-tight">{title}</h1>
-      <div className="ml-auto flex min-w-0 items-center gap-3 pl-3">
+          it is showing its own header, which names the product anyway. The
+          caption travels with the title for the same reason, and is the first
+          thing to give up width because the title alone still identifies the
+          screen. */}
+      <div className="flex min-w-0 items-baseline gap-2.5">
+        <h1 className="shrink-0 text-[13px] font-medium tracking-tight">{title}</h1>
+        {caption ? (
+          <p className="text-muted-foreground hidden min-w-0 truncate text-[12px] md:block">
+            {caption}
+          </p>
+        ) : null}
+      </div>
+      <div className="ml-auto flex min-w-0 flex-1 items-center justify-end gap-3 pl-3">
         <StatusStrip reach={reach} />
         {children}
       </div>

--- a/front/ui/src/features/geo/GeoView.tsx
+++ b/front/ui/src/features/geo/GeoView.tsx
@@ -93,8 +93,19 @@ export function GeoView({ reach }: { reach: Reachability }) {
 
       <GeoMap memories={plotted} types={types} dimmed={dimmed} />
 
-      <div className="text-muted-foreground pointer-events-none absolute top-3 left-4 z-10 text-[12px]">
-        {hasQuery ? "Where this answer happened" : "Where this profile's memory happened"}
+      <div className="pointer-events-none absolute top-3 left-4 z-10 flex flex-col gap-0.5">
+        <span className="text-muted-foreground text-[12px]">
+          {hasQuery ? "Where this answer happened" : "Where this profile's memory happened"}
+        </span>
+        {/* Said only before a query, because it is the one thing this map does
+            that is not visible from looking at it: searching does not swap the
+            points out, it turns the matching ones up. Without the line, a map
+            that stays put after a search reads as a map that ignored it. */}
+        {!hasQuery ? (
+          <span className="text-muted-foreground/60 text-[11px]">
+            Search to raise the points that match
+          </span>
+        ) : null}
       </div>
 
       <div

--- a/front/ui/src/features/inspector/Inspector.tsx
+++ b/front/ui/src/features/inspector/Inspector.tsx
@@ -165,7 +165,7 @@ export function Inspector() {
               {listed?.content_truncated ? (
                 <p className="text-muted-foreground/60 mt-1.5 text-[11px]">
                   Cut short — this memory is {listed.content_length} characters long.
-                  Searching for it returns the whole text.
+                  The listing carries a preview; a search result carries the whole text.
                 </p>
               ) : null}
 

--- a/front/ui/src/features/inspector/Inspector.tsx
+++ b/front/ui/src/features/inspector/Inspector.tsx
@@ -1,5 +1,10 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { skipToken, useQuery } from "@tanstack/react-query";
 import type { RecallResponse } from "@/lib/api";
+import {
+  corpusKey,
+  corpusToRecallMemory,
+  type CorpusListResponse,
+} from "@/lib/api/corpus";
 import { useSession } from "@/stores/session";
 import { ScoreBreakdown } from "./ScoreBreakdown";
 import { Badge } from "@/components/ui/badge";
@@ -53,19 +58,56 @@ export function Inspector() {
   const selectedEntityId = useSession((s) => s.selectedEntityId);
   const select = useSession((s) => s.select);
 
-  // Same key as ResultPane, read straight out of the cache.
+  // TWO CACHES, ONE PANE, and the second one is not an optimisation.
   //
-  // Deliberately `getQueryData` and not `useQuery({ enabled: false })`. That
-  // form still *registers* a query for the key, and a registration carrying no
-  // queryFn throws when nothing else has populated it — which is exactly the
-  // first-paint case here, before any search has run. A cache read has no such
-  // failure mode and cannot issue a request by accident.
-  const data = useQueryClient().getQueryData<RecallResponse>(recallKey(profile, query));
+  // Recall now opens onto the corpus rather than onto an instruction: with no
+  // query, the result column lists the newest memories and every row selects
+  // into this pane exactly like a result. But those rows come from the corpus
+  // listing, and the recall cache under an empty query has never been
+  // populated — so every one of those clicks landed here, found nothing, and
+  // was answered with "search, then select a result". A list whose rows are
+  // invitations and whose clicks say "do something else first" is a dead end in
+  // the one place the product asks a stranger to start.
+  //
+  // Both are read with `queryFn: skipToken`, which subscribes to a cache entry
+  // and can never issue the request itself. This replaces a bare
+  // `getQueryData` read, for a reason the earlier note here did not anticipate:
+  // a cache read is not a subscription, and both of these entries resolve
+  // underneath an Inspector that is already mounted — the corpus fetch lands on
+  // the first paint of /recall, and a fresh recall lands while a memory from the
+  // previous result set is still selected. Neither re-rendered this pane, so it
+  // went on showing a pre-load message, or a selected memory stripped of the
+  // attribution the response had just delivered, until something unrelated
+  // happened to re-render it.
+  //
+  // `skipToken` is specifically what the old note was reaching for and could not
+  // name: `enabled: false` with no `queryFn` registers a query that throws on an
+  // unpopulated key — which IS the first-paint case here — while `skipToken` is
+  // the supported form for "read this key, never fetch it". `useCorpus`/
+  // `useRecall` are not reused because both need `Reachability`, which this pane
+  // is not given and does not need: it only ever reads what those two wrote.
+  const { data } = useQuery<RecallResponse>({
+    queryKey: recallKey(profile, query),
+    queryFn: skipToken,
+  });
+  const { data: corpus } = useQuery<CorpusListResponse>({
+    queryKey: corpusKey(profile),
+    queryFn: skipToken,
+  });
 
-  const memory = data?.memories.find((m) => m.id === selectedId);
+  // Preference order matters: a memory present in BOTH is read from the recall
+  // response, because that copy carries the retrieval evidence — score
+  // attribution, tier as retrieved, and the lineage below. The corpus copy is
+  // the fallback and knows none of that.
+
+  const recalled = data?.memories.find((m) => m.id === selectedId);
+  const listed = recalled ? undefined : corpus?.memories.find((m) => m.id === selectedId);
+  const memory = recalled ?? (listed ? corpusToRecallMemory(listed) : undefined);
 
   // Chain 2: the causal edges that connect this memory to others in the same
-  // result set. The server returns these already — no extra endpoint.
+  // result set. The server returns these already — no extra endpoint. A memory
+  // reached from the corpus listing has none: lineage is a property of a
+  // retrieval, not of a memory, and there is no retrieval to be part of.
   const lineage = (data?.lineage ?? []).filter(
     (e) => e.from === selectedId || e.to === selectedId,
   );
@@ -104,15 +146,28 @@ export function Inspector() {
         ) : !memory ? (
           <Empty
             body={
-              data
-                ? "Select a result to see what it is, why it surfaced, and what it connects to."
-                : "Search, then select a result to see why it surfaced."
+              data || corpus
+                ? "Select a memory to see what it is, when it was recorded, and what it connects to."
+                : "This profile's memory is still loading."
             }
           />
         ) : (
           <>
             <div className="px-4 py-3">
               <p className="text-[13px] leading-relaxed">{memory.experience.content}</p>
+
+              {/* `GET /api/list` caps content at 500 characters and says so on
+                  the row (src/handlers/crud.rs). Recall does not truncate, so
+                  this can only appear on a memory reached from the pre-query
+                  listing — and text that silently stops mid-sentence in a pane
+                  whose whole job is trust has to be labelled as cut, not left
+                  to look like the whole record. */}
+              {listed?.content_truncated ? (
+                <p className="text-muted-foreground/60 mt-1.5 text-[11px]">
+                  Cut short — this memory is {listed.content_length} characters long.
+                  Searching for it returns the whole text.
+                </p>
+              ) : null}
 
               {memory.experience.tags.length > 0 ? (
                 <Field label="Entities">

--- a/front/ui/src/features/inspector/ScoreBreakdown.tsx
+++ b/front/ui/src/features/inspector/ScoreBreakdown.tsx
@@ -41,6 +41,26 @@ const FACTORS: { key: keyof ScoreAttribution; label: string; hint: string }[] = 
   { key: "quality_gate", label: "Quality gate", hint: "Content richness" },
 ];
 
+/**
+ * The retrieval legs, in the words the result rows use.
+ *
+ * `sources` carries the server's own tokens — `"graph"` and `"vector"`, pushed
+ * at src/memory/mod.rs:4172 and :4226 — and printing them raw put two things on
+ * screen that should not have been there. `vector` is a lie by omission: it
+ * labels the HYBRID leg, which is BM25 and vector search already fused
+ * (mod.rs:4176-4196), so a reader is told "vector" about a result an exact
+ * keyword match found. And it contradicted the same fact stated in words one
+ * pane to the left, on the row this panel is explaining (features/recall/why.ts).
+ *
+ * An unknown token is shown verbatim rather than dropped: this is the panel
+ * whose entire job is to account for the score, and silently discarding a leg
+ * the server said contributed would be the one failure it cannot have.
+ */
+const LEG_LABEL: Record<string, string> = {
+  vector: "Meaning and wording",
+  graph: "The graph",
+};
+
 /** A multiplier is "neutral" if it left the score alone. Float noise means an
  *  exact 1.0 comparison would leak 0.9999 rows into the list. */
 const NEUTRAL_EPSILON = 0.005;
@@ -89,13 +109,16 @@ export function ScoreBreakdown({ attr }: { attr: ScoreAttribution }) {
       <h3 className="text-[12px] font-medium tracking-tight">Why this surfaced</h3>
 
       {sources.length > 0 ? (
-        <div className="mt-2 flex flex-wrap gap-1">
-          {sources.map((s) => (
-            <Badge key={s} className="mono">
-              {s}
-            </Badge>
-          ))}
-        </div>
+        <>
+          <p className="text-muted-foreground/70 mt-2 text-[11px]">
+            Reached by
+          </p>
+          <div className="mt-1 flex flex-wrap gap-1">
+            {sources.map((s) => (
+              <Badge key={s}>{LEG_LABEL[s] ?? s}</Badge>
+            ))}
+          </div>
+        </>
       ) : null}
 
       {/* Additive fusion base, split by leg. */}

--- a/front/ui/src/features/recall/GraphStage.tsx
+++ b/front/ui/src/features/recall/GraphStage.tsx
@@ -154,7 +154,13 @@ export function GraphStage({ reach }: { reach: Reachability }) {
               ))}
             </div>
           </div>
-          <span className="text-muted-foreground/70 text-[11px]">
+          {/* `shrink-0`: this row wraps, and without it the hint is squeezed
+              into a narrow column instead of dropping to a line of its own —
+              at the stage width /recall actually has (viewport minus rail,
+              result column and Inspector) it was rendering as four stacked
+              fragments. Refusing to shrink makes the wrap happen at the row
+              level, which is what `flex-wrap` is here for. */}
+          <span className="text-muted-foreground/70 shrink-0 text-[11px]">
             {/* Say what the edges ARE, not just how to move the camera. Zero
                 causal edges across a result set is a finding about the corpus,
                 not a broken canvas, and staying silent about it invites the

--- a/front/ui/src/features/recall/RecallView.tsx
+++ b/front/ui/src/features/recall/RecallView.tsx
@@ -1,10 +1,13 @@
 import { useMemo } from "react";
+import { cn } from "@/lib/utils";
 import { ApiError, NetworkError, type Reachability } from "@/lib/api";
-import { corpusToRecallMemory, useCorpus } from "@/lib/api/corpus";
+import { corpusToRecallMemory, useCorpus, type CorpusMemory } from "@/lib/api/corpus";
 import { EmptyState } from "@/components/ui/empty-state";
+import { useSession } from "@/stores/session";
 import { ResultList, ResultListSkeleton } from "./ResultList";
 import { GraphStage } from "./GraphStage";
 import { useRecall } from "./useRecall";
+import { corpusCues } from "./cues";
 
 /**
  * Recall — the search surface, and the entry point to both chains.
@@ -14,7 +17,125 @@ import { useRecall } from "./useRecall";
  * every keystroke would spend that repeatedly to answer prefixes nobody asked
  * about. A search field that acts on Enter is also what the control already
  * promises.
+ *
+ * Both states of the result column are headed, and the heading is the column's
+ * only chance to say what the rows underneath it ARE. Before a query they are
+ * the corpus, newest first, and the head offers the first move. After one they
+ * are an answer, and the head says how much was searched, how long it took, and
+ * the one thing about this product that a competing screenful of results cannot
+ * claim: none of it was written.
  */
+
+/** How many of the newest memories the pre-query listing shows. Enough to make
+ *  the column obviously scrollable and to convey what kind of thing is stored;
+ *  not so many that the browser lays out the whole corpus to say it. */
+const RECENT_LIMIT = 50;
+
+/**
+ * The pre-query head: what is here, and what to do first.
+ *
+ * The cues are the first action. They are not suggestions in the marketing
+ * sense — each one is a tag the extraction pipeline wrote against these
+ * memories, shown verbatim, and clicking it runs it as the query (see cues.ts
+ * for why they can be trusted on a corpus nobody has seen). On a corpus whose
+ * tags are all lower-case debris this renders no row at all, which is the
+ * correct outcome: an empty row is honest, an invented cue is not.
+ */
+function CorpusHead({ memories, total }: { memories: CorpusMemory[] | undefined; total: number }) {
+  const setActiveQuery = useSession((s) => s.setActiveQuery);
+  const cues = useMemo(() => corpusCues(memories), [memories]);
+
+  return (
+    <div className="border-border shrink-0 border-b px-4 py-2.5">
+      <p className="text-muted-foreground text-[11px] leading-relaxed">
+        {total} {total === 1 ? "memory" : "memories"} here, newest first. Search to rank
+        them by relevance.
+      </p>
+
+      {cues.length > 0 ? (
+        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          {/* Named, because four bare words under a sentence read as tags on the
+              screen rather than as things to press. */}
+          <span className="text-muted-foreground/60 mr-0.5 text-[11px]">Mentioned most</span>
+          {cues.map((cue) => (
+            <button
+              key={cue.text}
+              type="button"
+              onClick={() => setActiveQuery(cue.text)}
+              // The visible label is a word and a number, which announces as
+              // "Seagirt 10" and says neither what pressing it does nor what
+              // the number counts. The heading above supplies both visually and
+              // is not associated with the control, so the control says it.
+              aria-label={`Search for ${cue.text} — mentioned in ${cue.count} ${
+                cue.count === 1 ? "memory" : "memories"
+              }`}
+              className={cn(
+                "border-border text-foreground/90 hover:border-ring/50 hover:bg-accent/60",
+                "focus-visible:ring-ring flex items-baseline gap-1 rounded-full border px-2 py-0.5",
+                "text-[11px] transition-colors duration-100 focus-visible:ring-2 focus-visible:outline-none",
+              )}
+            >
+              {cue.text}
+              {/* The count is why these four and not four others. Without it the
+                  row is a taste; with it, it is a reading of the corpus. */}
+              <span className="text-muted-foreground/60 mono text-[10px]">{cue.count}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The post-query head.
+ *
+ * Two facts and one claim, and every part of it is read off the response rather
+ * than asserted:
+ *
+ *  - the count of what surfaced against the count of what was there to search;
+ *  - `retrieval_stats.retrieval_time_us`, which the server measures and returns
+ *    on every debug query (types.ts cites the struct). It is SERVER-SIDE
+ *    RETRIEVAL time and is labelled as such — it excludes the network hop and
+ *    everything the browser does, so calling it "response time" would overclaim
+ *    a number that is not that. When the field is absent the clause is absent;
+ *    there is no fallback estimate, because an estimate presented in the same
+ *    typeface as a measurement is worse than silence;
+ *  - "nothing here was written by a model", which is the product's actual edge
+ *    and is checkable on this screen: every row is a stored memory rendered
+ *    verbatim, and the Inspector traces each one to what recorded it. The
+ *    stronger-sounding claim — that no model runs at all — is NOT made, because
+ *    it is false: retrieval embeds the query with a local encoder
+ *    (src/embeddings/minilm.rs, and `embedding_time_us` is a line item in the
+ *    server's own timing). Generation is what is absent here, and generation is
+ *    what the claim says.
+ */
+function AnswerHead({
+  shown,
+  total,
+  retrievalUs,
+}: {
+  shown: number;
+  total: number;
+  retrievalUs: number | undefined;
+}) {
+  return (
+    <div className="border-border shrink-0 border-b px-4 py-2.5">
+      <p className="text-muted-foreground text-[11px]">
+        {shown} of {total} {total === 1 ? "memory" : "memories"}
+        {retrievalUs !== undefined ? (
+          <span title="Time the server spent retrieving and ranking. Excludes the network round trip.">
+            {" · retrieved in "}
+            <span className="mono">{Math.round(retrievalUs / 1000)} ms</span>
+          </span>
+        ) : null}
+      </p>
+      <p className="text-muted-foreground/60 mt-1 text-[11px] leading-relaxed">
+        Nothing here was written by a model — these are stored memories, ranked.
+      </p>
+    </div>
+  );
+}
 
 function ResultPane({ reach }: { reach: Reachability }) {
   // The query itself lives in `useRecall` — the graph stage renders the same
@@ -29,7 +150,7 @@ function ResultPane({ reach }: { reach: Reachability }) {
     () =>
       [...(corpus.data?.memories ?? [])]
         .sort((a, b) => b.created_at.localeCompare(a.created_at))
-        .slice(0, 50)
+        .slice(0, RECENT_LIMIT)
         .map(corpusToRecallMemory),
     [corpus.data],
   );
@@ -67,9 +188,10 @@ function ResultPane({ reach }: { reach: Reachability }) {
     }
     return (
       <div className="flex min-h-0 flex-1 flex-col">
-        <div className="text-muted-foreground border-border shrink-0 border-b px-4 py-2 text-[11px]">
-          Newest memories — search above to rank by relevance
-        </div>
+        <CorpusHead
+          memories={corpus.data?.memories}
+          total={corpus.data?.total ?? recent.length}
+        />
         <ResultList memories={recent} />
       </div>
     );
@@ -100,7 +222,19 @@ function ResultPane({ reach }: { reach: Reachability }) {
     );
   }
 
-  return data ? <ResultList memories={data.memories} /> : null;
+  return data ? (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <AnswerHead
+        shown={data.memories.length}
+        total={corpus.data?.total ?? data.memories.length}
+        retrievalUs={data.retrieval_stats?.retrieval_time_us}
+      />
+      {/* The lineage the server returned with this result set, so a row can say
+          how many of the others it is causally linked to. Same object the graph
+          canvas plots and the Inspector walks — one response, three readings. */}
+      <ResultList memories={data.memories} lineage={data.lineage} />
+    </div>
+  ) : null;
 }
 
 export function RecallView({ reach }: { reach: Reachability }) {

--- a/front/ui/src/features/recall/RecallView.tsx
+++ b/front/ui/src/features/recall/RecallView.tsx
@@ -122,7 +122,11 @@ function AnswerHead({
   return (
     <div className="border-border shrink-0 border-b px-4 py-2.5">
       <p className="text-muted-foreground text-[11px]">
-        {shown} of {total} {total === 1 ? "memory" : "memories"}
+        {/* "Top", not a bare count: `shown` is capped by the request limit
+            (lib/api/recall.ts sends 25), so "25 of 74" would read as "25
+            matched" when it means "the 25 best of what matched". "Top 5 of 74"
+            stays exact when fewer come back. */}
+        Top {shown} of {total} {total === 1 ? "memory" : "memories"}
         {retrievalUs !== undefined ? (
           <span title="Time the server spent retrieving and ranking. Excludes the network round trip.">
             {" · retrieved in "}

--- a/front/ui/src/features/recall/ResultList.tsx
+++ b/front/ui/src/features/recall/ResultList.tsx
@@ -1,8 +1,9 @@
 import { cn } from "@/lib/utils";
-import type { RecallMemory } from "@/lib/api";
+import type { RecallLineageEdge, RecallMemory } from "@/lib/api";
 import { useSession } from "@/stores/session";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
+import { whyItSurfaced } from "./why";
 
 /**
  * The result column.
@@ -10,7 +11,21 @@ import { Skeleton } from "@/components/ui/skeleton";
  * A row is the entry point to both chains in WORKFLOWS.md — selecting it opens
  * the Inspector, which is the only object-detail surface in the product. So the
  * row's job is to carry just enough to choose between candidates, and nothing
- * more: the content, when it was recorded, and how strongly it surfaced.
+ * more: the content, when it was recorded, how strongly it surfaced, and — the
+ * one addition — why.
+ *
+ * WHY THE REASON IS ON THE ROW. The full attribution has always been one click
+ * away in the Inspector, and one click away is where it stayed: a ranked list
+ * with no stated reason reads as a black box, and nobody opens a panel to
+ * check a list they have already decided not to trust. So the strongest single
+ * line comes forward and the arithmetic stays behind (see why.ts, which is also
+ * where the constraints on the wording live). It is one line, muted, under the
+ * content — a reason competing with the memory for attention would have traded
+ * one unreadable row for another.
+ *
+ * The line is absent, not blank, when the server attributed nothing: corpus
+ * rows in the pre-query listing were never retrieved and have no reason to
+ * give, and a row of dashes standing in for that would be a fabrication.
  *
  * The score shown is the server's normalised `score`, not the raw fusion
  * output. It is rendered as a bar rather than a number because the useful
@@ -30,9 +45,16 @@ function relativeDay(iso: string): string {
   return `${Math.floor(days / 365)}y ago`;
 }
 
-function ResultRow({ memory }: { memory: RecallMemory }) {
+function ResultRow({
+  memory,
+  lineage,
+}: {
+  memory: RecallMemory;
+  lineage: RecallLineageEdge[] | undefined;
+}) {
   const selected = useSession((s) => s.selectedMemoryId === memory.id);
   const select = useSession((s) => s.select);
+  const why = whyItSurfaced(memory, lineage);
 
   return (
     <button
@@ -53,6 +75,20 @@ function ResultRow({ memory }: { memory: RecallMemory }) {
       >
         {memory.experience.content}
       </p>
+
+      {/* Why it is here, in the human's words. Two clauses at most, and each is
+          omitted independently: a memory the graph reached with no lineage to
+          the rest of the set says only the first, one in a set with no
+          attribution says only the second. */}
+      {why ? (
+        <p className="text-muted-foreground/70 mt-1.5 text-[11px] leading-relaxed">
+          {why.legs}
+          {why.legs !== null && why.links > 0 ? " · " : null}
+          {why.links > 0
+            ? `Connects to ${why.links} other${why.links === 1 ? "" : "s"} here`
+            : null}
+        </p>
+      ) : null}
 
       <div className="mt-2 flex items-center gap-2">
         {/* Relative strength against the top hit, which is what the server's
@@ -77,12 +113,20 @@ function ResultRow({ memory }: { memory: RecallMemory }) {
   );
 }
 
-export function ResultList({ memories }: { memories: RecallMemory[] }) {
+export function ResultList({
+  memories,
+  lineage,
+}: {
+  memories: RecallMemory[];
+  /** The causal edges the same response carried. Optional because the pre-query
+   *  corpus listing is not a result set and has none. */
+  lineage?: RecallLineageEdge[];
+}) {
   return (
     <ScrollArea role="list" className="min-h-0 flex-1">
       {memories.map((m) => (
         <div role="listitem" key={m.id}>
-          <ResultRow memory={m} />
+          <ResultRow memory={m} lineage={lineage} />
         </div>
       ))}
     </ScrollArea>

--- a/front/ui/src/features/recall/cues.ts
+++ b/front/ui/src/features/recall/cues.ts
@@ -1,0 +1,86 @@
+import type { CorpusMemory } from "@/lib/api/corpus";
+
+/**
+ * The first thing to search, derived from what is actually stored.
+ *
+ * A destination that holds memory but has never been queried has to offer a
+ * first move, and the honest way to offer one is to read the corpus rather than
+ * to ship a list of strings. Hardcoded examples are a promise about someone
+ * else's data: "try: bridge collapse" is a lie on a profile of engineering
+ * notes, and the moment it is wrong it teaches that nothing else on the screen
+ * is trustworthy either.
+ *
+ * WHAT THIS READS. `CorpusMemory.tags` — the entity mentions the extraction
+ * pipeline wrote at remember time, already on screen in the Inspector under
+ * "Entities". Nothing here is generated, scored or rephrased; a cue is one of
+ * those strings, verbatim, and clicking it runs it as the query.
+ *
+ * WHY THE CAPITAL LETTER IS THE FILTER. Extraction emits two very different
+ * kinds of tag from the same field: named things (`Dali`, `Seagirt`,
+ * `Port of Baltimore`) and ordinary sentence debris (`completed`, `week`,
+ * `blocked`). Only the first kind is a cue anybody would recognise, and the
+ * only signal separating them that is present on the wire is the case the
+ * extractor preserved. So a group qualifies when at least one of its surface
+ * forms starts with a capital — which is a filter on the DATA, not a guess
+ * about it, and it degrades to "no cues" rather than to bad cues on a corpus
+ * that has none.
+ *
+ * Counting is case-insensitive and display is not: `seagirt` (6) and `Seagirt`
+ * (4) are one thing mentioned ten times, and the form shown is the capitalised
+ * one because that is how a person would write it back.
+ */
+
+/** Below this a "name" is an abbreviation or noise (`bay`, `gate`, `Ltd`), and
+ *  a two-letter cue would retrieve half the corpus. */
+const MIN_CUE_LENGTH = 4;
+
+/** Four is what fits on one row of a 340px column without wrapping into a
+ *  block that competes with the list underneath it. */
+const MAX_CUES = 4;
+
+export interface Cue {
+  /** The tag verbatim, as both the label and the query it runs. */
+  text: string;
+  /** How many memories in the corpus carry it, in any casing. */
+  count: number;
+}
+
+export function corpusCues(memories: CorpusMemory[] | undefined): Cue[] {
+  if (!memories || memories.length === 0) return [];
+
+  // key: lower-cased tag → total mentions, and every surface form seen.
+  const groups = new Map<string, { count: number; forms: Map<string, number> }>();
+
+  for (const memory of memories) {
+    for (const tag of memory.tags) {
+      const trimmed = tag.trim();
+      if (trimmed.length < MIN_CUE_LENGTH) continue;
+      const key = trimmed.toLowerCase();
+      const group = groups.get(key) ?? { count: 0, forms: new Map<string, number>() };
+      group.count += 1;
+      group.forms.set(trimmed, (group.forms.get(trimmed) ?? 0) + 1);
+      groups.set(key, group);
+    }
+  }
+
+  const cues: Cue[] = [];
+  for (const group of groups.values()) {
+    // The capitalised surface forms only. `[a-z]` is deliberately not the test:
+    // an all-caps acronym is a name too.
+    const named = [...group.forms.entries()].filter(([form]) => {
+      const first = form[0];
+      return first !== undefined && first !== first.toLowerCase();
+    });
+    if (named.length === 0) continue;
+
+    // The form written most often wins; longer wins a tie, because the longer
+    // form is the more specific one someone would recognise.
+    named.sort((a, b) => b[1] - a[1] || b[0].length - a[0].length);
+    cues.push({ text: named[0]![0], count: group.count });
+  }
+
+  // Most-mentioned first. Alphabetical within a tie so the row does not
+  // reshuffle between renders of the same corpus.
+  cues.sort((a, b) => b.count - a.count || a.text.localeCompare(b.text));
+  return cues.slice(0, MAX_CUES);
+}

--- a/front/ui/src/features/recall/why.ts
+++ b/front/ui/src/features/recall/why.ts
@@ -1,0 +1,74 @@
+import type { RecallLineageEdge, RecallMemory } from "@/lib/api";
+
+/**
+ * The one line of "why is this here" that belongs on the row itself.
+ *
+ * The full account already exists — `ScoreBreakdown` renders every factor the
+ * server attributed — but it lives in the Inspector, which is one click and one
+ * decision away. A list of ranked results with no stated reason reads as a
+ * black box no matter how good the panel behind it is, so the strongest single
+ * sentence comes forward and the arithmetic stays where it was.
+ *
+ * WHICH SENTENCE IS STRONGEST. `ScoreBreakdown` already says it in its own
+ * comment: which legs found the memory at all is the most decodable thing in
+ * the panel. "The graph reached this, nothing in the text matched" is a claim
+ * about the product that a person can check by reading the memory; "×0.87
+ * recency" is not.
+ *
+ * WHAT THE LEG NAMES MEAN, EXACTLY. `ScoreAttribution.sources` carries at most
+ * two values, both pushed in src/memory/mod.rs:
+ *
+ *   "graph"  (mod.rs:4172) — the memory was in the graph leg: spreading
+ *            activation reached it from the entities the cue touched.
+ *   "vector" (mod.rs:4226-4227) — the memory was in the HYBRID leg, which is
+ *            BM25 and vector search fused before this point (mod.rs:4176-4196).
+ *            The name is the server's; it does not mean the vector leg alone,
+ *            and the copy below must not claim it does. That is why the phrase
+ *            is "meaning and wording" and not "vector".
+ *
+ * Anything else the server may push in future is ignored rather than printed:
+ * a raw enum token on a result row would be exactly the jargon leak this file
+ * exists to prevent.
+ *
+ * ABSENT MEANS ABSENT. `score_attribution` only arrives with `debug: true`, and
+ * corpus rows (the pre-query listing) have no attribution at all because they
+ * were never retrieved. Both cases return null and the row renders no line —
+ * never a placeholder, never a guess.
+ */
+
+export interface Why {
+  /** Which legs reached it, in plain words. Null when the server said nothing. */
+  legs: string | null;
+  /** How many other results in this set it is causally linked to. */
+  links: number;
+}
+
+export function whyItSurfaced(
+  memory: RecallMemory,
+  lineage: RecallLineageEdge[] | undefined,
+): Why | null {
+  const sources = memory.score_attribution?.sources ?? [];
+  const byGraph = sources.includes("graph");
+  const byHybrid = sources.includes("vector");
+
+  const legs = byGraph
+    ? byHybrid
+      ? "Meaning, wording and the graph"
+      : // The differentiator, stated where it happens: nothing in the text
+        // matched, and it surfaced anyway because activation travelled to it.
+        "No text matched — the graph reached it"
+    : byHybrid
+      ? "Meaning and wording"
+      : null;
+
+  // Distinct partners, not edge count: two edges between the same pair would
+  // otherwise read as two connected memories.
+  const partners = new Set<string>();
+  for (const edge of lineage ?? []) {
+    if (edge.from === memory.id) partners.add(edge.to);
+    else if (edge.to === memory.id) partners.add(edge.from);
+  }
+
+  if (legs === null && partners.size === 0) return null;
+  return { legs, links: partners.size };
+}

--- a/front/ui/src/lib/api/corpus.ts
+++ b/front/ui/src/lib/api/corpus.ts
@@ -32,8 +32,14 @@ export interface CorpusMemory {
   geo_location?: [number, number, number];
 }
 
-interface ListResponse {
+/** Exported because the Inspector reads this cache entry directly, the same way
+ *  it already reads the recall one: a memory selected before any query has run
+ *  exists only here, and refetching it to render a detail view would pay again
+ *  for data the app is already holding. */
+export interface CorpusListResponse {
   memories: CorpusMemory[];
+  /** Every memory in the profile, which is NOT `memories.length` — the request
+   *  caps at `CORPUS_LIMIT`. */
   total: number;
 }
 
@@ -72,7 +78,7 @@ export function useCorpus(reach: Reachability) {
   const { data, error, isFetching } = useQuery({
     queryKey: corpusKey(profile),
     queryFn: ({ signal }) =>
-      api.get<ListResponse>(
+      api.get<CorpusListResponse>(
         `/api/list/${encodeURIComponent(profile!)}?limit=${CORPUS_LIMIT}`,
         signal,
       ),

--- a/front/ui/src/lib/api/types.ts
+++ b/front/ui/src/lib/api/types.ts
@@ -73,6 +73,24 @@ export interface RecallMemory {
   score_attribution?: ScoreAttribution;
 }
 
+/**
+ * `RetrievalStats` — src/memory/types.rs:3128. Only the fields this UI renders;
+ * the struct also carries candidate counts, per-leg weights, hop counts and a
+ * `stage_timings` breakdown, none of which belong on an analyst's first screen.
+ *
+ * Present whenever the request set `debug: true`, which this client always does
+ * (lib/api/recall.ts) — src/handlers/recall.rs:601-611 populates it from
+ * `recall_with_diagnostics` on that branch and passes `None` otherwise, and
+ * src/handlers/types.rs:169 skips it when absent. Optional here for that reason.
+ */
+export interface RetrievalStats {
+  /** Total time the server spent retrieving, in MICROseconds
+   *  (src/memory/types.rs:3160-3161). This is the retrieval itself — it does not
+   *  include the network hop, JSON encoding or anything the browser then does,
+   *  so it must never be presented as an end-to-end figure. */
+  retrieval_time_us: number;
+}
+
 /** `RecallFact` — src/handlers/types.rs */
 export interface RecallFact {
   id: string;
@@ -113,6 +131,7 @@ export interface RecallLineageEdge {
 export interface RecallResponse {
   memories: RecallMemory[];
   count: number;
+  retrieval_stats?: RetrievalStats;
   todos?: RecallTodo[];
   todo_count?: number;
   facts?: RecallFact[];

--- a/front/ui/src/stores/session.ts
+++ b/front/ui/src/stores/session.ts
@@ -71,7 +71,15 @@ export const useSession = create<SessionState>((set) => ({
     }),
   select: (selectedMemoryId) => set({ selectedMemoryId, selectedEntityId: null }),
   selectEntity: (selectedEntityId) => set({ selectedEntityId, selectedMemoryId: null }),
-  setActiveQuery: (activeQuery) => set({ activeQuery }),
+  // Committing a query starts a new answer, and the selected object belonged to
+  // the previous one. Left standing, it stays open in the Inspector beside a
+  // result set it is not part of — verified in the browser: search from the
+  // pre-query corpus listing with a row selected and the detail pane holds a
+  // memory that appears nowhere in the results, which reads as a stale panel
+  // rather than as a deliberate carry-over. Clearing both is the same rule
+  // `setProfile` and `reconcileProfiles` already follow for the same reason.
+  setActiveQuery: (activeQuery) =>
+    set({ activeQuery, selectedMemoryId: null, selectedEntityId: null }),
 
   reconcileProfiles: (profiles) =>
     set((s) => {


### PR DESCRIPTION
Investor feedback named four gaps: what am I looking at, why this result, what is the edge, where do I start. This works all four — and drops every claim the code could not back.

**What each screen is.** `TopBar` renders the destination's caption beside its title, read from the same `DESTINATIONS` source as the rail, so the two cannot disagree. Captions rewritten to drop subsystem words and to be true of the screen *as it opens*.

**The search affordance.** Framed control with a leading glyph, up to 420px, a visible `/` hint, `/` and ⌘/Ctrl-K to focus, Escape to leave. The hotkey no-ops while focus is in an input, so the conversation composer keeps its slashes. Also fixes a real defect: `draft` was seeded once, so a query committed from elsewhere left the field empty beside its own results.

**Why this result.** `features/recall/why.ts` puts one muted line on each row — which legs reached it, and how many other results it is causally linked to (distinct partners, not edge count). Absent, never a placeholder, when the server attributed nothing. `sources: ["vector"]` is the server's name for the fused BM25+vector leg (`src/memory/mod.rs:4176-4196`), so the copy says "meaning and wording", and `ScoreBreakdown` badges were changed to match — the panel had been contradicting the row explaining it.

**The edge, honestly.** `retrieval_stats.retrieval_time_us` is genuinely on the wire (this client always sends `debug: true`, `src/handlers/recall.rs:601-611`), so the head shows the measured value, labelled as server-side retrieval excluding the network hop. Claims dropped after checking the code: "retrieval runs with no model" is FALSE — `embedding_time_us` proves a neural encoder runs in-path, so the on-screen claim is now about generation ("nothing here was written by a model — these are stored memories, ranked"); "on this machine" dropped because the client cannot verify the server is local; no latency number is hardcoded; "deterministic" is written nowhere, because Hebbian strengthening runs on traversed edges and bit-identical repeats were not verified.

**A first action.** `features/recall/cues.ts` derives cues from tags extraction actually wrote, merged across casing and ranked by mentions — zero rows on a corpus with no named tags, rather than hardcoded strings that would lie elsewhere.

**Two dead ends fixed.** The Inspector resolved memories only from the recall cache, so clicking a pre-query corpus row showed "Search, then select a result" — it now falls back to the corpus cache via `corpusToRecallMemory`, with retrieval-evidence sections absent rather than empty. And both Inspector cache reads were `getQueryData`, which is not a subscription, so a new recall landing under a stale selection never re-rendered; both are subscriptions now and `setActiveQuery` clears a selection it no longer owns.

Verified in headless Chrome against the live seeded store at several widths (1440/1280/1180/1024/860): cues render and commit, `/` focuses without stealing from other inputs, why-lines and the head render on real results, corpus-row selection opens the Inspector, no horizontal overflow, focus ring visible. `tsc -b --noEmit` clean. Not verified: the truncation note (no memory in the corpus exceeds 500 chars) and ⌘/Ctrl-K (only `/` was driven).