### PR TITLE
fix(workbench): the Inspector opens on Anomalies too

### DIFF
--- a/front/ui/src/app/App.tsx
+++ b/front/ui/src/app/App.tsx
@@ -50,7 +50,7 @@ const INSPECTOR_OFFSET = "pr-[min(280px,36vw)]";
  *  that selected something with nowhere to show it would be a dead end. On a
  *  destination with no selectable objects the Inspector could show nothing but
  *  an explanation of itself, so it stays off those. */
-const ROUTES_WITH_INSPECTOR = ["/recall", "/geo", "/graph"];
+const ROUTES_WITH_INSPECTOR = ["/recall", "/geo", "/graph", "/anomalies"];
 
 /** Destinations that render a recall result and therefore need the cue that
  *  produced it. Without the field, Geo would depend on the user having visited


### PR DESCRIPTION
Anomalies rows drive the same global selection every other list does, and both the row and the plot answer it — but `/anomalies` was missing from `ROUTES_WITH_INSPECTOR` (App.tsx:53), so clicking a finding highlighted it and opened nothing. Spotting an outlier and then asking "where did this come from" is the whole point of the destination.

The Inspector's corpus fallback (shipped in #453) already handles this: an anomalies row is a corpus memory rather than a recall hit, and the fallback renders it with the retrieval-evidence sections absent rather than empty.

One line. Typecheck clean.