### PR TITLE
fix(graph): consolidation counts evidence, not elapsed minutes

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -888,6 +888,49 @@ pub const TIER_PROMOTION_SESSION_IMPORTANCE: f32 = 0.5;
 /// Reference: Rasch & Born (2013) "About Sleep's Role in Memory"
 pub const TIER_PROMOTION_SESSION_AGE_SECS: i64 = 86400; // 24 hours
 
+/// Distinct attesting episodes required for an edge to leave L1 (working) for
+/// L2 (episodic).
+///
+/// The *evidence* half of the edge-tier promotion gate, and the reason batch
+/// ingest is no longer a dead end. Wall-clock separation
+/// ([`TIER_PROMOTION_WORKING_AGE_SECS`]) was the only proxy for "independent
+/// evidence", which silently made elapsed minutes a precondition for
+/// consolidation. Every corpus import, every eval run and every seeded
+/// deployment creates all of its edges within one pass, so no edge could ever
+/// satisfy it: the whole graph froze at L1 with a 0.20 retrieval trust
+/// multiplier and then aged out on the L1 prune schedule.
+///
+/// Distinct *episodes* measure what the clock was standing in for. Two
+/// different source memories independently attesting the same entity pair is
+/// evidence; the same conversation re-read forty times is not, and does not
+/// move this counter — `merge_provenance` deduplicates by `source_episode_id`,
+/// so repeated attestation from one episode only raises that record's
+/// `mention_count`, which promotion deliberately ignores.
+///
+/// 2 is the smallest count that can distinguish corroboration from a single
+/// observation, matching the tier's meaning: L2/episodic is "seen more than
+/// once", not "seen a lot".
+pub const TIER_PROMOTION_L2_MIN_EPISODES: usize = 2;
+
+/// Distinct attesting episodes required for an edge to leave L2 (episodic) for
+/// L3 (semantic). See [`TIER_PROMOTION_L2_MIN_EPISODES`].
+///
+/// Deliberately cumulative rather than "N more since the last promotion": because
+/// 4 > 2, an edge cannot reach L3 without acquiring two attestations beyond the
+/// ones that earned it L2, so "independent evidence since entering this tier"
+/// holds without persisting a per-tier episode counter — no schema change, and
+/// no new field that could drift out of agreement with the trail it summarises.
+///
+/// 4 distinct source episodes *plus* strength ≥ `L2_PROMOTION_THRESHOLD` is a
+/// far higher bar than the pre-clock behaviour this replaces, where THREE
+/// strengthen calls arising from a SINGLE observation inside one request reached
+/// L3.
+///
+/// Bounded above by `SHODH_PROVENANCE_MAX_SOURCES` (default 8), which caps the
+/// trail: setting that env var below this value disables the episode route to
+/// L3 entirely, leaving only the wall-clock route.
+pub const TIER_PROMOTION_L3_MIN_EPISODES: usize = 4;
+
 /// Potentiation boost applied during each maintenance cycle
 /// Applied to ALL memories based on access count (Hebbian strengthening)
 ///

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -1344,17 +1344,15 @@ impl RelationshipEdge {
         // Independent-evidence gate: corroboration OR elapsed time.
         // `promoted_at.unwrap_or(created_at)` is the moment this edge entered
         // its current tier.
-        let separated_by_clock = match self.tier.promotion_min_separation_secs() {
-            Some(min_secs) => {
-                let entered_tier_at = self.promoted_at.unwrap_or(self.created_at);
-                (now - entered_tier_at).num_seconds() >= min_secs
-            }
-            None => false,
-        };
-        let corroborated = match self.tier.promotion_min_episodes() {
-            Some(min_episodes) => self.distinct_attesting_episodes() >= min_episodes,
-            None => false,
-        };
+        let entered_tier_at = self.promoted_at.unwrap_or(self.created_at);
+        let separated_by_clock = self
+            .tier
+            .promotion_min_separation_secs()
+            .is_some_and(|min_secs| (now - entered_tier_at).num_seconds() >= min_secs);
+        let corroborated = self
+            .tier
+            .promotion_min_episodes()
+            .is_some_and(|min_episodes| self.distinct_attesting_episodes() >= min_episodes);
         if !separated_by_clock && !corroborated {
             return None;
         }

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -553,26 +553,6 @@ impl EdgeTier {
         }
     }
 
-    /// Minimum elapsed time, in seconds, between the moment an edge entered this
-    /// tier and the moment it may leave it for the next one.
-    ///
-    /// Strength alone is not evidence of consolidation. From the birth weight of
-    /// 0.4 a single `strengthen` call clears `L1_PROMOTION_THRESHOLD` and three
-    /// clear `L2_PROMOTION_THRESHOLD`, while three independent strengthen paths
-    /// touch the same entity edges within one request — so without a clock, one
-    /// conversational turn promoted an edge from "working" all the way to
-    /// "near-permanent semantic".
-    ///
-    /// The separations deliberately **mirror the memory-tier clock** rather than
-    /// inventing a second set of numbers: 30 minutes for the first step
-    /// ([`TIER_PROMOTION_WORKING_AGE_SECS`](crate::constants::TIER_PROMOTION_WORKING_AGE_SECS))
-    /// and 24 hours for the second
-    /// ([`TIER_PROMOTION_SESSION_AGE_SECS`](crate::constants::TIER_PROMOTION_SESSION_AGE_SECS)).
-    /// Those are the synaptic-consolidation window (McGaugh 2000) and the
-    /// sleep-dependent hippocampal→cortical transfer window (Rasch & Born 2013)
-    /// respectively — the same biology the edge tiers cite, so the two
-    /// consolidation clocks now at least tick in the same units.
-    ///
     /// How fast an edge in this tier experiences time on the Wixted hybrid decay
     /// curve, relative to the L2/episodic reference.
     ///
@@ -588,12 +568,69 @@ impl EdgeTier {
         }
     }
 
-    /// `None` for L3: there is no next tier.
+    /// Minimum elapsed time, in seconds, between the moment an edge entered this
+    /// tier and the moment it may leave it for the next one. `None` for L3:
+    /// there is no next tier.
+    ///
+    /// Strength alone is not evidence of consolidation. From the birth weight of
+    /// 0.4 a single `strengthen` call clears `L1_PROMOTION_THRESHOLD` and three
+    /// clear `L2_PROMOTION_THRESHOLD`, while three independent strengthen paths
+    /// touch the same entity edges within one request — so without a gate, one
+    /// conversational turn promoted an edge from "working" all the way to
+    /// "near-permanent semantic".
+    ///
+    /// The separations deliberately **mirror the memory-tier clock** rather than
+    /// inventing a second set of numbers: 30 minutes for the first step
+    /// ([`TIER_PROMOTION_WORKING_AGE_SECS`](crate::constants::TIER_PROMOTION_WORKING_AGE_SECS))
+    /// and 24 hours for the second
+    /// ([`TIER_PROMOTION_SESSION_AGE_SECS`](crate::constants::TIER_PROMOTION_SESSION_AGE_SECS)).
+    /// Those are the synaptic-consolidation window (McGaugh 2000) and the
+    /// sleep-dependent hippocampal→cortical transfer window (Rasch & Born 2013)
+    /// respectively — the same biology the edge tiers cite, so the two
+    /// consolidation clocks at least tick in the same units.
+    ///
+    /// This is now **one of two** ways to satisfy the sustained-evidence gate;
+    /// see [`promotion_min_episodes`](Self::promotion_min_episodes) for why the
+    /// clock alone was not merely conservative but wrong.
     pub fn promotion_min_separation_secs(&self) -> Option<i64> {
         use crate::constants::*;
         match self {
             Self::L1Working => Some(TIER_PROMOTION_WORKING_AGE_SECS),
             Self::L2Episodic => Some(TIER_PROMOTION_SESSION_AGE_SECS),
+            Self::L3Semantic => None,
+        }
+    }
+
+    /// Minimum number of **distinct attesting episodes** an edge must carry to
+    /// leave this tier. `None` for L3: there is no next tier.
+    ///
+    /// The clock was a *proxy* for independent evidence, and it was the wrong
+    /// one. Elapsed minutes are a property of the ingest schedule, not of the
+    /// evidence: a corpus imported in one pass — which is how every import,
+    /// every eval run and every seeded deployment works — creates all of its
+    /// edges within minutes, so under a clock-only gate not one of them could
+    /// ever promote. They stayed at L1 with `EDGE_TIER_TRUST_L1` (0.20, a 4×
+    /// retrieval-trust penalty against L3) and then aged out on the L1 prune
+    /// schedule. That is not a consolidation policy; it is scheduled data loss
+    /// that happens to spare interactively-built graphs.
+    ///
+    /// Distinct episodes measure the thing the clock was standing in for. The
+    /// anti-burst intent is fully preserved, because the counter is
+    /// deduplicated by `source_episode_id` in `merge_provenance`: one
+    /// conversation mentioning two entities forty times is ONE episode however
+    /// many times it is re-read, and however many of the three in-request
+    /// strengthen paths touch the edge. Only a genuinely different source
+    /// memory advances it.
+    ///
+    /// See [`TIER_PROMOTION_L2_MIN_EPISODES`](crate::constants::TIER_PROMOTION_L2_MIN_EPISODES)
+    /// and [`TIER_PROMOTION_L3_MIN_EPISODES`](crate::constants::TIER_PROMOTION_L3_MIN_EPISODES)
+    /// for the values and for why cumulative counts give "evidence acquired
+    /// since entering this tier" without persisting a per-tier counter.
+    pub fn promotion_min_episodes(&self) -> Option<usize> {
+        use crate::constants::*;
+        match self {
+            Self::L1Working => Some(TIER_PROMOTION_L2_MIN_EPISODES),
+            Self::L2Episodic => Some(TIER_PROMOTION_L3_MIN_EPISODES),
             Self::L3Semantic => None,
         }
     }
