### PR TITLE
feat(workbench): density pass — tokens and disclosure instead of prose

### DIFF
--- a/front/ui/src/components/layout/Sidebar.tsx
+++ b/front/ui/src/components/layout/Sidebar.tsx
@@ -51,10 +51,10 @@ import shodhMark from "@/assets/shodh-mark.png";
 /**
  * The destinations, and the one line each of them is.
  *
- * A caption is not a tooltip and not a tagline. It is the sentence someone
- * needs in order to know what they are looking at the moment they arrive, so it
- * says what the DATA on that screen is, in the words a person would use. Three
- * rules it is held to, all of them learned from copy that failed them:
+ * A caption is not a tooltip and not a tagline. It is what someone needs in
+ * order to know what they are looking at the moment they arrive, so it says
+ * what the DATA on that screen is, in the words a person would use. Four rules
+ * it is held to, all of them learned from copy that failed them:
  *
  *  - No subsystem words. "corpus", "session store", "spreading activation" name
  *    parts of this program, not things a reader has.
@@ -63,6 +63,20 @@ import shodhMark from "@/assets/shodh-mark.png";
  *    reads as the wrong screen rather than as a fuller one.
  *  - It labels; it does not sell. No adjective that the screen cannot be
  *    checked against.
+ *  - A NOUN PHRASE, NOT A SENTENCE, AND UNDER SIX WORDS. These were clauses —
+ *    "Search this memory, and see what connects to what" — sitting permanently
+ *    beside a one-word title in a 48px bar, on every screen, on every visit.
+ *    The caption has to survive being read at a glance by someone who has read
+ *    it forty times before, and a clause does not: it gets skipped, which makes
+ *    it cost its space and pay nothing. Naming the data in three words is read
+ *    every time.
+ *
+ * Deliberately NOT moved behind an info affordance, and this is the one place
+ * in the density pass where that was the wrong tool. The documented failure
+ * this caption was added to fix is people arriving somewhere and not knowing
+ * what the data means — and by definition those people do not know there is
+ * anything to ask about, so an icon pays out to nobody. It gets shorter; it
+ * does not get hidden.
  *
  * Read in two places — the rail (`Placeholder`, for destinations with nothing
  * behind them yet) and the header, next to the title (TopBar.tsx). Both read it
@@ -74,49 +88,49 @@ export const DESTINATIONS = [
     path: "/chat",
     label: "Conversations",
     icon: MessageSquare,
-    caption: "Ask a model that can read this memory",
+    caption: "A model that can read this memory",
   },
   {
     id: "recall",
     path: "/recall",
     label: "Recall",
     icon: Search,
-    caption: "Search this memory, and see what connects to what",
+    caption: "Search memory and its connections",
   },
   {
     id: "graph",
     path: "/graph",
     label: "Graph",
     icon: Share2,
-    caption: "The things this memory knows about, and how they relate",
+    caption: "Entities, and how they relate",
   },
   {
     id: "geo",
     path: "/geo",
     label: "Geo",
     icon: Globe,
-    caption: "Where this memory happened, on a map",
+    caption: "Where memory happened",
   },
   {
     id: "anomalies",
     path: "/anomalies",
     label: "Anomalies",
     icon: TriangleAlert,
-    caption: "What stands out against this profile's own normal",
+    caption: "What deviates from this profile's normal",
   },
   {
     id: "tasks",
     path: "/tasks",
     label: "Tasks",
     icon: ListChecks,
-    caption: "Open work picked up from what was recorded",
+    caption: "Open work found in memory",
   },
   {
     id: "providers",
     path: "/providers",
     label: "Providers",
     icon: KeyRound,
-    caption: "Where models run, and the keys they need",
+    caption: "Where models run, and their keys",
   },
 ] as const;
 

--- a/front/ui/src/components/layout/StatusStrip.tsx
+++ b/front/ui/src/components/layout/StatusStrip.tsx
@@ -25,7 +25,7 @@ export function StatusStrip({ reach }: { reach: Reachability }) {
         ? {
             tone: "text-warn",
             state: "No profiles",
-            remedy: "Connected, but this instance holds no memory yet",
+            remedy: "connected, nothing stored yet",
           }
         : {
             tone: "text-[var(--live)]",
@@ -39,12 +39,17 @@ export function StatusStrip({ reach }: { reach: Reachability }) {
         ? {
             tone: "text-destructive",
             state: "Key rejected",
-            remedy: `Server answered ${reach.status} — set SHODH_API_KEY to the key it was started with`,
+            // The remedy names the variable and the value it needs, which is
+            // the whole of the fix. What the server answered is the evidence
+            // for the diagnosis and stays with it; anything past that is
+            // reassurance, and a broken state is not where reassurance earns
+            // room in a 26px strip.
+            remedy: `${reach.status} — set SHODH_API_KEY to the server's key`,
           }
         : {
             tone: "text-warn",
             state: "Not running",
-            remedy: "Start the shodh backend — nothing is lost while it is down",
+            remedy: "start the shodh backend",
           };
 
   return (

--- a/front/ui/src/components/ui/empty-state.tsx
+++ b/front/ui/src/components/ui/empty-state.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { InfoHint } from "./info-hint";
 
 /**
  * The centred title+body message. Before this, `Placeholder.tsx` and
@@ -9,15 +10,28 @@ import { cn } from "@/lib/utils";
  * into the other whenever someone copied a block. `size` keeps both call
  * sites, `panel` is the narrower default because more callers are panels
  * than whole pages.
+ *
+ * `body` IS ONE SHORT SENTENCE, AND THE TYPE CANNOT ENFORCE IT. These had grown
+ * to two and three sentences apiece — a state, its cause, and a mechanism
+ * explaining the cause — which is documentation standing in the middle of a
+ * screen someone arrived at by accident. The state and what to do about it stay
+ * in `body`; the mechanism moves to `more`, which is the same click-to-open
+ * affordance the rest of the product uses for read-once copy. An empty state is
+ * the one place a reader has nothing else to do, so the detail must remain
+ * reachable — it just must not be the first thing on screen.
  */
 export function EmptyState({
   title,
   body,
+  more,
   size = "panel",
   className,
 }: {
   title: string;
   body: string;
+  /** Mechanism: why this state exists, what produces the data when it does.
+   *  Never the state itself, and never a remedy the reader has to act on. */
+  more?: string;
   size?: "panel" | "page";
   className?: string;
 }) {
@@ -39,6 +53,13 @@ export function EmptyState({
           )}
         >
           {body}
+          {more ? (
+            // Inline with the last word rather than on its own row: a centred
+            // block with a lone icon underneath reads as an unlabelled button.
+            <InfoHint label={title} className="ml-1.5 translate-y-[1px] text-left">
+              {more}
+            </InfoHint>
+          ) : null}
         </p>
       </div>
     </div>

--- a/front/ui/src/components/ui/info-hint.tsx
+++ b/front/ui/src/components/ui/info-hint.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/** Panel width, and the gap it keeps from the edge of the window. Both are
+ *  needed in the clamp below, so neither is a magic number in the class list. */
+const PANEL_WIDTH = 280;
+const VIEWPORT_MARGIN = 8;
+
+/**
+ * The one disclosure affordance in the product, and the only sanctioned place
+ * for copy that a returning user should not have to read again.
+ *
+ * WHY THIS EXISTS. Every screen here had acquired an explanatory paragraph:
+ * what the destination is, how a measure works, which mouse gesture zooms. All
+ * of it true, none of it worth permanent screen space on an instrument whose
+ * users are reading it for the tenth time. Deleting the copy would have cost
+ * real information, so it moves one level down instead — the standard
+ * progressive-disclosure trade, and deliberately ONE level: NN/g finds designs
+ * beyond two disclosure levels have low usability because people lose their
+ * place between them. A row still leads to the Inspector; nothing in this
+ * product now leads to a third level.
+ *
+ * WHY IT IS A BUTTON AND NOT A `title` TOOLTIP. Three separate constraints, all
+ * of which a hover tooltip fails:
+ *
+ *  - It has to be reachable without a pointer. Hover-triggered content is
+ *    unavailable to keyboard and touch, and WCAG 1.4.13 additionally requires
+ *    such content to be dismissible and to stay put while it is being read —
+ *    which the native `title` does not do.
+ *  - It has to be dismissible. Escape closes it and returns focus, and a click
+ *    anywhere else closes it; the panel never traps anyone.
+ *  - It has to be able to hold more than a phrase. A native tooltip clips,
+ *    delays, and cannot be read at leisure.
+ *
+ * WHAT MAY GO IN HERE, AND WHAT MAY NOT. This holds MECHANISM — how a measure
+ * is computed, what a screen is for, which gesture pans a canvas. It must never
+ * hold a CAVEAT that changes how the visible numbers should be read, because
+ * NN/g's finding on info tips is blunt: most users never open them. So "the
+ * spread fell back to a mean because half the corpus shares one coordinate"
+ * stays on screen as a visible token, and only the full explanation of what a
+ * robust scale is comes in here. The rule is applied per call site; there is no
+ * way to enforce it in the type.
+ */
+export function InfoHint({
+  /** Names the subject, for screen readers: "About Out of place". */
+  label,
+  children,
+  /** Which edge of the button the panel is anchored to. Footers on the right of
+   *  a canvas need "right" or the panel renders off the viewport. */
+  align = "left",
+  /** Which edge it opens toward. Anything docked to the bottom of a canvas
+   *  needs "up" for the same reason. */
+  side = "down",
+  className,
+}: {
+  label: string;
+  children: React.ReactNode;
+  align?: "left" | "right";
+  side?: "up" | "down";
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const root = useRef<HTMLSpanElement>(null);
+  const trigger = useRef<HTMLButtonElement>(null);
+  const panel = useRef<HTMLSpanElement>(null);
+  const panelId = useId();
+
+  /**
+   * WHERE THE PANEL GOES, IN VIEWPORT COORDINATES, IN A PORTAL.
+   *
+   * The obvious implementation — an absolutely positioned child of the trigger
+   * — was built first and was wrong in the browser. Three of the call sites sit
+   * inside `overflow-hidden` canvases (GeoView, GraphView, GraphStage all clip
+   * so a force layout cannot spill), and on /recall the stage is narrow enough
+   * that the panel opened straight through its left edge and was sliced
+   * mid-word. Nothing about the trigger's own box can fix that: the clip is an
+   * ancestor's, and the panel has to leave the subtree to escape it.
+   *
+   * So it renders into `document.body` at `position: fixed`, from the trigger's
+   * measured rect. `align` and `side` pick the preferred corner; the clamp then
+   * keeps the whole panel inside the window, which is what makes the choice at
+   * each call site a preference rather than a bet on a viewport width. A panel
+   * that would sit below the fold flips above the trigger instead of being
+   * pushed up over it.
+   *
+   * Fixed positioning does not follow a scroll, so a scroll closes it — which
+   * is also the behaviour a reader expects from something they opened to read
+   * one thing.
+   */
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open || !trigger.current || !panel.current) {
+      setPos(null);
+      return;
+    }
+    const t = trigger.current.getBoundingClientRect();
+    const height = panel.current.offsetHeight;
+
+    let left = align === "right" ? t.right - PANEL_WIDTH : t.left;
+    left = Math.max(
+      VIEWPORT_MARGIN,
+      Math.min(left, window.innerWidth - PANEL_WIDTH - VIEWPORT_MARGIN),
+    );
+
+    const below = t.bottom + 6;
+    const above = t.top - 6 - height;
+    const fitsBelow = below + height <= window.innerHeight - VIEWPORT_MARGIN;
+    const fitsAbove = above >= VIEWPORT_MARGIN;
+    const top =
+      side === "up" ? (fitsAbove ? above : below) : fitsBelow ? below : fitsAbove ? above : below;
+
+    setPos({ left, top: Math.max(VIEWPORT_MARGIN, top) });
+  }, [open, align, side]);
+
+  useEffect(() => {
+    if (!open) return;
+    // Pointerdown rather than click: a click that lands on another control
+    // should both close this and activate that control, and click ordering
+    // makes the second half of that unreliable. The panel is checked as well as
+    // the trigger — it is portaled out of the subtree, so `root` no longer
+    // contains it and selecting text inside it would otherwise close it.
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Node;
+      if (root.current?.contains(target) || panel.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      setOpen(false);
+      // Focus goes back to what opened it, or Escape strands the keyboard at
+      // the top of the document.
+      trigger.current?.focus();
+    };
+    const dismiss = () => setOpen(false);
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    // Capture, because the scrollers here are inner panes rather than the
+    // window and their scroll events do not bubble.
+    window.addEventListener("scroll", dismiss, true);
+    window.addEventListener("resize", dismiss);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("scroll", dismiss, true);
+      window.removeEventListener("resize", dismiss);
+    };
+  }, [open]);
+
+  return (
+    // `pointer-events-auto`: several call sites live inside canvas overlays that
+    // are `pointer-events-none` so drags reach the map underneath. The trigger
+    // has to opt back in or it cannot be clicked at all.
+    <span ref={root} className={cn("pointer-events-auto inline-flex", className)}>
+      <button
+        ref={trigger}
+        type="button"
+        aria-label={`About ${label}`}
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          "text-muted-foreground/50 hover:text-foreground focus-visible:ring-ring",
+          "inline-flex size-4 shrink-0 items-center justify-center rounded",
+          "transition-colors duration-100 focus-visible:ring-2 focus-visible:outline-none",
+          open && "text-foreground",
+        )}
+      >
+        <Info aria-hidden="true" className="size-3" strokeWidth={2} />
+      </button>
+
+      {open
+        ? createPortal(
+            <span
+              ref={panel}
+              id={panelId}
+              role="note"
+              style={{
+                width: PANEL_WIDTH,
+                left: pos?.left ?? 0,
+                top: pos?.top ?? 0,
+                // Hidden for the one frame between mounting (which is what
+                // makes it measurable) and being placed. Without this the
+                // panel is briefly visible at the top-left of the window.
+                visibility: pos ? "visible" : "hidden",
+              }}
+              className={cn(
+                "border-border bg-popover text-popover-foreground pointer-events-auto fixed z-50",
+                "rounded-md border p-2.5 text-[11px] leading-relaxed shadow-xl",
+              )}
+            >
+              {children}
+            </span>,
+            document.body,
+          )
+        : null}
+    </span>
+  );
+}

