### PR TITLE
feat(anomalies): see the outliers before reading a word

### DIFF
--- a/front/ui/src/features/anomalies/AnomaliesView.tsx
+++ b/front/ui/src/features/anomalies/AnomaliesView.tsx
@@ -9,32 +9,51 @@ import { Meta, Stat } from "@/components/ui/meta";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import { SpatialPlot } from "./SpatialPlot";
+import { RatioPlot } from "./RatioPlot";
+import { DegreePlot } from "./DegreePlot";
 import {
   isolatedMemories,
   offPatternLocations,
   quantityOutliers,
   type Finding,
+  type LensChart,
   type LensResult,
+  type Pattern,
 } from "./measures";
 
 /**
  * Anomalies — what deviates from this profile's own baseline.
  *
- * The destination exists to answer three questions a reader has in front of
- * any result: what am I looking at, why was this one chosen, and what did the
- * choosing. So every finding carries the measure that produced it, in the same
- * row, naming the numbers being compared. Nothing here says "anomalous" and
- * leaves it there.
+ * THE SCREEN'S JOB IS THAT YOU SEE THE FINDINGS BEFORE YOU READ ANYTHING. Two
+ * earlier passes computed the right things and then printed them: a vertical
+ * list of memory sentences with a number attached, which asks a reader to
+ * RECONSTRUCT a distribution from four rows of prose and to notice, unaided,
+ * that two of those rows are the same event. Compressing the sentences into
+ * tokens made the list shorter and left it a list. Nothing was plotted, nothing
+ * showed where a flagged value sat relative to normal, and nothing showed that
+ * two findings were one finding.
  *
- * WHERE THE COMPARISON IS SPLIT, AND WHY. Every measure is a comparison, and a
- * comparison has two halves: the baseline, which is the same for every row in a
- * section, and the memory's own magnitude, which is not. Stating both on every
- * row produced the exact wall this screen was rebuilt to remove — four rows
- * reading "260 km / 259 km / 31 km / 18 km from the middle of the cluster the
- * other 35 placed memories form, which normally sit 2.4 km out". So the
- * baseline is stated ONCE, as tokens under the section title, and the row
- * carries only what distinguishes it. The evidence is intact; the sentence is
- * gone.
+ * So every lens that reaches a conclusion now DRAWS ITS POPULATION FIRST, with
+ * the flagged points in it, and the rows underneath are confirmation. Each
+ * graphic is chosen for the shape of its own measure rather than for
+ * consistency with the others — a distance-from-centre with a heavy tail, a
+ * ratio between two magnitudes, and a degree distribution are three different
+ * kinds of quantity, and one house chart type would have flattered exactly none
+ * of them. The reasoning for each is in its own file.
+ *
+ * MEMORY TEXT IS EVIDENCE, NOT THE HEADLINE. It sat first and ran to two or
+ * three lines, which is what made the screen a wall: the sentence is the part
+ * a reader needs LAST, once the plot and the magnitude have already told them
+ * which memory to care about. It is now one truncated line under the numbers,
+ * with the Inspector one click away for the whole record.
+ *
+ * PATTERNS ARE A SEPARATE CLAIM AND ARE MARKED AS ONE. Findings that the
+ * measure can show belong together are drawn tied on the plot and bracketed in
+ * the list, with the evidence for the grouping stated in the bracket. The rule
+ * is deliberately strict and lives in measures.ts; what matters here is that a
+ * group never asserts a CAUSE, it states what two findings have in common and
+ * lets the reader supply the rest.
  *
  * THREE REGISTERS, AND THE RULE THAT SEPARATES THEM. `facts` (the baseline
  * numbers) and `caveat` (anything that changes how those numbers should be
@@ -49,6 +68,10 @@ import {
  * a median absolute deviation over great-circle distance, unit-matched number
  * comparison, and term overlap. No model is called, here or on the server, and
  * that is the claim the header makes: the store finds these in its own data.
+ * The rebuild changed what those measures REPORT — they now return the whole
+ * distribution rather than only the points past the line, because a flagged
+ * value is meaningless without the ordinary ones it was judged against — and
+ * changed nothing about how any of them decides.
  *
  * NO REQUEST OF ITS OWN. It reads `useCorpus`, the same single react-query
  * entry Recall and Geo already populate (lib/api/corpus.ts), so arriving here
@@ -72,29 +95,44 @@ interface Lens {
   result: LensResult;
 }
 
+function LensGraphic({ chart, patterns }: { chart: LensChart; patterns: Pattern[] }) {
+  switch (chart.kind) {
+    case "spatial":
+      return <SpatialPlot chart={chart} patterns={patterns} />;
+    case "ratio":
+      return <RatioPlot chart={chart} />;
+    case "degree":
+      return <DegreePlot chart={chart} />;
+  }
+}
+
 /**
  * One flagged memory.
  *
  * Selecting sets the one global selection (`useSession().select`), exactly as
  * a recall result row does, so an anomaly is the same kind of object as any
- * other memory in the product and hands off to the same Inspector. The row also
- * shows its own selected state, so the click reads as having landed even before
- * the detail pane resolves.
+ * other memory in the product. NOTE that this route does not itself mount the
+ * Inspector — `ROUTES_WITH_INSPECTOR` is `/recall`, `/geo`, `/graph`
+ * (app/App.tsx:53) — so the selection made here is carried BY the session to
+ * those destinations rather than opening a pane in place. The row therefore has
+ * to show its own selected state or the click would appear to do nothing, and
+ * the plot above lights the same memory, so a click in either place is visibly
+ * answered in both.
  *
- * SEVERITY IS POSITION, AND ONLY POSITION. Rows are ordered furthest-first and
- * carry no severity mark. Not a colour, because hue in this product means
- * memory type and a second categorical palette on the same surface would put
- * two encodings on one channel. Not a bar either, and that one was tried and
- * removed: the underlying magnitudes are unbounded, so on a real corpus where
- * one memory sits 126 robust scales out and the next sits 14, a bar scaled to
- * the largest drew the second as an empty stub — it made a genuine finding look
- * like a rounding error, which is the exact clarity defect this destination
- * exists to fix. Every row states its own magnitude instead, in the units of
- * its own measure, where it can be checked against the memory above it.
+ * THE MAGNITUDE LEADS, IN THE MONO FACE, and the memory's own words follow in
+ * one clamped line. That order is the whole difference between this and the
+ * wall it replaces: a column of numerals is scannable without reading, which is
+ * the same argument that puts numerics in their own column in a dense table,
+ * and the sentence is there to confirm a finding the reader has already found
+ * rather than to deliver it.
  *
- * The magnitude leads and is set in the mono face, so a column of them is
- * scannable without reading a single label — the same argument that puts
- * numerics in their own right-aligned column in a dense table.
+ * SEVERITY IS POSITION, AND ONLY POSITION — no bar, no colour ramp, no badge.
+ * A bar was tried here and removed: the underlying magnitudes are unbounded, so
+ * on a real corpus where one memory sits 126 robust scales out and the next
+ * sits 14, a bar scaled to the largest drew the second as an empty stub. The
+ * plot above now carries the magnitude comparison on a scale built to survive
+ * that range, which is where an unbounded quantity belongs; the row states its
+ * own number and takes its rank from its position in the list.
  */
 function FindingRow({ finding }: { finding: Finding }) {
   const selected = useSession((s) => s.selectedMemoryId === finding.memoryId);
@@ -106,28 +144,63 @@ function FindingRow({ finding }: { finding: Finding }) {
       onClick={() => select(finding.memoryId)}
       aria-current={selected ? "true" : undefined}
       className={cn(
-        "border-border w-full border-b px-4 py-2.5 text-left transition-colors duration-100",
+        "border-border w-full border-b px-4 py-2 text-left transition-colors duration-100",
         "focus-visible:ring-ring focus-visible:-outline-offset-2 focus-visible:ring-2 focus-visible:outline-none",
         selected ? "bg-primary/10" : "hover:bg-accent/60",
       )}
     >
+      {/* The evidence, first. Two tokens, not a sentence: what this one
+          measured, and what that measurement is of. The baseline it is measured
+          against is the section's, stated once above and drawn once above. */}
+      <Meta className="text-[12px]">
+        <Stat value={finding.value} />
+        <span>{finding.against}</span>
+      </Meta>
       <p
         className={cn(
-          "line-clamp-2 text-[13px] leading-relaxed",
-          selected ? "text-foreground" : "text-foreground/90",
+          "mt-0.5 truncate text-[12px] leading-relaxed",
+          selected ? "text-foreground/80" : "text-muted-foreground",
         )}
       >
         {finding.content}
       </p>
-
-      {/* The evidence, under the memory it judged. Two tokens, not a sentence:
-          what this one measured, and what that measurement is of. The baseline
-          it is measured against is the section's, stated once above. */}
-      <Meta className="mt-1">
-        <Stat value={finding.value} />
-        <span>{finding.against}</span>
-      </Meta>
     </button>
+  );
+}
+
+/**
+ * Findings the measure can show belong together.
+ *
+ * The bracket is a rule down the left and one line of evidence — not a heading,
+ * not a colour, and above all not a stated cause. What the arithmetic knows is
+ * that these findings share a term, and a magnitude or a type; what it does not
+ * know is why, and the difference between those two is the difference between
+ * this screen and one that guesses.
+ */
+function PatternGroup({ pattern, findings }: { pattern: Pattern; findings: Finding[] }) {
+  return (
+    // `--node-anomalous` is a graph-canvas custom property, deliberately
+    // outside the shadcn set and so outside `@theme inline` — there is no
+    // `border-node-anomalous` utility for Tailwind to generate, and writing one
+    // would compile clean and render nothing. The token is applied directly.
+    <div
+      className="border-l-2"
+      style={{ borderColor: "color-mix(in oklab, var(--node-anomalous) 45%, transparent)" }}
+    >
+      <div className="px-4 pt-2">
+        <Meta className="text-[11px]">
+          <span className="text-foreground/70">
+            {findings.length} findings, one pattern
+          </span>
+          {pattern.evidence.map((e) => (
+            <span key={e}>{e}</span>
+          ))}
+        </Meta>
+      </div>
+      {findings.map((f) => (
+        <FindingRow key={`${f.memoryId}-${f.value}`} finding={f} />
+      ))}
+    </div>
   );
 }
 