@@ -886,21 +923,49 @@ fn provenance_max_sources() -> usize {
 }
 
 /// Default minimum number of distinct attesting episodes for corroboration to
-/// shield an edge from strength-based pruning (used when `SHODH_PROVENANCE_AWARE_PRUNE=1`).
-const PROVENANCE_PRUNE_CORROBORATION_MIN_DEFAULT: usize = 3;
+/// shield an edge from strength-based pruning.
+///
+/// **Deliberately equal to [`TIER_PROMOTION_L2_MIN_EPISODES`](crate::constants::TIER_PROMOTION_L2_MIN_EPISODES),
+/// and derived from it so the two cannot drift.** The invariant is: *the
+/// evidence that earns promotion also earns survival.*
+///
+/// It has to be, because promotion and pruning read the same evidence but push
+/// in opposite directions. L2's prune threshold (0.2) is double L1's (0.1),
+/// while the executed decay rate is near-identical across the two tiers over the
+/// first three days (L1 λ = 0.029/hour ≈ 0.696/day; L2's hybrid consolidation
+/// leg λ = `DECAY_LAMBDA_CONSOLIDATION` = 0.693/day). So promotion, taken alone,
+/// makes an edge prunable EARLIER — for a batch-ingested edge at birth weight,
+/// ~41.5 idle hours at L2 against ~58.8 at L1. Protecting at a HIGHER episode
+/// count than promotion requires would leave exactly the newly-promoted band
+/// (2 episodes here) promoted-but-unprotected, i.e. it would consolidate an
+/// edge and shorten its life in the same step.
+const PROVENANCE_PRUNE_CORROBORATION_MIN_DEFAULT: usize =
+    crate::constants::TIER_PROMOTION_L2_MIN_EPISODES;
 
 /// Resolve the provenance-aware-pruning corroboration threshold from the env.
 ///
-/// `SHODH_PROVENANCE_AWARE_PRUNE` gates the whole feature and is cached (read
-/// once per process; eval/production set it before start):
-/// - unset / `0` / `false` / empty → `None` (feature OFF — only LTP protects,
-///   exactly the pre-existing behavior),
+/// `SHODH_PROVENANCE_AWARE_PRUNE` gates the feature and is cached (read once per
+/// process; eval/production set it before start):
+/// - unset → `Some(PROVENANCE_PRUNE_CORROBORATION_MIN_DEFAULT)` (feature ON),
+/// - `0` / `false` / empty → `None` (kill switch: only LTP protects, the
+///   pre-existing behavior),
 /// - `1` / `true` → `Some(PROVENANCE_PRUNE_CORROBORATION_MIN_DEFAULT)`,
 /// - an explicit integer `N ≥ 1` → `Some(N)` (lets an A/B sweep the threshold).
 ///
+/// **The unset default flipped from OFF to ON**, because the edge-tier fix made
+/// it load-bearing rather than experimental. Promotion is now driven by distinct
+/// attesting episodes so that a batch-ingested corpus can consolidate at all;
+/// but promotion moves an edge onto a tier whose prune threshold is twice as
+/// high at essentially the same decay rate, so consolidating an edge without
+/// also honouring its corroboration on the prune side would shorten the life of
+/// the very edges the fix is meant to rescue. The two halves are one policy:
+/// evidence that promotes must also protect.
+///
 /// When `Some(min)`, an edge attested by at least `min` distinct episodes is
-/// protected from STRENGTH-based pruning only — age-based reaping still applies,
-/// so there are no immortal edges.
+/// protected from STRENGTH-based pruning only — age-based reaping
+/// (`exceeded_max_age`) still applies, so there are no immortal edges, and
+/// single-attestation edges are not protected at all and still die on their
+/// tier's schedule.
 fn provenance_prune_min() -> Option<usize> {
     static FLAG: std::sync::OnceLock<Option<usize>> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| match std::env::var("SHODH_PROVENANCE_AWARE_PRUNE") {
@@ -914,7 +979,7 @@ fn provenance_prune_min() -> Option<usize> {
                 v.parse::<usize>().ok().filter(|&n| n > 0)
             }
         }
-        Err(_) => None,
+        Err(_) => Some(PROVENANCE_PRUNE_CORROBORATION_MIN_DEFAULT),
     })
 }
 
@@ -1191,25 +1256,78 @@ impl RelationshipEdge {
         self.try_promote_at(now)
     }
 
+    /// Number of DISTINCT source episodes that have attested this edge.
+    ///
+    /// This is `provenance.len()` and is only a distinct count because
+    /// [`merge_provenance`] is the sole writer of the trail and deduplicates by
+    /// `source_episode_id` — a repeat observation from an episode already in the
+    /// trail raises that record's `mention_count` instead of appending. Anything
+    /// that appends to `provenance` without going through `merge_provenance`
+    /// breaks the invariant this method's callers rely on.
+    ///
+    /// Saturates at `SHODH_PROVENANCE_MAX_SOURCES` (default 8), the trail cap,
+    /// and is monotonically non-decreasing below it: `merge_provenance` only
+    /// truncates when the length *exceeds* the cap, so an edge cannot lose
+    /// corroboration it has already earned and tiers cannot flap.
+    pub fn distinct_attesting_episodes(&self) -> usize {
+        self.provenance.len()
+    }
+
+    /// Re-evaluate this edge's tier without strengthening it.
+    ///
+    /// [`try_promote_at`](Self::try_promote_at) used to be reachable from
+    /// exactly one place — `strengthen_scaled_at` — which made promotion
+    /// conditional on being *re-strengthened later*. That is precisely what a
+    /// batch-ingested edge, or an edge that receives all of its evidence in one
+    /// burst and is then left alone, never gets: its provenance trail can grow
+    /// to full corroboration and its strength can sit far above the threshold,
+    /// and nothing would ever look. Worse, on the ingest path the strengthen
+    /// call happened BEFORE the incoming attestation was merged, so the gate was
+    /// always evaluated one episode stale.
+    ///
+    /// The two callers are the two branches of
+    /// [`GraphMemory::add_relationship`], each immediately after the provenance
+    /// trail reaches its final state for that write. Promotion is deliberately
+    /// NOT driven from the decay/maintenance sweep: that would restore
+    /// "strengthen once, wait out the clock, promote" — burst promotion on a
+    /// timer — for edges with no corroborating episode at all.
+    pub fn reconsider_promotion_at(&mut self, now: DateTime<Utc>) -> Option<(String, String)> {
+        self.try_promote_at(now)
+    }
+
     /// The one place an edge changes tier upward.
     ///
     /// Two conditions, both required:
     ///
     /// 1. **Strength** ≥ the current tier's promotion threshold — the original
     ///    criterion, unchanged.
-    /// 2. **Sustained evidence**: at least
-    ///    [`EdgeTier::promotion_min_separation_secs`] has elapsed since this edge
-    ///    entered its current tier. The anchor is `promoted_at`, falling back to
-    ///    `created_at` for an edge that has never been promoted — which covers
-    ///    both legacy records (field absent, decodes to `None`) and the two
-    ///    production paths that mint directly into L2 (lineage bridges, fact
-    ///    edges) without ever passing through here.
+    /// 2. **Independent evidence**, satisfied by EITHER of:
+    ///    - at least [`EdgeTier::promotion_min_episodes`] distinct source
+    ///      episodes have attested the edge, or
+    ///    - at least [`EdgeTier::promotion_min_separation_secs`] has elapsed
+    ///      since this edge entered its current tier. The anchor is
+    ///      `promoted_at`, falling back to `created_at` for an edge that has
+    ///      never been promoted — which covers both legacy records (field
+    ///      absent, decodes to `None`) and the two production paths that mint
+    ///      directly into L2 (lineage bridges, fact edges) without ever passing
+    ///      through here.
     ///