--- a/front/ui/src/components/ui/meta.tsx
+++ b/front/ui/src/components/ui/meta.tsx
@@ -1,0 +1,65 @@
+import { Fragment } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * A row of facts, separated by middots.
+ *
+ * The unit of copy on this product's status surfaces is the TOKEN, not the
+ * sentence. `36 located · 13 matched` is read at a glance and re-read at no
+ * cost; "13 of the 36 placed memories matched this search" is read once,
+ * carefully, and then skipped forever after. Every heading, footer and status
+ * line here that used to be a clause is now a list of these.
+ *
+ * The separators are rendered rather than typed into the strings for two
+ * reasons. Callers assemble their tokens conditionally — a matched count only
+ * exists once a search has run — and string concatenation around optional parts
+ * is exactly how a strip ends up starting with a stray "·". And a separator
+ * that is real markup can be `aria-hidden`, so a screen reader reads three
+ * facts rather than "36 located middot 13 matched".
+ *
+ * Falsy children are dropped, so a call site can pass a conditional straight in
+ * without guarding the separator itself.
+ */
+export function Meta({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const items = (Array.isArray(children) ? children : [children]).flat(Infinity).filter(Boolean);
+
+  return (
+    <span className={cn("text-muted-foreground inline-flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px]", className)}>
+      {items.map((item, i) => (
+        <Fragment key={i}>
+          {i > 0 ? (
+            <span aria-hidden="true" className="text-muted-foreground/35 select-none">
+              ·
+            </span>
+          ) : null}
+          <span className="inline-flex items-center gap-1">{item}</span>
+        </Fragment>
+      ))}
+    </span>
+  );
+}
+
+/**
+ * A measured quantity inside a `Meta` row: the number in the mono face, the
+ * word for what it counts in the text face.
+ *
+ * The split is what makes a strip scannable vertically as well as horizontally
+ * — the eye finds the digits without reading the labels, which is the whole
+ * argument for right-aligning numerics in a dense table and applies just as
+ * well to a row of them. `value` first because the number is the thing being
+ * looked for; the label qualifies it.
+ */
+export function Stat({ value, label }: { value: React.ReactNode; label?: string }) {
+  return (
+    <>
+      <span className="mono text-foreground/85">{value}</span>
+      {label ? <span>{label}</span> : null}
+    </>
+  );
+}

--- a/front/ui/src/features/anomalies/AnomaliesView.tsx
+++ b/front/ui/src/features/anomalies/AnomaliesView.tsx
@@ -4,6 +4,8 @@ import { ApiError, NetworkError, type Reachability } from "@/lib/api";
 import { useCorpus } from "@/lib/api/corpus";
 import { useSession } from "@/stores/session";
 import { EmptyState } from "@/components/ui/empty-state";
+import { InfoHint } from "@/components/ui/info-hint";
+import { Meta, Stat } from "@/components/ui/meta";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
@@ -21,8 +23,27 @@ import {
  * The destination exists to answer three questions a reader has in front of
  * any result: what am I looking at, why was this one chosen, and what did the
  * choosing. So every finding carries the measure that produced it, in the same
- * row, in words that name the numbers being compared. Nothing here says
- * "anomalous" and leaves it there.
+ * row, naming the numbers being compared. Nothing here says "anomalous" and
+ * leaves it there.
+ *
+ * WHERE THE COMPARISON IS SPLIT, AND WHY. Every measure is a comparison, and a
+ * comparison has two halves: the baseline, which is the same for every row in a
+ * section, and the memory's own magnitude, which is not. Stating both on every
+ * row produced the exact wall this screen was rebuilt to remove — four rows
+ * reading "260 km / 259 km / 31 km / 18 km from the middle of the cluster the
+ * other 35 placed memories form, which normally sit 2.4 km out". So the
+ * baseline is stated ONCE, as tokens under the section title, and the row
+ * carries only what distinguishes it. The evidence is intact; the sentence is
+ * gone.
+ *
+ * THREE REGISTERS, AND THE RULE THAT SEPARATES THEM. `facts` (the baseline
+ * numbers) and `caveat` (anything that changes how those numbers should be
+ * read) are always on screen. `looksFor` and `detail` — what the lens is for,
+ * and how the arithmetic works — sit behind the section's info affordance,
+ * because they are read once and then known. A caveat never goes behind it: the
+ * published finding on info tips is that most people never open them, and a
+ * limitation nobody reads makes the screen look like it claimed more than it
+ * did.
  *
  * The measures are in measures.ts and are pure arithmetic — a median centre and
  * a median absolute deviation over great-circle distance, unit-matched number
@@ -44,7 +65,9 @@ interface Lens {
   id: string;
   icon: LucideIcon;
   title: string;
-  /** What this looks for, before any data — true even when there is none. */
+  /** What this looks for, before any data — true even when there is none. Read
+   *  once and then known, so it lives behind the section's info affordance
+   *  rather than as a permanent line above every list. */
   looksFor: string;
   result: LensResult;
 }
@@ -66,9 +89,12 @@ interface Lens {
  * one memory sits 126 robust scales out and the next sits 14, a bar scaled to
  * the largest drew the second as an empty stub — it made a genuine finding look
  * like a rounding error, which is the exact clarity defect this destination
- * exists to fix. Every row states its own magnitude in words instead, in the
- * units of its own measure, where it can be checked against the memory above
- * it.
+ * exists to fix. Every row states its own magnitude instead, in the units of
+ * its own measure, where it can be checked against the memory above it.
+ *
+ * The magnitude leads and is set in the mono face, so a column of them is
+ * scannable without reading a single label — the same argument that puts
+ * numerics in their own right-aligned column in a dense table.
  */
 function FindingRow({ finding }: { finding: Finding }) {
   const selected = useSession((s) => s.selectedMemoryId === finding.memoryId);
@@ -80,40 +106,42 @@ function FindingRow({ finding }: { finding: Finding }) {
       onClick={() => select(finding.memoryId)}
       aria-current={selected ? "true" : undefined}
       className={cn(
-        "border-border w-full border-b px-4 py-3 text-left transition-colors duration-100",
+        "border-border w-full border-b px-4 py-2.5 text-left transition-colors duration-100",
         "focus-visible:ring-ring focus-visible:-outline-offset-2 focus-visible:ring-2 focus-visible:outline-none",
         selected ? "bg-primary/10" : "hover:bg-accent/60",
       )}
     >
       <p
         className={cn(
-          "line-clamp-3 text-[13px] leading-relaxed",
+          "line-clamp-2 text-[13px] leading-relaxed",
           selected ? "text-foreground" : "text-foreground/90",
         )}
       >
         {finding.content}
       </p>
 
-      {/* The measure sits under the memory it judged, indented by the same
-          rule the section's own basis line uses, so "this is the reasoning
-          about the thing above" reads the same way at both levels. */}
-      <p className="text-muted-foreground border-border/60 mt-2 border-l pl-3 text-[11px] leading-relaxed">
-        {finding.measure}
-      </p>
+      {/* The evidence, under the memory it judged. Two tokens, not a sentence:
+          what this one measured, and what that measurement is of. The baseline
+          it is measured against is the section's, stated once above. */}
+      <Meta className="mt-1">
+        <Stat value={finding.value} />
+        <span>{finding.against}</span>
+      </Meta>
     </button>
   );
 }
 
 /**
- * The sentence explaining how a section reached its conclusion.
+ * A limitation on what the section above could conclude.
  *
- * Present in every state, including the ones with no findings, because the
- * mechanism is the point: a reader who learns how the line was drawn can judge
- * an empty section as readily as a full one.
+ * Marked, indented and always rendered — never folded into the info panel. It
+ * is the one thing on this screen that is neither a finding nor an explanation:
+ * it says the measure could not reach as far as the reader would assume, and a
+ * reader who misses it credits the screen with a stronger result than it has.
  */
-function Basis({ children }: { children: React.ReactNode }) {
+function Caveat({ children }: { children: React.ReactNode }) {
   return (
-    <p className="text-muted-foreground/70 border-border/60 mt-2 border-l pl-3 text-[11px] leading-relaxed">
+    <p className="text-muted-foreground/80 border-warn/40 mt-2 border-l pl-2.5 text-[11px] leading-relaxed">
       {children}
     </p>
   );
@@ -121,10 +149,14 @@ function Basis({ children }: { children: React.ReactNode }) {
 
 function LensSection({ lens }: { lens: Lens }) {
   const Icon = lens.icon;
-  const count = lens.result.state === "findings" ? lens.result.findings.length : 0;
+  const result = lens.result;
+  const count = result.state === "findings" ? result.findings.length : 0;
 
   return (
     <section>
+      {/* Title, count, and the affordance that holds everything this section
+          used to say in prose — all on the one sticky row, so scrolling past a
+          section never loses the ability to ask what it was measuring. */}
       <div className="border-border bg-muted/50 sticky top-0 z-10 flex items-center gap-2 border-b px-4 py-1.5 backdrop-blur-sm">
         <Icon aria-hidden="true" className="text-muted-foreground size-3" strokeWidth={1.8} />
         <span className="text-muted-foreground text-[11px] font-medium tracking-wide uppercase">
@@ -133,25 +165,49 @@ function LensSection({ lens }: { lens: Lens }) {
         {count > 0 ? (
           <span className="text-muted-foreground/60 mono text-[10px]">{count}</span>
         ) : null}
+        <InfoHint label={lens.title}>
+          <span className="block">{lens.looksFor}</span>
+          {result.detail ? (
+            <span className="text-muted-foreground mt-1.5 block">{result.detail}</span>
+          ) : null}
+          {count > 1 ? (
+            <span className="text-muted-foreground mt-1.5 block">
+              Ordered furthest from the baseline first.
+            </span>
+          ) : null}
+        </InfoHint>
+        {/* The section's verdict, right, where the eye finishes the row —
+            global identity left, contextual state right, as a status bar
+            does. "Clear" and "not enough data" are different claims and each
+            gets its own word; neither is ever a blank space. */}
+        <span className="text-muted-foreground/60 ml-auto text-[11px]">
+          {result.state === "clear"
+            ? "Nothing flagged"
+            : result.state === "insufficient"
+              ? "No baseline"
+              : null}
+        </span>
       </div>
 
-      <div className="border-border border-b px-4 py-3">
-        <p className="text-foreground/80 text-[12px] leading-relaxed">{lens.looksFor}</p>
-        {lens.result.state === "insufficient" ? (
-          <Basis>{lens.result.reason}</Basis>
-        ) : (
-          <Basis>
-            {lens.result.basis}
-            {/* Order is the only severity encoding on this screen, so it is
-                stated rather than left to be inferred. */}
-            {count > 1 ? " Furthest from the baseline first." : ""}
-          </Basis>
-        )}
+      <div className="border-border border-b px-4 py-2">
+        {/* The baseline: where this lens drew its line on this corpus, as
+            numbers. This is the half of every row's comparison that does not
+            change, and stating it here is what lets each row below be two
+            tokens instead of a sentence. */}
+        <Meta>
+          {result.facts.map((f) => (
+            <span key={f}>{f}</span>
+          ))}
+        </Meta>
+        {result.state === "insufficient" ? <Caveat>{result.reason}</Caveat> : null}
+        {result.state !== "insufficient" && result.caveat ? (
+          <Caveat>{result.caveat}</Caveat>
+        ) : null}
       </div>
 
-      {lens.result.state === "findings"
-        ? lens.result.findings.map((f) => (
-            <FindingRow key={`${lens.id}-${f.memoryId}-${f.measure}`} finding={f} />
+      {result.state === "findings"
+        ? result.findings.map((f) => (
+            <FindingRow key={`${lens.id}-${f.memoryId}-${f.value}`} finding={f} />
           ))
         : null}
     </section>
@@ -229,7 +285,7 @@ export function AnomaliesView({ reach }: { reach: Reachability }) {
       <EmptyState
         size="page"
         title="Not connected"
-        body="Deviations are measured against this profile's own memory, which needs the memory server running."
+        body="These measures read this profile's memory, which needs the server running."
       />
     );
   }
@@ -239,7 +295,7 @@ export function AnomaliesView({ reach }: { reach: Reachability }) {
       <EmptyState
         size="page"
         title="No profile to measure"
-        body="A baseline is built from one profile's memories, so there has to be a profile before anything can deviate from it."
+        body="A baseline is built from one profile's memories."
       />
     );
   }
@@ -274,7 +330,8 @@ export function AnomaliesView({ reach }: { reach: Reachability }) {
       <EmptyState
         size="page"
         title="Nothing remembered yet"
-        body="Every measure on this screen compares a memory against the others in the same profile. With none stored, there is no baseline and nothing to compare."
+        body="Nothing to compare against."
+        more="Every measure here compares a memory with the others in the same profile, so a baseline needs memories to be built from. These appear as soon as anything is stored."
       />
     );
   }
@@ -282,22 +339,35 @@ export function AnomaliesView({ reach }: { reach: Reachability }) {
   return (
     <ScrollArea className="h-full">
       <div className="mx-auto max-w-2xl pb-16">
-        <header className="border-border border-b px-4 py-4">
-          {/* The one line a stranger reads first. It says what the screen is
-              and, in the same breath, what makes it unusual: the finding is
-              arithmetic over the store's own contents, not a judgement fetched
-              from somewhere else. */}
-          <h1 className="text-[14px] font-medium tracking-tight">
-            What stands out in this profile's memory — measured against the rest of it, by
-            arithmetic rather than by a model.
-          </h1>
-          <p className="text-muted-foreground mt-1.5 text-[12px] leading-relaxed">
-            Three measures run over the {memories.length} memories stored here, each comparing a
-            memory with its own corpus and naming the comparison it made.{" "}
-            {flagged > 0
-              ? `${flagged} ${flagged === 1 ? "memory is" : "memories are"} flagged below; select one to inspect it.`
-              : "Nothing is flagged; each measure states below what it looked at."}
-          </p>
+        {/* The header a stranger reads first, and a returning reader skips.
+            It is a count, not a claim about the screen: the destination is
+            already named in the top bar, and repeating "what stands out in
+            this profile's memory" underneath it was two lines of sentence
+            saying what one number says.
+
+            The one thing that is NOT obvious from looking — that these
+            findings are arithmetic over the store's own contents rather than a
+            judgement fetched from somewhere else — stays on screen as a chip,
+            because it is the product's actual claim and a claim behind an icon
+            is a claim nobody reads. The icon holds only how it works. */}
+        <header className="border-border flex flex-wrap items-center gap-x-3 gap-y-1.5 border-b px-4 py-3">
+          <Meta className="text-[12px]">
+            <Stat value={flagged} label="flagged" />
+            <Stat value={memories.length} label="memories" />
+            <Stat value={lenses.length} label="measures" />
+          </Meta>
+          {/* Not "No model": the seat's egress badge already occupies that
+              exact phrase in the corner of every screen, and two unrelated
+              claims wearing one wording is worse than either being longer. */}
+          <span className="border-border text-muted-foreground ml-auto flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px]">
+            Arithmetic, not a model
+            <InfoHint label="how these are found">
+              Every finding on this screen is arithmetic over the memories already stored here — a
+              median centre and a robust spread, unit-matched number comparison, and term overlap.
+              No model is called, here or on the server, and nothing is inferred that the corpus
+              does not already state.
+            </InfoHint>
+          </span>
         </header>
 
         {lenses.map((lens) => (

--- a/front/ui/src/features/anomalies/measures.ts
+++ b/front/ui/src/features/anomalies/measures.ts
@@ -27,7 +27,7 @@ import type { CorpusMemory } from "@/lib/api/corpus";
 // SHARED SHAPE
 // =============================================================================
 
-/** One flagged memory, with the sentence that justifies flagging it. */
+/** One flagged memory, with the evidence that justifies flagging it. */
 export interface Finding {
   memoryId: string;
   /** The memory's own text (a 500-char preview — `content_truncated` on the
@@ -42,27 +42,62 @@ export interface Finding {
    * never drawn and never printed: the magnitudes it ranks are unbounded (one
    * memory in this corpus sits 126 robust scales out, another 14), so any bar
    * scaled to the largest would render every other genuine finding as a stub
-   * and understate it. What each row states in words — the distance, the two
-   * quantities, the term count — is the honest presentation of its own
-   * magnitude, and position in the list is the comparison.
+   * and understate it. What each row states — the distance, the two quantities,
+   * the term count — is the honest presentation of its own magnitude, and
+   * position in the list is the comparison.
    */
   deviation: number;
-  /** The measure, stated in words, with the values it compared. */
-  measure: string;
+  /**
+   * THE ROW'S OWN MAGNITUDE, AND NOTHING THAT IS TRUE OF EVERY ROW.
+   *
+   * This used to be one sentence per finding, and on a real corpus four
+   * consecutive rows read "260 km / 259 km / 31 km / 18 km from the middle of
+   * the cluster the other 35 placed memories form, which normally sit 2.4 km
+   * out" — twelve identical words, three times over, for four numbers. The
+   * shared half of every comparison belongs to the SECTION, which states it
+   * once in `facts`; the row states only what distinguishes it.
+   *
+   * `value` is the measured quantity and is set in the mono face. `against` is
+   * the short phrase naming what it is a quantity OF — never a restatement of
+   * the section's baseline, and never omitted, because a bare "260 km" on a row
+   * is the cryptic token this split exists to avoid.
+   */
+  value: string;
+  against: string;
 }
 
 /**
- * What a lens has to say.
+ * What a lens says about itself, in the two registers the screen distinguishes.
+ *
+ * `facts` are short tokens rendered permanently under the section title — the
+ * numbers that define where this lens drew its line on THIS corpus. They are
+ * the section's half of every finding's comparison, stated once.
+ *
+ * `caveat` is a limitation that changes how the visible numbers should be read
+ * — a spread that fell back to a weaker estimator, memories excluded from the
+ * judgement entirely. It is ALWAYS rendered, never folded into an info panel:
+ * the published finding on info tips is that most people never open them, and a
+ * caveat nobody reads is worse than one that was never written, because the
+ * screen then looks like it made a stronger claim than it did.
+ *
+ * `detail` is elaboration for the section's info panel — true, useful, and
+ * never load-bearing. Nothing that qualifies a number on screen may go here.
  *
  * `insufficient` is a first-class outcome rather than an empty list, because
  * "no anomalies" and "not enough data to have an opinion" are different claims
  * and collapsing them into one blank panel would make the weaker one look like
- * the stronger one. The reason string names the shortfall in numbers.
+ * the stronger one. The reason names the shortfall in numbers.
  */
+interface LensBasis {
+  facts: string[];
+  caveat?: string;
+  detail?: string;
+}
+
 export type LensResult =
-  | { state: "findings"; findings: Finding[]; basis: string }
-  | { state: "clear"; basis: string }
-  | { state: "insufficient"; reason: string };
+  | ({ state: "findings"; findings: Finding[] } & LensBasis)
+  | ({ state: "clear" } & LensBasis)
+  | ({ state: "insufficient"; reason: string } & LensBasis);
 
 // =============================================================================
 // ROBUST STATISTICS
@@ -170,10 +205,13 @@ export function offPatternLocations(memories: CorpusMemory[]): LensResult {
   if (located.length < MIN_LOCATED) {
     return {
       state: "insufficient",
+      facts: [`${located.length} of ${memories.length} placed`, `${MIN_LOCATED} needed`],
       reason:
         located.length === 0
-          ? `Nothing here carries coordinates. A memory only has a position when whatever wrote it supplied one, and none of these ${memories.length} did — so there is no cluster to be outside of.`
-          : `A baseline needs at least ${MIN_LOCATED} placed memories to be worth trusting; this profile has ${located.length}. With fewer, every point is as much "the cluster" as any other.`,
+          ? "Nothing here carries coordinates, so there is no cluster to be outside of."
+          : "With fewer, every point is as much the cluster as any other.",
+      detail:
+        "A memory only carries a position when whatever wrote it supplied one. Imported corpora usually do; session captures usually do not.",
     };
   }
 
@@ -190,7 +228,9 @@ export function offPatternLocations(memories: CorpusMemory[]): LensResult {
   if (spread === null) {
     return {
       state: "clear",
-      basis: `All ${located.length} placed memories sit the same distance from the middle of the group, so there is no spread for anything to stand outside of.`,
+      facts: [`${located.length} placed`, "no spread"],
+      caveat:
+        "Every placed memory sits the same distance from the centre, so there is nothing for one to stand outside of.",
     };
   }
 
@@ -203,28 +243,35 @@ export function offPatternLocations(memories: CorpusMemory[]): LensResult {
       memoryId: memory.id,
       content: memory.content,
       deviation: (km - typical) / spread.scale,
-      measure: `${formatKm(km)} from the middle of the cluster the other ${others} placed memories form, which normally sit ${formatKm(typical)} out.`,
+      // Only the distance. "…from the middle of the cluster the other 35
+      // placed memories form, which normally sit 2.4 km out" is true of every
+      // row in this section and is stated once, above, in `facts`.
+      value: formatKm(km),
+      against: "from cluster centre",
     }))
     .sort((a, b) => b.deviation - a.deviation);
 
-  // The spread clause has to describe the estimator that actually produced the
-  // number. Saying "half of them fall within" of a MEAN deviation would be a
-  // false statement about the arithmetic, on a screen whose entire claim is
-  // that the arithmetic is stated.
-  const spreadClause = spread.robust
-    ? `and half of them fall within ${formatKm(spread.scale)} of that`
-    : `and more than half of them share one exact position — so the usual half-of-them spread came out at zero and the average distance from the centre, ${formatKm(spread.scale)}, stands in for it, which is a looser reading`;
+  // The spread token has to describe the estimator that actually produced the
+  // number. Saying "half within" of a MEAN deviation would be a false statement
+  // about the arithmetic, on a screen whose entire claim is that the arithmetic
+  // is stated — so the non-robust case does not get the token at all. It gets a
+  // caveat, on screen, in the state's own words.
+  const facts = [
+    `${located.length} placed`,
+    `typical ${formatKm(typical)} out`,
+    spread.robust ? `half within ${formatKm(spread.scale)}` : `spread ${formatKm(spread.scale)}`,
+    `flagged above ${formatKm(cutoff)}`,
+  ];
 
-  const basis =
-    `Centre and spread come from the ${located.length} placed memories themselves: the middle one sits ${formatKm(typical)} from the group's centre, ${spreadClause}. ` +
-    `Anything more than ${formatKm(cutoff)} out is listed.`;
+  const caveat = spread.robust
+    ? undefined
+    : `More than half of these share one exact position, so the median spread came out at zero and the average distance stands in for it — a looser line than the other measures draw.`;
+
+  const detail = `Centre is the median latitude and longitude of the ${located.length} placed memories, and distance is great-circle from there. The cutoff is ${MODIFIED_Z_CUTOFF} robust scales past the typical distance — Iglewicz & Hoaglin's published modified-z cutoff, not a number tuned to this corpus. The remaining ${others} placed memories are the baseline every row is measured against.`;
 
   return findings.length > 0
-    ? { state: "findings", findings, basis }
-    : {
-        state: "clear",
-        basis: `${basis} Nothing is.`,
-      };
+    ? { state: "findings", findings, facts, caveat, detail }
+    : { state: "clear", facts, caveat, detail };
 }
 
 // =============================================================================
@@ -383,7 +430,11 @@ export function quantityOutliers(memories: CorpusMemory[]): LensResult {
         memoryId: memory.id,
         content: memory.content,
         deviation: Math.log10(factor),
-        measure: `Two ${unit} figures in one memory that do not agree: ${formatValue(low.value)} and ${formatValue(high.value)} — a factor of ${factor.toFixed(1)}.`,
+        // Both numbers and the factor between them, which is the whole finding.
+        // What is NOT said is which one is wrong: the arithmetic cannot know,
+        // and a row that picked a side would be asserting past its evidence.
+        value: `${formatValue(low.value)} vs ${formatValue(high.value)} ${unit}`,
+        against: `${factor.toFixed(1)}× apart in one memory`,
       });
     }
   }
@@ -422,37 +473,58 @@ export function quantityOutliers(memories: CorpusMemory[]): LensResult {
         memoryId: entry.memory.id,
         content: entry.memory.content,
         deviation: z,
-        measure: `${formatValue(entry.value)} ${unit}, against a typical ${formatValue(centre)} ${unit} across the ${entries.length} memories that state one.`,
+        // The baseline stays on the row here, unlike the location lens: this
+        // section mixes units, so "typical 38 t" is true of the tonnes rows and
+        // false of the hours rows and cannot be hoisted into one section line.
+        value: `${formatValue(entry.value)} ${unit}`,
+        against: `typical ${formatValue(centre)} ${unit} across ${entries.length} memories`,
       });
     }
   }
 
   const parsedCount = perMemory.filter((p) => p.quantities.length > 0).length;
 
+  const unitMethod =
+    "Only a number written next to a known unit is read, and values are only ever compared within one unit. Percentages are left out on purpose: a percentage of one thing tells you nothing about a percentage of another.";
+
   if (parsedCount === 0) {
     return {
       state: "insufficient",
-      reason: `None of these ${memories.length} memories states a number with a unit attached. Counts on their own — containers, transactions, people — are not compared, because two counts of different things share nothing but a number.`,
+      facts: [`0 of ${memories.length} state a unit`],
+      reason: "Nothing here writes a number next to a unit this measure recognises.",
+      detail: `${unitMethod} Bare counts — containers, transactions, people — are not compared either, because two counts of different things share nothing but a number.`,
     };
   }
 
   const shortSummary = shortUnits
     .sort((a, b) => b.count - a.count)
     .slice(0, 4)
-    .map((u) => `${u.unit} (${u.count})`)
+    .map((u) => `${u.unit} ${u.count}`)
     .join(", ");
 
-  const basis =
-    `Read from the text of ${parsedCount} of the ${memories.length} memories: only a number written next to a known unit counts, values are only ever compared with the same unit, and percentages are left out because a percentage of one thing tells you nothing about a percentage of another. ` +
-    (comparedUnits.length > 0
-      ? `${comparedUnits.join(", ")} appear in enough memories (${MIN_UNIT_SAMPLES} or more) to have a normal range worth comparing against.`
-      : `No unit yet appears in the ${MIN_UNIT_SAMPLES} separate memories needed to establish a normal range${shortSummary ? ` — the most common so far are ${shortSummary}` : ""}. Until one does, only disagreements inside a single memory can be found.`);
+  const facts = [
+    `${parsedCount} of ${memories.length} state a unit`,
+    comparedUnits.length > 0
+      ? `range compared: ${comparedUnits.join(", ")}`
+      : `no unit reaches ${MIN_UNIT_SAMPLES} memories`,
+  ];
+
+  // A scope limit, not a footnote: with no unit populous enough to have a
+  // normal range, this section CANNOT have found a corpus-wide outlier, and a
+  // reader who does not know that would read an empty section as "checked, and
+  // nothing was out of range".
+  const caveat =
+    comparedUnits.length > 0
+      ? undefined
+      : "No unit yet appears in enough separate memories to establish a normal range, so only disagreements inside a single memory can be found.";
+
+  const detail = `${unitMethod} A unit needs ${MIN_UNIT_SAMPLES} separate memories before a normal range is claimed for it${shortSummary ? `; the most common so far are ${shortSummary}` : ""}.`;
 
   findings.sort((a, b) => b.deviation - a.deviation);
 
   return findings.length > 0
-    ? { state: "findings", findings, basis }
-    : { state: "clear", basis: `${basis} Nothing stands out.` };
+    ? { state: "findings", findings, facts, caveat, detail }
+    : { state: "clear", facts, caveat, detail };
 }
 
 // =============================================================================
@@ -495,7 +567,10 @@ export function isolatedMemories(memories: CorpusMemory[]): LensResult {
   if (memories.length < MIN_CORPUS_FOR_ISOLATION) {
     return {
       state: "insufficient",
-      reason: `"Connected to nothing else" needs something else to be connected to. This profile holds ${memories.length} ${memories.length === 1 ? "memory" : "memories"}; below ${MIN_CORPUS_FOR_ISOLATION} the answer says more about the corpus than about any memory in it.`,
+      facts: [`${memories.length} stored`, `${MIN_CORPUS_FOR_ISOLATION} needed`],
+      reason: "Below this, the answer says more about the corpus than about any memory in it.",
+      detail:
+        '"Connected to nothing else" needs something else to be connected to. Two memories count as connected when the extraction pulled the same term out of both.',
     };
   }
 
@@ -527,26 +602,31 @@ export function isolatedMemories(memories: CorpusMemory[]): LensResult {
       // none of which any other memory names, is further out than one naming
       // two. Ordering only — never shown as a number.
       deviation: own.size,
-      measure: `All ${own.size} of the terms taken from this memory — ${[...own].slice(0, 4).join(", ")}${own.size > 4 ? ", …" : ""} — appear nowhere else in the ${memories.length} memories here.`,
+      value: `${own.size} ${own.size === 1 ? "term" : "terms"}`,
+      // The terms themselves, not a count of them: this is the one lens whose
+      // evidence is words rather than a quantity, and "12 terms, none shared"
+      // with nothing to check is an assertion. Four is what fits on a row.
+      against: `none shared — ${[...own].slice(0, 4).join(", ")}${own.size > 4 ? ", …" : ""}`,
     });
   }
 
   findings.sort((a, b) => b.deviation - a.deviation);
 
   const judged = memories.length - unextracted.length;
+  const facts = [`${judged} of ${memories.length} have terms to compare`];
+
+  // Which memories were judged at all is a limit on the finding, not a
+  // footnote about it: a reader who thinks all 74 were checked reads an empty
+  // section as a stronger result than it is.
   const caveat =
     unextracted.length > 0
-      ? ` ${unextracted.length} of the ${memories.length} yielded no terms at all, so nothing can be said about what they connect to — they are left out rather than counted as isolated.`
-      : "";
+      ? `${unextracted.length} of the ${memories.length} yielded no terms at all, so nothing can be said about what they connect to — they are left out rather than counted as isolated.`
+      : undefined;
 
-  const basis = `Two memories count as connected when the extraction pulled the same term out of both. ${judged} of the ${memories.length} memories here have terms to compare; these share none of theirs with any other.${caveat}`;
+  const detail =
+    "Two memories count as connected when the extraction pulled the same term out of both — including broad terms, so a memory reaches this list only by sharing nothing at all. The measure under-reports rather than over-reports, which is the safe direction on a screen like this one.";
 
-  if (findings.length === 0) {
-    return {
-      state: "clear",
-      basis: `Two memories count as connected when the extraction pulled the same term out of both. Every one of the ${judged} memories with terms shares at least one with another.${caveat}`,
-    };
-  }
-
-  return { state: "findings", findings, basis };
+  return findings.length > 0
+    ? { state: "findings", findings, facts, caveat, detail }
+    : { state: "clear", facts, caveat, detail };
 }

--- a/front/ui/src/features/geo/GeoView.tsx
+++ b/front/ui/src/features/geo/GeoView.tsx
@@ -2,6 +2,8 @@ import { useMemo } from "react";
 import type { Reachability } from "@/lib/api";
 import { corpusToRecallMemory, useCorpus } from "@/lib/api/corpus";
 import { EmptyState } from "@/components/ui/empty-state";
+import { InfoHint } from "@/components/ui/info-hint";
+import { Meta, Stat } from "@/components/ui/meta";
 import { useRecall } from "@/features/recall/useRecall";
 import { useMemoryTypes } from "@/features/recall/GraphCanvas";
 import { GeoMap } from "./GeoMap";
@@ -55,7 +57,7 @@ export function GeoView({ reach }: { reach: Reachability }) {
       <EmptyState
         size="page"
         title="Not connected"
-        body="The map draws from memory, which needs the memory server running."
+        body="The map draws from memory, which needs the server running."
       />
     );
   }
@@ -65,7 +67,7 @@ export function GeoView({ reach }: { reach: Reachability }) {
       <EmptyState
         size="page"
         title="No profile selected"
-        body="The map shows where a profile's memory happened, so it needs a profile that already exists."
+        body="The map is per-profile, and none exists yet."
       />
     );
   }
@@ -80,7 +82,8 @@ export function GeoView({ reach }: { reach: Reachability }) {
       <EmptyState
         size="page"
         title="No coordinates in this corpus"
-        body="A memory only carries coordinates when whatever wrote it supplied them — imported corpora like GDELT do, session captures do not. Once one does, it appears here without any search."
+        body="Nothing stored here carries a position."
+        more="A memory only carries coordinates when whatever wrote it supplied them — imported corpora like GDELT do, session captures do not. The first one that does appears here without any search."
       />
     );
   }
@@ -93,20 +96,26 @@ export function GeoView({ reach }: { reach: Reachability }) {
 
       <GeoMap memories={plotted} types={types} dimmed={dimmed} />
 
-      <div className="pointer-events-none absolute top-3 left-4 z-10 flex flex-col gap-0.5">
-        <span className="text-muted-foreground text-[12px]">
-          {hasQuery ? "Where this answer happened" : "Where this profile's memory happened"}
-        </span>
-        {/* Said only before a query, because it is the one thing this map does
-            that is not visible from looking at it: searching does not swap the
-            points out, it turns the matching ones up. Without the line, a map
-            that stays put after a search reads as a map that ignored it. */}
-        {!hasQuery ? (
-          <span className="text-muted-foreground/60 text-[11px]">
-            Search to raise the points that match
+      {/* NO TITLE HERE ANY MORE. "Where this profile's memory happened" was a
+          restatement of the destination's own caption in the bar directly
+          above it — the same words, twice, ten pixels apart. Duplicating a
+          visible label is information pollution, and on a map it was competing
+          with the only thing in this corner worth reading.
+
+          What survives is the one thing the map does that is NOT visible from
+          looking at it: a search does not swap the points out, it turns the
+          matching ones up. Without that cue, a map that stays put after a
+          search reads as a map that ignored it — a documented, real confusion,
+          so it stays on screen rather than moving behind an affordance. It is
+          shown only before a query, because after one the dimming and the
+          matched count say it better than a sentence could. */}
+      {!hasQuery ? (
+        <div className="pointer-events-none absolute top-3 left-4 z-10">
+          <span className="text-muted-foreground/70 text-[11px]">
+            Search raises the points that match
           </span>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
 
       <div
         className="pointer-events-none absolute inset-x-4 bottom-3 z-10 flex flex-wrap items-center justify-between gap-x-6 gap-y-2"
@@ -123,16 +132,26 @@ export function GeoView({ reach }: { reach: Reachability }) {
             </span>
           ))}
         </div>
-        <span className="text-muted-foreground/70 text-[11px]">
-          {hasQuery
-            ? error
-              ? "That search did not complete — showing the corpus"
-              : isFetching && !data
-                ? "Searching…"
-                : `${matched.length} matched of ${located.length} placed`
-            : `${located.length} located ${located.length === 1 ? "memory" : "memories"}`}
-          {" · scroll to zoom · drag to pan · click a point to inspect"}
-        </span>
+        {/* Counts on the right, gestures behind the icon beside them. What is
+            ON the map is data and belongs on screen; how to move the camera is
+            learned once, and printing it under every session is three of the
+            strip's six words spent on something nobody reads twice. */}
+        <Meta className="shrink-0">
+          {/* "showing all" is not decoration: with no matched count beside it,
+              a bare "search failed" leaves the reader to guess whether the
+              points on screen are a partial answer or the whole corpus. */}
+          {hasQuery && error ? <span className="text-warn">search failed — showing all</span> : null}
+          {hasQuery && !error && isFetching && !data ? <span>searching…</span> : null}
+          {hasQuery && !error && !(isFetching && !data) ? (
+            <Stat value={matched.length} label="matched" />
+          ) : null}
+          <Stat value={located.length} label="located" />
+          <InfoHint label="map controls" align="right" side="up">
+            Scroll to zoom, drag to pan, click a point to inspect it. A search does not change
+            which points are drawn — it raises the ones that match and dims the rest, so an answer
+            is always seen against the corpus it came from.
+          </InfoHint>
+        </Meta>
       </div>
     </section>
   );

--- a/front/ui/src/features/graph/GraphView.tsx
+++ b/front/ui/src/features/graph/GraphView.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import type { Reachability } from "@/lib/api";
 import { EmptyState } from "@/components/ui/empty-state";
+import { InfoHint } from "@/components/ui/info-hint";
+import { Meta, Stat } from "@/components/ui/meta";
 import { useSession } from "@/stores/session";
 import { useUniverse } from "./useUniverse";
 import { EntityCanvas, levelFor, type Level } from "./EntityCanvas";
@@ -126,7 +128,7 @@ export function GraphView({ reach }: { reach: Reachability }) {
       <EmptyState
         size="page"
         title="Not connected"
-        body="The knowledge graph is built from the memory server's entity store, which needs the server running."
+        body="The graph is built from the entity store, which needs the server running."
       />
     );
   }
@@ -136,7 +138,7 @@ export function GraphView({ reach }: { reach: Reachability }) {
       <EmptyState
         size="page"
         title="No profile to show"
-        body="The graph is per-profile — each one has its own entity store. This instance holds none yet."
+        body="The graph is per-profile, and none exists yet."
       />
     );
   }
@@ -146,7 +148,8 @@ export function GraphView({ reach }: { reach: Reachability }) {
       <EmptyState
         size="page"
         title="Graph failed to load"
-        body="The entity universe did not come back. The graph endpoint returns the whole corpus in one response, so this fails all at once rather than partially."
+        body="The entity universe did not come back."
+        more="The graph endpoint returns the whole corpus in one response, so it fails all at once rather than partially — there is no partial graph to show."
       />
     );
   }
