### PR TITLE
feat(seat): say what a model swap does, where the swap happens

### DIFF
--- a/front/ui/src/features/chat/ChatView.tsx
+++ b/front/ui/src/features/chat/ChatView.tsx
@@ -228,6 +228,7 @@ export function ChatView({ reach, seat }: { reach: Reachability; seat: SeatReach
             <ModelPicker
               current={convo?.model ?? activeSummary?.model ?? null}
               disabled={convo?.streaming}
+              swap
               onSelect={async (model) => {
                 const applied = await changeModel(activeId, model.provider, model.id);
                 setModel(activeId, applied);

--- a/front/ui/src/features/chat/ConversationOverlay.tsx
+++ b/front/ui/src/features/chat/ConversationOverlay.tsx
@@ -251,6 +251,7 @@ export function ConversationOverlay({ seat }: { seat: SeatReachability }) {
               <ModelPicker
                 current={model}
                 disabled={streaming}
+                swap
                 onSelect={async (m) => {
                   const applied = await changeModel(activeId, m.provider, m.id);
                   setModel(activeId, applied);

--- a/front/ui/src/features/chat/EvidencePanel.tsx
+++ b/front/ui/src/features/chat/EvidencePanel.tsx
@@ -28,6 +28,18 @@ import { ScrollArea } from "@/components/ui/scroll-area";
  *
  * Two levels: a digest of every turn's evidence (newest first), and a
  * memory-detail view any inline chip, citation or digest row focuses.
+ *
+ * The strip under the header appears ONLY once this conversation has actually
+ * changed model — it is a report of something that happened, not a standing
+ * claim. That is what makes it checkable: the reader watched the swap, and
+ * the rows underneath are the same rows. It survives a reload because
+ * `model_changed` is a durable event (seat/src/store.ts persists every
+ * non-delta event) and `buildTurns` replays it into `ops`.
+ *
+ * "Already retrieved" is the exact scope. Turns taken after the swap do add
+ * new rows below, retrieved by a new pass the new model drove — so the line
+ * says the swap did not change what was retrieved, and never that the list
+ * stopped growing or that any model retrieves the same memories.
  */
 
 interface ResolvedMemory {
@@ -292,6 +304,16 @@ export function EvidencePanel({
     return resolveSelection(convo.turns, selected.turn, selected.memoryId);
   }, [selected, convo, conversationId]);
 
+  // A swap that this conversation actually performed. The op only reaches the
+  // client when the seat flushes its pending events at the start of the next
+  // turn (seat/src/conversation.ts sendMessage), so this line arrives with the
+  // new model's first answer — the moment the reader is looking for the
+  // difference the swap made to the evidence.
+  const swapped = useMemo(
+    () => (convo?.turns ?? []).some((turn) => turn.ops.some((op) => op.type === "model_changed")),
+    [convo],
+  );
+
   const turnsWithEvidence = useMemo(
     () =>
       (convo?.turns ?? [])
@@ -322,6 +344,16 @@ export function EvidencePanel({
           </Button>
         ) : null}
       </header>
+
+      {/* Its own strip rather than a second header line: the header is h-10 to
+          stay level with the conversation's, and this sentence has to WRAP at
+          the panel's narrow widths (min(340px,26vw) — 266px at 1024) instead of
+          truncating into half a claim. */}
+      {swapped ? (
+        <p className="border-border text-muted-foreground shrink-0 border-b px-4 py-1.5 text-[11px] leading-relaxed">
+          Switching models did not change what was already retrieved.
+        </p>
+      ) : null}
 
       <ScrollArea className="min-h-0 flex-1">
         {resolved && selected ? (

--- a/front/ui/src/features/chat/ModelPicker.tsx
+++ b/front/ui/src/features/chat/ModelPicker.tsx
@@ -24,14 +24,36 @@ import { Badge } from "@/components/ui/badge";
  * navigation. Radix would bring this prebuilt, but this is the only popover
  * in the app and the dependency's cost is the whole point of the "zero net
  * new chrome dependencies" line this UI holds.
+ *
+ * The footer states what a SWAP does, while the choice is still being made —
+ * this control is the one moment the product's strongest property is on
+ * screen, and it was previously unsaid there. It is a guarantee, not a
+ * slogan: PATCH /v1/conversations/{id}/model reassigns the model and nothing
+ * else (seat/src/conversation.ts setModel writes `agent.state.model`, leaving
+ * `agent.state.messages` untouched; seat/src/store.ts setModel UPDATEs the
+ * three model columns, never the transcripts or events tables), and on this
+ * side stores/chat.ts setModel replaces `model` and carries `turns` — where
+ * the retrieved memories live — through unchanged.
+ *
+ * Scope is deliberate and load-bearing. It says memories ALREADY retrieved,
+ * because every later turn runs a fresh proactive pass and the new model
+ * chooses its own recall cues: "a different model retrieves the same
+ * memories" is not something this code guarantees, so it is not said.
+ *
+ * `swap` gates it, because this same picker also opens on the new-conversation
+ * screen, where nothing has been retrieved for the sentence to be about. There
+ * it is a first choice, not a switch, and NewConversation says so itself.
  */
 export function ModelPicker({
   current,
   disabled,
+  swap,
   onSelect,
 }: {
   current: ModelRef | null;
   disabled?: boolean;
+  /** This picker changes the model of a conversation already under way. */
+  swap?: boolean;
   /** Resolves when the seat accepted the change; rejections surface inline. */
   onSelect: (model: SeatModelInfo) => Promise<void>;
 }) {
@@ -229,6 +251,13 @@ export function ModelPicker({
               ))
             )}
           </ul>
+
+          {swap ? (
+            <p className="border-border text-muted-foreground border-t px-3 py-2 text-[11px] leading-relaxed">
+              Changes which model answers next. Memories already retrieved here
+              stay as they are.
+            </p>
+          ) : null}
 
           {Object.entries(data?.local_errors ?? {}).length > 0 ? (
             <div className="border-border text-muted-foreground border-t px-3 py-2 text-[11px]">


### PR DESCRIPTION
The product's strongest claim — the model is replaceable, the memory is not — was demonstrated by the swap and stated nowhere.

Verified before writing it: `setModel` reassigns the model pointer and touches nothing else (`seat/src/conversation.ts:781-789`), the store UPDATE writes only provider/model columns (`store.ts:258-265`), and evidence is doubly durable as transcript tool results plus `memory_recall` events (`server.ts:643-661, 685-692`). Client-side, `stores/chat.ts:385-392` carries `turns` through unchanged.

Two lines:
- **Model picker footer** (gated on a conversation existing): "Changes which model answers next. Memories already retrieved here stay as they are."
- **Evidence panel strip** (only after a `model_changed` op): "Switching models did not change what was already retrieved." A report of what the reader just watched, not a standing boast.

Scope limit that shaped the wording: this is true of evidence ALREADY retrieved. Each new turn runs a fresh proactive pass and the new model picks its own cues, so post-swap turns legitimately retrieve different memories. The claim "a different model retrieves the same memories" was dropped as unverifiable and probably false.

Driven for real in headless Chrome against the live seat: 12 evidence rows under Haiku 4.5, swapped to Opus 4.5 mid-conversation, **rows identical** — same order, same labels; survived a full reload from the store; both models cited the same memory. Verified at 1440 and 1024 and on the docked overlay's picker. `tsc -b --noEmit` clean.

Known gap, fails absent rather than false: `model_changed` reaches the client via the pending-events flush at the next message, so a seat restart between swap and next message, or a swap on a conversation not live in the process, drops the strip.