-    /// Consequence, and the point of the change: a burst of strengthen calls
-    /// inside a single request can advance an edge **at most one tier**, no
-    /// matter how many paths touch it. Reaching L3 now takes ≥30 minutes to L2
-    /// and ≥24 hours more to L3, which is what "consolidated" is supposed to
-    /// mean. Promotion remains monotonic and at most one step per call.
+    /// The disjunction is the fix, and the two arms are not redundant. The
+    /// episode arm is what a batch-ingested graph can actually reach: a clock is
+    /// a property of the ingest schedule, not of the evidence, so a clock-only
+    /// gate froze every imported corpus at L1 permanently (see
+    /// [`EdgeTier::promotion_min_episodes`]). The clock arm is what edges with
+    /// no provenance trail can reach — memory↔memory `CoRetrieved` edges carry
+    /// `source_episode_id: None` and so never accumulate episodes; removing the
+    /// clock would make those, and every legacy record already on disk,
+    /// permanently unpromotable.
+    ///
+    /// The anti-burst property survives both arms. A burst of strengthen calls
+    /// inside one request moves neither: the clock does not advance, and the
+    /// episode count cannot move because all three in-request strengthen paths
+    /// derive from the SAME observation and `merge_provenance` deduplicates by
+    /// episode. Promotion remains monotonic and at most one step per call, so
+    /// reaching L3 always takes at least two separate calls.
     ///
     /// Returns `Some((old_tier_name, new_tier_name))` on promotion. This enables
     /// the memory-edge coupling: edge promotions can signal the memory layer to
@@ -1223,13 +1341,22 @@ impl RelationshipEdge {
         }
         let next_tier = self.tier.next_tier()?;
 
-        // Sustained-evidence gate. `promoted_at.unwrap_or(created_at)` is the
-        // moment this edge entered its current tier.
-        if let Some(min_secs) = self.tier.promotion_min_separation_secs() {
-            let entered_tier_at = self.promoted_at.unwrap_or(self.created_at);
-            if (now - entered_tier_at).num_seconds() < min_secs {
-                return None;
+        // Independent-evidence gate: corroboration OR elapsed time.
+        // `promoted_at.unwrap_or(created_at)` is the moment this edge entered
+        // its current tier.
+        let separated_by_clock = match self.tier.promotion_min_separation_secs() {
+            Some(min_secs) => {
+                let entered_tier_at = self.promoted_at.unwrap_or(self.created_at);
+                (now - entered_tier_at).num_seconds() >= min_secs
             }
+            None => false,
+        };
+        let corroborated = match self.tier.promotion_min_episodes() {
+            Some(min_episodes) => self.distinct_attesting_episodes() >= min_episodes,
+            None => false,
+        };
+        if !separated_by_clock && !corroborated {
+            return None;
         }
 
         let old_tier = self.tier;
@@ -4091,19 +4218,19 @@ impl GraphMemory {
                 }
             }
 
-            // Strengthen existing edge instead of creating duplicate
-            let _ = existing.strengthen();
-            existing.last_activated = now;
-
-            // Update context if new context is more informative
-            if edge.context.len() > existing.context.len() {
-                existing.context = edge.context;
-            }
-
             // Provenance capture (Increment 1, bug fix): the prior implementation
             // strengthened the synapse but DISCARDED the new attestation's source
             // episode. Merge the incoming attestation into the trail so every
             // source episode that wires this edge is recorded — not just the last.
+            //
+            // ORDERING IS LOAD-BEARING: this merge runs BEFORE `strengthen()`.
+            // Promotion is gated on the number of distinct attesting episodes
+            // (`EdgeTier::promotion_min_episodes`), and `strengthen()` ends by
+            // calling `try_promote_at`. Merging afterwards evaluated the gate
+            // against a trail that was always one attestation stale, so the
+            // episode that *earned* a promotion could never be the one that
+            // triggered it — on a batch ingest, where an edge's last attestation
+            // is usually its last write ever, that lost the promotion outright.
             if edge.provenance.is_empty() {
                 // Synthesize one attestation from the incoming edge's source
                 // episode. With no source episode there is nothing to attest, so
@@ -4126,6 +4253,16 @@ impl GraphMemory {
                 for record in edge.provenance.drain(..) {
                     merge_provenance(&mut existing.provenance, record);
                 }
+            }
+
+            // Strengthen existing edge instead of creating duplicate. This also
+            // runs the promotion gate, now against the up-to-date trail.
+            let _ = existing.strengthen_at(now);
+            existing.last_activated = now;
+
+            // Update context if new context is more informative
+            if edge.context.len() > existing.context.len() {
+                existing.context = edge.context;
             }
 
             // Persist the strengthened edge
@@ -4168,6 +4305,25 @@ impl GraphMemory {
             });
             edge.provenance.truncate(cap);
         }
+
+        // Reachability: an edge can be BORN corroborated. The SemanticFact path
+        // (`MemorySystem::connect_facts_to_graph`) seeds the trail from
+        // `fact.source_memories` — every memory that attested the fact — and
+        // mints straight into L2 without ever calling `strengthen`. Under the
+        // old code `try_promote_at` was reachable only from `strengthen_scaled_at`,
+        // so such an edge could carry full corroboration from birth and still
+        // never be considered for its tier unless something happened to
+        // re-strengthen it later.
+        //
+        // This cannot manufacture a tier on its own: birth strength is
+        // `EdgeTier::{L1,L2}::initial_weight()` scaled by semantic similarity
+        // (≤ 0.4 and ≤ 0.5 respectively), both strictly below the corresponding
+        // promotion thresholds (0.5 and 0.7), so the strength condition in
+        // `try_promote_at` rejects every currently-minted edge. It is here so
+        // that the invariant "promotion is evaluated wherever the evidence
+        // changes" holds at the choke point rather than by coincidence.
+        let born_at = edge.created_at;
+        let _ = edge.reconsider_promotion_at(born_at);
 
         // Store relationship
         let key = edge.uuid.as_bytes();
@@ -10465,6 +10621,323 @@ mod tests {
         }
         assert_eq!(promotions, 1, "the importance path shares the same clock");
         assert_eq!(edge.tier, EdgeTier::L2Episodic);