@@ -158,7 +161,7 @@ export function GraphView({ reach }: { reach: Reachability }) {
         title={isFetching ? "Building the graph" : "Nothing to draw"}
         body={
           isFetching
-            ? "Fetching every entity and relation in this profile, then finding the communities in them. This is one request for the whole corpus."
+            ? "One request for every entity and relation here."
             : "No entity universe came back for this profile."
         }
       />
@@ -170,18 +173,22 @@ export function GraphView({ reach }: { reach: Reachability }) {
       <EmptyState
         size="page"
         title="No entities yet"
-        body="Nothing has been extracted into the knowledge graph for this profile. Entities appear as memories are written and the extraction pipeline types what is in them."
+        body="Nothing has been extracted for this profile yet."
+        more="Entities appear as memories are written and the extraction pipeline types what is in them, so the graph fills in behind the corpus rather than being built separately."
       />
     );
   }
 
   const cluster = clusterId !== null ? (model.clusters[clusterId] ?? null) : null;
-  const shown =
+  // Split into the number and the noun so the strip can set the digits in the
+  // mono face and the word in the text face — the number is what the eye is
+  // hunting for, and "341 entities" rendered wholly in mono buries it.
+  const shownCount =
+    level === "clusters" ? model.clusters.length : (cluster?.size ?? model.nodes.length);
+  const shownNoun =
     level === "clusters"