@@ -151,6 +224,44 @@ function LensSection({ lens }: { lens: Lens }) {
   const Icon = lens.icon;
   const result = lens.result;
   const count = result.state === "findings" ? result.findings.length : 0;
+
+  /**
+   * The findings in display order, with grouped ones kept together.
+   *
+   * A pattern's members take the position of whichever of them ranked highest,
+   * so grouping never reorders the section's furthest-first logic more than it
+   * has to — the strongest finding stays where a reader expects it and brings
+   * its relatives with it.
+   */
+  const blocks = useMemo(() => {
+    if (result.state !== "findings") return [];
+    const patternOf = new Map<string, Pattern>();
+    for (const p of result.patterns) {
+      for (const id of p.memoryIds) patternOf.set(id, p);
+    }
+    const done = new Set<Pattern>();
+    const out: Array<
+      { kind: "single"; finding: Finding } | { kind: "pattern"; pattern: Pattern; findings: Finding[] }
+    > = [];
+    for (const finding of result.findings) {
+      const pattern = patternOf.get(finding.memoryId);
+      if (!pattern) {
+        out.push({ kind: "single", finding });
+        continue;
+      }
+      if (done.has(pattern)) continue;
+      done.add(pattern);
+      out.push({
+        kind: "pattern",
+        pattern,
+        findings: result.findings.filter((f) => pattern.memoryIds.includes(f.memoryId)),
+      });
+    }
+    return out;
+  }, [result]);
+
+  const chart = result.state === "insufficient" ? undefined : result.chart;
+  const patterns = result.state === "findings" ? result.patterns : [];
 
   return (
     <section>
@@ -205,11 +316,29 @@ function LensSection({ lens }: { lens: Lens }) {
         ) : null}
       </div>
 
-      {result.state === "findings"
-        ? result.findings.map((f) => (
-            <FindingRow key={`${lens.id}-${f.memoryId}-${f.value}`} finding={f} />
-          ))
-        : null}
+      {/* The population, drawn. Above the rows because it is what the rows are
+          confirming, and present on a clear result too — "nothing flagged" over
+          a drawn distribution is a result, over an empty panel it is a shrug. */}
+      {chart ? (
+        <div className="border-border border-b">
+          <LensGraphic chart={chart} patterns={patterns} />
+        </div>
+      ) : null}
+
+      {blocks.map((block) =>
+        block.kind === "single" ? (
+          <FindingRow
+            key={`${lens.id}-${block.finding.memoryId}-${block.finding.value}`}
+            finding={block.finding}
+          />
+        ) : (
+          <PatternGroup
+            key={`${lens.id}-pattern-${block.pattern.memoryIds.join("-")}`}
+            pattern={block.pattern}
+            findings={block.findings}
+          />
+        ),
+      )}
     </section>
   );
 }
@@ -222,12 +351,9 @@ function LensSkeleton() {
       </div>
       <div className="border-border border-b px-4 py-3">
         <Skeleton className="h-3 w-[70%]" />
-        <Skeleton className="mt-2 h-2.5 w-[90%]" />
       </div>
       <div className="border-border border-b px-4 py-3">
-        <Skeleton className="h-[13px] w-full" />
-        <Skeleton className="mt-1.5 h-[13px] w-[62%]" />
-        <Skeleton className="mt-2.5 h-2.5 w-[80%]" />
+        <Skeleton className="h-[132px] w-full" />
       </div>
     </section>
   );
@@ -279,6 +405,15 @@ export function AnomaliesView({ reach }: { reach: Reachability }) {
     }
     return ids.size;
   }, [lenses]);
