### PR TITLE
chore: save local audit records and config; keep the vault out of this repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,9 @@ tests/recall/longmemeval/
 
 # reconstructed front crate build dir
 front/target/
+
+# Private strategy vault — its own repo, never part of this public one.
+shodh-vault/
+
+# Demo capture artifacts (large binaries, regenerated on demand).
+demo-frames/

--- a/.mcp.json
+++ b/.mcp.json
@@ -10,6 +10,10 @@
     "linear": {
       "command": "npx",
       "args": ["-y", "mcp-remote", "https://mcp.linear.app/mcp"]
+    },
+    "code-review-graph": {
+      "command": "python",
+      "args": ["-m", "code_review_graph", "mcp"]
     }
   }
 }

--- a/AUDIT-DATAFLOW-2026-07-21.md
+++ b/AUDIT-DATAFLOW-2026-07-21.md
@@ -1,0 +1,132 @@
+# Data-Flow Audit — 2026-07-21 (graph-guided, 5 parallel deep passes)
+
+Method: code-review-graph at `e69ce0dd` (7576 nodes / 102991 edges) used to pick the five macro flows covering the system — write path (`handle_remember`, 419 nodes/44 files), read path (`recall`, 353/31), todo path (`create_todo`, 423/46 — the largest flow in the system), maintenance (`canonicalize_user_graph`/`rebuild_user_graph`/vector lifecycle), control plane (`handleCallTool`/streaming/hooks). One deep-read agent per flow, every finding verified against source with quoted lines. All findings below are NEW — deduped against AUDIT-TASKS-2026-07-21.md (T1–T44); overlaps are cited as "extends Tn".
+
+Naming: W=write, R=read, D=todo, M=maintenance, C=control-plane.
+
+---
+
+## ⚠ BRANCH-CRITICAL INTERACTION
+
+**Merging `feat/spacy-parser-autoload` activates the auto-canonicalization hazards M3/M4/M8.** The 6-hourly heavy-maintenance canonicalize (`state.rs:2159-2180`, `SHODH_CONSOLIDATE_CANON` default true) has been a de-facto no-op without the dependency parser. This branch auto-loads the parser, so the merge turns on a job that (M3) destroys episode provenance on every entity merge, (M4) writes fake Hebbian strengthen+recency signal, and (M8) holds the graph write lock across an O(n²) clustering run, stalling all recalls and ingest. Decide M3/M4/M8 posture BEFORE merging the branch (or default `SHODH_CONSOLIDATE_CANON` off until fixed).
+
+---
+
+## Cross-cutting classes (the audit's real output)
+
+**Class A — Vector-index lifecycle has no single owner; both vector stores corrupt themselves.**
+Todo store: every todo's vector is destroyed milliseconds after creation (D1), the update handler undoes its own re-index (D2), indices are never persisted and restart cross-wires mappings (D3). Main store: runtime "rebuild" reloads a stale snapshot and resurrects deleted vectors (M1), instant-load recovery re-ids vectors without persisting the remap → permanent cross-wire (M2), runtime rebuild races concurrent inserts (M9). And the verify/repair tools are blind to every one of these classes (M12, M13). Root shape: index add/remove is owned by handlers while destruction is owned by stores; startup-only code paths are reachable at runtime; no invariant check exists that a mapped id's vector actually belongs to that memory.
+
+**Class B — Multiple ingestion pipelines with no authority → systematic duplication.**
+`autoStreamContext` re-ingests `remember` bodies and `recall` queries over the WS pipeline, cross-pipeline so dedup can't catch it (C1). Temporal facts are stored twice per memory, more on retries, with non-deterministic ids (W1). Dedup-hits silently discard the new request's tags/type/importance and still emit "created" events (W4). Todo mirror memories are never cleaned up on todo/project delete (D9). Together with tracked T4 (stop-hook dup) this is one architecture question: which layer owns ingestion?
+
+**Class C — Learning/plasticity signals are polluted by bookkeeping.**
+Recall persists the query-specific final score into RocksDB; stale scores re-enter later rankings via hierarchy expansion (R1). Access-count/importance updates land on deep clones so cached memories' frequency signal is pinned (R2). Proactive habituation punishes memories that were never shown and durably penalizes their entities' graph salience (R4). Canonicalize routes merged edges through the Hebbian strengthen path, inflating strength and resetting recency for edges nobody touched (M4). Violates the brain-fidelity north star: ACT-R-style signals must be driven by genuine use, not by maintenance or serialization accidents.
+
+**Class D — Maintenance jobs damage the structures they maintain.**
+Merge destroys episode inverted-index provenance (M3); delete-then-add edge repoint loses edges on error, no atomicity (M6); unowned stemmed/lowercase index deletes cause dedup churn loops (M5); rebuild swallows clear_all failure (M10) and strips all entity name embeddings, permanently degrading tier-4 dedup and the contrastive adapter (M11); panic leaks the per-user consolidation lock until restart (M7).
+
+**Class E — Silent contract violations at API boundaries.**
+Hierarchy/companion/lineage expansions bypass all query filters and the limit (R5); `session_id` silently overrides mode to Temporal, dropping the graph leg (R6); MCP blocks `causal` mode the backend supports (R11); four todo alias routes 500 on every call (D5); `reorder_todo` has always been a no-op (D4); shim/server content caps disagree 100k chars vs 50k bytes (W12); MCP token budget counts output before surfaced-memory appends (C4).
+
+---
+
+## P1 findings
+
+| id | Finding | Where |
+|---|---|---|
+| D1 | Todo semantic search dead system-wide: `add_activity` blob-rewrite fires `remove_todo_indices`, deleting the vector mapping created milliseconds earlier; repeats on every comment/complete/reorder; recurrence todos never indexed | `handlers/todos.rs:1005-1045`, `memory/todos.rs:634-641,517-546` |
+| D2 | update_todo handler re-index undone by its own next line (`let _ = update_todo` after indexing), despite a comment claiming the opposite | `handlers/todos.rs:1506-1551` |
+| D3 | Todo vector indices never persisted (`TodoStore::flush` has zero callers); restart reassigns vids from 0 while stale rev-mappings survive → deleting an old todo kills a new todo's vector (T2-class, separate store); startup "will rebuild on first use" message is false | `memory/todos.rs:1347-1365,305-331`, `state.rs:1689-1696,933` |
+| R1 | Recall persists query-specific final score into the record (`score` serialized against its own "not stored" contract); stale scores re-enter later rankings via hierarchy expansion (`unwrap_or(0.0)` sort) | `mod.rs:5189-5198`, `storage.rs:1794-1798`, `types.rs:1716,1069`, `mod.rs:5322-5326` |
+| M1 | Runtime auto-rebuild/compaction reloads the ~6h-stale `.vamana` snapshot instead of rebuilding: discards this cycle's soft-deletes (resurrects deleted vectors), re-adds post-save vectors greedily (no alpha-RNG), restores stale rebuild counter → alpha rebuild never runs | `retrieval.rs:236-246,443,478,1623-1635`, `vamana_persist.rs:376-378` |
+| M2 | Instant-load recovery re-ids vectors in RAM, never persists remap; after next save the stale RocksDB ids are in-range → permanent, checksum-clean cross-wired retrieval (distinct site from T2; T2's fix doesn't cover it). Chunked memories collapse to single vector or become permanently unsearchable | `retrieval.rs:503-548` (esp. 510-518) vs `1588-1597` |
+| M3 | Canonicalize-merge destroys merged mentions' episode provenance: `delete_entity` wipes `entity_episodes` rows, nothing re-indexes under canonical UUID; `entity_refs` dangle; mention counts/labels/attributes discarded. Default-on every 6h once parser loads (this branch) | `graph_memory.rs:3044-3062,3530-3557,4949` |
+| W1 | Temporal facts stored twice per memory (core path + handler Task 3), random ids so re-stores never overwrite; dedup-hit retries append copy #3+ | `mod.rs:1123-1150`, `remember.rs:848-865`, `temporal_facts.rs:395` |
+| W2 | Update-path index failure deletes the pre-existing memory: `store_inner` rollback (built for creates) runs on `update()` after `remove_from_indices`, converting a transient index error into total loss incl. version history (extends T20) | `storage.rs:1763-1768,1438-1450` |
+
+## P2 findings
+
+- **W3** MIF-imported memories never BM25-indexed (`remember_with_id` skips hybrid_search; also skips dedup/temporal facts/patterns); permanent keyword-search hole invisible to verify/repair. `mod.rs:860-903`, `mif.rs:231`.
+- **W4** Content-hash dedup-hit discards new tags/type/importance/metadata, still emits MemoryCreated/SSE/success; MCP renders fields as stored. `mod.rs:917-926`, `remember.rs:692-719`.
+- **W5** `process_experience_into_graph` (NER + up-to-20 embedder calls + parser) runs directly on tokio runtime threads; `batch_remember` does it inline for up to 1000 items (re-creates the #109 timeout-retry loop). `remember.rs:782,1070-1080,1253`, `todos.rs:2119`.
+- **W6** `metadata`/`action_params`/`outcome_details` wholly unvalidated (to ~2MB axum default); metadata cloned into every graph episode; `validate_metadata` is dead code. `remember.rs:637-650`, `state.rs:3357`, `validation.rs:265`.
+- **W7** Graph writes race under shared `graph.read()`: concurrent new-entity check-then-act mints duplicate UUIDs for one name (write-path-minted entity split); typed-edge find-or-strengthen races likewise. `state.rs:3297`, `graph_memory.rs:3223-3348,3871-3970`.
+- **R2** Access/importance updates applied to deep clones; cached (working/session-tier) memories' access_count pinned at original+1; `boost_importance` effectively never fires on the semantic path; non-semantic path behaves differently. `types.rs:1101-1109`, `mod.rs:4838,6501-6510`.
+- **R3** Any storage read error during result fetch (IO/corrupt, not just not-found) soft-deletes the memory's vectors + vmapping permanently; also ignores `SHODH_RECALL_READONLY`. `mod.rs:4962-4969`, `retrieval.rs:766-787`.
+- **R4** proactive_context habituation increments `surfacings_without_utility` and applies entity-salience penalties for ALL threshold-passing candidates, then `.take(max_results)` — ranks 6+ ratchet down forever, and only shown items can dishabituate. `recall.rs:2310,2323-2346,2353`.
+- **R5** Hierarchy/companion/lineage expansions bypass matches_filters (time/session/tags/robot/geo) and exceed `limit`. `mod.rs:5879-5904,5293-5297`, `recall.rs:756-780`.
+- **R6** `session_id` force-overwrites mode to Temporal → graph leg silently off; handler comment describes a `temporal_search()` flow unreachable from `/api/recall`. `recall.rs:461-481`, `mod.rs:2687-2691`.
+- **D6** No per-todo concurrency: whole-blob RMW loses concurrent comment/update; store `update_todo` = non-batched remove-indices-then-store → crash leaves todo invisible to all listings (unlisted T20-class site). `memory/todos.rs:634-641,708-790,803-859`.
+- **D7** Bare-number short-id resolves to first `seq_num` match across projects (every project has a #1); destructive ops (delete cascades subtasks) can hit the wrong todo, order mutates with priorities/due dates. `memory/todos.rs:589-595,904-922`.
+- **D8** `add_todo_comment` runs full remember+NER+graph synchronously on the request path (graph phase not even spawn_blocking). `handlers/todos.rs:2108-2134`.
+- **M4** Canonicalize repoint routes through `add_relationship` dedup → `strengthen()` + `last_activated = now` per collapsed edge: fake Hebbian signal + dormancy anomalies every 6h. `graph_memory.rs:3057,3912-3929`.
+- **M5** `delete_entity` removes stemmed/lowercase index keys unconditionally without ownership check; proper-noun add/delete asymmetry lets one delete break an unrelated entity's tier-3 resolution → duplicate-mint/re-merge churn loop. `graph_memory.rs:3364-3411 vs 3471-3483`.
+- **M6** Canonicalize edge repoint is `let _ = delete` then `add` with both failures ignored; add-failure permanently destroys edge+provenance; no WriteBatch. `graph_memory.rs:3054-3057`.
+- **M7** Timer maintenance path leaks per-user consolidation AtomicBool on panic (HTTP path has RAII guard, timer doesn't); user silently excluded from all maintenance + manual consolidate until restart. `state.rs:1965,2183`, vs `consolidation.rs:66-79`.
+- **M8** Heavy-cycle canonicalize holds `graph.write()` across O(n²) Fellegi-Sunter clustering (block key folds most content entities into one block) → multi-minute recall/ingest stalls at 10k+ entities; `invalidate_relationship` takes write lock on the async runtime. `state.rs:2162-2180`, `fs_matcher.rs:453-465`, `graph.rs:429`.
+- **M9** Runtime `rebuild_from_rocksdb` snapshots storage before taking index locks → concurrently indexed memories dropped from new index with live RocksDB mappings (ghost/cross-wire). `retrieval.rs:252-302`.
+- **C1** `autoStreamContext` double-ingests: skip list (4 meta tools) misses `remember`/`recall` → remember bodies stored twice (HTTP + WS extraction), recall queries ingested as memories; cross-pipeline, dedup-proof; default ON. `index.ts:1675-1692,1708,407`. (Distinct site from T32.)
+- **C2** MCP handshake never sends `session_id`; each WS reconnect orphans a server session (1h GC, 1000 cap) → flapping connection kills all streaming capture silently (buffer FIFO-evicts, C8). `index.ts:341-350,379-393`, `streaming.rs:524-527,576,734-739`.
+
+## P3 findings (compact)
+
+- **W8** Content-dedup races: concurrent identical stores both persist; single-valued `content_hash` key hides one twin; deleting either erases dedup for both (hash key deleted without value check). `storage.rs:1930-1934`.
+- **W9** Chunk-boundary embedding inconsistency: short memories indexed content-only, long ones content+entities+context — augmentation applies only past the chunk threshold. `retrieval.rs:647-707,802-849`.
+- **W10** Write behavior forks by route: agent-tagged memories skip interference/patterns/modality/stats; batch/upsert/zenoh/todo pass `None` entity embeddings → tier-4 merge off; entity identity depends on ingest endpoint. `mod.rs:1317-1435`, `remember.rs:1074`.
+- **W11** One invalid `memory_type` aborts an entire batch (`?` inside loop) after per-item validation was promised. `remember.rs:955`.
+- **W12** Shim allows 100k chars, server rejects >50k bytes; 50–100k (or multibyte >50KB) always passes shim, always 400s; hook captures silently lost. `index.ts:204`, `validation.rs:9,134`.
+- **R7** Facts leg non-deterministic: `HashSet` iteration + `take(10/15)` → fact sets churn across restarts (breaks repeat-determinism gate). `recall.rs:904,2621`.
+- **R8** FLAT+V2 flag combo produces mixed-mode fusion (leg branch order differs) → silently corrupted eval attribution. `mod.rs:4037-4054 vs 4100-4123`.
+- **R9** `SHODH_LEG=graph` isolation leaks hybrid leg under RRF/V2 and pads zero-score entries under FLAT → per-leg numbers lie. `mod.rs:3669,4099-4127`.
+- **R10** Post-truncation score mutations (competition demotion, quality gate) only conditionally re-sorted → demotion is a ranking no-op on the default path; non-monotonic displayed scores. `mod.rs:5102-5160,5307-5330`.
+- **R11** MCP `validModes` omits `causal`; backend supports it. `index.ts:1877`, `recall.rs:52`.
+- **R12** T5-class filter-after-truncation, three unlisted sites: recall todos leg, proactive todos leg, proactive quality gate. `recall.rs:838-848,2692-2703,2046-2056`.
+- **D4** `reorder_todo` permanent silent no-op: `sort_order` never assigned non-zero anywhere; `UpdateTodoRequest.sort_order` declared but never applied. `memory/todos.rs:803-859`, `types.rs:3755`, `handlers/todos.rs:270`.
+- **D5** Four alias routes (`/api/todos/update|complete|delete|reorder`) bind Path-extracting handlers with no path param → guaranteed 500. `router.rs:291-294`.
+- **D9** delete_todo/delete_project never clean mirrored memories/graph entities; 3+ near-dup mirror memories per todo lifecycle pollute the retrieval corpus. `handlers/todos.rs:1831-1882,2580-2650`.
+- **D10** delete_project(delete_todos=false) orphans todos + stale project index rows + seq counter. `memory/todos.rs:1285-1334`.
+- **D11** parse_recurrence hardcodes day-1/Mon-Fri, ignoring the todo's own due date. `handlers/todos.rs:427-442`.
+- **D12** Unparseable due date on update silently CLEARS the existing due date. `handlers/todos.rs:1468-1470`.
+- **D13** MCP add_todo always sends `contexts: []` → server skips @context auto-extraction advertised in the tool description. `index.ts:3643,3688`, `handlers/todos.rs:946-950`.
+- **D14** check_context_reminders substitutes zero-vector on embed failure → reminders silently never fire (T13-class site). `handlers/todos.rs:715-722`.
+- **M10** rebuild_user_graph discards `clear_all` failure (partial clear → double-strengthen; full failure → silent no-op reporting success). `graph.rs:340-344`.
+- **M11** Rebuild passes `None` entity embeddings → post-rebuild graph permanently loses tier-4 merge + adapter evidence; nothing backfills. `graph.rs:366` vs `remember.rs:741-786`.
+- **M12** verify_index_integrity: ghosts cancel orphans in the count (`is_healthy` can be true with non-empty orphan list); no cross-wire/dim/chunk checks — blind to T2/M1/M2 corruption; repair can't see or fix cross-wires. `mod.rs:7362-7371,7282-7347`.
+- **M13** Instant-load counts a chunked memory recovered if ANY chunk id in range; other chunks permanently unsearchable + ghost reverse-mappings. `retrieval.rs:462-468`.
+- **C3** proactive_context module-global feedback state corrupts under overlapping calls (guard cleared by first finisher; `lastUserContext` overwritten pre-await) → wrong turn pairs into reinforcement. `index.ts:295-297,2821-2849`.
+- **C4** Token budget counts resultText before surfaced-memories append + alert prepend; `_meta.token_status` reflects pre-append count → alerts fire late. `index.ts:4144-4178`.
+- **C5** recall geo/reward filters unvalidated at both layers (remember does validate) → deep 500s instead of 400s. `index.ts:1884-1892`, `recall.rs:394-413`.
+- **C6** proactive summary counts unfiltered facts while display filters conf≥0.4 → "3 facts" header above empty facts block; empty-result fast path skipped. `index.ts:2856,2937-2938,3006`.
+- **C7** ReadResource `memory://` list-scans first 100 then `.find` → existing memory beyond cap = "not found"; dedicated GET-by-id route unused (sibling of T7). `index.ts:4432-4441`.
+- **C8** Client streamBuffer FIFO-evicts oldest at 100 while disconnected — silent capture loss (client-side sibling of T10). `index.ts:310-311,425-430`.
+- **C9** `forget` has no `id` presence guard (`DELETE /api/memory/undefined`); same raw-interpolation site as T1 — fold into the apiPath() fix. `index.ts:2382-2384`.
+
+---
+
+## Data-flow maps (condensed; full detail in agent transcripts)
+
+**Write:** MCP shim (100k-char check) → `/api/remember` validate (50KB bytes) + NER/YAKE (merged into BOTH entities and tags, cap 50) → `MemorySystem::remember` under user RwLock.read in spawn_blocking: hash-dedup (early return) → importance → embed (cache) → `storage.store` (main CF put + 14 index families; rollback deletes main on index failure) → working memory → vector index (chunk decision on augmented text, index content-only embedding if unchunked) → BM25 (failure warn-only) → patterns → temporal facts (site #1) → interference → session tier → BM25 commit. Post-response detached task: entity embeddings → `process_experience_into_graph` (on runtime thread) → parent resolution → temporal facts AGAIN (site #2) → lineage. Partial-success matrix spans 8 stores; only vector-index orphans are detectable/repairable.
+
+**Read:** MCP (limit clamp 250) → handler: session→Temporal override → spawn_blocking: NER annotate → `recall()` → `semantic_retrieve_inner`: temporal/attribute/fact prefilters → embedding (cache) → graph leg (Hybrid/Assoc/Causal only; PPR default ON; leg score = mini-fusion already containing semantic cosine — 2026-06-10 pollution confirmed live) → vector leg (k×3) → BM25+vector internal RRF → FLAT calibrated-max fusion w/ fitted symmetric gate (default ON) → multiplicative boost stack (attribute ×2.5, temporal-fact ×2.0, causal-origin pins roots ×2-above-max) → truncate to max_results (T5 site) → fetch+filter → L5 multipliers → conditional final sort → access persist (writes scores to disk = R1) → hierarchy/companion expansion (filter bypass = R5). Handler: lineage boost (absolute, fusion-mode-scale-sensitive) → lineage expansion (unfiltered) → normalize ×0.95 → todos/facts legs (nondeterministic entity pick).
+
+**Todo:** create → project auto-create → full-scan prefix resolution → get_user_memory (constructs whole per-user memory system) → embed SYNC → todo Vamana index + mapping rows → store_todo (seq under mutex, blob + 7 index families) → add_activity → **update_todo → remove_todo_indices → vector just created is destroyed (D1)** → detached mirror-memory task (full remember + graph on runtime thread). Todos are deliberately first-class memories (mirror Experience + tags + recall/proactive todo legs) but write-side mirror soft-fails invisibly while read-side hard-fails.
+
+**Maintenance:** 6h timer → per-user sequential: AtomicBool lock (leak-on-panic, M7) → decay/potentiation → heavy: fact decay, auto_repair_and_compact (→ stale-snapshot reload, M1/M2/M9) → edge replay boosts → apply_decay (orphan-entity deletion → M5 churn) → canonicalize under graph.write() (M3/M4/M6/M8) → flush_all (skips TodoStore, D3).
+
+**Control plane:** every tool call → connectStream + autoStreamContext (C1 double-ingest) → health check round-trip → executeTool switch → apiCall (GET retried, mutations not) → format → count tokens (C4: before appends) → streamToolCall (T32) → surfaced memories append → token_status meta. Hook events: prompt→proactive(auto_ingest), PostToolUse Edit/Write/Bash-error→rememberEnriched, Stop→summary (T4). Triple-ingest architecture: hooks + WS auto-stream + HTTP writes, no authoritative layer.
+
+---
+
+## Discussion agenda
+
+1. **Branch gate:** default `SHODH_CONSOLIDATE_CANON` off (or land M3/M4/M6/M8 fixes) before merging spacy-parser-autoload?
+2. **Todo vector index:** keep per-user Vamana (then move index ops inside store_todo/update_todo as a matched pair) or replace with brute-force cosine over blob-persisted embeddings — todo counts are small; dissolves D1/D2/D3 and the mapping CF entirely.
+3. **Score serialization (R1):** blank `score` in `MemoryFlat::serialize` — but hierarchy expansion currently *depends* on the stale-score accident (fresh items would sort to 0.0 and be truncated); the two must be fixed together (make expansion a separate annotated section?).
+4. **Ingestion authority:** who owns capture — hooks, WS streaming, or explicit HTTP writes? C1 + T4 + T32 + W1 are all symptoms of "all three at once".
+5. **Canonicalize shape:** in-place mutation vs copy-on-write merge-plan applied as one WriteBatch (preserving edge strength, episode index, mention counts) — fixes M3/M4/M6 + crash-consistency in one design.
+6. **Instant-load reachability:** add `force: bool` to `rebuild_from_rocksdb` so runtime rebuild never takes the `.vamana` fast path (dissolves M1, shrinks M2 to real startups).
+7. **Verify/repair scope:** grow `verify_index` into an invariant checker (id-range, spot-check vector↔memory cosine, chunk counts, BM25 doc-count arm) — currently it certifies exactly the corruptions the rebuild paths produce.
+8. **Fact-id determinism (W1):** `tf-{memory_id}-{seq}` makes retries idempotent by construction; also decide the canonical store site (core vs handler).
+9. **Session-scoped recall (R6):** should session_id add a filter instead of overriding mode and dropping the graph leg?
+10. **Tags=entities conflation (write-path question):** `merged_entities` assigned to BOTH `entities` and `tags` (remember.rs:633-634) — intentional?

--- a/AUDIT-MEMORY-2026-08-06.md
+++ b/AUDIT-MEMORY-2026-08-06.md
@@ -1,0 +1,467 @@
+# Memory Subsystem Audit — 2026-08-06 (INCOMPLETE — halted at user request)
+
+**Status: PARTIAL.** Seven parallel Fable review agents were dispatched across the memory
+subsystem and **all seven were stopped mid-flight** when the session hit a usage limit. None
+returned a final report. This document contains only what was **verified first-hand**, plus the
+scope/method needed to resume. Do not read the absence of findings in a slice as a clean bill.
+
+Scope assumption: "the memory" = the memory subsystem of this repo — `src/memory/**`,
+`src/graph_memory.rs`, `src/handlers/{remember,recall,crud,state,todos}.rs`, `src/decay.rs`,
+`src/relevance.rs`, `mcp-server/index.ts`, `hooks/` — not the `~/.claude` markdown store.
+
+Baseline: prior audit `AUDIT-TASKS-2026-07-21.md` (T1–T44) + `AUDIT-DATAFLOW-2026-07-21.md`
+(W/R/D/M/C) at commit `e69ce0dd`. HEAD is `4a7ae671`, **36 commits / +6817 −170 across 31 files**
+ahead — geotemporal Phase 0+1, GDELT ingest, eval harness, CI stack.
+
+---
+
+## 1. Verified findings (first-hand, this session)
+
+### A1 · `cargo clippy --all-targets` does NOT compile on this branch — P1
+
+`tests/memory_tiering_tests.rs:452-455`:
+
+```rust
+assert!(
+    forgotten >= 0,
+    "Forget operation should complete successfully"
+);
+```
+
+`forget()` returns an unsigned count, so `forgotten >= 0` is **always true**. Clippy denies this:
+
+```
+tests\memory_tiering_tests.rs:453:9: error: this comparison involving the minimum or maximum
+element for this type contains a case that is always true or always false
+error: could not compile `shodh-memory` (test "memory_tiering_tests") due to 1 previous error
+```
+
+Two distinct consequences:
+
+1. **The assertion cannot fail.** The test is named for verifying `ForgetCriteria::LowImportance`
+   and its own comment concedes "actual count depends on importance calculation" — so it asserts
+   nothing at all. If `forget()` silently became a no-op returning 0, this test still passes. This
+   is the exact class `CLAUDE.md` forbids: *"NEVER lower thresholds, weaken assertions, skip tests,
+   or relax criteria."* A test that cannot fail is worse than no test.
+2. **`clippy --all-targets` is red on `docs/geotemporal-design`.** Worth weighing against the
+   "CI was fake-green ~2.5 months" thread — check whether CI runs clippy with `--all-targets` or
+   only over `src/`, because the latter would not catch this.
+
+Caveat on method: my clippy invocation was piped to `tail`, so the reported exit code 0 was
+`tail`'s, not clippy's. The error text above is from the captured output and is real.
+
+### A2 · `src/memory/storage.rs.patch` is a **tracked** file in the source tree — P3
+
+1646 bytes, dated Jan 23 2026, sitting next to `storage.rs`. It is **committed**, not stray
+working-tree detritus (`git ls-files` matches it; last touched by `35ccbdcd style: format code` —
+i.e. a formatting commit reached into a `.patch` file).
+
+Its content is **already applied and since superseded**. The patch adds `STORAGE_MAGIC`,
+`deserialize_memory`, and `crc32_simple`; all three exist in `storage.rs` today
+(`:65`, `:698`, `:1064`) in a more evolved form — the shipped version handles SHO v1 (bincode 2.x)
+vs v2 (postcard) with a migration flag, which the patch does not.
+
+So the file is dead documentation that describes an *older* design than the shipped one. Delete it.
+
+**Open question worth one focused check on resume:** the patch's original `deserialize_memory`
+verified the CRC32 and, on mismatch, only `tracing::warn!`'d before decoding the payload anyway —
+i.e. it tolerated silent corruption by design. The shipped path delegates to
+`crate::serialization::unwrap_sho`. **I did not verify whether `unwrap_sho` actually checks the
+CRC or what it does on mismatch.** If it warns-and-proceeds, that is a silent-data-corruption
+finding on the memory read path and belongs on the T-list. Unverified — do not cite as fact.
+
+### A3 · Reinforcement metric cannot distinguish success from failure — P1 (NEW)
+
+`src/memory/mod.rs:7740-7761`, `record_reinforcement`. Verified first-hand:
+
+```rust
+match graph.read().record_memory_coactivation(&memory_uuids) {
+    Ok(count) => { stats.associations_strengthened = count; }
+    Err(e) => {
+        tracing::warn!(error = %e, "Failed to record memory coactivation");
+        // Fallback: count pairs
+        let n = memory_ids.len();
+        stats.associations_strengthened = n * (n - 1) / 2;
+    }
+}
+} else {
+    // No graph memory available — count pairs directly
+    let n = memory_ids.len();
+    stats.associations_strengthened = n * (n - 1) / 2;
+}
+```
+
+Three paths write `associations_strengthened`, and **two of them fabricate `C(n,2)` from the input
+length without touching the graph** — one when `graph_memory` is `None`, one when the real call
+*errored*. So the reported figure is maximal precisely when the subsystem failed, and 0 when it
+succeeded (because the shipped strengthen-only default returns 0 for fresh pairs — see A4).
+
+Failure scenario: graph lock poisoned or RocksDB read error during `record_memory_coactivation`
+on a 10-memory recall. The real path fails; `stats.associations_strengthened` is set to 45 — the
+value a *perfectly wired* graph would report. The only signal is a `warn!`. Any dashboard, eval,
+or consolidation report reading this field sees peak Hebbian activity at the moment the layer
+broke. This inverts the metric, and it violates the brain-fidelity north star in the same way
+Class C findings do: the plasticity signal is produced by bookkeeping, not by use.
+
+### A4 · The Hebbian memory↔memory layer is inert, and 11 tests pin the no-op — P1 (corroborated)
+
+A subagent hunt for tests-that-cannot-fail survived the shutdown and returned verified results;
+its central claim is confirmed against source above.
+
+**Mechanism.** `record_memory_coactivation` (`src/memory/mod.rs:7740-7761`) is strengthen-only by
+default (`SHODH_COACT_STRENGTHEN_ONLY`, default-on since `f6b730ee`, 2026-07-10). The *mint*
+branch is the only writer of the `mem_edge:{a}:{b}` pair index that the *strengthen* branch reads —
+so it returns 0 for every fresh memory pair, permanently. This is the concrete mechanism behind
+the long-standing "layer INERT since 07-10" thread.
+
+**Correction to MEMORY.md:** the pin set is **11 tests, not ~14** —
+`tests/hebbian_learning_tests.rs:284, 327, 397, 833, 908, 995, 1043, 1115`;
+`tests/consolidation_tests.rs:951, 1039`; `tests/brutal_stress_tests.rs:607`.
+
+These are **deliberate, documented pins**, not accidents — `tests/consolidation_tests.rs:1076-1077`
+states: *"Pinned positively so a future revive of the layer will trip this test rather than
+silently passing."* That is defensible engineering. The cost is that reviving the layer fails all
+11, which is the real content of the pending remove-vs-revive decision.
+
+**Three test names assert the opposite of their bodies** — `test_coactivation_during_retrieve_forms_edges`
+(`:995`) asserts zero edges form; `test_co_retrieval_strengthens_association` (`:284`) asserts
+nothing is strengthened; `test_repeated_co_retrieval_increases_strength` (`:327`) asserts `(0,0,0)`.
+Anyone grepping test names for Hebbian coverage gets three false positives.
+
+**Additional tautological assertions found** (same class as A1):
+- `tests/adaptive_memory_tests.rs:980` — `assert!(stats.node_count >= 0)` on a `usize`; it is the
+  *only* assertion in `test_graph_maintenance`, so the test checks panic-freedom and nothing else.
+- `tests/adaptive_memory_tests.rs:951` — `assert!(node_count > 0 || edge_count >= 0)`; the right
+  disjunct is unconditionally true, killing the left one, which is the check that would catch an
+  empty graph after ingest.
+- `tests/adaptive_memory_tests.rs:212, 284` — the suite's only *positive* `associations_strengthened`
+  assertions (`3` and `1`) pin the `graph_memory: None` arithmetic fallback from A3, not Hebbian
+  work. `create_test_system()` never calls `set_graph_memory`. They cannot detect any regression.
+- `tests/hebbian_learning_tests.rs:377, 464` assert `Default::default()` back to itself — both
+  fields are structurally unreachable from non-zero (`len() >= 2` gate; empty-slice early return).
+- `src/recall_harness/bridge_harness.rs:863-935` — `#[ignore]`d *and* its three substantive
+  assertions sit behind `SHODH_BRIDGE_GATE=strict` (default off). The default-path assertion has
+  0.2 slack on a [0,1] recall metric whose baseline the comment concedes is "~0". Declared openly
+  in-comment, so a known ratchet rather than a hidden one — but it is not coverage.
+
+Explicitly cleared by that hunt (worth recording so they are not re-flagged): the
+`consolidation_tests.rs` event-buffer trio was deliberately rewritten to be non-vacuous;
+`cognitive_stress_test.rs`'s hebbian matches are fixture strings and timers only; the nine
+`#[ignore]`s are runtime-cost exclusions with stated reasons, none suppressing a broken feature.
+
+### A5 · `SHODH_SPREAD_FIX` silently applies to only half the queries — the eval arm measures a blend — P1 (NEW)
+
+A second surviving subagent (diverged-duplicate-logic hunt) found this; I verified it directly.
+
+`grep -rn "spread_fix" src/ --include=*.rs` returns **exactly two lines**: the bind at
+`src/memory/graph_retrieval.rs:184` and the single use at `:241`, both inside
+`spread_single_direction` — which is called only from `bidirectional_spread` (`:399`, `:408`).
+
+The unidirectional path at `graph_retrieval.rs:1423-1428` is an **inline copy** of the spreading
+formula that never reads the flag and still runs the acknowledged double-use of `effective`
+(it sets the decay rate *and* is multiplied in — precisely what the fix removes).
+
+Branch selection is `graph_retrieval.rs:1318`: `else if entity_data.len() >= BIDIRECTIONAL_MIN_ENTITIES`.
+So a query resolving to **2+ focal entities** gets the fixed formula; a query resolving to
+**exactly 1 focal entity** silently keeps the buggy one regardless of the env var.
+
+**Why this is the serious one.** `src/recall_harness/runner.rs:1343` registers the eval arm
+`("+spread-fix", vec![("SHODH_SPREAD_FIX", "1")])`. Single-entity queries contribute *unchanged
+baseline* numbers to that arm. The measured effect of the spread fix is therefore diluted by an
+unknown fraction of the query set, and the dilution is invisible in the reported number. Any
+decision taken on that arm — including a decision not to ship the fix because the gain looked
+small — rests on a blended measurement. This belongs in the same family as the fake-green CI
+thread: the number is real, but it does not measure what its name says.
+
+### A6 · Graph leg and semantic leg score the same memory with 2×–5× different boost weights — P1 (NEW)
+
+Verified directly. `src/constants.rs:1190,1202,1213` define `RECENCY_BOOST_SCALE = 0.5`,
+`AROUSAL_BOOST_SCALE = 0.15`, `CREDIBILITY_BOOST_SCALE = 0.2`. The semantic leg
+(`mod.rs:4772-4799`) uses them. The graph leg (`graph_retrieval.rs:1739-1759`) **hardcodes**
+`0.1`, `0.05`, `0.1` — a 5×, 3×, and 2× divergence.
+
+Corroborating detail: `constants.rs:3177-3180` documents all three as having a single call site
+(`memory/mod.rs`), i.e. the graph-leg copies are untracked by the project's own constant registry.
+The graph-leg comments are self-inconsistent with their own code — `// Source credibility boost
+(5% contribution)` sits directly above `* 0.1`.
+
+Failure scenario: a 1-day-old memory contributes a recency term of `exp(-0.24)*0.1 ≈ 0.079` via the
+graph leg but `exp(-0.24)*0.5 ≈ 0.393` via the semantic leg. `graph_retrieval.rs:1765-1766` sorts
+by that sum and truncates at `GRAPH_CANDIDATE_CAP = 200`, so the same memory can survive in one leg
+and be cut in the other purely from which leg surfaced it — before RRF fusion ever sees it.
+Additionally, the caller-supplied `query.recency_weight` override (`mod.rs:4761`) has **no effect
+at all** on the graph leg.
+
+### A7 · Further divergences reported by that hunt — NOT independently verified
+
+Recorded for follow-up. I confirmed A5/A6 against source; the four below I did **not**, and they
+should be re-checked before being acted on:
+
+- **`formatSurfacedMemories` duplicated in `mcp-server/index.ts:568-576` (live) vs
+  `string-utils.ts:37-50` (dead but the only one under test).** The tested copy appends a bare
+  `...` even to complete content, which `memory-format.ts:1-9` explicitly names as the failure
+  class it exists to remove. `tests/string-utils.test.ts:~176` pins the obsolete behavior. Same
+  drift vector for `getContent`/`getType` (currently byte-equivalent).
+- **`SHODH_FEEDBACK_MOMENTUM_SCALE` applied to the score (`mod.rs:4745-4748,4885-4893`) but not to
+  the attribution reported for it (`capture_l5_diagnostics`, `mod.rs:4994-5005`, which uses the
+  raw constant).** The recall diagnostics panel surfaced via `index.ts:2133` would disagree with
+  the ranking it claims to explain — exactly when someone is tuning the knob.
+- **Three `split_sentences` implementations**; the fact-extraction copy (`compression.rs:1396-1417`)
+  lacks the abbreviation/decimal guard that `query_parser.rs:1594-1632` and
+  `segmentation.rs:233-250` have. Claimed consequence: sentences containing a decimal or a titled
+  name get severed into sub-20-char fragments and dropped by the length filter at
+  `compression.rs:1120`, so retrieval indexes a sentence fact-extraction never stored.
+- **`cosine_similarity_inline` (`distance_inline.rs:444-457`) guards length with `debug_assert_eq!`**,
+  a no-op in release, while every sibling copy returns `0.0` on mismatch. One non-test caller
+  (`vamana.rs:759`). The agent explicitly flagged this as its weakest finding — no call site
+  proven to pass mismatched dimensions — so it is a guard divergence, not a demonstrated bug.
+  (This overlaps prior finding **T28**.)
+
+Also worth recording: that hunt verified several *suspected* duplicates as genuinely equivalent —
+fact decay (`mod.rs:10078-10095` vs `compression.rs:1483-1496`), todo RocksDB index key
+construction, and tag-key lowercasing. Those need not be re-walked.
+
+### A8 · Constant/env drift: the tuning surface is substantially fictional — P1 (NEW)
+
+A third surviving subagent ran a grep-proven constants/env sweep. I re-verified its dead-constant
+claims independently — `grep -rlw <NAME> src/ tui/src crates/ --include=*.rs | grep -v constants.rs`
+returns **0 files** for every one of: `SPREADING_DECAY_RATE`, `IMPORTANCE_TYPE_OBSERVATION`,
+`EDGE_HALF_LIFE_HOURS`, `EdgeWeight`, `L1_TARGET_DENSITY`, `TIER_RETRIEVAL_SUCCESS_BOOST`.
+
+The unifying defect: **`constants.rs` carries a self-documenting usage table (`:3054-3180`) that
+names call sites which do not exist.** The file is the project's tuning interface and it is lying
+in at least four places. Verified instances:
+
+- **`SPREADING_DECAY_RATE = 0.5`** (`constants.rs:966-974`) is documented with the formula
+  `A(d) = A₀ × e^(-λd)` and listed at `:3120` as used by `graph_retrieval.rs`. It is read
+  **nowhere**. Real decay comes from `calculate_importance_weighted_decay`
+  (`graph_retrieval.rs:109-113`) yielding **λ ∈ [0.05, 0.15]**. At hop 6 that is
+  `e^-0.3 ≈ 0.74` retention versus the advertised `e^-3 ≈ 0.05` — spreading reaches vastly more
+  of the graph than the named constant implies, and lowering it to tighten recall does nothing.
+- **`EDGE_INITIAL_STRENGTH` / `EDGE_MIN_STRENGTH` / `EDGE_HALF_LIFE_HOURS`**
+  (`constants.rs:167,177,202`) are listed at `:3054-3056` as used by `EdgeWeight::default()` and
+  `EdgeWeight::decay()`. **The `EdgeWeight` type does not exist in the repo** — those three comment
+  lines are its only remaining trace. Edge forgetting actually runs through the LTP path
+  (`LTP_DECAY_HALF_LIFE_DAYS = 14.0`), a **14-day** half-life where the constant file promises 24
+  hours.
+- **The entire `IMPORTANCE_TYPE_*` table** (`constants.rs:548-593`, 10 constants) is dead.
+  `mod.rs:6029-6038` hardcodes the literals in a match arm that **omits `Observation`** — which
+  `types.rs:114` makes the *default* experience type — so it falls to `_ => 0.05`, exactly half the
+  documented `IMPORTANCE_TYPE_OBSERVATION = 0.10`. Auto-captured memories therefore clear
+  `DEFAULT_IMPORTANCE_THRESHOLD`/`REPLAY_IMPORTANCE_THRESHOLD` less often than the table implies.
+  A third scale exists in `streaming.rs:1133-1135` (base `0.5` with its own ladder), so streamed
+  and remembered memories are not on a comparable importance scale at all.
+- **Five tier constants dead** (`L1/L2/L3_TARGET_DENSITY`, `TIER_RETRIEVAL_SUCCESS_BOOST`,
+  `TIER_LTP_THRESHOLD`) while their block-siblings are live — which is what makes the gap
+  non-obvious. Nothing enforces per-tier density; graph density is bounded only by
+  `MAX_ENTITY_DEGREE = 500`.
+
+**`SHODH_TOPOLOGY_AWARE_DECAY` — a CI-visible variant of the fake-green pattern.** Verified:
+
+```rust
+// feature gate, graph_memory.rs:6617-6619  → "0" means OFF
+.map(|v| v == "1" || v.eq_ignore_ascii_case("true")).unwrap_or(false)
+
+// test gate,    graph_memory.rs:12456-12458 → "0" means SET, so SKIP
+if std::env::var_os("SHODH_TOPOLOGY_AWARE_DECAY").is_some() { return; }
+```
+
+A CI job that pins `SHODH_TOPOLOGY_AWARE_DECAY=0` to assert "feature off" gets the feature off
+**and** silently skips the byte-identical-pruning regression test guarding it. The test's own
+comment says "No in-suite test sets it, so this is normally live" — that assumption breaks the
+moment the var is set anywhere in the environment, and the skip is invisible in a green run.
+
+**Reported but NOT independently verified** (re-check before acting):
+- Rust/TS request-limit disagreement: content `50_000` (`validation.rs:9`) vs `100_000`
+  (`index.ts:204`) — client cap **fails open**, so 50–100k content passes the client and 400s at
+  the server; query `50_000` vs `10_000` and limit `10_000` vs `250` fail closed. Aggravated by JS
+  UTF-16 `.length` vs Rust UTF-8 `.len()`, so a 40k-char CJK payload is ~120k bytes. A fourth
+  private cap `MAX_LIST_LIMIT` duplicates `validation::MAX_LIMIT` (`crud.rs:52`). Overlaps **W12**.
+- `SHODH_API_URL` vs `SHODH_SERVER_URL`: the `Tui` subcommand (`cli.rs:102-108`) is the only one
+  reading `SHODH_SERVER_URL`; the TUI binary is also internally split — statusline honors both
+  (`tui/src/main.rs:607-609`), dashboard and search honor only `SHODH_SERVER_URL` (`:739-742`,
+  `:817-820`). Everything else (MCP, all hooks) reads `SHODH_API_URL` only.
+- `SHODH_OFFLINE` parsed case-sensitively at three sites and case-insensitively at a fourth, all
+  within model init — so `SHODH_OFFLINE=TRUE` splits the offline decision mid-path, which the
+  comment at `gliner.rs:149-151` warns can poison ort's global mutex.
+
+That sweep also verified as **consistent** (need not be re-walked): `SHODH_IPC_REQUIRED`,
+`SHODH_ZENOH_ENABLED`, `SHODH_FUSION_V2`, `SHODH_COMPANION_WEIGHT`, `SHODH_ONNX_THREADS`,
+`SHODH_PORT`, `SHODH_ENV`, `RECENCY_DECAY_RATE`, `SHODH_ROCKSDB_BLOCK_CACHE_MB`.
+
+---
+
+## 2. Toolchain / environment state
+
+- **`code-review-graph` rebuilt at HEAD.** It was stale at `e69ce0dd` — the exact prior-audit
+  baseline. Now: **7817 nodes / 105521 edges / 284 files** (was 7576 / 102991 / 275).
+  Delta: +241 nodes, +2530 edges, +9 files. The MCP server is configured in `.mcp.json` but
+  **failed to connect this session**; the CLI (`python -m code_review_graph`) works.
+- Clippy: see A1. Other output is test/bench-only lint noise (unused imports, redundant closures,
+  never-used test helpers) — not reported as findings.
+
+---
+
+## 3. Literature cross-read — two papers, mapped onto this codebase
+
+Both were requested mid-session. Both are directly on-target, and both were read in full text
+(WebFetch returned only PDF metadata; text was extracted locally via PyMuPDF).
+
+### 3.1 · Reddy & Challaram, *Reliable Post-Retrieval Assembly for Agent Memory* (arXiv 2606.01435v2, COLM 2026 Lifelong Agent Workshop)
+
+**Claim.** Retrieval success does not guarantee reliable *use* of retrieved evidence.
+Factoring answer generation into `K = E(q,R)` (LLM extracts a structured candidate set, version
+metadata preserved) then `ŷ = A_π(K)` (a separate stage executes an explicit policy) beats a
+direct one-call pipeline by **+10.8 pp average, +21 pp at 262K** on MAB v3 FactConsolidation —
+with *identical top-10 retrieved evidence in both arms*. Reaches 82%/93% single-hop
+(gpt-4o-mini/gpt-4o) vs HippoRAG-v2 54%, BM25 48%, Mem0 18%, Zep 7%; GPT-4o long-context 60%.
+
+**The load-bearing ablation, and why it matters here.** Swapping the *policy executor* from LLM to
+deterministic code contributes only **+2.0 pp average and 0 pp at 262K**. So the gain is **not**
+from deterministic selection — it is from *externalising semantic matching into an inspectable
+intermediate representation before the decision*. Authors are explicit: "reliable systems should
+separate evidence identification from explicit policy execution whenever the policy and metadata
+are known."
+
+**Honest bound (they state it themselves).** LongMemEval knowledge-update is a **null result**:
+26/45 structured vs 29/45 baseline, paired exact McNemar **p = 0.45**. The benefit is scoped to
+*current-value questions with explicit version markers*. It does not address partial orders,
+historical queries ("what was the previous status"), aggregation, or Yes/No synthesis — those are
+precisely the five baseline-only wins they inspected. Do not cite this paper as a general win.
+
+**Bearing on shodh-memory.** This repo's entire measured surface is the *retrieval* half
+(fusion, boost stack, PPR, recall@k). The assembly half is delegated implicitly to the calling
+LLM via the MCP response. The paper's contribution is to name that as a distinct reliability
+boundary that should be *designed and evaluated explicitly*. Two known findings are assembly-layer
+defects in this exact sense, not retrieval defects:
+- **R1** (recall persists the query-specific final score into the record, and stale scores re-enter
+  later rankings) — the intermediate representation is not clean; it is contaminated by a prior
+  decision.
+- **R10** (post-truncation score mutations only conditionally re-sorted, so demotion is a no-op on
+  the default path) — the policy is not actually executed.
+
+### 3.2 · Ziming Wang, *TOKI: A Bitemporal Operator Algebra for Contradiction Resolution in LLM-Agent Persistent Memory* (arXiv 2606.06240v1, cs.DB, 4 Jun 2026)
+
+**Claim.** Contradiction resolution *is* write-time concurrency control. The four production
+heuristics — last-writer-wins `⊕t`, evidence-weighted `⊕p`, await-confirmation `⊕?`, per-rule `⊕c`
+— are one isolation-indexed operator family over a dual-row bitemporal schema. Each carries an
+isolation precondition (RC / SI / RC+cb / SR) and admits a named Berenson–Adya anomaly
+(P4 lost update / A5B write skew / callback boundary / P3 phantom). Every write commits a
+**current** row beside an **audit** row holding the losing fact plus provenance, under a
+CHECK-bound `row_kind` discriminator.
+
+**The three agent-specific anomalies** the classical alphabet cannot name — this is the useful
+part for us:
+- **N1 replay inconsistency** — re-adjudicating the same contradiction returns a different winner.
+- **N2 belief-drift skew** — concurrent confidence revisions corrupt a (subject, predicate) partition.
+- **N3 audit erasure** — the overwritten fact becomes unrecoverable.
+
+Verdict matrix over 8 systems: **every** agent-memory baseline (mem0 v2/v3, Graphiti, Letta, Zep,
+MIRIX) admits at least one. N3 is universal among the five with a documented provenance path.
+Only TOKI excludes all three while keeping a judge on the write path; WorldDB excludes all three
+only by removing the judge entirely.
+
+**Honest bound.** The empirical component is weak relative to the theory: the audit-row defence
+moves its natural-workload LoCoMo slice by **0.86 accuracy points**, and ablating the typed memory
+layer removes **0.49** on 1,444 answerable LoCoMo questions. The paper explicitly states the
+cross-system comparison "stays underpowered and claims no superiority." The contribution is the
+**contract**, not a benchmark win. Cite it for vocabulary and soundness framing, not for numbers.
+
+**Bearing on shodh-memory — this is the sharp one.** TOKI's three anomalies name three *already
+known* findings in this repo precisely, which is strong evidence they are structural rather than
+incidental:
+
+| TOKI anomaly | shodh-memory finding | Site |
+|---|---|---|
+| **N3 audit erasure** | **M3** — canonicalize-merge destroys merged mentions' episode provenance; `delete_entity` wipes `entity_episodes`, nothing re-indexes under the canonical UUID, `entity_refs` dangle | `graph_memory.rs:3044-3062,3530-3557` |
+| **N3 audit erasure** | **M6** — edge repoint is `let _ = delete` then `add`, both failures ignored, no WriteBatch; add-failure destroys edge + provenance permanently | `graph_memory.rs:3054-3057` |
+| **N1 replay inconsistency** | **W1** — temporal facts stored twice per memory with *random* ids, so re-stores never overwrite and retries append copy #3+ | `mod.rs:1123-1150`, `remember.rs:848-865`, `temporal_facts.rs:395` |
+| **N1 replay inconsistency** | **R7** — facts leg iterates a `HashSet` then `take(10/15)`, so fact sets churn across restarts | `recall.rs:904,2621` |
+| **N2 belief-drift skew** | **W7** — graph writes race under a shared `graph.read()`; concurrent check-then-act mints duplicate UUIDs for one entity name | `state.rs:3297`, `graph_memory.rs:3223-3348` |
+| **N2 belief-drift skew** | **M4** — canonicalize routes merged edges through the Hebbian `strengthen()` path, inflating strength and resetting recency for edges nobody touched | `graph_memory.rs:3057,3912-3929` |
+
+**The actionable question this raises for the geotemporal work**, which landed since the last audit
+and which no agent survived long enough to check: TOKI's core object is a fact stamped with
+**both** a valid-time period *and* a system-time period. Does the shipped geotemporal schema
+distinguish **valid time** (when the fact was true in the world) from **transaction/system time**
+(when it was recorded)? If it collapses them onto one axis, then M3/M4/W1 are not separate bugs —
+they are symptoms of a missing bitemporal dimension, and fixing them individually will not hold.
+The paper cites TSM recovering **12.2 accuracy points** on LongMemEval and LoCoMo purely by
+separating dialogue time from occurrence time — "an axis production memories collapse."
+
+**This is the single highest-value unverified question in this audit.** It is a schema question,
+answerable by reading `src/memory/types.rs` + `src/memory/temporal_facts.rs` + the geo diff.
+
+---
+
+## 4. What was NOT covered — resume here
+
+All seven slices were dispatched with evidence requirements (`file:line` + quoted code + concrete
+failure scenario) and a full dedupe list against T1–T44 / W/R/D/M/C. All were killed before
+reporting. Re-dispatch as-is:
+
+1. **Geotemporal delta** (`e69ce0dd..HEAD`) — filter-bypass interactions, new RocksDB key
+   encodings + migration, PRECEDES promotion idempotence under the 6h cycle, whether geo fields
+   populate on *all* write routes, back-compat deserialization, and divergence from
+   `docs/superpowers/specs/2026-07-28-geotemporal-design.md`. **Add the bitemporal question from
+   §3.2.** (This agent's last trace showed it examining Layer 4.46 injection in the fusion flow
+   and the default fusion mode — that thread is worth picking up.)
+2. **Status verification of T1–T17, W1–W2, R1, M1–M3, D1–D3 at HEAD** — FIXED / STILL OPEN /
+   MOVED / REFUTED, plus current defaults for every gating `SHODH_*` env var. Nothing in this
+   session re-confirmed any prior finding; **treat all of T1–T44 as still open until this runs.**
+3. **Write path** — `remember.rs` → `mod.rs` → `storage.rs` → indexing → `process_experience_into_graph`.
+4. **Read path** — `recall.rs` → fusion → boost stack → expansions; determinism and leg isolation.
+5. **MCP + hooks surface** — including whether the MCP layer now exposes geo/temporal recall
+   params and whether its validation matches `handlers/recall.rs` (extends C5).
+6. **Maintenance / integrity** — canonicalize, rebuild, verify/repair blindness, backup.
+   (The Hebbian-inertness half of this slice is **answered** — see A3/A4. Still open: whether
+   `verify_index_integrity` can return `is_healthy: true` over live cross-wire corruption, M12's
+   core claim, and the M1/M2/M9 rebuild trio.)
+7. **Structural rot** — dead code with unkept promises, constant/env-default drift, panic surface,
+   and diverged duplicate logic. (The tests-that-cannot-fail hunt is **done** — A1/A4.)
+
+---
+
+## 5. Bottom line
+
+Six findings verified first-hand, plus four recorded-but-unverified (A7). Two are small: a test
+assertion that cannot fail and simultaneously breaks `clippy --all-targets` (A1), and a committed
+stale `.patch` file describing a superseded storage design (A2). Four are not:
+
+- **A5** — `SHODH_SPREAD_FIX` reaches only the bidirectional spreading path (2+ focal entities).
+  Single-entity queries silently run the old double-use formula, so the `+spread-fix` eval arm in
+  `runner.rs:1343` reports a **blend of fixed and unfixed behavior** under a name that claims
+  otherwise. Fix this before trusting any conclusion drawn from that arm.
+- **A6** — the graph leg hardcodes recency/arousal/credibility boosts at 5×/3×/2× off the
+  canonical constants the semantic leg uses, and `query.recency_weight` does not reach it at all.
+  The same memory ranks differently depending on which leg surfaced it, before fusion.
+- **A8** — the tuning surface is substantially fictional. `constants.rs`'s own usage table names
+  call sites that do not exist; `SPREADING_DECAY_RATE`, the whole `IMPORTANCE_TYPE_*` table, the
+  three `EDGE_*` constants (whose `EdgeWeight` type is gone from the repo), and five tier
+  constants are all read nowhere. Real spreading decay is 3–10× weaker than advertised, and the
+  default `Observation` experience type scores half its documented importance.
+
+**A common thread across A5, A6 and A8:** the *named, documented* control surface and the *actual*
+behavior have drifted apart in at least four independent places, always silently, and in three of
+them the stale documentation is a comment table asserting the opposite. Anyone tuning this system
+— or reading an eval arm's name — is working from a map that no longer matches the terrain. That
+is a single systemic problem, not eight unrelated ones, and it is the same failure shape as the
+fake-green CI thread.
+
+- **A3** — `associations_strengthened` is fabricated as `C(n,2)` on two of its three write paths,
+  including the *error* path. The metric peaks exactly when the subsystem fails and reads 0 when
+  it succeeds. Anything consuming it — dashboards, consolidation reports, eval — is inverted.
+- **A4** — the Hebbian memory↔memory layer's inertness now has a precise mechanism (the mint
+  branch is the sole writer of the pair index the strengthen branch reads), and the pin set is
+  **11 tests, not ~14**. Worth correcting in MEMORY.md. The pins are deliberate and documented;
+  the genuine cost of "revive" is those 11 tests, which sharpens the pending decision.
+
+The substantive result of this session is **§3.2**: two independent 2026 papers, read against this
+codebase, converge on the same diagnosis. TOKI's N1/N2/N3 anomaly triple maps one-to-one onto six
+findings the July audit had already logged as separate bugs across `graph_memory.rs`,
+`temporal_facts.rs`, and `recall.rs`. That convergence reframes them as one structural gap —
+most likely a collapsed valid-time/system-time axis — rather than six independent defects. If
+that holds, the current fix-list attacks symptoms. **Verify the bitemporal schema question before
+spending effort on M3/M4/M6/W1 individually.**
+
+Nothing was committed, pushed, or posted. No code was modified.

--- a/AUDIT-TASKS-2026-07-21.md
+++ b/AUDIT-TASKS-2026-07-21.md
@@ -1,0 +1,74 @@
+# Audit Tasks — 2026-07-21
+
+Source: comprehensive audit @ `e69ce0dd` (branch `feat/spacy-parser-autoload`). All items verified against source by an adversarial re-verify pass. Ordered by fix priority. `[ ]` = todo.
+
+Legend: **P0** fix first · **P1** high · **P2** medium · **P3** ops/hygiene · **P4** low/optional.
+
+---
+
+## P0 — CRITICAL (data loss / security)
+
+- [ ] **T1 · MCP `forget` path-traversal → whole-user wipe.** `mcp-server/index.ts:2384` interpolates `id` raw; `id="../users/<uid>"` normalizes to `DELETE /api/users/<uid>` (router.rs:147). Fix: add `apiPath(...segments)` helper that `encodeURIComponent`s every segment; apply at forget (2384), dismiss_reminder (3617), todos (3783/3812/3829/3845), subtasks (3956), comments (3979/4004/4027/4052), and `read_memory` memory_id (4092).
+- [ ] **T2 · Vector-id rebuild permutation → silent cross-wired retrieval.** `src/memory/retrieval.rs:300-311` never persists the regrouped mapping. Fix: write the new mapping back to RocksDB inside `rebuild_from_rocksdb` (mirror `force_quality_rebuild` at 1588-1597); add a layout-generation stamp checked at instant-load; index chunk vectors, not only `experience.embeddings`.
+- [ ] **T3 · Backup restore destroys live DB, no rollback/verify.** `src/backup.rs:324`, `src/handlers/consolidation.rs:586-649`. Fix: call `verify_backup` (checksum) first; restore into `storage.restore_tmp` then rename-aside (as secondary stores do at 441-491); hold a per-user exclusive restore gate that `get_user_memory` (state.rs:1242) respects.
+- [ ] **T4 · Stop-hook duplicates memories every turn.** `hooks/memory-hook.ts:1541-1764`, `hooks/claude-settings.json:26-36`. Fix: move session-summary + `deleteState()` to `SessionEnd`; if `Stop` stays, keep it incremental with a persisted `lastTranscriptOffset` (no reset).
+
+## P1 — HIGH
+
+- [ ] **T5 · Filters applied after top-k truncation → empty/short results.** `src/memory/mod.rs:4584` then `4911-4975`. Fix: drain the fused list until `max_results` survivors pass filters (budget-capped), then truncate.
+- [ ] **T6 · `read_memory` (and siblings) mask backend errors as "not found"/empty.** `index.ts:4090-4103`; same class `session_history`/`fact_narratives`/`purge_facts` (3177/3257/3311). Fix: rethrow non-404 with `isError:true`; return "not found" only on real 404; map `success:false` → `isError`.
+- [ ] **T7 · Reads silently capped at 100.** `index.ts:2222/2325/4433` (context_summary prints wrong `Total`, 2269); backend default 100 (crud.rs:83). Fix: pass `limit`, page via `total`; fetch `memory://<id>` by `GET /api/memory/{id}` not list-scan.
+- [ ] **T8 · Causal-origin mislabels hubs as roots, pins wrong rank-1 (default ON).** `src/graph_memory.rs:4336-4354`, `mod.rs:4489-4499`. Fix: fetch causal-typed incoming edges directly (typed pair index / relation-filtered scan) instead of untyped strength top-64.
+- [ ] **T9 · Graph edge-direction fix default-OFF → PPR self-loops, backward edges invisible.** `src/memory/graph_retrieval.rs:511-532`. Fix: run the pending A/B and flip `SHODH_GRAPH_EDGE_DIR` default to true; at minimum exclude `nb==u` self-edges from PPR adjacency.
+- [ ] **T10 · Streaming buffer unbounded + bypasses 50KB cap.** `src/streaming.rs:669-686`, `webhooks.rs:191-225`. Fix: byte-cap merged content, call `validate_content` per message, set `max_message_size` on upgrade.
+- [ ] **T11 · Codebase-index path blocklist dead on Windows + is a read primitive.** `src/handlers/files.rs:195-344`. Fix: strip `\\?\` (dunce) before compare; switch blocklist → allowlist root (`SHODH_INDEX_ROOT`).
+- [ ] **T12 · `verify_backup` ignores `shared/` SSTs → corrupt backup passes.** `src/backup.rs:651-664`. Fix: hash `shared/` + `meta/`, or use RocksDB's native `verify_backup`.
+- [ ] **T13 · BM25/hybrid failure silently degrades to vector-only.** `src/memory/mod.rs:3525-3531`. Fix: `warn!` + Prometheus counter (mirror `commit_failures`).
+- [ ] **T14 · Backend child-process lifecycle: shim exit kills shared server; no respawn.** `index.ts:5012-5044`, `1711-1722`. Fix: don't kill a detached backend on shim exit (refcount via pidfile); re-run `ensureServerRunning` on health-check failure.
+- [ ] **T15 · Auto-spawn API-key race → loser 401s all session.** `index.ts:107-123`, `4909-5008`. Fix: persist the auto-generated key to a file next to the data dir so all shims share it; validate after spawn.
+- [ ] **T16 · Hooks default to a dev key the auto-spawned server rejects → capture silently dead.** `hooks/memory-hook.ts:19` (+ session-start/stop/user-prompt `.sh:6`). Fix: share the persisted key (T15); fail loudly at SessionStart on auth failure.
+- [ ] **T17 · `setup-hooks` writes unquoted path (breaks on spaces) + wrong matcher shape.** `mcp-server/scripts/setup-hooks.cjs:40-44,50/68/74`. Fix: quote the script path; use Claude Code string matchers.
+
+## P2 — MEDIUM
+
+- [ ] **T18 · Flat authorization — every API key is root over every user.** `src/auth.rs:169-185`. Fix: bind key→user (scoping) or explicitly document no-tenancy.
+- [ ] **T19 · `DELETE /api/users/{id}` needs no confirm token** while `clear_all_memories` does. `src/handlers/users.rs:56-68`. Fix: require a confirmation token.
+- [ ] **T20 · `store_inner` non-atomic across CFs despite "ATOMIC" claim.** `src/memory/storage.rs:1421-1453`. Fix: single cross-CF `WriteBatch` (default CF + index CF).
+- [ ] **T21 · `import_mif` dedup `unwrap_or_default()` + no rollback → silent double-import.** `src/handlers/mif.rs:204-282`. Fix: propagate the read error; make import transactional or report partial state.
+- [ ] **T22 · Unauth `POST /api/context/status` + CORS `Any`.** `router.rs:65-68`, `health.rs:236-307`, `config.rs:160-162`. Fix: bind to loopback or require token; validate/cap `session_id`. (Scope: growth is 5-min-bounded, cross-origin still needs key — lower than first flagged.)
+- [ ] **T23 · List endpoints full-scan + full deserialize per page.** `src/handlers/crud.rs:294-427`. Fix: index-driven cursor iteration. (Runs in `spawn_blocking`, so CPU/RAM cost, not worker-block.)
+- [ ] **T24 · `create_backup` handler runs checkpoint+SHA256 synchronously.** `consolidation.rs:414-499`, `backup.rs:689-699`. Fix: `spawn_blocking`.
+- [ ] **T25 · Post-remember graph/embedding failures logged at `debug!` (invisible).** `src/handlers/remember.rs:766/770/803`. Fix: `warn!` + a failure counter.
+- [ ] **T26 · Verbosity-bias quality factor active by default.** `src/memory/mod.rs:5022-5031` (gated only by `SHODH_FUSION_V2` off). Fix: decouple the verbosity drop from the V2 umbrella and default it on.
+- [ ] **T27 · Vamana can return <k live results under clustered soft-deletes.** `src/vector_db/vamana.rs:786-807`. Fix: skip deleted during greedy search instead of post-filtering a padded k.
+- [ ] **T28 · SIMD distance kernels: debug-only length check.** `src/vector_db/distance_inline.rs:28-29`. Fix: one dimension check at `search`/`search_ids` entry (guards a latent UB path).
+- [ ] **T29 · Hook leaks secrets: tool-output snippet incl. `Read` of `.env` unredacted.** `hooks/memory-hook.ts:1284-1287`, matcher includes `Read`. Fix: redaction pass (`sk-…`/`AKIA…`/`ghp_…`) before any payload; exclude `Read` outputs.
+- [ ] **T30 · Hook state file non-atomic → lost/duplicated capture under parallel tool calls.** `hooks/memory-hook.ts:157-190`. Fix: temp-file + atomic rename; merge instead of last-writer-wins.
+- [ ] **T31 · Three shell hooks are dead (wrong shapes).** `user-prompt.sh:31` parses `.results[]` (API returns `memories`); `stop.sh:16` reads non-existent `CLAUDE_TRANSCRIPT_FILE`; `claude-code-ingest.sh:51` `jq '.[-2:]'` on JSONL. Fix or delete each.
+- [ ] **T32 · `streamToolCall` re-ingests read-only tool results (old memory content).** `index.ts:4139-4141` (skip list lacks read_memory/context_summary). Fix: exclude all read-only/display tools. (Mode-gated: streaming only.)
+- [ ] **T33 · Unbounded MCP response sizes.** `index.ts:2054` (recall full_content ×250), `4123` (read_memory). Fix: cap total bytes, emit explicit truncation marker + pagination hint.
+- [ ] **T34 · Remove dead id-corrupting `auto_rebuild_if_needed` enum passthrough.** `src/vector_db/mod.rs:220-223` (zero callers, footgun). Fix: delete passthrough or make `pub(crate)` with a screaming name.
+
+## P3 — GitHub / ops / hygiene
+
+- [ ] **T35 · Enable Dependabot / vulnerability alerts** (currently disabled on public repo).
+- [ ] **T36 · Add required-PR-review to `main` branch protection** (only `CI Summary` required today; direct push possible).
+- [ ] **T37 · Triage IPC hardening issues #401 (HKDF subkey — probe MAC is a chosen-challenge oracle), #402 (anti-replay), #403 (default)** — live weaknesses in merged code, untriaged since 2026-07-15.
+- [ ] **T38 · Fix the weekly recall-trend workflow before next Sunday** (broke 2026-07-20, 5h30m cancelled, unparseable output to #367).
+- [ ] **T39 · Cut a release (v0.2.1 / v0.3.0)** — newest software release v0.2.0 is ~3.5 months / ~80 commits stale; users waiting on shipped fixes.
+- [ ] **T40 · Delete 11 merged-but-undeleted branches** from the 07-14/15 merge train.
+- [ ] **T41 · Verify #392 (BIO subword) fixed by entity-hygiene train → close; resolve #318 hold/rebase and stale #231.**
+
+## P4 — LOW / optional
+
+- [ ] **T42 · Remove dead `spreading_activation_retrieve` wrapper** (graph_retrieval.rs:1010, zero `src/` callers).
+- [ ] **T43 · Sanitize/length-prefix RocksDB composite index key components** (`:` collisions can drop rows). `src/memory/storage.rs:1904/1917/1938`.
+- [ ] **T44 · Decide fate of stale Feb/Mar branches tied to memory-leak #90** before deleting (possible salvage).
+
+---
+
+### Dropped after verification (do NOT track)
+- ~~Committed `nul` file~~ — refuted, no such tracked file.
+- ~~`storage.rs:2029` plaintext-downgrade blocker~~ — not in tree; lives only in unmerged PR #318.
+- ~~`streaming.rs:774` WebSocket deadlock~~ — already fixed.
+- "Raw transcript stored by hook" — overstated; only scored assistant text blocks (the `.env` tool-output leak, T29, is the real part).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+| 0.2.x   | :white_check_mark: |
+| 0.1.x   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Nothing was lost, but three audit documents existed only as untracked files in one working tree. This commits them, plus two small config corrections, and adds ignore rules so private content cannot be committed here by accident.

- **Audits**: dataflow (five macro flows, graph-first), tasks T1-T44 (adversarially re-verified), and the 2026-08-06 memory audit which is marked INCOMPLETE in its own header — it was halted mid-flight and should not be read as a finished pass.
- **Config**: register the `code-review-graph` MCP server; correct the security support table (0.2.x supported, 0.1.x no longer).
- **.gitignore**: `shodh-vault/` is a separate private repository checked out inside this tree and must never land here; `demo-frames/` is 16MB of capture artifacts regenerated on demand.

Scanned all three audit files for strategy, funding, pricing and partner terms before committing — clean (the single grep hit was the word "raises").