+    }
+
+    // =====================================================================
+    // Episode-based promotion: the evidence arm of the gate.
+    //
+    // The wall-clock arm alone made elapsed minutes a PRECONDITION for
+    // consolidation, which a batch ingest can never satisfy — every import,
+    // eval run and seeded deployment creates all of its edges within one
+    // pass, so the entire graph froze at L1 (trust 0.20) and then aged out
+    // on the L1 prune schedule. These tests pin both directions: a burst
+    // inside ONE episode must not promote, and genuine evidence across
+    // DISTINCT episodes must promote with no waiting.
+    // =====================================================================
+
+    /// Build an attestation for `episode`, observed at `at`.
+    fn attestation(episode: Uuid, at: DateTime<Utc>) -> ProvenanceRecord {
+        ProvenanceRecord {
+            source_episode_id: episode,
+            mention_count: 1,
+            first_observed: at,
+            last_observed: at,
+            confidence: None,
+            evidence_span: None,
+            typed_by: None,
+        }
+    }
+
+    #[test]
+    fn a_burst_inside_one_episode_never_promotes() {
+        // The anti-burst intent, restated in the units that actually carry it.
+        // One conversation mentioning two entities forty times is ONE source
+        // episode. It may hammer the edge through every strengthen path there
+        // is; with no elapsed time and no second episode, neither arm of the
+        // gate opens.
+        use crate::constants::*;
+        let now = Utc::now();
+        let episode = Uuid::new_v4();
+
+        let mut edge = create_test_edge(L1_INITIAL_WEIGHT, 0);
+        edge.created_at = now;
+        edge.last_activated = now;
+
+        // Forty mentions, all from the same episode, merged the way the ingest
+        // path merges them.
+        for _ in 0..40 {
+            merge_provenance(&mut edge.provenance, attestation(episode, now));
+            let promotion = edge.strengthen_at(now);
+            assert!(
+                promotion.is_none(),
+                "a burst inside one episode must not promote, got {promotion:?}"
+            );
+        }
+
+        assert_eq!(
+            edge.distinct_attesting_episodes(),
+            1,
+            "forty mentions of one episode are one episode"
+        );
+        assert_eq!(edge.provenance[0].mention_count, 40);
+        assert_eq!(
+            edge.tier,
+            EdgeTier::L1Working,
+            "the edge must still be L1 after a forty-mention burst"
+        );
+        // It is the EVIDENCE, not the strength, that is holding it back — the
+        // same property the clock-only gate asserted.
+        assert!(
+            edge.strength >= L2_PROMOTION_THRESHOLD,
+            "strength {} should already clear even the L3 bar",
+            edge.strength
+        );
+    }
+
+    #[test]
+    fn distinct_episodes_promote_with_no_wall_clock_wait() {
+        // The batch-ingest case: every attestation arrives within the same
+        // millisecond, from DIFFERENT source memories. This is real
+        // corroboration and must consolidate, which under a clock-only gate it
+        // never could.
+        use crate::constants::*;
+        let now = Utc::now();
+        let mut edge = create_test_edge(L1_INITIAL_WEIGHT, 0);
+        edge.created_at = now;
+        edge.last_activated = now;
+
+        // Episode 1: single observation. Not corroborated yet.
+        merge_provenance(&mut edge.provenance, attestation(Uuid::new_v4(), now));
+        assert!(edge.strengthen_at(now).is_none());
+        assert_eq!(edge.tier, EdgeTier::L1Working);
+
+        // Episode 2, same instant: L1 → L2, with zero elapsed time.
+        merge_provenance(&mut edge.provenance, attestation(Uuid::new_v4(), now));
+        let promotion = edge.strengthen_at(now);
+        assert_eq!(
+            promotion,
+            Some(("L1Working".to_string(), "L2Episodic".to_string())),
+            "two distinct attesting episodes must promote regardless of the clock"
+        );
+        assert_eq!(edge.tier, EdgeTier::L2Episodic);
+        assert_eq!(edge.promoted_at, Some(now));
+
+        // Episode 3, still the same instant: short of TIER_PROMOTION_L3_MIN_EPISODES.
+        merge_provenance(&mut edge.provenance, attestation(Uuid::new_v4(), now));
+        assert!(
+            edge.strengthen_at(now).is_none(),
+            "3 episodes is short of the {TIER_PROMOTION_L3_MIN_EPISODES} required for L3"
+        );
+        assert_eq!(edge.tier, EdgeTier::L2Episodic);
+
+        // Episode 4: L2 → L3. Two attestations BEYOND the two that earned L2 —
+        // the cumulative thresholds encode "evidence since entering this tier"
+        // without persisting a per-tier counter.
+        merge_provenance(&mut edge.provenance, attestation(Uuid::new_v4(), now));
+        assert_eq!(
+            edge.strengthen_at(now),
+            Some(("L2Episodic".to_string(), "L3Semantic".to_string()))
+        );
+        assert_eq!(edge.tier, EdgeTier::L3Semantic);
+
+        // L3 is still terminal.
+        assert!(edge.strengthen_at(now).is_none());
+    }
+
+    #[test]
+    fn corroboration_still_advances_at_most_one_tier_per_call() {
+        // The episode arm must not become a bypass for the one-step invariant:
+        // an edge that arrives fully corroborated may not skip L2.
+        use crate::constants::*;
+        let now = Utc::now();
+        let mut edge = create_test_edge(L1_INITIAL_WEIGHT, 0);
+        edge.created_at = now;
+        for _ in 0..TIER_PROMOTION_L3_MIN_EPISODES + 4 {
+            merge_provenance(&mut edge.provenance, attestation(Uuid::new_v4(), now));
+        }
+
+        let first = edge.strengthen_at(now);
+        assert_eq!(
+            first,
+            Some(("L1Working".to_string(), "L2Episodic".to_string())),
+            "however corroborated, the first step is L1 → L2"
+        );
+        assert_eq!(edge.tier, EdgeTier::L2Episodic);
+    }
+
+    #[test]
+    fn a_batch_ingested_edge_is_neither_frozen_at_l1_nor_pruned_out() {
+        // The two halves of the defect, end to end on one edge: under a
+        // clock-only gate a corroborated batch-ingested edge stayed at L1 with
+        // EDGE_TIER_TRUST_L1 = 0.20 and then fell below L1_PRUNE_THRESHOLD on
+        // the L1 decay schedule — roughly 79 idle hours — deleting an imported
+        // corpus on a timer. Corroboration now lifts it to L2, whose schedule it
+        // survives.
+        use crate::constants::*;
+        let ingest = Utc::now();
+        let mut edge = create_test_edge(L1_INITIAL_WEIGHT, 0);
+        edge.created_at = ingest;
+        edge.last_activated = ingest;
+
+        // Two source memories in the same import pass attest the same pair.
+        for _ in 0..2 {
+            merge_provenance(&mut edge.provenance, attestation(Uuid::new_v4(), ingest));
+            edge.strengthen_at(ingest);
+        }
+        assert_eq!(
+            edge.tier,
+            EdgeTier::L2Episodic,
+            "a corroborated batch-ingested edge must not be frozen at L1"
+        );
+        assert!(
+            EDGE_TIER_TRUST_L2 > EDGE_TIER_TRUST_L1,
+            "and must therefore no longer carry the L1 retrieval-trust penalty"
+        );
+
+        // Leaving L1 also unlocks the LTP machinery, which is an L2+ mechanism:
+        // `record_activation_timestamp` returns early for L1, so an edge frozen
+        // at L1 can never accumulate the activation history that Burst/Weekly
+        // LTP are detected from, and can therefore never earn LTP's decay
+        // protection or its prune shield, no matter how well attested it is.
+        assert!(
+            edge.activation_timestamps.is_some(),
+            "promotion must seed the activation history that LTP is detected from"
+        );
+
+        // Survives the L1 death horizon: an L1 edge from this ingest is prunable
+        // by ~59 idle hours (0.55 · e^{-0.029·59} < L1_PRUNE_THRESHOLD).
+        let mut frozen = create_test_edge(L1_INITIAL_WEIGHT, 0);
+        frozen.created_at = ingest;
+        frozen.last_activated = ingest;
+        frozen.strengthen_at(ingest);
+        assert_eq!(frozen.tier, EdgeTier::L1Working);
+        assert!(
+            frozen.decay_at(ingest + Duration::hours(59)),
+            "a single-attestation L1 edge at strength {} must still be prunable \
+             after 59 idle hours — singletons keep dying on the L1 schedule, \
+             which is the intended L1 semantics and is NOT what the fix changes",
+            frozen.strength
+        );
+
+        // The corroborated edge survives the same horizon — but NOT by
+        // arithmetic: its effective strength at 59h is ~0.12 against an L2
+        // prune threshold of 0.2, so on strength alone it would die EARLIER
+        // than the L1 singleton (~41.5h vs ~58.8h), because L2's threshold is
+        // double L1's at essentially the same executed decay rate. What saves
+        // it is `corroboration_protected()`: the same distinct-episode evidence
+        // that earned the promotion also shields it from strength-based
+        // pruning. Promotion and protection are one policy; splitting them
+        // would consolidate an edge and shorten its life in the same step.
+        let idle = ingest + Duration::hours(59);
+        assert!(
+            !edge.decay_at(idle),
+            "the corroborated edge must survive that horizon"
+        );
+        assert!(
+            edge.effective_strength() < edge.tier.prune_threshold(),
+            "and it must be surviving on corroboration, not on strength: \
+             effective {} vs threshold {}",
+            edge.effective_strength(),
+            edge.tier.prune_threshold()
+        );
+        // `decay_at`'s return value is only one of three prune doors. This is
+        // the one the lazy on-read path in `get_edges_for_entity` consults —
+        // the path that actually deletes edges out from under a live reader.
+        assert!(
+            edge.is_prune_protected(),
+            "the lazy on-read prune path must see the corroboration too"
+        );
+    }
+
+    #[test]
+    fn the_evidence_that_promotes_also_protects() {
+        // The load-bearing coupling, pinned so the two thresholds cannot drift
+        // apart. If the prune-protection minimum ever exceeds the L1→L2
+        // promotion minimum, edges in between are promoted onto a tier with
+        // DOUBLE the prune threshold while still unprotected — the fix would
+        // then shorten the life of exactly the batch-ingested edges it exists
+        // to rescue (~41.5 idle hours at L2 vs ~58.8 at L1, at birth weight).
+        use crate::constants::*;
+        assert!(
+            PROVENANCE_PRUNE_CORROBORATION_MIN_DEFAULT <= TIER_PROMOTION_L2_MIN_EPISODES,
+            "prune protection ({PROVENANCE_PRUNE_CORROBORATION_MIN_DEFAULT}) must not \
+             require more evidence than promotion ({TIER_PROMOTION_L2_MIN_EPISODES})"
+        );
+
+        // And the feature must be ON by default, or the coupling is inert.
+        assert_eq!(
+            provenance_prune_min(),
+            Some(PROVENANCE_PRUNE_CORROBORATION_MIN_DEFAULT),
+            "provenance-aware pruning must default to ON; if this fails because \
+             SHODH_PROVENANCE_AWARE_PRUNE is set in the environment, that is the \
+             kill switch working as designed"
+        );
+
+        // A single attestation is still unprotected: the fix rescues corroborated
+        // knowledge, not everything.
+        assert!(!corroboration_meets(
+            1,
+            Some(PROVENANCE_PRUNE_CORROBORATION_MIN_DEFAULT)
+        ));
+        assert!(corroboration_meets(
+            TIER_PROMOTION_L2_MIN_EPISODES,
+            Some(PROVENANCE_PRUNE_CORROBORATION_MIN_DEFAULT)
+        ));
+    }
+
+    #[test]
+    fn an_edge_with_no_provenance_still_obeys_the_clock() {
+        // Every RelationshipEdge already on disk predates the provenance trail,
+        // and memory↔memory CoRetrieved edges carry source_episode_id: None and
+        // so never accumulate episodes at all. Dropping the clock arm would make
+        // both permanently unpromotable. The disjunction is not belt-and-braces.
+        use crate::constants::*;
+        let birth = Utc::now();
+        let mut edge = create_test_edge(L1_INITIAL_WEIGHT, 0);
+        edge.created_at = birth;
+        assert_eq!(edge.distinct_attesting_episodes(), 0);
+
+        assert!(
+            edge.strengthen_at(birth).is_none(),
+            "no episodes and no elapsed time: neither arm is satisfied"
+        );
+        assert_eq!(edge.tier, EdgeTier::L1Working);
+
+        let past_window = birth + Duration::seconds(TIER_PROMOTION_WORKING_AGE_SECS + 1);
+        assert_eq!(
+            edge.strengthen_at(past_window),
+            Some(("L1Working".to_string(), "L2Episodic".to_string())),
+            "the clock arm must still work on its own"
+        );
+    }
+
+    #[test]
+    fn promotion_min_episodes_encodes_evidence_since_entering_the_tier() {
+        // The cumulative thresholds are what let the gate mean "independent
+        // evidence acquired since this edge entered its tier" without a
+        // persisted per-tier counter: L3's requirement must exceed L2's, or an
+        // edge could reach L3 on exactly the evidence that earned it L2.
+        use crate::constants::*;
+        let l1 = EdgeTier::L1Working.promotion_min_episodes().unwrap();
+        let l2 = EdgeTier::L2Episodic.promotion_min_episodes().unwrap();
+        assert!(
+            l2 > l1,
+            "L3 must require strictly more distinct episodes than L2: {l2} vs {l1}"
+        );
+        assert!(l1 >= 2, "corroboration means more than one observation");
+        assert_eq!(l1, TIER_PROMOTION_L2_MIN_EPISODES);
+        assert_eq!(l2, TIER_PROMOTION_L3_MIN_EPISODES);
+        assert_eq!(EdgeTier::L3Semantic.promotion_min_episodes(), None);
+
+        // The episode route to L3 is only reachable if the provenance trail can
+        // hold that many distinct sources. If SHODH_PROVENANCE_MAX_SOURCES is
+        // set below it the route silently closes (the clock route remains), so
+        // the DEFAULT cap must not close it.
+        assert!(
+            PROVENANCE_MAX_SOURCES_DEFAULT >= TIER_PROMOTION_L3_MIN_EPISODES,
+            "the default provenance cap ({PROVENANCE_MAX_SOURCES_DEFAULT}) must be able \
+             to hold {TIER_PROMOTION_L3_MIN_EPISODES} distinct episodes"
+        );
     }
 
     #[test]

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -4296,14 +4296,22 @@ impl GraphMemory {
                     },
                 );
             }