+
+  const patternCount = useMemo(
+    () =>
+      lenses.reduce(
+        (a, lens) => a + (lens.result.state === "findings" ? lens.result.patterns.length : 0),
+        0,
+      ),
+    [lenses],
+  );
 
   if (reach.state !== "online") {
     return (
@@ -353,6 +488,7 @@ export function AnomaliesView({ reach }: { reach: Reachability }) {
         <header className="border-border flex flex-wrap items-center gap-x-3 gap-y-1.5 border-b px-4 py-3">
           <Meta className="text-[12px]">
             <Stat value={flagged} label="flagged" />
+            {patternCount > 0 ? <Stat value={patternCount} label="pattern" /> : null}
             <Stat value={memories.length} label="memories" />
             <Stat value={lenses.length} label="measures" />
           </Meta>

--- a/front/ui/src/features/anomalies/DegreePlot.tsx
+++ b/front/ui/src/features/anomalies/DegreePlot.tsx
@@ -1,0 +1,189 @@
+import { useMemo } from "react";
+import { PlotFrame, MARK } from "./Plot";
+import type { DegreeChart } from "./measures";
+
+/**
+ * Connected to nothing, drawn against everything that is connected.
+ *
+ * WHY A DISTRIBUTION AND NOT A NODE-LINK GRAPH. "Isolation is graph structure"
+ * is right, and the obvious drawing — every memory a node, every shared term an
+ * edge — is the wrong one here. Seventy-one memories with a median of four
+ * neighbours is a few hundred edges, which force-directed layout renders as a
+ * hairball with six dots parked outside it. The hairball carries no information
+ * a reader can extract: you cannot count a node's edges by looking, so you
+ * cannot see that the mass sits at four and the findings sit at zero. It also
+ * costs a simulation and a frame budget to say one thing.
+ *
+ * The one thing it says is a DEGREE distribution, so that is what is drawn.
+ * Every judged memory is placed by how many distinct other memories it reaches
+ * through a shared term. The connected mass becomes a shape with a mode you can
+ * see, and the findings become a column at zero — the same fact the hairball
+ * was going to communicate, at a glance rather than after squinting, and
+ * legible on a corpus of seventy or seven thousand.
+ *
+ * THE GAP AT ZERO IS THE POINT. Zero is not "a bit less than one" on this
+ * measure, it is a different kind of statement: a memory at one shares a term
+ * with something and is reachable, a memory at zero is not reachable at all.
+ * The column at zero is therefore drawn in the flagged tone and separated by a
+ * real gap, so the categorical break in the data is a visible break on screen
+ * rather than the leftmost bar of a continuum.
+ *
+ * Memories that yielded no terms are ABSENT, not drawn at zero. Nothing can be
+ * said about what they connect to, and putting them in the zero column would
+ * merge "shares nothing" with "we could not tell", which is the one confusion
+ * the lens's caveat exists to prevent.
+ */
+
+const W = 480;
+const TOP = 18;
+const PLOT_H = 96;
+const AXIS_H = 34;
+const PLOT_L = 34;
+const PLOT_R = 468;
+/** The visible break between "reaches nothing" and "reaches something". */
+const ZERO_GAP = 10;
+
+export function DegreePlot({ chart }: { chart: DegreeChart }) {
+  const bins = useMemo(() => {
+    const counts = new Array<number>(chart.maxCount + 1).fill(0);
+    for (const c of chart.counts) counts[c] += 1;
+    return counts;
+  }, [chart.counts, chart.maxCount]);
+
+  const tallest = bins.reduce((a, b) => Math.max(a, b), 1);
+  const slots = chart.maxCount + 1;
+  const slotW = (PLOT_R - PLOT_L - ZERO_GAP) / slots;
+  const barW = Math.max(3, slotW * 0.74);
+  const height = TOP + PLOT_H + AXIS_H;
+  const baseY = TOP + PLOT_H;
+
+  const xFor = (degree: number) =>
+    PLOT_L + (degree >= 1 ? ZERO_GAP : 0) + degree * slotW + (slotW - barW) / 2;
+
+  /** Round y gridlines that do not invent precision: at most three, on a step
+   *  that divides the tallest bar sensibly. */
+  const gridStep = tallest <= 4 ? 1 : tallest <= 10 ? 5 : 10;
+
+  const summary = useMemo(() => {
+    const reachAtLeastOne = chart.judged - chart.isolatedCount;
+    return `Every judged memory placed by how many other memories it shares an extracted term with. ${chart.isolatedCount} of ${chart.judged} reach none — the separated column at zero. The other ${reachAtLeastOne} reach between 1 and ${chart.maxCount}, with a median of ${chart.medianCount}.`;
+  }, [chart]);
+
+  return (
+    <PlotFrame
+      title="How many other memories each one connects to"
+      summary={summary}
+      viewBox={`0 0 ${W} ${height}`}
+    >
+      {Array.from({ length: Math.floor(tallest / gridStep) + 1 }, (_, i) => i * gridStep)
+        .filter((v) => v > 0)
+        .map((v) => {
+          const y = baseY - (v / tallest) * PLOT_H;
+          return (
+            <g key={v}>
+              <line
+                x1={PLOT_L}
+                y1={y}
+                x2={PLOT_R}
+                y2={y}
+                stroke={MARK.rule}
+                strokeWidth={1}
+                opacity={0.6}
+              />
+              <text
+                x={PLOT_L - 5}
+                y={y + 3}
+                textAnchor="end"
+                className="mono"
+                fontSize={8.5}
+                fill={MARK.ink}
+              >
+                {v}
+              </text>
+            </g>
+          );
+        })}
+
+      <line x1={PLOT_L} y1={baseY} x2={PLOT_R} y2={baseY} stroke={MARK.rule} strokeWidth={1} />
+
+      {bins.map((n, degree) => {
+        if (n === 0) return null;
+        const h = (n / tallest) * PLOT_H;
+        const isolated = degree === 0;
+        return (
+          <rect
+            key={degree}
+            x={xFor(degree)}
+            y={baseY - h}
+            width={barW}
+            height={h}
+            rx={1.5}
+            fill={isolated ? MARK.flagged : MARK.baseline}
+            opacity={isolated ? 0.95 : 0.42}
+          />
+        );
+      })}
+
+      {/* The finding, counted on the plot. The only bar that gets a number,
+          because it is the only bar that is a claim. */}
+      {bins[0] > 0 ? (
+        <text
+          x={xFor(0) + barW / 2}
+          y={baseY - (bins[0] / tallest) * PLOT_H - 5}
+          textAnchor="middle"
+          className="mono"
+          fontSize={10.5}
+          fill={MARK.flagged}
+        >
+          {bins[0]}
+        </text>
+      ) : null}
+
+      {/* Where the ordinary memory sits, so the zero column has something to be
+          far from. */}
+      <g>
+        <line
+          x1={xFor(chart.medianCount) + barW / 2}
+          y1={TOP - 6}
+          x2={xFor(chart.medianCount) + barW / 2}
+          y2={baseY}
+          stroke={MARK.ink}
+          strokeWidth={1}
+          strokeDasharray="2 3"
+          opacity={0.75}
+        />
+        <text
+          x={xFor(chart.medianCount) + barW / 2}
+          y={TOP - 9}
+          textAnchor="middle"
+          fontSize={8.5}
+          fill={MARK.ink}
+        >
+          median
+        </text>
+      </g>
+
+      {/* Ticks every five, plus zero, which always gets one because it is the
+          column the section is about. */}
+      {Array.from({ length: slots }, (_, d) => d)
+        .filter((d) => d === 0 || d % 5 === 0)
+        .map((d) => (
+          <text
+            key={d}
+            x={xFor(d) + barW / 2}
+            y={baseY + 13}
+            textAnchor="middle"
+            className="mono"
+            fontSize={9}
+            fill={d === 0 ? MARK.flagged : MARK.ink}
+          >
+            {d}
+          </text>
+        ))}
+
+      <text x={PLOT_L} y={baseY + 27} textAnchor="start" fontSize={9} fill={MARK.ink} opacity={0.8}>
+        memories sharing a term
+      </text>
+    </PlotFrame>
+  );
+}

--- a/front/ui/src/features/anomalies/Plot.tsx
+++ b/front/ui/src/features/anomalies/Plot.tsx
@@ -1,0 +1,101 @@
+import { useId } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The frame every anomaly graphic sits in, and the accessibility contract that
+ * comes with it.
+ *
+ * SVG, NOT CANVAS, AND FOR A DIFFERENT REASON THAN GEO. GeoMap.tsx draws to a
+ * canvas because it paints a 177-country basemap under a zoom behaviour, where
+ * a retained-mode tree of tens of thousands of path nodes would cost more than
+ * it returns. These graphics plot at most a few dozen static marks with no
+ * basemap and no zoom, so the tradeoff inverts: SVG marks are real DOM, which
+ * means they take `<title>` elements, CSS transitions and hit-testing for
+ * free, and — the part that actually decides it — they survive a screenshot at
+ * any device pixel ratio without the manual dpr bookkeeping canvas needs.
+ *
+ * THE TEXT EQUIVALENT IS THE POINT OF THIS COMPONENT. A plot that communicates
+ * only visually fails the "one look" test for someone who cannot see it, so
+ * every graphic here carries `summary` — one sentence stating what the plot
+ * shows, with the numbers in it. It is rendered twice: into the SVG's `<desc>`
+ * for assistive technology, and as a VISIBLE caption under the plot, because a
+ * sentence that tells a sighted reader "32 of 36 sit within 9.5 km" is not a
+ * concession to accessibility, it is the fastest way for anyone to confirm
+ * that what they think they are seeing is what is there.
+ *
+ * The marks themselves are `role="img"` and not focusable. That is the rule
+ * this codebase already set in GeoMap.tsx:313-325 — a plot may be pointer-only
+ * when a column of real buttons beside it reaches the same objects — and here
+ * the findings list under every plot is exactly that column. Making the marks
+ * focusable AS WELL would put every point in the tab order twice, which is a
+ * worse keyboard experience than one clean path, not a better one.
+ */
+export function PlotFrame({
+  /** Names what is plotted. Read by assistive technology, never shown — the
+   *  section heading above it already says this to a sighted reader. */
+  title,
+  /** One sentence, with numbers, stating what the plot shows. Shown AND read. */
+  summary,
+  /** The plot's aspect, as viewBox units. Marks are authored in this space and
+   *  the frame scales them to whatever width the column gives it. */
+  viewBox,
+  className,
+  children,
+}: {
+  title: string;
+  summary: string;
+  viewBox: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const titleId = useId();
+  const descId = useId();
+
+  return (
+    <figure className={cn("px-4 pt-3 pb-2", className)}>
+      <svg
+        viewBox={viewBox}
+        // Width-filling with a preserved aspect: the column is 640px at 1440
+        // and around 470px at 1024, and a plot that reflowed its geometry
+        // between the two would need its own layout pass at every breakpoint.
+        // Scaling one authored composition keeps the marks in the same
+        // relationship to each other at every width.
+        preserveAspectRatio="xMidYMid meet"
+        className="block h-auto w-full"
+        role="img"
+        aria-labelledby={`${titleId} ${descId}`}
+      >
+        <title id={titleId}>{title}</title>
+        <desc id={descId}>{summary}</desc>
+        {children}
+      </svg>
+      <figcaption className="text-muted-foreground/80 mt-1.5 text-[11px] leading-relaxed">
+        {summary}
+      </figcaption>
+    </figure>
+  );
+}
+
+/**
+ * The two states a mark can be in, as tokens rather than literals.
+ *
+ * These names are the ones index.css already settled, and the settlement is
+ * worth restating because it is the reason this screen does not invent a
+ * palette. `--node-anomalous` is the pink-red reserved for "deviates from
+ * baseline"; `--node-active` is the orange accent reserved for "this is the
+ * current selection". They are deliberately different hues so an alarm and a
+ * focus ring never read as each other.
+ *
+ * COLOUR IS NEVER THE ONLY DIFFERENCE. Every flagged mark in these plots is
+ * also further out than the drawn cutoff, drawn larger, and carries its own
+ * value as a direct label. A reader who cannot separate the two hues still
+ * sees position, size and a number, which is three encodings deep before
+ * colour is asked to do anything.
+ */
+export const MARK = {
+  baseline: "var(--muted-foreground)",
+  flagged: "var(--node-anomalous)",
+  selected: "var(--node-active)",
+  rule: "var(--border)",
+  ink: "var(--muted-foreground)",
+} as const;

--- a/front/ui/src/features/anomalies/RatioPlot.tsx
+++ b/front/ui/src/features/anomalies/RatioPlot.tsx
@@ -1,0 +1,239 @@
+import { useMemo } from "react";
+import { scaleLog } from "d3";
+import { useSession } from "@/stores/session";
+import { PlotFrame, MARK } from "./Plot";
+import type { RatioChart } from "./measures";
+
+/**
+ * Numbers that do not fit, drawn as the gap between them.
+ *
+ * THE AXIS IS A RATIO, WHICH IS WHY THERE IS ONLY ONE OF THEM. This section
+ * mixes units by construction — a kilogram disagreement and a millisecond
+ * disagreement are both findings here — and the first instinct, an axis per
+ * unit, is the dual-axis mistake wearing a different hat: two scales on one
+ * picture, with the reader silently invited to compare lengths that are not
+ * comparable. So the plotted quantity is `max / min`, which is DIMENSIONLESS.
+ * "6.8× apart" and "3.7× apart" are the same kind of statement whether the
+ * numbers were kilograms or milliseconds, and a bar twice as long really does
+ * mean twice the disagreement. The absolute values stay on the row as text, in
+ * their own units, where they belong.
+ *
+ * THE AXIS IS LOG, WHICH IS HOW IT SURVIVES ORDERS OF MAGNITUDE. A declared
+ * weight against a weighbridge reading differs by 6.8×; a corpus outlier can
+ * differ by 500×. On a linear ratio axis the first would be a stub beside the
+ * second — the exact defect that got the earlier severity bar deleted. On a
+ * log axis every doubling is the same distance, so a 6.8× row and a 3.7× row
+ * are both legible on a plot that a 500× row would also fit.
+ *
+ * Every bar starts at 1×. That shared origin is what makes the lengths
+ * comparable at a glance, and it is also the honest zero of this measure: 1×
+ * is two numbers agreeing exactly.
+ */
+
+const W = 480;
+const ROW_H = 44;
+const TOP = 16;
+const AXIS_H = 30;
+/** Left of this is the low value's label; right of `PLOT_R` is the high
+ *  value's. Both are reserved rather than measured, so a long number never
+ *  reflows the axis and desynchronises one row from the next. */
+const PLOT_L = 92;
+const PLOT_R = 384;
+
+function formatValue(value: number): string {
+  return value.toLocaleString("en-US", { maximumFractionDigits: 2 });
+}
+
+/** 1, 2, 5 per decade — the standard log tick mantissas, which keep the labels
+ *  readable without implying a precision the scale does not have. */
+function logTicks(max: number): number[] {
+  const ticks: number[] = [];
+  for (let decade = 0; decade <= Math.ceil(Math.log10(max)); decade++) {
+    for (const mantissa of [1, 2, 5]) {
+      const value = mantissa * 10 ** decade;
+      if (value <= max) ticks.push(value);
+    }
+  }
+  return ticks;
+}
+
+export function RatioPlot({ chart }: { chart: RatioChart }) {
+  const selectedId = useSession((s) => s.selectedMemoryId);
+  const select = useSession((s) => s.select);
+
+  const pairs = chart.pairs.filter((p) => Number.isFinite(p.factor));
+  const height = TOP + pairs.length * ROW_H + AXIS_H;
+
+  // Headroom so the longest bar does not terminate exactly on the frame edge,
+  // where its end dot and its label would be clipped.
+  const domainMax = Math.max(chart.maxFactor * 1.25, 2);
+  const x = useMemo(
+    () => scaleLog().domain([1, domainMax]).range([PLOT_L, PLOT_R]).clamp(true),
+    [domainMax],
+  );
+
+  const summary = useMemo(() => {
+    if (pairs.length === 0) return "No pair of same-unit figures disagrees.";
+    const list = pairs
+      .map(
+        (p) =>
+          `${formatValue(p.lowValue)} against ${formatValue(p.highValue)} ${p.unit}, ${p.factor.toFixed(1)} times apart`,
+      )
+      .join("; ");
+    return `Each bar is the gap between two figures written in the same unit, on a shared log scale of how many times apart they are. ${list}.`;
+  }, [pairs]);
+
+  const ticks = logTicks(domainMax);
+
+  return (
+    <PlotFrame
+      title="How far apart the disagreeing figures are"
+      summary={summary}
+      viewBox={`0 0 ${W} ${height}`}
+    >
+      {/* Gridlines first and faint: the axis is a reading aid, the bars are
+          the data. */}
+      {ticks.map((t) => (
+        <line
+          key={t}
+          x1={x(t)}
+          y1={TOP - 6}
+          x2={x(t)}
+          y2={TOP + pairs.length * ROW_H}
+          stroke={MARK.rule}
+          strokeWidth={1}
+          opacity={t === 1 ? 1 : 0.55}
+        />
+      ))}
+
+      {pairs.map((pair, i) => {
+        const y = TOP + i * ROW_H + ROW_H / 2;
+        const x2 = x(pair.factor);
+        const isSelected = pair.memoryId === selectedId;
+        const colour = isSelected ? MARK.selected : MARK.flagged;
+        // For a corpus outlier the baseline end is the unit's median, and
+        // saying so matters: without it the row reads as though the memory
+        // stated both numbers, which is a different and stronger finding.
+        const baselineEndIsTypical = pair.scope === "corpus";
+        const flaggedAtLowEnd = pair.scope === "corpus" && pair.lowIsFlagged;
+
+        return (
+          <g
+            key={`${pair.memoryId}-${pair.unit}-${pair.factor}`}
+            onClick={() => select(pair.memoryId)}
+            className="cursor-pointer"
+          >
+            <title>
+              {`${formatValue(pair.lowValue)} against ${formatValue(pair.highValue)} ${pair.unit}, ${pair.factor.toFixed(1)} times apart`}
+            </title>
+
+            {/* The gap itself. Its LENGTH is the finding. */}
+            <line
+              x1={PLOT_L}
+              y1={y}
+              x2={x2}
+              y2={y}
+              stroke={colour}
+              strokeWidth={2}
+              strokeLinecap="round"
+              opacity={0.85}
+            />
+
+            {/* The two ends. The baseline end is hollow when it is a median
+                rather than a figure the memory wrote — a filled dot means "the
+                corpus states this number", and the distinction is free here. */}
+            <circle
+              cx={PLOT_L}
+              cy={y}
+              r={4}
+              fill={baselineEndIsTypical && !flaggedAtLowEnd ? "var(--background)" : colour}
+              stroke={colour}
+              strokeWidth={1.6}
+            />
+            <circle
+              cx={x2}
+              cy={y}
+              r={4}
+              fill={baselineEndIsTypical && flaggedAtLowEnd ? "var(--background)" : colour}
+              stroke={colour}
+              strokeWidth={1.6}
+            />
+
+            {/* The factor, above the bar it measures — the one number a reader
+                needs before any label. */}
+            <text
+              x={(PLOT_L + x2) / 2}
+              y={y - 8}
+              textAnchor="middle"
+              className="mono"
+              fontSize={11}
+              fill={colour}
+            >
+              {`${pair.factor.toFixed(1)}×`}
+            </text>
+
+            <text
+              x={PLOT_L - 8}
+              y={y + 3.6}
+              textAnchor="end"
+              className="mono"
+              fontSize={10.5}
+              fill="var(--foreground)"
+              opacity={0.85}
+            >
+              {formatValue(pair.lowValue)}
+            </text>
+            <text
+              x={x2 + 8}
+              y={y + 3.6}
+              textAnchor="start"
+              className="mono"
+              fontSize={10.5}
+              fill="var(--foreground)"
+              opacity={0.85}
+            >
+              {`${formatValue(pair.highValue)} ${pair.unit}`}
+            </text>
+
+            {baselineEndIsTypical ? (
+              <text
+                x={flaggedAtLowEnd ? x2 : PLOT_L}
+                y={y + 15}
+                textAnchor="middle"
+                fontSize={8.5}
+                fill={MARK.ink}
+              >
+                typical
+              </text>
+            ) : null}
+          </g>
+        );
+      })}
+
+      {/* The axis, last and quiet. */}
+      {ticks.map((t) => (
+        <text
+          key={t}
+          x={x(t)}
+          y={TOP + pairs.length * ROW_H + 14}
+          textAnchor="middle"
+          className="mono"
+          fontSize={9}
+          fill={MARK.ink}
+        >
+          {`${t}×`}
+        </text>
+      ))}
+      <text
+        x={PLOT_R + 8}
+        y={TOP + pairs.length * ROW_H + 14}
+        textAnchor="start"
+        fontSize={9}
+        fill={MARK.ink}
+        opacity={0.8}
+      >
+        apart
+      </text>
+    </PlotFrame>
+  );
+}

--- a/front/ui/src/features/anomalies/SpatialPlot.tsx
+++ b/front/ui/src/features/anomalies/SpatialPlot.tsx
@@ -1,0 +1,422 @@
+import { useMemo } from "react";
+import { scaleSymlog } from "d3";
+import { useSession } from "@/stores/session";
+import { PlotFrame, MARK } from "./Plot";
+import type { Pattern, SpatialChart } from "./measures";
+
+/**
+ * Out of place, drawn in the corpus's own coordinates.
+ *
+ * WHY POLAR AND NOT A MAP. A map of this corpus is unreadable: 32 of the 36
+ * placed memories sit inside one harbour and two sit 260 km away, so a
+ * projection fitted to the extent draws the harbour as a single pixel, and one
+ * fitted to the harbour pushes the findings off-canvas. Insets would fix the
+ * geometry and destroy the comparison, which is the only thing this lens is
+ * for. The measure does not compare places, it compares DISTANCE FROM THE
+ * CORPUS'S OWN CENTRE against the spread of those distances — so the plot is
+ * drawn in exactly those terms: radius is that distance, angle is the true
+ * bearing, and the cutoff the measure computed is a ring you can see points
+ * fall outside of.
+ *
+ * WHY THE RADIUS IS SYMMETRIC-LOG. This is the scaling problem the brief names
+ * and the reason the previous severity bar was deleted. The distances here run
+ * 1.02 km to 259.85 km — a factor of 255 — so a linear radius spends 96% of
+ * itself on the four outliers and renders the 32-memory cluster as one blob
+ * with no internal structure, which is precisely the "genuine finding drawn as
+ * a stub" failure that got the bar removed. A plain log scale fixes the range
+ * and introduces a worse bug: log(0) is negative infinity, and a memory sitting
+ * exactly at the cluster centre is not a corner case but the ordinary result of
+ * a corpus whose median coordinate IS one of its coordinates. `scaleSymlog` is
+ * linear through a region set by `constant` and logarithmic beyond it, so zero
+ * maps to zero honestly, no floor has to be invented, and the harbour keeps its
+ * internal spread while 260 km still fits on the same radius.
+ *
+ * The constant is the corpus's own typical distance rather than d3's default of
+ * 1. That makes the linear region mean something — "out to about as far as
+ * these normally sit, distance reads directly; past that it compresses" —
+ * instead of depending on whether the data happens to be denominated in
+ * kilometres or metres.
+ *
+ * WHAT THE ANGLE IS FOR, AND THE CLAIM IT CORRECTS. Bearing is real measured
+ * direction, and on this corpus it overturns the obvious reading of the two
+ * furthest findings. They sit at 259.3 km and 259.9 km — all but identical —
+ * and it is tempting to call them one diversion. They are at bearings of 175°
+ * and 52°: one went south to Norfolk, the other north-east to New York. Same
+ * cause, same distance, OPPOSITE directions. A distance-only plot would have
+ * hidden that, and a plot that drew them as one arrow would have asserted
+ * something false.
+ */
+
+/** Authored geometry. The frame scales this to the column's width, so these are
+ *  proportions rather than pixels — see PlotFrame. */
+const W = 480;
+const H = 300;
+const CX = 240;
+const CY = 150;
+/** Distance 0 does not collapse onto the centre mark: a memory AT the centre is
+ *  a real result and needs somewhere to be drawn that is not the crosshair. */
+const R0 = 16;
+const R_MAX = 124;
+
+/** Screen position of a polar coordinate. Bearing is clockwise from north and
+ *  the screen's y axis points down, which is why cos carries y and sin carries
+ *  x — the usual pairing, transposed once, here, and nowhere else. */
+function place(radius: number, bearing: number): [number, number] {
+  const t = (bearing * Math.PI) / 180;
+  return [CX + radius * Math.sin(t), CY - radius * Math.cos(t)];
+}
+
+function formatKm(km: number): string {
+  if (km < 1) return `${Math.round(km * 1000)} m`;
+  if (km < 10) return `${km.toFixed(1)} km`;
+  return `${Math.round(km)} km`;
+}
+
+/**
+ * Distances to mark along the radius, so the log scale is legible rather than
+ * merely correct.
+ *
+ * A reader who has not been told the radius is logarithmic will read it as
+ * linear and badly misjudge the cluster — which would be this plot lying by
+ * omission. Three ticks on the west spoke fix that: once "1 km" and "100 km"
+ * are visibly NOT twice as far apart as "1 km" and "2 km", the compression is
+ * self-evident and needs no caption.
+ *
+ * Candidates are the standard 1/2/5-per-decade values, thinned to at most three
+ * that are actually separated on screen — a ruler whose labels overlap teaches
+ * nothing.
+ */
+function rulerTicks(maxKm: number, radius: (km: number) => number): number[] {
+  const candidates: number[] = [];
+  for (let decade = -3; decade <= 5; decade++) {
+    for (const mantissa of [1, 2, 5]) {
+      const value = mantissa * 10 ** decade;
+      if (value > 0 && value < maxKm) candidates.push(value);
+    }
+  }
+  if (candidates.length === 0) return [];
+  const spread = radius(maxKm) - radius(candidates[0]);
+  const minGap = Math.max(18, spread / 4);
+  const chosen: number[] = [];
+  for (const value of candidates) {
+    if (chosen.length === 0 || radius(value) - radius(chosen[chosen.length - 1]) >= minGap) {
+      chosen.push(value);
+    }
+  }
+  return chosen.slice(-3);
+}
+
+export function SpatialPlot({
+  chart,
+  patterns,
+}: {
+  chart: SpatialChart;
+  patterns: Pattern[];
+}) {
+  const selectedId = useSession((s) => s.selectedMemoryId);
+  const select = useSession((s) => s.select);
+
+  const radius = useMemo(() => {
+    // The outer edge is the furthest memory, so the plot always uses its whole
+    // radius; a fixed maximum would leave a corpus that spans 40 km drawn
+    // inside a quarter of the circle for no reason.
+    const scale = scaleSymlog()
+      .domain([0, Math.max(chart.maxKm, chart.cutoffKm)])
+      .range([R0, R_MAX])
+      // A degenerate corpus where every memory shares one coordinate has a
+      // typical distance of 0, which is not a legal symlog constant.
+      .constant(Math.max(chart.typicalKm, 1e-6));
+    return (km: number) => scale(km);
+  }, [chart.maxKm, chart.cutoffKm, chart.typicalKm]);
+
+  const flagged = chart.points.filter((p) => p.flagged).sort((a, b) => b.km - a.km);
+  const baseline = chart.points.filter((p) => !p.flagged);
+  const stacked = chart.points.reduce((a, p) => Math.max(a, p.memoryIds.length), 0);
+
+  const summary = useMemo(() => {
+    const inside = chart.placed - flagged.reduce((a, p) => a + p.memoryIds.length, 0);
+    const list = flagged.map((p) => formatKm(p.km)).join(", ");
+    return `Distance from the cluster centre, on a log radius, against true bearing. ${inside} of ${chart.placed} placed memories sit within ${formatKm(chart.cutoffKm)} of the centre${
+      stacked > 1
+        ? `, sharing ${chart.points.length} distinct positions — the busiest holds ${stacked}`
+        : ""
+    }. ${
+      flagged.length === 0
+        ? "None fall outside the flag line."
+        : `${flagged.length} fall outside the flag line, at ${list}.`
+    }`;
+  }, [chart, flagged, stacked]);
+
+  const rCut = radius(chart.cutoffKm);
+  const rTyp = radius(chart.typicalKm);
+
+  return (
+    <PlotFrame title="Distance and direction from the cluster centre" summary={summary} viewBox={`0 0 ${W} ${H}`}>
+      {/* Spokes at the cardinals. Faint, because they are a reading aid for
+          angle and not a feature of the data — the same argument GeoMap makes
+          for drawing its graticule at 9% opacity. */}
+      {[0, 90, 180, 270].map((b) => {
+        const [x, y] = place(R_MAX + 4, b);
+        return (
+          <line key={b} x1={CX} y1={CY} x2={x} y2={y} stroke={MARK.rule} strokeWidth={1} opacity={0.5} />
+        );
+      })}
+
+      {/* THE RADIUS, MADE READABLE. Ticks run west, which is the one cardinal
+          this corpus's findings leave empty — and if a future corpus fills it,
+          they are still the smallest marks on the plot and sit under the
+          spoke, not on the data. */}
+      {rulerTicks(chart.maxKm, radius).map((km) => {
+        const r = radius(km);
+        return (
+          <g key={km}>
+            <line
+              x1={CX - r}
+              y1={CY - 3}
+              x2={CX - r}
+              y2={CY + 3}
+              stroke={MARK.rule}
+              strokeWidth={1}
+            />
+            {/* The number only. Repeating the unit on every tick put "200 km
+                50 km 10 km" into 60 pixels of radius, where the labels
+                collided and the ruler became the least legible thing on a plot
+                it exists to clarify. The unit is stated once, at the end, the
+                way an axis title does it. */}
+            <text
+              x={CX - r}
+              y={CY + 13}
+              textAnchor="middle"
+              className="mono"
+              fontSize={8.5}
+              fill={MARK.ink}
+              opacity={0.85}
+            >
+              {km >= 1 ? Math.round(km) : km}
+            </text>
+          </g>
+        );
+      })}
+      <text
+        x={CX - R_MAX - 13}
+        y={CY + 13}
+        textAnchor="end"
+        fontSize={8.5}
+        fill={MARK.ink}
+        opacity={0.7}
+      >
+        km
+      </text>
+
+      {/* The typical distance, unlabelled. It gives the eye a sense of where
+          "normal" ends without adding a second number to read; the section's
+          fact strip already states it, and a label here would land inside the
+          cluster it describes. */}
+      <circle cx={CX} cy={CY} r={rTyp} fill="none" stroke={MARK.rule} strokeWidth={1} opacity={0.9} />
+
+      {/* THE FLAG LINE. The one ring that is labelled, because it is the only
+          one a reader has to know to interpret the plot: everything outside it
+          is a finding. Dashed so it reads as a threshold rather than as data. */}
+      <circle
+        cx={CX}
+        cy={CY}
+        r={rCut}
+        fill="none"
+        stroke={MARK.flagged}
+        strokeWidth={1}
+        strokeDasharray="3 3"
+        opacity={0.55}
+      />
+      <text
+        x={CX}
+        y={CY - rCut - 5}
+        textAnchor="middle"
+        className="mono"
+        fontSize={9.5}
+        fill={MARK.flagged}
+        opacity={0.85}
+      >
+        {formatKm(chart.cutoffKm)}
+      </text>
+
+      {/* The centre the whole measure is relative to. */}
+      <g stroke={MARK.ink} strokeWidth={1} opacity={0.55}>
+        <line x1={CX - 4} y1={CY} x2={CX + 4} y2={CY} />
+        <line x1={CX} y1={CY - 4} x2={CX} y2={CY + 4} />
+      </g>
+
+      {/* PATTERN TIES. Drawn before the marks so a tie never sits on top of the
+          point it connects. An arc at constant radius is drawn ONLY when the
+          members really are at the same radius — that is the shape of "same
+          distance, different direction" and drawing it for findings at
+          different distances would be a picture of something untrue. Anything
+          else gets a straight tie, which claims only "these two are related". */}
+      {patterns.map((pattern) => {
+        const members = pattern.memoryIds
+          .map((id) => chart.points.find((p) => p.memoryIds.includes(id)))
+          .filter((p): p is NonNullable<typeof p> => p !== undefined);
+        if (members.length < 2) return null;
+        const radii = members.map((m) => m.km);
+        const lo = Math.min(...radii);
+        const hi = Math.max(...radii);
+        const sameRing = hi > 0 && (hi - lo) / hi <= 0.05;
+        const key = pattern.memoryIds.join("|");
+
+        if (sameRing && members.length === 2) {
+          const r = (radius(members[0].km) + radius(members[1].km)) / 2;
+          let [a, b] = members;
+          let sweep = (b.bearing - a.bearing + 360) % 360;
+          if (sweep > 180) {
+            [a, b] = [b, a];
+            sweep = 360 - sweep;
+          }
+          const [x1, y1] = place(r, a.bearing);
+          const [x2, y2] = place(r, b.bearing);
+          // The arc's own caption. Without it the tie reads as decoration; with
+          // it, the pattern is stated at the place the eye is already looking,
+          // and the reader never has to reach the list to learn that these two
+          // findings are one. It says what the geometry shows and no more —
+          // that they are the same distance out — and leaves the cause to the
+          // evidence line under the group.
+          const [lx, ly] = place(r + 13, a.bearing + sweep / 2);
+          return (
+            <g key={key}>
+              <path
+                d={`M ${x1} ${y1} A ${r} ${r} 0 0 1 ${x2} ${y2}`}
+                fill="none"
+                stroke={MARK.flagged}
+                strokeWidth={1.25}
+                strokeDasharray="1 3"
+                strokeLinecap="round"
+                opacity={0.75}
+              />
+              <text
+                x={lx}
+                y={ly}
+                textAnchor={lx >= CX ? "start" : "end"}
+                fontSize={9}
+                fill={MARK.flagged}
+                opacity={0.9}
+              >
+                same distance
+              </text>
+            </g>
+          );
+        }
+
+        return (
+          <g key={key}>
+            {members.slice(1).map((m, i) => {
+              const [x1, y1] = place(radius(members[i].km), members[i].bearing);
+              const [x2, y2] = place(radius(m.km), m.bearing);
+              return (
+                <line
+                  key={m.memoryIds[0]}
+                  x1={x1}
+                  y1={y1}
+                  x2={x2}
+                  y2={y2}
+                  stroke={MARK.flagged}
+                  strokeWidth={1.25}
+                  strokeDasharray="1 3"
+                  strokeLinecap="round"
+                  opacity={0.75}
+                />
+              );
+            })}
+          </g>
+        );
+      })}
+
+      {/* The ordinary memories. Area encodes how many share the position — a
+          berth holding twelve draws as one mark of twelve, never as one mark,
+          and never as twelve jittered marks at coordinates the corpus does not
+          contain. Area rather than radius because area is what the eye
+          actually compares. */}
+      {baseline.map((p) => {
+        const n = p.memoryIds.length;
+        const r = Math.min(8, 2.2 * Math.sqrt(n));
+        const [x, y] = place(radius(p.km), p.bearing);
+        return (
+          <g key={p.memoryIds[0]}>
+            <circle cx={x} cy={y} r={r} fill={MARK.baseline} opacity={0.45} />
+            {r >= 6 ? (
+              <text
+                x={x}
+                y={y + 2.6}
+                textAnchor="middle"
+                className="mono"
+                fontSize={7.5}
+                fill="var(--background)"
+                opacity={0.95}
+              >
+                {n}
+              </text>
+            ) : null}
+          </g>
+        );
+      })}
+
+      {/* The findings. Four encodings deep before colour is asked to do
+          anything: outside the drawn ring, larger, haloed, and carrying their
+          own distance as a direct label. */}
+      {flagged.map((p) => {
+        const id = p.memoryIds[0];
+        const isSelected = p.memoryIds.some((m) => m === selectedId);
+        const [x, y] = place(radius(p.km), p.bearing);
+        const right = x >= CX;
+        const colour = isSelected ? MARK.selected : MARK.flagged;
+        return (
+          <g
+            key={id}
+            onClick={() => select(id)}
+            className="cursor-pointer"
+            // The list below is the keyboard path to these same memories, so
+            // the mark carries a pointer affordance and a hover title only.
+            // See PlotFrame for why it is not separately focusable.
+          >
+            <title>{`${formatKm(p.km)} from the cluster centre, bearing ${Math.round(p.bearing)}°`}</title>
+            <circle cx={x} cy={y} r={9} fill={colour} opacity={isSelected ? 0.3 : 0.16} />
+            <circle
+              cx={x}
+              cy={y}
+              r={4.4}
+              fill={colour}
+              stroke="var(--background)"
+              strokeWidth={1.1}
+            />
+            <text
+              x={right ? x + 9 : x - 9}
+              y={y + 3.4}
+              textAnchor={right ? "start" : "end"}
+              className="mono"
+              fontSize={10}
+              fill={colour}
+            >
+              {formatKm(p.km)}
+            </text>
+          </g>
+        );
+      })}
+
+      {/* A compass rose in the margin rather than letters on the rim: at this
+          corpus's bearings a rim label would land under the 259 km mark. */}
+      <g transform="translate(132, 60)" opacity={0.75}>
+        <line x1={0} y1={-11} x2={0} y2={11} stroke={MARK.rule} strokeWidth={1} />
+        <line x1={-11} y1={0} x2={11} y2={0} stroke={MARK.rule} strokeWidth={1} />
+        <text x={0} y={-14} textAnchor="middle" fontSize={8} fill={MARK.ink}>
+          N
+        </text>
+        <text x={15} y={3} textAnchor="middle" fontSize={8} fill={MARK.ink}>
+          E
+        </text>
+        <text x={0} y={21} textAnchor="middle" fontSize={8} fill={MARK.ink}>
+          S
+        </text>
+        <text x={-15} y={3} textAnchor="middle" fontSize={8} fill={MARK.ink}>
+          W
+        </text>
+      </g>
+    </PlotFrame>
+  );
+}

--- a/front/ui/src/features/anomalies/SpatialPlot.tsx
+++ b/front/ui/src/features/anomalies/SpatialPlot.tsx
@@ -131,21 +131,29 @@ export function SpatialPlot({
 
   const flagged = chart.points.filter((p) => p.flagged).sort((a, b) => b.km - a.km);
   const baseline = chart.points.filter((p) => !p.flagged);
-  const stacked = chart.points.reduce((a, p) => Math.max(a, p.memoryIds.length), 0);
+  /** The busiest stack INSIDE the line. Counting the flagged points into this
+   *  would be arithmetic about a different set than the sentence is describing. */
+  const busiest = baseline.reduce((a, p) => Math.max(a, p.memoryIds.length), 0);
 
   const summary = useMemo(() => {
     const inside = chart.placed - flagged.reduce((a, p) => a + p.memoryIds.length, 0);
     const list = flagged.map((p) => formatKm(p.km)).join(", ");
+    // The position count has to be the count for the memories the clause is
+    // about — the ones inside the line — not the plot's total. Saying "32 sit
+    // within 9.5 km, sharing 16 distinct positions" folded the four outliers'
+    // own positions into a sentence about the cluster, which is a small false
+    // statement on a screen whose entire argument is that its arithmetic can be
+    // checked.
     return `Distance from the cluster centre, on a log radius, against true bearing. ${inside} of ${chart.placed} placed memories sit within ${formatKm(chart.cutoffKm)} of the centre${
-      stacked > 1
-        ? `, sharing ${chart.points.length} distinct positions — the busiest holds ${stacked}`
+      busiest > 1
+        ? `, across ${baseline.length} distinct positions — the busiest holding ${busiest}`
         : ""
     }. ${
       flagged.length === 0
         ? "None fall outside the flag line."
         : `${flagged.length} fall outside the flag line, at ${list}.`
     }`;
-  }, [chart, flagged, stacked]);
+  }, [chart, flagged, baseline.length, busiest]);
 
   const rCut = radius(chart.cutoffKm);
   const rTyp = radius(chart.typicalKm);
@@ -285,10 +293,14 @@ export function SpatialPlot({
                 d={`M ${x1} ${y1} A ${r} ${r} 0 0 1 ${x2} ${y2}`}
                 fill="none"
                 stroke={MARK.flagged}
-                strokeWidth={1.25}
-                strokeDasharray="1 3"
+                strokeWidth={1.5}
+                // Heavier than a hairline dot pattern: at 1px on a 3px gap the
+                // tie read as part of the ring system rather than as a
+                // deliberate connector between two findings, which is the one
+                // thing on this plot the reader is most likely to miss.
+                strokeDasharray="2.5 3"
                 strokeLinecap="round"
-                opacity={0.75}
+                opacity={0.85}
               />
               <text
                 x={lx}

--- a/front/ui/src/features/anomalies/measures.ts
+++ b/front/ui/src/features/anomalies/measures.ts
@@ -33,18 +33,29 @@ export interface Finding {
   /** The memory's own text (a 500-char preview — `content_truncated` on the
    *  corpus row says when more exists). Shown so the finding can be checked. */
   content: string;
+  /** The memory's own type, carried so grouping can ask whether two findings
+   *  are the same KIND of record. Never used as a hue here — hue means
+   *  memory_type elsewhere in the product and this screen does not restate it. */
+  memoryType: string;
   /**
    * How far past the flag line this memory sits, in the lens's own terms.
    * Unitless and comparable only WITHIN a lens — a geo modified z-score and a
    * quantity ratio are different quantities and are never compared.
    *
-   * Used to ORDER the findings within a section, and for nothing else. It is
-   * never drawn and never printed: the magnitudes it ranks are unbounded (one
-   * memory in this corpus sits 126 robust scales out, another 14), so any bar
-   * scaled to the largest would render every other genuine finding as a stub
-   * and understate it. What each row states — the distance, the two quantities,
-   * the term count — is the honest presentation of its own magnitude, and
-   * position in the list is the comparison.
+   * Used to ORDER the findings within a section, and for nothing else. THIS
+   * NUMBER IS NEVER DRAWN AND NEVER PRINTED. The magnitudes it ranks are
+   * unbounded — one memory in this corpus sits 126 robust scales out, another
+   * 14 — so any bar scaled to the largest would render every other genuine
+   * finding as a stub and understate it. That mistake was made once here and
+   * reverted.
+   *
+   * What IS drawn is each lens's own measured quantity on a scale built for
+   * it: kilometres on a symmetric-log radius, a dimensionless ratio on a log
+   * axis, a connection count on a linear one. Those scales are defined by the
+   * `*Chart` payloads below, which carry the WHOLE distribution rather than
+   * only the flagged points — a flagged value means nothing without the
+   * ordinary values it is being judged against, and a screen that plots only
+   * the outliers is asking to be taken on faith.
    */
   deviation: number;
   /**
@@ -64,6 +75,227 @@ export interface Finding {
    */
   value: string;
   against: string;
+}
+
+// =============================================================================
+// WHAT THE GRAPHICS ARE DRAWN FROM
+// =============================================================================
+
+/**
+ * Every plotted point of the location lens, flagged or not.
+ *
+ * One entry per DISTINCT COORDINATE, not per memory: 20 of this corpus's 36
+ * placed memories share a coordinate with another (12 sit on one berth), and
+ * plotting them as 36 marks would draw 16 dots while the section title claims
+ * 36. `memoryIds` carries the stack, so the count is encoded by area and the
+ * plot and the caption agree. Jitter was rejected outright — inventing a
+ * position on a plot whose entire claim is positional honesty is the one thing
+ * this destination cannot do.
+ *
+ * `bearing` is the true initial bearing from the cluster centre, in degrees
+ * clockwise from north. It is real measured direction, not decoration: on this
+ * corpus the two furthest memories sit at nearly the same distance in almost
+ * OPPOSITE directions (52° and 175°), which a distance-only plot cannot show
+ * and which changes what the pair means.
+ */
+export interface SpatialPoint {
+  /** Every memory at this exact coordinate. Length is the stack size. */
+  memoryIds: string[];
+  /** Great-circle distance from the cluster centre, km. */
+  km: number;
+  /** Initial bearing from the cluster centre, degrees clockwise from north. */
+  bearing: number;
+  flagged: boolean;
+}
+
+export interface SpatialChart {
+  kind: "spatial";
+  points: SpatialPoint[];
+  typicalKm: number;
+  cutoffKm: number;
+  maxKm: number;
+  /** Memories, not points — the caption's denominator. */
+  placed: number;
+}
+
+/**
+ * One magnitude disagreement, as the two numbers that disagree.
+ *
+ * The plotted axis is `factor`, which is DIMENSIONLESS — max over min. That is
+ * the only way a kilogram row and a millisecond row can share one axis without
+ * a second scale, and it is the honest comparison: "6.8× apart" and "3.7×
+ * apart" are the same kind of quantity even though kilograms and milliseconds
+ * are not. Absolute values stay on the row as text, in their own units.
+ *
+ * `factor` is always ≥ 1 and the bar always grows rightward from 1×, including
+ * for a corpus outlier that sits BELOW its unit's median — in that case the
+ * baseline is the larger number and `lowIsFlagged` says so, rather than the
+ * bar running backwards off a shared origin.
+ */
+export interface RatioPair {
+  memoryId: string;
+  unit: string;
+  lowValue: number;
+  highValue: number;
+  /** max / min. Always ≥ 1. */
+  factor: number;
+  /** Whether the flagged value is the smaller of the two. Only meaningful for
+   *  `scope: "corpus"`, where the other end is the unit's median. */
+  lowIsFlagged: boolean;
+  /** `within` — both numbers written in one memory. `corpus` — this memory's
+   *  value against the median of every other memory using the same unit. */
+  scope: "within" | "corpus";
+}
+
+export interface RatioChart {
+  kind: "ratio";
+  pairs: RatioPair[];
+  maxFactor: number;
+}
+
+/**
+ * How many other memories each judged memory shares an extracted term with.
+ *
+ * The whole distribution, because isolation is only legible against connection:
+ * six memories at zero is a shrug on its own and unmistakable beside a mass
+ * sitting at one to seventeen. This is the honest extension the graphic needed
+ * — the lens already computed who was isolated, it simply never reported the
+ * population that made "isolated" mean anything.
+ *
+ * Memories that yielded NO terms are excluded, exactly as they are excluded
+ * from the findings: nothing can be said about what they connect to, and
+ * drawing them at zero would put them in the same bucket as a memory that has
+ * terms and shares none, which is a different and much stronger statement.
+ */
+export interface DegreeChart {
+  kind: "degree";
+  /** One connection count per judged memory. */
+  counts: number[];
+  medianCount: number;
+  maxCount: number;
+  isolatedCount: number;
+  judged: number;
+}
+
+export type LensChart = SpatialChart | RatioChart | DegreeChart;
+
+/**
+ * Findings that belong together, and the evidence that says so.
+ *
+ * WHY THE RULE IS DELIBERATELY HARD TO SATISFY. A pattern claim is the
+ * strongest thing this screen says — it asserts that two findings have one
+ * cause — so it is the claim most worth being wrong about. Three signals are
+ * available between any two findings: a shared extracted term, magnitudes
+ * within `MAGNITUDE_TOLERANCE` of each other, and the same memory type. None
+ * of them is sufficient alone. A shared term can be a broad one; equal
+ * magnitudes can be coincidence; and memory type is nearly free on a corpus
+ * that is 57/74 Observation, so a rule of "any two signals" would group two
+ * unrelated observations that happened to land at a similar distance.
+ *
+ * So a SHARED TERM IS REQUIRED, and a second signal must corroborate it. That
+ * is stricter than grouping on magnitude alone, and it is the direction to err
+ * in: a missed pattern costs a reader an insight, an invented one costs the
+ * screen its credibility.
+ *
+ * `evidence` is rendered verbatim next to the group, including the term
+ * itself, so a reader can see the grouping was made on the word "port" and
+ * discount it accordingly. The screen never asserts the cause — it shows what
+ * the two findings have in common and stops there.
+ */
+export interface Pattern {
+  memoryIds: string[];
+  evidence: string[];
+}
+
+/** Two magnitudes this close count as "the same magnitude". 5% is loose enough
+ *  to join 259.3 km and 259.9 km and tight enough to keep 18 km and 31 km
+ *  apart, and it is relative so it means the same thing at every scale. */
+const MAGNITUDE_TOLERANCE = 0.05;
+
+interface Groupable {
+  memoryId: string;
+  memoryType: string;
+  magnitude: number;
+  terms: Set<string>;
+  /** A lens-specific attribute two findings can have in common — the unit, for
+   *  the quantity lens. Corroborates a shared term exactly as an equal
+   *  magnitude or a matching type does, and renders in the group's evidence in
+   *  the lens's own words rather than as a synthetic term. */
+  attribute?: { label: string; value: string };
+}
+
+/**
+ * Findings joined into components by the two-signal rule above.
+ *
+ * Pairs that qualify are merged transitively — if A groups with B and B with
+ * C, all three are one pattern — because a pattern is a claim about a set, and
+ * reporting {A,B} and {B,C} as two overlapping patterns would double-count B
+ * and describe the same structure twice.
+ */
+function findPatterns(items: Groupable[]): Pattern[] {
+  const parent = items.map((_, i) => i);
+  const find = (i: number): number => (parent[i] === i ? i : (parent[i] = find(parent[i])));
+  const union = (a: number, b: number) => {
+    parent[find(a)] = find(b);
+  };
+
+  const reasons = new Map<number, string[]>();
+
+  for (let i = 0; i < items.length; i++) {
+    for (let j = i + 1; j < items.length; j++) {
+      const a = items[i];
+      const b = items[j];
+
+      const shared = [...a.terms].filter((t) => b.terms.has(t));
+      if (shared.length === 0) continue;
+
+      const larger = Math.max(Math.abs(a.magnitude), Math.abs(b.magnitude));
+      const closeMagnitude =
+        larger > 0 && Math.abs(a.magnitude - b.magnitude) / larger <= MAGNITUDE_TOLERANCE;
+      const sameType = a.memoryType === b.memoryType;
+      const sameAttribute =
+        a.attribute !== undefined &&
+        b.attribute !== undefined &&
+        a.attribute.label === b.attribute.label &&
+        a.attribute.value === b.attribute.value;
+      if (!closeMagnitude && !sameType && !sameAttribute) continue;
+
+      union(i, j);
+      const key = find(i);
+      const evidence = reasons.get(key) ?? [];
+      const term = `share “${shared[0]}”`;
+      if (!evidence.includes(term)) evidence.push(term);
+      if (closeMagnitude) {
+        const gap = larger > 0 ? (Math.abs(a.magnitude - b.magnitude) / larger) * 100 : 0;
+        const token = gap < 1 ? "same magnitude" : `${gap.toFixed(0)}% apart`;
+        if (!evidence.includes(token)) evidence.push(token);
+      }
+      if (sameAttribute && a.attribute) {
+        const token = `both ${a.attribute.label} ${a.attribute.value}`;
+        if (!evidence.includes(token)) evidence.push(token);
+      }
+      if (sameType) {
+        const token = `both ${a.memoryType}`;
+        if (!evidence.includes(token)) evidence.push(token);
+      }
+      reasons.set(key, evidence);
+    }
+  }
+
+  const components = new Map<number, string[]>();
+  for (let i = 0; i < items.length; i++) {
+    const root = find(i);
+    const bucket = components.get(root);
+    if (bucket) bucket.push(items[i].memoryId);
+    else components.set(root, [items[i].memoryId]);
+  }
+
+  const patterns: Pattern[] = [];
+  for (const [root, memoryIds] of components) {
+    if (memoryIds.length < 2) continue;
+    patterns.push({ memoryIds, evidence: reasons.get(root) ?? [] });
+  }
+  return patterns;
 }
 
 /**
@@ -94,9 +326,16 @@ interface LensBasis {
   detail?: string;
 }
 
+/**
+ * `chart` rides on `clear` as well as on `findings`, and that is the point.
+ * "Nothing flagged" over an empty panel is indistinguishable from "this lens
+ * did not run"; the same words over a drawn distribution with every point
+ * inside the line is a result a reader can check. A lens that reached a
+ * conclusion shows its population either way.
+ */
 export type LensResult =
-  | ({ state: "findings"; findings: Finding[] } & LensBasis)
-  | ({ state: "clear" } & LensBasis)
+  | ({ state: "findings"; findings: Finding[]; chart: LensChart; patterns: Pattern[] } & LensBasis)
+  | ({ state: "clear"; chart?: LensChart } & LensBasis)
   | ({ state: "insufficient"; reason: string } & LensBasis);
 
 // =============================================================================
@@ -173,6 +412,23 @@ function greatCircleKm(aLat: number, aLon: number, bLat: number, bLon: number): 
   return 2 * EARTH_RADIUS_KM * Math.asin(Math.min(1, Math.sqrt(h)));
 }
 
+/**
+ * Initial bearing from a to b, degrees clockwise from true north.
+ *
+ * The forward azimuth of the great circle, which is the direction you would
+ * actually set off in — not the angle of the straight line between two points
+ * on a flat plot of latitude against longitude, which is wrong by the cosine
+ * of the latitude and gets worse the further north the corpus sits.
+ */
+function bearingDegrees(aLat: number, aLon: number, bLat: number, bLon: number): number {
+  const dLon = toRadians(bLon - aLon);
+  const y = Math.sin(dLon) * Math.cos(toRadians(bLat));
+  const x =
+    Math.cos(toRadians(aLat)) * Math.sin(toRadians(bLat)) -
+    Math.sin(toRadians(aLat)) * Math.cos(toRadians(bLat)) * Math.cos(dLon);
+  return ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360;
+}
+
 function formatKm(km: number): string {
   if (km < 1) return `${Math.round(km * 1000)} m`;
   if (km < 10) return `${km.toFixed(1)} km`;
@@ -242,6 +498,7 @@ export function offPatternLocations(memories: CorpusMemory[]): LensResult {
     .map(({ memory, km }) => ({
       memoryId: memory.id,
       content: memory.content,
+      memoryType: memory.memory_type,
       deviation: (km - typical) / spread.scale,
       // Only the distance. "…from the middle of the cluster the other 35
       // placed memories form, which normally sit 2.4 km out" is true of every
@@ -250,6 +507,56 @@ export function offPatternLocations(memories: CorpusMemory[]): LensResult {
       against: "from cluster centre",
     }))
     .sort((a, b) => b.deviation - a.deviation);
+
+  // Every placed memory becomes a plotted point, collapsed onto its exact
+  // coordinate so a berth holding twelve memories draws as one mark of twelve
+  // rather than as one mark. Keyed on the raw numbers rather than a rounded
+  // string: two coordinates that differ in the seventh decimal are different
+  // positions and the plot should not decide otherwise.
+  const stacks = new Map<string, SpatialPoint>();
+  located.forEach((m, i) => {
+    const key = `${m.geo_location[0]},${m.geo_location[1]}`;
+    const existing = stacks.get(key);
+    if (existing) {
+      existing.memoryIds.push(m.id);
+      return;
+    }
+    stacks.set(key, {
+      memoryIds: [m.id],
+      km: distances[i],
+      bearing: bearingDegrees(centreLat, centreLon, m.geo_location[0], m.geo_location[1]),
+      flagged: distances[i] > cutoff,
+    });
+  });
+
+  const chart: SpatialChart = {
+    kind: "spatial",
+    points: [...stacks.values()],
+    typicalKm: typical,
+    cutoffKm: cutoff,
+    maxKm: distances.reduce((a, b) => Math.max(a, b), 0),
+    placed: located.length,
+  };
+
+  // Grouping asks about the flagged memories only. Whether two ordinary
+  // memories in the cluster share a term is a fact about the corpus, not a
+  // pattern among anomalies, and drawing it here would bury the four findings
+  // under thirty-odd ties that are not what this screen is for.
+  const flaggedIds = new Set(findings.map((f) => f.memoryId));
+  const patterns = findPatterns(
+    located.flatMap((m, i) =>
+      flaggedIds.has(m.id)
+        ? [
+            {
+              memoryId: m.id,
+              memoryType: m.memory_type,
+              magnitude: distances[i],
+              terms: new Set(m.tags.map((t) => t.trim().toLowerCase()).filter((t) => t.length > 0)),
+            },
+          ]
+        : [],
+    ),
+  );
 
   // The spread token has to describe the estimator that actually produced the
   // number. Saying "half within" of a MEAN deviation would be a false statement
@@ -267,11 +574,11 @@ export function offPatternLocations(memories: CorpusMemory[]): LensResult {
     ? undefined
     : `More than half of these share one exact position, so the median spread came out at zero and the average distance stands in for it — a looser line than the other measures draw.`;
 
-  const detail = `Centre is the median latitude and longitude of the ${located.length} placed memories, and distance is great-circle from there. The cutoff is ${MODIFIED_Z_CUTOFF} robust scales past the typical distance — Iglewicz & Hoaglin's published modified-z cutoff, not a number tuned to this corpus. The remaining ${others} placed memories are the baseline every row is measured against.`;
+  const detail = `Centre is the median latitude and longitude of the ${located.length} placed memories, and distance is great-circle from there. The cutoff is ${MODIFIED_Z_CUTOFF} robust scales past the typical distance — Iglewicz & Hoaglin's published modified-z cutoff, not a number tuned to this corpus. The remaining ${others} placed memories are the baseline every row is measured against. The plot places each memory at its true bearing from that centre and its distance on a symmetric-log radius, so a cluster spanning one harbour and a diversion 260 km away are legible on one scale.`;
 
   return findings.length > 0
-    ? { state: "findings", findings, facts, caveat, detail }
-    : { state: "clear", facts, caveat, detail };
+    ? { state: "findings", findings, chart, patterns, facts, caveat, detail }
+    : { state: "clear", chart, facts, caveat, detail };
 }
 
 // =============================================================================
@@ -411,6 +718,7 @@ export function quantityOutliers(memories: CorpusMemory[]): LensResult {
   const perMemory = memories.map((m) => ({ memory: m, quantities: parseQuantities(m.content) }));
 
   const findings: Finding[] = [];
+  const pairs: RatioPair[] = [];
 
   // --- within one memory ---------------------------------------------------
   for (const { memory, quantities } of perMemory) {
@@ -426,9 +734,19 @@ export function quantityOutliers(memories: CorpusMemory[]): LensResult {
       const high = values.reduce((a, b) => (a.value >= b.value ? a : b));
       if (high.value === low.value) continue;
       const factor = high.value / low.value;
+      pairs.push({
+        memoryId: memory.id,
+        unit,
+        lowValue: low.value,
+        highValue: high.value,
+        factor,
+        lowIsFlagged: false,
+        scope: "within",
+      });
       findings.push({
         memoryId: memory.id,
         content: memory.content,
+        memoryType: memory.memory_type,
         deviation: Math.log10(factor),
         // Both numbers and the factor between them, which is the whole finding.
         // What is NOT said is which one is wrong: the arithmetic cannot know,
@@ -469,9 +787,25 @@ export function quantityOutliers(memories: CorpusMemory[]): LensResult {
     for (const entry of entries) {
       const z = Math.abs(entry.value - centre) / spread.scale;
       if (z <= MODIFIED_Z_CUTOFF) continue;
+      // The pair being drawn is this memory's value against its unit's median.
+      // A value below the median is just as much an outlier as one above, so
+      // the bar is built from the larger over the smaller and `lowIsFlagged`
+      // records which end the memory actually sits on.
+      const low = Math.min(entry.value, centre);
+      const high = Math.max(entry.value, centre);
+      pairs.push({
+        memoryId: entry.memory.id,
+        unit,
+        lowValue: low,
+        highValue: high,
+        factor: low > 0 ? high / low : Number.POSITIVE_INFINITY,
+        lowIsFlagged: entry.value < centre,
+        scope: "corpus",
+      });
       findings.push({
         memoryId: entry.memory.id,
         content: entry.memory.content,
+        memoryType: entry.memory.memory_type,
         deviation: z,
         // The baseline stays on the row here, unlike the location lens: this
         // section mixes units, so "typical 38 t" is true of the tonnes rows and
@@ -521,10 +855,41 @@ export function quantityOutliers(memories: CorpusMemory[]): LensResult {
   const detail = `${unitMethod} A unit needs ${MIN_UNIT_SAMPLES} separate memories before a normal range is claimed for it${shortSummary ? `; the most common so far are ${shortSummary}` : ""}.`;
 
   findings.sort((a, b) => b.deviation - a.deviation);
+  pairs.sort((a, b) => b.factor - a.factor);
+
+  const chart: RatioChart = {
+    kind: "ratio",
+    pairs,
+    maxFactor: pairs.reduce((a, p) => (Number.isFinite(p.factor) ? Math.max(a, p.factor) : a), 1),
+  };
+
+  // Grouping here asks the same two-signal question as the location lens, with
+  // the magnitude being the factor between the two numbers. On a corpus whose
+  // disagreements are one in kilograms and one in milliseconds, sharing no
+  // term, it correctly finds nothing — and the section says so rather than
+  // manufacturing a tie out of the fact that both are "numbers".
+  const byId = new Map(memories.map((m) => [m.id, m]));
+  const patterns = findPatterns(
+    pairs.flatMap((p) => {
+      const memory = byId.get(p.memoryId);
+      if (!memory) return [];
+      return [
+        {
+          memoryId: p.memoryId,
+          memoryType: memory.memory_type,
+          magnitude: p.factor,
+          terms: new Set(
+            memory.tags.map((t) => t.trim().toLowerCase()).filter((t) => t.length > 0),
+          ),
+          attribute: { label: "in", value: p.unit },
+        },
+      ];
+    }),
+  );
 
   return findings.length > 0
-    ? { state: "findings", findings, facts, caveat, detail }
-    : { state: "clear", facts, caveat, detail };
+    ? { state: "findings", findings, chart, patterns, facts, caveat, detail }
+    : { state: "clear", chart, facts, caveat, detail };
 }
 
 // =============================================================================
@@ -577,15 +942,24 @@ export function isolatedMemories(memories: CorpusMemory[]): LensResult {
   const terms = (m: CorpusMemory) =>
     new Set(m.tags.map((t) => t.trim().toLowerCase()).filter((t) => t.length > 0));
 
-  // How many DISTINCT memories each term appears in — not how many times it was
-  // extracted, so a term repeated within one memory never looks like a link.
-  const reach = new Map<string, number>();
+  // Which DISTINCT memories each term appears in. The SET, not a count: the
+  // count alone answers "is this term shared", which is all the finding needed,
+  // but the plot needs "how many other memories does this one reach", and
+  // rebuilding that by comparing every memory with every other is O(n²) in
+  // memories where this is O(total terms). The set is also the honest
+  // definition — a term repeated inside one memory can never look like a link.
+  const holders = new Map<string, Set<string>>();
   for (const m of memories) {
-    for (const term of terms(m)) reach.set(term, (reach.get(term) ?? 0) + 1);
+    for (const term of terms(m)) {
+      const bucket = holders.get(term);
+      if (bucket) bucket.add(m.id);
+      else holders.set(term, new Set([m.id]));
+    }
   }
 
   const unextracted: CorpusMemory[] = [];
   const findings: Finding[] = [];
+  const counts: number[] = [];
 
   for (const m of memories) {
     const own = terms(m);
@@ -593,11 +967,23 @@ export function isolatedMemories(memories: CorpusMemory[]): LensResult {
       unextracted.push(m);
       continue;
     }
-    const shared = [...own].filter((t) => (reach.get(t) ?? 0) > 1);
+    // Distinct OTHER memories reached through any shared term. A memory that
+    // reaches the same neighbour through six terms is connected to one
+    // neighbour, not six.
+    const neighbours = new Set<string>();
+    for (const term of own) {
+      for (const id of holders.get(term) ?? []) {
+        if (id !== m.id) neighbours.add(id);
+      }
+    }
+    counts.push(neighbours.size);
+
+    const shared = [...own].filter((t) => (holders.get(t)?.size ?? 0) > 1);
     if (shared.length > 0) continue;
     findings.push({
       memoryId: m.id,
       content: m.content,
+      memoryType: m.memory_type,
       // More unique terms is stronger isolation: a memory naming twelve things,
       // none of which any other memory names, is further out than one naming
       // two. Ordering only — never shown as a number.
@@ -624,9 +1010,27 @@ export function isolatedMemories(memories: CorpusMemory[]): LensResult {
       : undefined;
 
   const detail =
-    "Two memories count as connected when the extraction pulled the same term out of both — including broad terms, so a memory reaches this list only by sharing nothing at all. The measure under-reports rather than over-reports, which is the safe direction on a screen like this one.";
+    "Two memories count as connected when the extraction pulled the same term out of both — including broad terms, so a memory reaches this list only by sharing nothing at all. The measure under-reports rather than over-reports, which is the safe direction on a screen like this one. The plot counts, for every judged memory, how many DISTINCT other memories it reaches through any shared term; the isolated ones are the column at zero.";
+
+  const chart: DegreeChart = {
+    kind: "degree",
+    counts,
+    medianCount: counts.length > 0 ? medianOf(counts) : 0,
+    maxCount: counts.reduce((a, b) => Math.max(a, b), 0),
+    isolatedCount: findings.length,
+    judged,
+  };
+
+  // THIS LENS CANNOT HAVE PATTERNS, and the reason is structural rather than
+  // circumstantial: a memory qualifies as isolated precisely BY sharing no term
+  // with any other memory, so no two findings here can ever share a term, and a
+  // shared term is what this screen requires before it will call two findings
+  // one pattern. Passing an empty list rather than skipping the call keeps that
+  // an explicit, testable statement instead of an omission a later reader has
+  // to reconstruct.
+  const patterns: Pattern[] = [];
 
   return findings.length > 0
-    ? { state: "findings", findings, facts, caveat, detail }
-    : { state: "clear", facts, caveat, detail };
+    ? { state: "findings", findings, chart, patterns, facts, caveat, detail }
+    : { state: "clear", chart, facts, caveat, detail };
 }

--- a/front/ui/src/features/anomalies/measures.ts
+++ b/front/ui/src/features/anomalies/measures.ts
@@ -260,9 +260,25 @@ function findPatterns(items: Groupable[]): Pattern[] {
         a.attribute.value === b.attribute.value;
       if (!closeMagnitude && !sameType && !sameAttribute) continue;
 
+      // THE TWO COMPONENTS' EVIDENCE HAS TO BE CARRIED ACROSS THE UNION.
+      // `reasons` is keyed by component root, and a union re-roots one of the
+      // trees — so reading `reasons.get(find(i))` AFTER the union can land on a
+      // root that has never been written to, silently discarding everything
+      // learned about the component that just lost its root. Three findings
+      // joined as (A,B) then (A,C) reported only the second pair's tokens, and
+      // the failure is invisible: the members are right and the evidence is
+      // merely thin, which is the worst shape for a bug on a screen whose whole
+      // job is showing its reasoning.
+      const rootA = find(i);
+      const rootB = find(j);
+      const carried = [...(reasons.get(rootA) ?? []), ...(reasons.get(rootB) ?? [])];
+      reasons.delete(rootA);
+      reasons.delete(rootB);
+
       union(i, j);
       const key = find(i);
-      const evidence = reasons.get(key) ?? [];
+      const evidence: string[] = [];
+      for (const token of carried) if (!evidence.includes(token)) evidence.push(token);
       const term = `share “${shared[0]}”`;
       if (!evidence.includes(term)) evidence.push(term);
       if (closeMagnitude) {


### PR DESCRIPTION
The destination was still a list of sentences with numbers attached — compressing the prose did not fix it, because the screen asked you to READ findings you should SEE. Each lens now leads with a graphic in which the outlier is unmistakable, and the rows became supporting evidence.

**Out of place — log-radial polar plot.** Radius is distance from the corpus's own median centre, angle is true bearing, and the measure's cutoff is a dashed ring you watch points fall outside of. A map was rejected: 32 of 36 memories sit in one harbour and two sit 260 km away, so any fitted projection draws the cluster as a pixel or pushes findings off-canvas.

**Numbers that don't fit — dumbbell on a shared log ratio axis.** The section mixes units by construction, so an axis per unit would be the dual-axis mistake. `max/min` is dimensionless, so the kg row and the ms row are legitimately comparable lengths.

**Connected to nothing — degree distribution.** A node-link drawing of 71 memories at median degree 4 is a hairball whose edges cannot be counted by eye; the histogram shows the same fact instantly, with the 6 isolates as a separated column at zero.

**Scaling.** `scaleSymlog`, not log: distances run 1.02→259.85 km (255×), linear collapses the cluster, and plain log has no honest place for a memory *at* the centre. Symlog maps 0→0 with no invented floor, and its linear constant is the corpus's own typical distance. A labelled ruler states the scale, because a log radius read as linear misleads by omission. This is the same failure mode that killed the earlier severity bar, solved rather than repeated.

**Pattern grouping — and a correction.** The brief claimed the two 259 km diversions share a direction. They do not: bearings are 51.5° (Newark, NE) and 175.3° (Norfolk, S), verified from coordinates. The plot draws the truth — an arc at constant radius, which is what "same distance, opposite directions" looks like. Grouping requires a shared extracted term plus corroboration (equal magnitude, matching type, or shared unit); type alone is nearly free here (57 of 74 are Observation) and equal magnitude alone is coincidence. Evidence renders verbatim so a reader can discount a group resting on one broad token.

**Two bugs found while building.** A caption claimed the cluster occupied 16 distinct positions — 16 is the count for all 36; the cluster holds 12. And `findPatterns` dropped evidence on transitive merges (union re-roots the tree, so the reason lookup started empty), verified fixed against a synthetic A-x-B, B-y-C corpus.

Measures now return whole populations rather than only flagged points. **No threshold, estimator or cutoff changed.** Rendered and screenshotted at 1440 and 1024 across all three lenses; `tsc -b --noEmit` clean.

Known gap, documented not worked around: `/anomalies` is absent from `ROUTES_WITH_INSPECTOR` (App.tsx:53), so selection is answered in the row and the plot but opens no pane. App.tsx was outside this agent's scope.