-      ? `${model.clusters.length} cluster${model.clusters.length === 1 ? "" : "s"}`
-      : cluster
-        ? `${cluster.size} entit${cluster.size === 1 ? "y" : "ies"}`
-        : `${model.nodes.length} entit${model.nodes.length === 1 ? "y" : "ies"}`;
+      ? `cluster${model.clusters.length === 1 ? "" : "s"} of ${model.totalEntities} entities`
+      : `entit${shownCount === 1 ? "y" : "ies"} of ${model.totalEntities}`;
 
   return (
     <section className="relative h-full min-h-0 min-w-0 overflow-hidden">
@@ -229,6 +236,15 @@ export function GraphView({ reach }: { reach: Reachability }) {
                 <span className="text-muted-foreground/60">{l.count}</span>
               </span>
             ))}
+            {/* The third encoding, moved here from the status strip on the
+                right. It belongs with the other two: a key is where a reader
+                decodes the picture, and "size = mentions" is a decoding, not a
+                status. Two dots of different sizes carry it without a word. */}
+            <span className="text-muted-foreground/70 flex items-center gap-1.5 text-[11px]">
+              <span className="bg-muted-foreground/50 size-1.5 rounded-full" />
+              <span className="bg-muted-foreground/50 size-2.5 rounded-full" />
+              size = mentions
+            </span>
           </div>
           {level === "entities" ? (
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
@@ -251,21 +267,42 @@ export function GraphView({ reach }: { reach: Reachability }) {
             </div>
           ) : null}
         </div>
-        <span className="text-muted-foreground/70 text-[11px]">
-          {/* Every reduction between the corpus and the pixels is stated. The
-              endpoint is uncapped, so any cut happened on this side, and a view
-              that quietly drops most of a graph is worse than one that admits
-              it. Size encoding is named for the same reason — an unexplained
-              size channel is decoration that looks like data. */}
-          {shown} of {model.totalEntities} · {model.totalConnections} relations
-          {model.edgesDropped > 0 ? ` · budget dropped ${model.edgesDropped}` : ""}
-          {stats.hiddenEdges > 0
-            ? ` · ${stats.hiddenEdges} weakest co-occurrence edges hidden (below ${stats.floor.toFixed(2)})`
-            : ""}{" "}
-          · size = mentions ·{" "}
-          {level === "clusters" ? "click a cluster to drill in" : "click an entity to inspect"} ·
-          scroll to zoom
-        </span>
+        {/* EVERY REDUCTION BETWEEN THE CORPUS AND THE PIXELS IS STILL STATED —
+            that rule has not moved. What has changed is that each reduction is
+            now a token rather than a clause, and the exact co-occurrence floor
+            that produced one of them sits behind the icon: "12 weak edges
+            hidden" is the fact a reader needs on screen, "below 0.14" is how it
+            was computed. The endpoint is uncapped, so any cut happened on this
+            side, and a view that quietly drops most of a graph is worse than
+            one that admits it.
+
+            The two gestures and the size encoding left the strip entirely. Size
+            is a legend entry — an unexplained size channel is decoration that
+            looks like data — and it now sits with the other two encodings in
+            the key on the left, where a reader decoding the picture is already
+            looking. */}
+        <Meta className="shrink-0">
+          <Stat value={shownCount} label={shownNoun} />
+          <Stat value={model.totalConnections} label="relations" />
+          {model.edgesDropped > 0 ? (
+            <Stat value={model.edgesDropped} label="dropped to budget" />
+          ) : null}
+          {stats.hiddenEdges > 0 ? (
+            <Stat value={stats.hiddenEdges} label="weak edges hidden" />
+          ) : null}
+          <InfoHint label="canvas controls" align="right" side="up">
+            Scroll to zoom, and{" "}
+            {level === "clusters"
+              ? "click a cluster to drill into the entities inside it."
+              : "click an entity to inspect it."}
+            {stats.hiddenEdges > 0 ? (
+              <span className="mt-1.5 block">
+                Hidden edges are co-occurrences weaker than {stats.floor.toFixed(2)} — the pairs
+                that appear together too rarely to be worth a line.
+              </span>
+            ) : null}
+          </InfoHint>
+        </Meta>
       </div>
     </section>
   );