-        } else if edge.provenance.len() > provenance_max_sources() {
-            let cap = provenance_max_sources();
-            edge.provenance.sort_by(|a, b| {
-                b.mention_count
-                    .cmp(&a.mention_count)
-                    .then_with(|| b.last_observed.cmp(&a.last_observed))
-            });
-            edge.provenance.truncate(cap);
+        } else {
+            // A caller-seeded trail goes through `merge_provenance` too, rather
+            // than being capped in place. `merge_provenance` is the ONLY writer
+            // that maintains the trail's defining invariant — one record per
+            // distinct `source_episode_id` — and promotion now reads
+            // `provenance.len()` as a count of DISTINCT attesting episodes
+            // (see `RelationshipEdge::distinct_attesting_episodes`). The in-place
+            // sort+truncate that used to live here deduplicated nothing, so a
+            // caller that seeded the same episode twice (e.g. a `SemanticFact`
+            // whose `source_memories` repeats a memory id) would have inflated
+            // its own corroboration count. It also applies the same
+            // keep-the-strongest cap, so nothing is lost by routing through it.
+            let seeded = std::mem::take(&mut edge.provenance);
+            for record in seeded {
+                merge_provenance(&mut edge.provenance, record);
+            }
         }
 
         // Reachability: an edge can be BORN corroborated. The SemanticFact path
@@ -10908,6 +10916,43 @@ mod tests {
             edge.strengthen_at(past_window),
             Some(("L1Working".to_string(), "L2Episodic".to_string())),
             "the clock arm must still work on its own"
+        );
+    }
+
+    #[test]
+    fn a_caller_seeded_trail_is_deduplicated_by_episode() {
+        // `provenance.len()` is only a count of DISTINCT attesting episodes
+        // because `merge_provenance` is the sole writer. The `SemanticFact`
+        // ingest path seeds a whole trail at once from `fact.source_memories`,
+        // and nothing guarantees that list has no repeats — an edge could
+        // otherwise claim four attestations from one memory cited four times
+        // and promote straight past L2 on evidence it does not have.
+        let now = Utc::now();
+        let repeated = Uuid::new_v4();
+        let other = Uuid::new_v4();
+
+        let mut trail: Vec<ProvenanceRecord> = Vec::new();
+        for record in [
+            attestation(repeated, now),
+            attestation(repeated, now),
+            attestation(repeated, now),
+            attestation(other, now),
+        ] {
+            merge_provenance(&mut trail, record);
+        }
+
+        assert_eq!(
+            trail.len(),
+            2,
+            "one memory cited three times is one attesting episode"
+        );
+        let repeated_record = trail
+            .iter()
+            .find(|p| p.source_episode_id == repeated)
+            .expect("repeated episode present");
+        assert_eq!(
+            repeated_record.mention_count, 3,
+            "the repeats must land on mention_count, which promotion ignores"
         );
     }
 

--- a/tests/edge_tier_consolidation.rs
+++ b/tests/edge_tier_consolidation.rs
@@ -40,7 +40,13 @@ fn store_root(name: &str) -> PathBuf {
 }
 
 struct Store {
-    graph: GraphMemory,
+    /// `Option` so `Drop` can CLOSE the database before deleting its directory.
+    /// `Drop::drop` runs before the struct's fields are dropped, so holding a
+    /// plain `GraphMemory` here meant RocksDB still had the files open when
+    /// `remove_dir_all` ran: on Windows the delete fails, and because the
+    /// result was discarded it failed silently, leaving a multi-megabyte store
+    /// behind after every run. Always `take()` and drop the handle first.
+    graph: Option<GraphMemory>,
     path: PathBuf,
 }
 
@@ -49,14 +55,29 @@ impl Store {
         let path = store_root(name);
         std::fs::create_dir_all(&path).expect("create store dir");
         let graph = GraphMemory::new(&path, None).expect("open graph memory");
-        Store { graph, path }
+        Store {
+            graph: Some(graph),
+            path,
+        }
+    }
+
+    fn graph(&self) -> &GraphMemory {
+        self.graph.as_ref().expect("store is open")
     }
 }
 
 impl Drop for Store {
     fn drop(&mut self) {
-        // Best effort: RocksDB may still hold handles if a test panicked.
-        let _ = std::fs::remove_dir_all(&self.path);
+        // Close the DB first (see the field comment), then delete.
+        drop(self.graph.take());
+        if let Err(e) = std::fs::remove_dir_all(&self.path) {
+            // Report rather than swallow: a test store left under C:\smt is a
+            // real leak, and a silent one is how it goes unnoticed.
+            eprintln!(
+                "warning: could not delete test store {}: {e}",
+                self.path.display()
+            );
+        }
     }
 }
 
@@ -219,9 +240,9 @@ fn batch_ingest_consolidates_by_evidence_not_by_clock() {
         corpus.len()
     );
 
-    let ingest_secs = ingest(&store.graph, &corpus);
-    let census = store.graph.edge_tier_census().expect("census");
-    let edges = store.graph.get_all_relationships().expect("all edges");
+    let ingest_secs = ingest(store.graph(), &corpus);
+    let census = store.graph().edge_tier_census().expect("census");
+    let edges = store.graph().get_all_relationships().expect("all edges");
 
     // --- Episode histogram: the evidence the gate actually reads. ---
     let mut hist: HashMap<usize, usize> = HashMap::new();