--- a/front/ui/src/features/inspector/Inspector.tsx
+++ b/front/ui/src/features/inspector/Inspector.tsx
@@ -8,6 +8,7 @@ import {
 import { useSession } from "@/stores/session";
 import { ScoreBreakdown } from "./ScoreBreakdown";
 import { Badge } from "@/components/ui/badge";
+import { InfoHint } from "@/components/ui/info-hint";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { relName } from "@/features/recall/relation";
 import { memoryTier, MEMORY_TIER_LABEL, MEMORY_TIER_MEANING } from "@/features/recall/tier";
@@ -122,16 +123,17 @@ export function Inspector() {
       // viewport at all.
       className="border-border bg-card absolute top-12 right-0 bottom-0 z-20 flex w-[min(280px,36vw)] flex-col border-l"
     >
-      <header className="border-border shrink-0 border-b px-4 py-3">
+      {/* The two kinds of object this pane holds answer different questions, so
+          the header names the one on screen — but it names it, it no longer
+          describes it. "Every belief traces back to the sessions it came from"
+          was a claim about the product printed above a panel that then goes on
+          to demonstrate it, on every selection, forever. One word does the
+          orientation; the panel itself does the rest. */}
+      <header className="border-border flex shrink-0 items-baseline gap-2 border-b px-4 py-2.5">
         <h2 className="text-[12px] font-medium tracking-tight">Detail</h2>
-        <p className="text-muted-foreground mt-0.5 text-[11px] leading-relaxed">
-          {/* The two kinds of object this pane holds answer different
-              questions, so the subtitle names the one on screen rather than
-              making one claim that is only true half the time. */}
-          {selectedEntityId
-            ? "What the corpus knows about this, and how it is connected."
-            : "Every belief traces back to the sessions it came from."}
-        </p>
+        <span className="text-muted-foreground/60 text-[11px]">
+          {selectedEntityId ? "entity" : memory ? "memory" : null}
+        </span>
       </header>
 
       <ScrollArea className="min-h-0 flex-1">
@@ -147,7 +149,7 @@ export function Inspector() {
           <Empty
             body={
               data || corpus
-                ? "Select a memory to see what it is, when it was recorded, and what it connects to."
+                ? "Select a memory or an entity."
                 : "This profile's memory is still loading."
             }
           />
@@ -163,9 +165,17 @@ export function Inspector() {
                   whose whole job is trust has to be labelled as cut, not left
                   to look like the whole record. */}
               {listed?.content_truncated ? (
-                <p className="text-muted-foreground/60 mt-1.5 text-[11px]">
-                  Cut short — this memory is {listed.content_length} characters long.
-                  The listing carries a preview; a search result carries the whole text.
+                <p className="text-muted-foreground/60 mt-1.5 flex items-center gap-1.5 text-[11px]">
+                  {/* The label stays on screen — text that silently stops
+                      mid-sentence in a pane whose whole job is trust has to be
+                      marked as cut. Why it is cut, and how to get the rest, is
+                      mechanism and goes behind the icon. */}
+                  Preview · <span className="mono">{listed.content_length}</span> characters in full
+                  <InfoHint label="why this is a preview">
+                    The corpus listing caps content at 500 characters so one request can carry the
+                    whole profile. A search result carries the whole text — the same memory reached
+                    from a query shows in full here.
+                  </InfoHint>
                 </p>
               ) : null}
 

--- a/front/ui/src/features/recall/GraphStage.tsx
+++ b/front/ui/src/features/recall/GraphStage.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from "react";
 import { cn } from "@/lib/utils";
 import type { Reachability } from "@/lib/api";
+import { InfoHint } from "@/components/ui/info-hint";
+import { Meta, Stat } from "@/components/ui/meta";
 import { RecallDiagram } from "./RecallDiagram";
 import { GraphCanvas, useMemoryTypes } from "./GraphCanvas";
 import { useRecall } from "./useRecall";
@@ -160,20 +162,34 @@ export function GraphStage({ reach }: { reach: Reachability }) {
               result column and Inspector) it was rendering as four stacked
               fragments. Refusing to shrink makes the wrap happen at the row
               level, which is what `flex-wrap` is here for. */}
-          <span className="text-muted-foreground/70 shrink-0 text-[11px]">
-            {/* Say what the edges ARE, not just how to move the camera. Zero
-                causal edges across a result set is a finding about the corpus,
-                not a broken canvas, and staying silent about it invites the
-                opposite reading. */}
-            {/* "lineage edges", not "causal edges". Every edge here comes from
-                the causal lineage graph, but only some classify as the bright
-                causal class (Caused, TriggeredBy) — InformedBy and ResolvedBy
-                draw cool. Calling all twelve "causal" while two thirds render
-                in the typed colour reads as a bug in the legend. */}
-            {edgeCount > 0
-              ? `${edgeCount} lineage ${edgeCount === 1 ? "edge" : "edges"} · scroll to zoom · drag to pan · click a node to inspect`
-              : "No lineage edges connect these results · scroll to zoom · drag to pan · click a node to inspect"}
-          </span>
+          {/* WHAT IS DRAWN, AND NOTHING ABOUT THE MOUSE. Half of this strip was
+              "scroll to zoom · drag to pan · click a node to inspect" — three
+              gestures, identical on all three canvases in this product, printed
+              under every session of every one of them. They are learned once,
+              so they moved behind the icon. The count of what is on screen did
+              not, because it is a finding.
+
+              Say what the edges ARE, not just how to move the camera: zero
+              causal edges across a result set is a fact about the corpus, not a
+              broken canvas, and staying silent about it invites the opposite
+              reading.
+
+              "lineage edges", not "causal edges". Every edge here comes from
+              the causal lineage graph, but only some classify as the bright
+              causal class (Caused, TriggeredBy) — InformedBy and ResolvedBy
+              draw cool. Calling all twelve "causal" while two thirds render in
+              the typed colour reads as a bug in the legend. */}
+          <Meta className="shrink-0">
+            {edgeCount > 0 ? (
+              <Stat value={edgeCount} label={`lineage ${edgeCount === 1 ? "edge" : "edges"}`} />
+            ) : (
+              <span>No lineage edges connect these results</span>
+            )}
+            <InfoHint label="canvas controls" align="right" side="up">
+              Scroll to zoom, drag to pan, click a node to inspect it. Nodes are the memories this
+              search returned; edges are the causal links the same response carried.
+            </InfoHint>
+          </Meta>
         </div>
       ) : null}
     </section>