@@ -377,9 +398,9 @@ fn corroborated_edges_survive_the_lazy_prune_path() {
     // promotion also shields it from strength-based pruning.
     let store = Store::open("prune");
     let corpus: Vec<CorpusItem> = load_corpus().into_iter().take(200).collect();
-    ingest(&store.graph, &corpus);
+    ingest(store.graph(), &corpus);
 
-    let edges = store.graph.get_all_relationships().expect("all edges");
+    let edges = store.graph().get_all_relationships().expect("all edges");
     let corroborated: Vec<_> = edges
         .iter()
         .filter(|e| e.distinct_attesting_episodes() >= TIER_PROMOTION_L2_MIN_EPISODES)

--- a/tests/edge_tier_consolidation.rs
+++ b/tests/edge_tier_consolidation.rs
@@ -97,15 +97,20 @@ fn load_corpus() -> Vec<CorpusItem> {
 /// reads. A census taken through the fallback would be a census of the fallback.
 fn build_ner() -> shodh_memory::embeddings::ner::NeuralNer {
     use shodh_memory::embeddings::ner::{NerConfig, NeuralNer};
-    NeuralNer::new(NerConfig::from_env()).unwrap_or_else(|e| {
-        panic!(
-            "this measurement requires the real NER weights, and refuses to \
-             silently substitute the rule-based fallback (different entity \
-             population => different episode-repeat distribution => a census of \
-             the fallback rather than of the corpus). Point \
-             SHODH_GLINER_MODEL_PATH at the model directory. Loader said: {e}"
-        )
-    })
+    let ner = NeuralNer::new(NerConfig::from_env()).expect("construct NER");
+    // `NeuralNer::new` NEVER returns Err for a missing model — it logs a warning
+    // and degrades to the rule-based fallback. A census taken through the
+    // fallback is a census of the fallback: a different entity population gives
+    // a different cross-episode repeat distribution, which is the only input
+    // this measurement reads. Fail loudly instead.
+    assert!(
+        !ner.is_fallback_mode(),
+        "this measurement requires the real GLiNER weights and refuses to \
+         silently substitute the rule-based fallback. Set SHODH_GLINER_MODEL_PATH \
+         to a directory containing model.onnx, tokenizer.json and \
+         label_embeddings.bin"
+    );
+    ner
 }
 
 /// Ingest a corpus the way `MemorySystem::connect_entities_in_graph` does:

--- a/tests/edge_tier_consolidation.rs
+++ b/tests/edge_tier_consolidation.rs
@@ -1,0 +1,404 @@
+//! Edge-tier consolidation on a BATCH-INGESTED store.
+//!
+//! Every import, every eval run and every seeded deployment ingests its corpus
+//! in one pass, so every edge is created within minutes of every other edge.
+//! Promotion used to be gated purely on wall-clock separation since an edge
+//! entered its tier (30 min L1→L2, 24 h L2→L3), which such a store can never
+//! satisfy: the entire graph stayed at `L1Working`, carrying `EDGE_TIER_TRUST_L1`
+//! (0.20, a 4x retrieval-trust penalty against L3) and aging out on the L1 prune
+//! schedule. The gate now also accepts distinct attesting *episodes*, which is
+//! what the clock was standing in for.
+//!
+//! These tests measure that on a real RocksDB store built from a real corpus
+//! through the real `add_relationship` ingest path, and pin the invariants that
+//! keep the result defensible in BOTH directions: no edge may be promoted
+//! without independent evidence, and no edge WITH independent evidence may be
+//! left frozen at L1.
+//!
+//! Run with `--nocapture` to see the census and the episode histogram.
+
+use shodh_memory::constants::{
+    L1_INITIAL_WEIGHT, TIER_PROMOTION_L2_MIN_EPISODES, TIER_PROMOTION_L3_MIN_EPISODES,
+    TIER_PROMOTION_WORKING_AGE_SECS,
+};
+use shodh_memory::graph_memory::{
+    EdgeTier, EntityLabel, EntityNode, GraphMemory, LtpStatus, RelationType, RelationshipEdge,
+};
+use shodh_memory::uuid::Uuid;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Where test stores live.
+///
+/// NOT under the repo and NOT under any synced/indexed directory: a file watcher
+/// of the search-indexer/AV class silently drops tantivy commits there, which
+/// makes a store look intact while being subtly wrong. Short path also keeps
+/// RocksDB's internal filenames inside MAX_PATH on Windows.
+fn store_root(name: &str) -> PathBuf {
+    let base = std::env::var("SHODH_TEST_STORE_ROOT").unwrap_or_else(|_| "C:/smt".to_string());
+    PathBuf::from(base).join(format!("tierstore-{name}-{}", Uuid::new_v4()))
+}
+
+struct Store {
+    graph: GraphMemory,
+    path: PathBuf,
+}
+
+impl Store {
+    fn open(name: &str) -> Self {
+        let path = store_root(name);
+        std::fs::create_dir_all(&path).expect("create store dir");
+        let graph = GraphMemory::new(&path, None).expect("open graph memory");
+        Store { graph, path }
+    }
+}
+
+impl Drop for Store {
+    fn drop(&mut self) {
+        // Best effort: RocksDB may still hold handles if a test panicked.
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+/// One corpus item: the unit that becomes one memory, i.e. one *episode*.
+struct CorpusItem {
+    id: String,
+    content: String,
+}
+
+/// Load the LoCoMo gate corpus — 629 real conversational turns, the same text
+/// the CI recall gate runs on. Deliberately a REAL corpus: the only property
+/// this measurement depends on is how often the same entity pair recurs across
+/// DIFFERENT episodes, and that distribution must come from real data rather
+/// than from a shape chosen by whoever wrote the test.
+fn load_corpus() -> Vec<CorpusItem> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/recall/corpora/locomo-gate.jsonl");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read corpus {}: {e}", path.display()));
+
+    raw.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|line| {
+            let v: serde_json::Value = serde_json::from_str(line).expect("corpus line is JSON");
+            CorpusItem {
+                id: v["id"].as_str().expect("corpus item id").to_string(),
+                content: v["content"].as_str().expect("corpus item content").to_string(),
+            }
+        })
+        .collect()
+}
+
+/// Extract entity mentions with the production NER.
+///
+/// Uses the real GLiNER weights, never `new_fallback`: the fallback extractor
+/// produces a different entity population and therefore a different
+/// cross-episode repeat distribution, which is the ONLY thing this measurement
+/// reads. A census taken through the fallback would be a census of the fallback.
+fn build_ner() -> shodh_memory::embeddings::ner::NeuralNer {
+    use shodh_memory::embeddings::ner::{NerConfig, NeuralNer};
+    NeuralNer::new(NerConfig::from_env()).unwrap_or_else(|e| {
+        panic!(
+            "this measurement requires the real NER weights, and refuses to \
+             silently substitute the rule-based fallback (different entity \
+             population => different episode-repeat distribution => a census of \
+             the fallback rather than of the corpus). Point \
+             SHODH_GLINER_MODEL_PATH at the model directory. Loader said: {e}"
+        )
+    })
+}
+
+/// Ingest a corpus the way `MemorySystem::connect_entities_in_graph` does:
+/// resolve each mention to an entity, then attest a `CoOccurs` edge for every
+/// unordered pair of distinct entities in the episode, tagged with that
+/// episode's id. `add_relationship` does the rest — dedup onto the existing
+/// edge, provenance merge, strengthen, promotion.
+///
+/// Returns the wall-clock seconds the ingest took, which is load-bearing: the
+/// "before" figure in this measurement is a theorem, not an estimate, and it
+/// only holds while the whole pass fits inside one promotion window.
+fn ingest(graph: &GraphMemory, corpus: &[CorpusItem]) -> i64 {
+    let ner = build_ner();
+    let started = chrono::Utc::now();
+    // Entity name -> uuid, so the same name in different episodes is the same node.
+    let mut entities: HashMap<String, Uuid> = HashMap::new();
+
+    for item in corpus {
+        // One corpus item = one memory = one episode, minted exactly once here.
+        // This id is what `merge_provenance` deduplicates on, and therefore what
+        // "distinct attesting episodes" counts.
+        debug_assert!(!item.id.is_empty(), "corpus item must have an id");
+        let episode_id = Uuid::new_v4();
+
+        let mut names: Vec<String> = ner
+            .extract(&item.content)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|e| e.text.trim().to_string())
+            .filter(|n| !n.is_empty())
+            .collect();
+        names.sort();
+        names.dedup();
+        if names.len() < 2 {
+            continue;
+        }
+
+        let mut ids = Vec::with_capacity(names.len());
+        for name in &names {
+            let id = match entities.get(name) {
+                Some(id) => *id,
+                None => {
+                    let node = EntityNode {
+                        uuid: Uuid::new_v4(),
+                        name: name.clone(),
+                        labels: vec![EntityLabel::Concept],
+                        created_at: chrono::Utc::now(),
+                        last_seen_at: chrono::Utc::now(),
+                        mention_count: 1,
+                        summary: String::new(),
+                        attributes: HashMap::new(),
+                        name_embedding: None,
+                        salience: 0.5,
+                        is_proper_noun: true,
+                        selectivity: None,
+                        fine_type: None,
+                    };
+                    let id = graph.add_entity(node).expect("add entity");
+                    entities.insert(name.clone(), id);
+                    id
+                }
+            };
+            ids.push(id);
+        }
+
+        for i in 0..ids.len() {
+            for j in (i + 1)..ids.len() {
+                let now = chrono::Utc::now();
+                let edge = RelationshipEdge {
+                    uuid: Uuid::new_v4(),
+                    from_entity: ids[i],
+                    to_entity: ids[j],
+                    relation_type: RelationType::CoOccurs,
+                    strength: L1_INITIAL_WEIGHT,
+                    created_at: now,
+                    valid_at: now,
+                    invalidated_at: None,
+                    source_episode_id: Some(episode_id),
+                    context: String::new(),
+                    last_activated: now,
+                    activation_count: 1,
+                    ltp_status: LtpStatus::None,
+                    tier: EdgeTier::L1Working,
+                    activation_timestamps: None,
+                    entity_confidence: Some(0.8),
+                    endpoint_selectivity: None,
+                    forman_curvature: None,
+                    provenance: Vec::new(),
+                    promoted_at: None,
+                };
+                graph.add_relationship(edge).expect("add relationship");
+            }
+        }
+    }
+
+    (chrono::Utc::now() - started).num_seconds()
+}
+
+#[test]
+fn batch_ingest_consolidates_by_evidence_not_by_clock() {
+    let store = Store::open("census");
+    let corpus = load_corpus();
+    assert!(
+        corpus.len() > 100,
+        "expected the real gate corpus, got {} items",
+        corpus.len()
+    );
+
+    let ingest_secs = ingest(&store.graph, &corpus);
+    let census = store.graph.edge_tier_census().expect("census");
+    let edges = store.graph.get_all_relationships().expect("all edges");
+
+    // --- Episode histogram: the evidence the gate actually reads. ---
+    let mut hist: HashMap<usize, usize> = HashMap::new();
+    for e in &edges {
+        *hist.entry(e.distinct_attesting_episodes()).or_default() += 1;
+    }
+    let with_at_least = |n: usize| -> usize {
+        edges
+            .iter()
+            .filter(|e| e.distinct_attesting_episodes() >= n)
+            .count()
+    };
+    let total = edges.len();
+    let pct = |n: usize| if total == 0 { 0.0 } else { 100.0 * n as f64 / total as f64 };
+
+    println!("\n=== batch-ingested store: {} episodes, {total} edges ===", corpus.len());
+    println!("ingest wall-clock: {ingest_secs}s");
+    println!(
+        "AFTER (episode-aware gate):  L1 {} ({:.1}%)  L2 {} ({:.1}%)  L3 {} ({:.1}%)",
+        census.l1_working,
+        pct(census.l1_working),
+        census.l2_episodic,
+        pct(census.l2_episodic),
+        census.l3_semantic,
+        pct(census.l3_semantic),
+    );
+    println!(
+        "BEFORE (clock-only gate):    L1 {total} (100.0%)  L2 0 (0.0%)  L3 0 (0.0%)  [see assertion below]"
+    );
+    println!(
+        "mean strength: L1 {:.4}  L2 {:.4}  L3 {:.4}   below-prune-threshold: {}",
+        census.l1_mean_strength,
+        census.l2_mean_strength,
+        census.l3_mean_strength,
+        census.below_prune_threshold
+    );
+    let mut keys: Vec<_> = hist.keys().copied().collect();
+    keys.sort();
+    for k in keys {
+        println!("  edges attested by {k} distinct episode(s): {}", hist[&k]);
+    }
+    println!(
+        ">= {TIER_PROMOTION_L2_MIN_EPISODES} episodes: {} ({:.1}%)   >= {TIER_PROMOTION_L3_MIN_EPISODES} episodes: {} ({:.1}%)",
+        with_at_least(TIER_PROMOTION_L2_MIN_EPISODES),
+        pct(with_at_least(TIER_PROMOTION_L2_MIN_EPISODES)),
+        with_at_least(TIER_PROMOTION_L3_MIN_EPISODES),
+        pct(with_at_least(TIER_PROMOTION_L3_MIN_EPISODES)),
+    );
+
+    assert_eq!(
+        census.total_scanned, total,
+        "census must scan every edge — a shortfall means a decode failure it swallowed"
+    );
+
+    // --- The "before" figure is a theorem, not a measurement. ---
+    // The clock arm anchors at `promoted_at.unwrap_or(created_at)`, and every
+    // edge here was created during this ingest. If the whole pass fits inside
+    // one L1->L2 window, then NO edge could have satisfied the clock arm, so a
+    // clock-only gate leaves 100% of this store at L1. That is the entire
+    // defect: the outcome is a property of the ingest schedule, not of the
+    // evidence.
+    assert!(
+        ingest_secs < TIER_PROMOTION_WORKING_AGE_SECS,
+        "ingest took {ingest_secs}s, which is longer than the {TIER_PROMOTION_WORKING_AGE_SECS}s \
+         L1->L2 window; the 100%-L1 'before' figure only holds for a pass that fits inside it"
+    );
+
+    // --- Direction 1: nothing is promoted without independent evidence. ---
+    // This is the anti-burst intent, checked on every edge in a real store
+    // rather than on a hand-built one.
+    for e in &edges {
+        match e.tier {
+            EdgeTier::L1Working => {}
+            EdgeTier::L2Episodic => assert!(
+                e.distinct_attesting_episodes() >= TIER_PROMOTION_L2_MIN_EPISODES,
+                "L2 edge {} has only {} distinct attesting episode(s)",
+                e.uuid,
+                e.distinct_attesting_episodes()
+            ),
+            EdgeTier::L3Semantic => assert!(
+                e.distinct_attesting_episodes() >= TIER_PROMOTION_L3_MIN_EPISODES,
+                "L3 edge {} has only {} distinct attesting episode(s) — a semantic-tier \
+                 edge carries a 4x retrieval-trust multiplier and must be corroborated",
+                e.uuid,
+                e.distinct_attesting_episodes()
+            ),
+        }
+    }
+
+    // --- Direction 2: no edge WITH real support is left frozen at L1. ---
+    // An L1 edge may only be there because it lacks corroboration or because it
+    // has not reached the strength threshold; never because the wall clock
+    // refused to move during a batch ingest.
+    for e in &edges {
+        if e.tier == EdgeTier::L1Working
+            && e.distinct_attesting_episodes() >= TIER_PROMOTION_L2_MIN_EPISODES
+        {
+            assert!(
+                e.strength < EdgeTier::L1Working.promotion_threshold().unwrap(),
+                "edge {} has {} distinct attesting episodes and strength {} — it is \
+                 frozen at L1 for no reason the gate can justify",
+                e.uuid,
+                e.distinct_attesting_episodes(),
+                e.strength
+            );
+        }
+    }
+
+    // --- The store must actually consolidate something. ---
+    // Without this the two invariants above are trivially satisfiable by never
+    // promoting anything, which is precisely the defect.
+    assert!(
+        census.l2_episodic + census.l3_semantic > 0,
+        "a batch-ingested real corpus must consolidate SOME edges; got 100% L1, \
+         which is the clock-only behaviour this change exists to fix"
+    );
+
+    // --- And it must not consolidate everything. ---
+    // The other failure mode: a census on this class of store once showed 81%
+    // L3 under burst promotion. Rather than pinning a percentage (which would
+    // be a number chosen to match today's corpus), pin the structural claim:
+    // the L3 population cannot exceed the population that has the evidence for
+    // it. Combined with the histogram printed above, that bounds the outcome
+    // with a fact about the data instead of a tuned constant.
+    assert!(
+        census.l3_semantic <= with_at_least(TIER_PROMOTION_L3_MIN_EPISODES),
+        "more L3 edges ({}) than edges with {TIER_PROMOTION_L3_MIN_EPISODES}+ distinct \
+         attesting episodes ({})",
+        census.l3_semantic,
+        with_at_least(TIER_PROMOTION_L3_MIN_EPISODES)
+    );
+}
+
+#[test]
+fn corroborated_edges_survive_the_lazy_prune_path() {
+    // The second half of the defect: an edge frozen at L1 also faced lazy-prune
+    // deletion once its decayed strength fell under `L1_PRUNE_THRESHOLD`. The
+    // promotion fix alone does NOT rescue it — L2's prune threshold is double
+    // L1's at essentially the same executed decay rate over the first three
+    // days, so a promoted-but-unprotected edge becomes prunable EARLIER. What
+    // rescues it is that the same distinct-episode evidence which earns
+    // promotion also shields it from strength-based pruning.
+    let store = Store::open("prune");
+    let corpus: Vec<CorpusItem> = load_corpus().into_iter().take(200).collect();
+    ingest(&store.graph, &corpus);
+
+    let edges = store.graph.get_all_relationships().expect("all edges");
+    let corroborated: Vec<_> = edges
+        .iter()
+        .filter(|e| e.distinct_attesting_episodes() >= TIER_PROMOTION_L2_MIN_EPISODES)
+        .collect();
+    assert!(
+        !corroborated.is_empty(),
+        "corpus produced no corroborated edges; the rest of this test is vacuous"
+    );
+
+    for e in &corroborated {
+        assert!(
+            e.is_prune_protected(),
+            "edge {} is attested by {} distinct episodes and must not be deletable \
+             by the strength-only lazy prune path",
+            e.uuid,
+            e.distinct_attesting_episodes()
+        );
+    }
+
+    // Singletons are NOT protected. The fix rescues corroborated knowledge, not
+    // everything: an entity pair seen exactly once and never again still ages
+    // out, which is what L1/working memory means.
+    let singletons: Vec<_> = edges
+        .iter()
+        .filter(|e| e.distinct_attesting_episodes() <= 1)
+        .collect();
+    if !singletons.is_empty() {
+        assert!(
+            singletons.iter().all(|e| !e.is_prune_protected()),
+            "single-attestation edges must remain subject to normal pruning"
+        );
+    }
+    println!(
+        "corroborated (protected): {}   singletons (unprotected): {}",
+        corroborated.len(),
+        singletons.len()
+    );
+}