--- a/front/ui/src/features/recall/RecallView.tsx
+++ b/front/ui/src/features/recall/RecallView.tsx
@@ -1,8 +1,11 @@
 import { useMemo } from "react";
+import { Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ApiError, NetworkError, type Reachability } from "@/lib/api";
 import { corpusToRecallMemory, useCorpus, type CorpusMemory } from "@/lib/api/corpus";
 import { EmptyState } from "@/components/ui/empty-state";
+import { InfoHint } from "@/components/ui/info-hint";
+import { Meta, Stat } from "@/components/ui/meta";
 import { useSession } from "@/stores/session";
 import { ResultList, ResultListSkeleton } from "./ResultList";
 import { GraphStage } from "./GraphStage";
@@ -24,6 +27,15 @@ import { corpusCues } from "./cues";
  * are an answer, and the head says how much was searched, how long it took, and
  * the one thing about this product that a competing screenful of results cannot
  * claim: none of it was written.
+ *
+ * BOTH HEADS ARE COUNTS AND CHIPS, NOT SENTENCES. This column is 340px wide, so
+ * every clause in it wrapped to two or three lines and pushed the first result
+ * down the screen — the heading was costing more vertical space than the row it
+ * was introducing. Facts became tokens; the two statements that are genuinely
+ * claims rather than measurements ("nothing here was written by a model", "this
+ * time is server-side only") became a chip and an icon, so they are still on
+ * screen and still checkable but are no longer paragraphs a returning reader
+ * scrolls past every time.
  */
 
 /** How many of the newest memories the pre-query listing shows. Enough to make
@@ -46,17 +58,32 @@ function CorpusHead({ memories, total }: { memories: CorpusMemory[] | undefined;
   const cues = useMemo(() => corpusCues(memories), [memories]);
 
   return (
-    <div className="border-border shrink-0 border-b px-4 py-2.5">
-      <p className="text-muted-foreground text-[11px] leading-relaxed">
-        {total} {total === 1 ? "memory" : "memories"} here, newest first. Search to rank
-        them by relevance.
-      </p>
+    <div className="border-border shrink-0 border-b px-4 py-2">
+      {/* Two facts, not a sentence. "Search to rank them by relevance" was
+          telling a reader looking at a search field what a search field does;
+          the cue row below is a better version of the same instruction, because
+          pressing one carries it out. */}
+      <Meta>
+        <Stat value={total} label={total === 1 ? "memory" : "memories"} />
+        <span>newest first</span>
+      </Meta>
 
       {cues.length > 0 ? (
-        <div className="mt-2 flex flex-wrap items-center gap-1.5">
-          {/* Named, because four bare words under a sentence read as tags on the
-              screen rather than as things to press. */}
-          <span className="text-muted-foreground/60 mr-0.5 text-[11px]">Mentioned most</span>
+        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+          {/* A search glyph rather than the words "Mentioned most". Four bare
+              words under a line of text read as tags rather than as things to
+              press, which is why the heading existed — but a magnifier in front
+              of a row of pills says "these run a search" without spending a
+              line on it, and the count inside each pill still says why these
+              four. What the heading carried for a screen reader has not been
+              dropped: it was never associated with the buttons anyway, and each
+              button's own `aria-label` states its name, its count and what
+              pressing it does. */}
+          <Search
+            aria-hidden="true"
+            className="text-muted-foreground/50 mr-0.5 size-3 shrink-0"
+            strokeWidth={2}
+          />
           {cues.map((cue) => (
             <button
               key={cue.text}
@@ -120,23 +147,51 @@ function AnswerHead({
   retrievalUs: number | undefined;
 }) {
   return (
-    <div className="border-border shrink-0 border-b px-4 py-2.5">
-      <p className="text-muted-foreground text-[11px]">
+    // `items-start` in a column, not a wrapping row: this head lives in a
+    // 340px column and the chip never fits beside the counts, so a row that
+    // "wraps" only ever produces one arrangement — and `ml-auto` pushed the
+    // wrapped chip to the right margin, where it read as floating rather than
+    // as the head's second line.
+    <div className="border-border flex shrink-0 flex-col items-start gap-1 border-b px-4 py-2">
+      <Meta>
         {/* "Top", not a bare count: `shown` is capped by the request limit
             (lib/api/recall.ts sends 25), so "25 of 74" would read as "25
             matched" when it means "the 25 best of what matched". "Top 5 of 74"
             stays exact when fewer come back. */}
-        Top {shown} of {total} {total === 1 ? "memory" : "memories"}
+        <>
+          <span>Top</span>
+          <Stat value={`${shown} of ${total}`} label={total === 1 ? "memory" : "memories"} />
+        </>
         {retrievalUs !== undefined ? (
-          <span title="Time the server spent retrieving and ranking. Excludes the network round trip.">
-            {" · retrieved in "}
-            <span className="mono">{Math.round(retrievalUs / 1000)} ms</span>
-          </span>
+          <>
+            <Stat value={`${Math.round(retrievalUs / 1000)} ms`} label="retrieval" />
+            {/* The measurement is server-side retrieval only and is labelled as
+                such; what "server-side" excludes is the elaboration, not the
+                claim, so it is the one thing here that goes behind the icon. */}
+            <InfoHint label="retrieval time">
+              Time the server spent retrieving and ranking, as it reported it. It excludes the
+              network round trip and everything the browser then does, so it is not the time you
+              waited.
+            </InfoHint>
+          </>
         ) : null}
-      </p>
-      <p className="text-muted-foreground/60 mt-1 text-[11px] leading-relaxed">
-        Nothing here was written by a model — these are stored memories, ranked.
-      </p>
+      </Meta>
+
+      {/* The product's actual edge, and the one thing on this screen that
+          cannot be checked by looking at it — so it stays visible, as a chip,
+          rather than becoming a sentence that is read once and skipped
+          thereafter. The chip states the claim; the panel behind it states the
+          limit of the claim, which matters: a local encoder embeds the query on
+          every search, so "no model runs" would be false. Generation is what is
+          absent, and generation is what the chip says. */}
+      <span className="border-border text-muted-foreground/80 flex shrink-0 items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px]">
+        Retrieved, not generated
+        <InfoHint label="how these results were produced" align="right">
+          Every row is a stored memory rendered verbatim and ranked — nothing here was written by a
+          model, and the Inspector traces each one back to what recorded it. Retrieval does embed
+          your query with a local encoder; it is generation that is absent, not models.
+        </InfoHint>
+      </span>
     </div>
   );
 }
@@ -172,7 +227,8 @@ function ResultPane({ reach }: { reach: Reachability }) {
     return (
       <EmptyState
         title="No profile to search"
-        body="This instance holds no memory yet. Recall needs a profile that already exists — searching would otherwise create an empty one."
+        body="This instance holds no memory yet."
+        more="Recall needs a profile that already exists. Searching against an invented name would silently provision an empty store rather than fail, so the field stays closed until the server lists one."
       />
     );
   }
@@ -186,7 +242,7 @@ function ResultPane({ reach }: { reach: Reachability }) {
       return (
         <EmptyState
           title="Nothing remembered yet"
-          body="Once this profile holds memory, the newest entries appear here before any search."
+          body="The newest entries appear here as soon as this profile holds any."
         />
       );
     }
@@ -219,9 +275,13 @@ function ResultPane({ reach }: { reach: Reachability }) {
 
   if (data && data.memories.length === 0) {
     return (
+      // A zero-result is not an empty screen: it is a finding about the cue,
+      // and the useful half of it is the next move, so that is what the body
+      // is. Why nothing activated is the mechanism, and goes behind the icon.
       <EmptyState
         title="Nothing surfaced"
-        body="No memory in this profile activated strongly enough for that cue. A shorter, more general cue usually reaches further."
+        body="Try a shorter, more general cue."
+        more="No memory in this profile activated strongly enough for that cue. Recall reaches through meaning, wording and the graph at once, so a broader cue usually reaches further than a more precise one."
       />
     );
   }

--- a/front/ui/src/features/recall/ResultList.tsx
+++ b/front/ui/src/features/recall/ResultList.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils";
 import type { RecallLineageEdge, RecallMemory } from "@/lib/api";
 import { useSession } from "@/stores/session";
+import { Meta, Stat } from "@/components/ui/meta";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { whyItSurfaced } from "./why";
@@ -80,14 +81,23 @@ function ResultRow({
           omitted independently: a memory the graph reached with no lineage to
           the rest of the set says only the first, one in a set with no
           attribution says only the second. */}
+      {/* Two tokens, not two clauses. "Connects to 6 others here" said in five
+          words what "connects to 6 here" says in four and a mono numeral — and
+          this line repeats on all twenty-five rows, so a word saved is
+          twenty-five words off the column. The leg phrase is not shortened
+          further: "No text matched — the graph reached it" is the product's
+          differentiator stated where it happens, and it is the one thing on a
+          result row that a reader has never seen before. */}
       {why ? (
-        <p className="text-muted-foreground/70 mt-1.5 text-[11px] leading-relaxed">
+        <Meta className="mt-1 text-muted-foreground/70">
           {why.legs}
-          {why.legs !== null && why.links > 0 ? " · " : null}
-          {why.links > 0
-            ? `Connects to ${why.links} other${why.links === 1 ? "" : "s"} here`
-            : null}
-        </p>
+          {why.links > 0 ? (
+            <>
+              <span>connects to</span>
+              <Stat value={why.links} label="here" />
+            </>
+          ) : null}
+        </Meta>
       ) : null}
 
       <div className="mt-2 flex items-center gap-2">

--- a/front/ui/src/features/tasks/TasksView.tsx
+++ b/front/ui/src/features/tasks/TasksView.tsx
@@ -157,7 +157,7 @@ export function TasksView({ reach }: { reach: Reachability }) {
       <EmptyState
         size="page"
         title="No profile to browse"
-        body="This instance holds no memory yet, so there is nothing captured to show."
+        body="This instance holds no memory yet."
       />
     );
   }
@@ -189,7 +189,8 @@ export function TasksView({ reach }: { reach: Reachability }) {
       <EmptyState
         size="page"
         title="Nothing outstanding"
-        body="No open todos in this profile. Work captured from a session — yours or an agent's — will show up here."
+        body="No open todos in this profile."
+        more="Tasks are picked up from what was recorded in a session — yours or an agent's — rather than entered here, so they appear as work is captured."
       />
     );
   }


### PR DESCRIPTION
Today's clarity pass fixed the right gaps with the wrong delivery: it explained things in sentences, and an analyst instrument has to be scannable in a glance. This revises that work against surveyed practice — no information is lost, it changes form or moves one click away.

**Patterns applied** (primary sources fetched except where noted): title + metadata token rather than title + sentence (Polaris — search summary only, its routes 301); description behind a header info affordance (Grafana panel-header redesign); the info-tip eligibility test — definitions may go behind an icon, **caveats never** ([NN/g, Info Tips Are Bad](https://www.nngroup.com/articles/info-tips-bad/)); at most two disclosure levels (NN/g, GitLab Pajamas); labelled contribution list rather than narration (Elastic Explain API); named detector + magnitude with contributors one level down (Datadog Watchdog); numerals in their own visual channel (Material data tables); compact status bar of short tokens (VS Code UX); empty state as status + cue + pathway (NN/g, Elastic EUI); no duplicated labels (Grafana Saga); and the copy-length evidence behind a ≤6-word caption rule (NN/g).

**Rejected, with reasons in the commit**: hover-only disclosure of anything load-bearing (WCAG 1.4.13 — the new `InfoHint` is click/focus with Escape and outside-dismiss, not a `title`); first-visit localStorage gating; onboarding tours; illustration-heavy empty states; colour-only status.

**Biggest win — Anomalies.** Every measure is a comparison with two halves and both sat on every row, so four consecutive findings repeated twelve identical words for four numbers. The baseline now sits once under the section title (`36 placed · typical 2.4 km out · half within 2.0 km · flagged above 9.5 km`) and each row carries `260 km · from cluster centre`. Three sections and eight findings now fit where 1.5 sections did.

Also: `74 memories · newest first` replaces the corpus sentence; `Top 25 of 74 memories · 646 ms retrieval ⓘ` plus a **"Retrieved, not generated"** chip whose panel states the precise limit (a local encoder does embed the query — generation is what is absent); Geo's in-canvas title deleted as a duplicate of the TopBar caption; graph reductions kept but tokenised.

**Kept verbose on purpose**: every caveat (non-robust spread fallback, "no unit reaches 5 memories"), Geo's "search raises the points that match", StatusStrip remedies, and all code comments.

**A real defect found only by rendering**: the disclosure panel was clipped mid-word by `overflow-hidden` on the canvas views and clipped off-viewport in the 340px Recall column. Now portalled to `document.body` with viewport-clamped fixed positioning that flips near the bottom edge.

Verified in headless Chrome at 1440 and 1024: before/after screenshots for 8 screens, plus every disclosure panel opened and an Escape-closes proof. `tsc -b --noEmit` clean. Not rendered: `EmptyState.more` inline placement and the anomalies clear/insufficient verdicts — unreachable on the demo corpus without mutating the live store.