--- a/tests/edge_tier_consolidation.rs
+++ b/tests/edge_tier_consolidation.rs
@@ -93,8 +93,8 @@ struct CorpusItem {
 /// DIFFERENT episodes, and that distribution must come from real data rather
 /// than from a shape chosen by whoever wrote the test.
 fn load_corpus() -> Vec<CorpusItem> {
-    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/recall/corpora/locomo-gate.jsonl");
+    let path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/recall/corpora/locomo-gate.jsonl");
     let raw = std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("read corpus {}: {e}", path.display()));
 
@@ -104,7 +104,10 @@ fn load_corpus() -> Vec<CorpusItem> {
             let v: serde_json::Value = serde_json::from_str(line).expect("corpus line is JSON");
             CorpusItem {
                 id: v["id"].as_str().expect("corpus item id").to_string(),
-                content: v["content"].as_str().expect("corpus item content").to_string(),
+                content: v["content"]
+                    .as_str()
+                    .expect("corpus item content")
+                    .to_string(),
             }
         })
         .collect()
@@ -256,9 +259,18 @@ fn batch_ingest_consolidates_by_evidence_not_by_clock() {
             .count()
     };
     let total = edges.len();
-    let pct = |n: usize| if total == 0 { 0.0 } else { 100.0 * n as f64 / total as f64 };
+    let pct = |n: usize| {
+        if total == 0 {
+            0.0
+        } else {
+            100.0 * n as f64 / total as f64
+        }
+    };
 
-    println!("\n=== batch-ingested store: {} episodes, {total} edges ===", corpus.len());
+    println!(
+        "\n=== batch-ingested store: {} episodes, {total} edges ===",
+        corpus.len()
+    );
     println!("ingest wall-clock: {ingest_secs}s");
     println!(
         "AFTER (episode-aware gate):  L1 {} ({:.1}%)  L2 {} ({:.1}%)  L3 {} ({:.1}%)",

--- a/tests/edge_tier_consolidation.rs
+++ b/tests/edge_tier_consolidation.rs
@@ -272,9 +272,20 @@ fn batch_ingest_consolidates_by_evidence_not_by_clock() {
     );
 
     assert_eq!(
-        census.total_scanned, total,
-        "census must scan every edge — a shortfall means a decode failure it swallowed"
+        census.l1_working + census.l2_episodic + census.l3_semantic,
+        census.total_scanned,
+        "every scanned edge must land in exactly one tier bucket"
     );
+    // This ingest invalidates nothing, so the census (which counts all edges)
+    // and `get_all_relationships` (which drops invalidated ones) must agree. A
+    // shortfall here means the census swallowed a decode failure, which would
+    // make every percentage below a fraction of the wrong denominator.
+    assert_eq!(
+        census.total_scanned, total,
+        "census scanned {} edges but the store holds {total}",
+        census.total_scanned
+    );
+    assert!(total > 0, "ingest produced no edges");
 
     // --- The "before" figure is a theorem, not a measurement. ---
     // The clock arm anchors at `promoted_at.unwrap_or(created_at)`, and every


### PR DESCRIPTION
**Do not merge until the recall gate has run on this branch.** `EDGE_TIER_TRUST_*` moves 0.20 → 0.50/0.80 for 12.1% of edges on exactly the batch-ingested store shape the eval harness builds, so movement on the LoCoMo gate is likely and the direction is genuinely unpredictable. The baseline is untouched.

## The defect

Promotion's "sustained evidence" gate was wall-clock only, which made elapsed minutes a *precondition for consolidation*. The clock is a property of the ingest schedule, not of the evidence — so every batch-ingested corpus (every import, every eval run, every seeded deployment) froze at L1 with trust 0.20 and then faced lazy-prune death. Measured on a real store: 629 LoCoMo memories → 605 edges, ingested in 20s, **100% stuck at L1** because no edge could satisfy the 1800s clock.

Separately, `try_promote_at` was reachable only from `strengthen_scaled_at`, so promotion required being re-strengthened *later* — which is exactly what a batch-ingested edge never gets.

## The fix

The gate is now a **disjunction**: distinct attesting **episodes** ≥ threshold, OR the existing elapsed-time separation. Distinct episodes measure what the clock stood in for — `merge_provenance` deduplicates by `source_episode_id`, so one conversation mentioning two entities forty times is one episode however many times it is re-read, and repeats land on `mention_count`, which promotion ignores. The anti-burst intent survives intact; its pre-existing tests pass unmodified.

Thresholds are **cumulative** (2 for L1→L2, 4 for L2→L3), which gives "evidence since entering this tier" with **no persisted counter and no schema change** — `EDGE_PROVENANCE_DEFAULT_SUFFIX` stays 4 bytes and the old-bytes round-trip tests are untouched.

**The coupling that nearly shipped wrong**: promotion alone would have made things *worse* for the band it rescues. L2's prune threshold is double L1's while the executed decay rate is near-identical over the first three days, so a promoted edge becomes prunable at ~41.5 idle hours versus ~58.8 at L1. That calculation falsified the first draft of the test. `provenance_prune_min()` now defaults ON with its threshold **derived from** `TIER_PROMOTION_L2_MIN_EPISODES` so the two cannot drift, covering all three prune doors — a `decay_at`-only fix would have left the lazy on-read path deleting corroborated edges anyway. Invariant: the evidence that earns promotion also earns survival. Singletons stay unprotected.

**A one-line ordering bug found on the way**: provenance was merged *after* `strengthen_at` in `add_relationship`, so the gate was always evaluated one attestation stale and the episode that earned a promotion could never be the one that triggered it. On batch ingest, where an edge's last attestation is usually its last write ever, that lost the promotion outright.

Rejected, with reasons in the commits: removing the clock arm (memory↔memory `CoRetrieved` edges carry no episode id and every pre-trail record on disk would become permanently unpromotable — pinned by a test); a session-level guard (`Memory` has no session id; `session_id` is a recall *query* option, so this needs a schema change threaded through ingest); a persisted per-tier counter (cumulative thresholds get it free); and fixing the `min_prune_hours` bypass (would make every L2/L3 edge unprunable for 30/90 days regardless of evidence).

## Measured

| | L1 | L2 | L3 |
|---|---|---|---|
| Before (clock-only) | 605 (100%) | 0 | 0 |
| After | 532 (87.9%) | 54 (8.9%) | 19 (3.1%) |
| Historical burst semantics | — | — | ~81% |

73 edges have ≥2 episodes; 73 were promoted — every edge with the evidence got it, none without. Both earlier extremes (81% L3 under burst promotion, 100% L1 under the clock) are gone.

**Tests**: `cargo test --lib` 968 passed / 0 failed; integration 136 passed / 0 failed across consolidation, graph_memory, hebbian and tiering; the new `edge_tier_consolidation` suite run twice with bit-identical numbers. Executed in **debug** — see below.

## Part 1 (the release test-harness break) is NOT fixed

The handoff's description was wrong in its specifics: it is not `src/main.rs:142/159` and not E0308, but `src/bin/recall_eval.rs` with 14× E0599 on `.context()` plus E0277 on serde bounds. `cargo check --release --bins --tests` **passes**; `cargo test --test X` in debug **passes**; only `cargo test --release --test X` fails — so it is not dev-dependency feature unification, not bins-in-normal-mode, and not the release profile on bins. Duplicate-crate, no-std, and cfg-gating hypotheses were each killed with evidence.

Why nobody noticed, proven against ci.yml: every CI cell is green — `cargo build --release` (bins, no dev-deps), `cargo test --lib`, and `cargo test --test` in **debug**. The single broken cell is the one nothing exercises.

A labelled candidate remains (not established): `[profile.release] panic = "abort"` while test harnesses require unwind, making this the only command that builds abort bins alongside unwind harnesses. The confirming A/B was killed by machine contention. Handoff in the branch: run the failing command **unfiltered** and read the `note:` lines, then A/B with `CARGO_PROFILE_RELEASE_PANIC=unwind`.

## Follow-ups reported, deliberately not fixed

**L2 decay calibration is inverted**: executed L2 λ ≈ L1's, with double the prune threshold. `L2_DECAY_PER_DAY = 0.031` is documented but **inert** — `decay_at` routes L2 through the hybrid curve and never calls `tier_decay_factor(tier=1)`, a 22× gap between the documented and executed rate. "L2 = 30 days" is false in the executed path. Also: `min_prune_hours` is computed but applied only on the age branch, and `NeuralNer::new` never returns `Err` for missing GLiNER assets — it warns and silently degrades, so any measurement that does not assert `!is_fallback_mode()` may be measuring the fallback. This census asserts it.