### PR TITLE
fix(lineage): InformedBy reads forwards; rank before truncating

### DIFF
--- a/src/handlers/graph.rs
+++ b/src/handlers/graph.rs
@@ -209,9 +209,18 @@ pub async fn get_episode(
 pub struct GetAllEntitiesRequest {
     pub user_id: String,
     pub limit: Option<usize>,
+    /// Include each entity's 384-float `name_embedding` in the response.
+    ///
+    /// Defaults to FALSE. The embedding is roughly 3KB of JSON per entity, so a
+    /// 500-entity listing shipped about 3MB that every known caller discarded
+    /// on arrival. It stays available for a caller that genuinely wants to
+    /// compute similarity itself; it is no longer the price of asking which
+    /// entities exist.
+    #[serde(default)]
+    pub include_embeddings: bool,
 }
 
-/// POST /api/graph/entities/all - Get all entities
+/// POST /api/graph/entities/all - Get all entities, most salient first
 pub async fn get_all_entities(
     State(state): State<AppState>,
     Json(req): Json<GetAllEntitiesRequest>,
@@ -223,7 +232,8 @@ pub async fn get_all_entities(
         .map_err(AppError::Internal)?;
 
     let limit = req.limit.unwrap_or(100);
-    let entities = tokio::task::spawn_blocking(move || {
+    let include_embeddings = req.include_embeddings;
+    let mut entities = tokio::task::spawn_blocking(move || {
         let graph_guard = graph.read();
         graph_guard.get_all_entities()
     })
@@ -231,7 +241,31 @@ pub async fn get_all_entities(
     .map_err(|e| AppError::Internal(anyhow::anyhow!("Task join error: {e}")))?
     .map_err(|e| AppError::Internal(anyhow::anyhow!(e)))?;
 
-    let entities: Vec<_> = entities.into_iter().take(limit).collect();
+    // Rank BEFORE truncating. Taking `limit` straight off the iterator returned
+    // whatever storage order produced, so "the 100 entities" meant 100
+    // arbitrary ones — a caller asking for the graph's cast of characters got
+    // an unordered sample, and the most important entity in the graph could sit
+    // outside it for no reason it could observe.
+    //
+    // Salience is the ranking the graph already computes for exactly this
+    // question ("how much does this entity matter here"); mention count breaks
+    // ties, and name breaks those, so the order is total and the same request
+    // twice returns the same page.
+    entities.sort_by(|a, b| {
+        b.salience
+            .partial_cmp(&a.salience)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.mention_count.cmp(&a.mention_count))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    entities.truncate(limit);
+
+    if !include_embeddings {
+        for entity in &mut entities {
+            entity.name_embedding = None;
+        }
+    }
+
     let count = entities.len();
 
     Ok(Json(serde_json::json!({

--- a/src/memory/lineage.rs
+++ b/src/memory/lineage.rs
@@ -47,8 +47,11 @@ impl CausalRelation {
     ///
     /// When edge A→B has relation R, traversing B→A should show R.inverse().
     /// True pairs: Caused↔ResolvedBy. Directional relations (InformedBy,
-    /// TriggeredBy) are self-inverse because the from/to already encodes
-    /// directionality — "A informed-by B" reversed is "B informed A".
+    /// TriggeredBy) are self-inverse because the from/to already encodes the
+    /// direction: the edge label does not change when you walk it backwards,
+    /// only the sentence you read off it does. Edge A→B labelled InformedBy
+    /// reads "A informed B" forwards and "B was informed by A" backwards, and
+    /// both describe the same stored edge.
     pub fn inverse(&self) -> Self {
         match self {
             CausalRelation::Caused => CausalRelation::ResolvedBy,
@@ -82,7 +85,14 @@ impl CausalRelation {
         match self {
             CausalRelation::Caused => "caused",
             CausalRelation::ResolvedBy => "was resolved by",
-            CausalRelation::InformedBy => "was informed by",
+            // "informed", not "was informed by": every relation here is read
+            // FROM → TO, and the inference table writes (Learning, Decision) =>
+            // InformedBy with from = the learning that informed the decision
+            // (`infer_by_types`, and its own comment "observation informed a
+            // decision"). The passive reading inverted the causal arrow. The
+            // "-By" in the variant name is a label, not the sentence — the same
+            // is already true of TriggeredBy, which reads "triggered".
+            CausalRelation::InformedBy => "informed",
             CausalRelation::SupersededBy => "was superseded by",
             CausalRelation::TriggeredBy => "triggered",
             CausalRelation::BranchedFrom => "branched from",
@@ -468,8 +478,29 @@ impl LineageGraph {
         Ok(edges)
     }
 
-    /// List all edges for a user
+    /// List a user's lineage edges, newest first.
+    ///
+    /// `limit` bounds what is RETURNED, not what is scanned. The scan itself is
+    /// capped separately at [`EDGE_SCAN_LIMIT`] because the two limits answer
+    /// different questions: the caller says how many edges it wants, and the
+    /// cap says how much of the store we are willing to read to rank them.
+    ///
+    /// Truncating during the scan and sorting afterwards — which is what this
+    /// did — makes "newest first" untrue: it returns the newest members of an
+    /// arbitrary storage-order prefix, so an edge created a minute ago is
+    /// invisible behind `limit` older ones that happen to sort earlier by key.
+    /// A caller asking for the ten most recent edges got ten edges that were
+    /// merely recent among the first ten found.
     pub fn list_edges(&self, user_id: &str, limit: usize) -> Result<Vec<LineageEdge>> {
+        /// How many edges a single listing will read before it stops ranking.
+        ///
+        /// Ordering by recency requires seeing every candidate, but a user with
+        /// a very large lineage graph should not turn one listing into an
+        /// unbounded scan. Ten thousand matches the cap `stats()` already uses
+        /// for the same trade-off. Beyond it the result is still newest-first
+        /// within what was read, which is the same guarantee `stats()` gives.
+        const EDGE_SCAN_LIMIT: usize = 10_000;
+
         let prefix = format!("lineage:edges:{}:", user_id);
         let mut edges = Vec::new();
 
@@ -488,14 +519,15 @@ impl LineageGraph {
 
             if let Ok((edge, _)) = crate::serialization::try_decode::<LineageEdge>(&value) {
                 edges.push(edge);
-                if edges.len() >= limit {
+                if edges.len() >= EDGE_SCAN_LIMIT {
                     break;
                 }
             }
         }
 
-        // Sort by creation time (newest first)
+        // Rank the whole scanned set, THEN cut to what the caller asked for.
         edges.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        edges.truncate(limit);
         Ok(edges)
     }
 
@@ -1533,6 +1565,63 @@ mod tests {
 
         let to_edges = graph.get_edges_to("user-1", &to1).unwrap();
         assert_eq!(to_edges.len(), 1);
+    }
+
+    /// Every relation's verb must read correctly FROM → TO.
+    ///
+    /// This is the test whose absence let `InformedBy` describe itself as "was
+    /// informed by" while the inference table wrote `(Learning, Decision) =>
+    /// InformedBy` — from = the learning that informed the decision. The
+    /// sentence inverted the causal arrow, and nothing caught it because
+    /// `description()` has no callers inside this crate: it is rendered by
+    /// clients, so a wrong verb is invisible here and wrong everywhere else.
+    ///
+    /// Read each assertion as a sentence with the edge's endpoints substituted
+    /// in. "-By" in a variant name is a label, not the sentence: `TriggeredBy`
+    /// has always read "triggered" for the same reason.
+    #[test]
+    fn every_relation_reads_correctly_from_source_to_target() {
+        // (Error, Task) => Caused — "the error caused the task"
+        assert_eq!(CausalRelation::Caused.description(), "caused");
+        // (Task, Learning) => ResolvedBy — "the task was resolved by the learning"
+        assert_eq!(CausalRelation::ResolvedBy.description(), "was resolved by");
+        // (Learning, Decision) => InformedBy — "the learning informed the decision"
+        assert_eq!(CausalRelation::InformedBy.description(), "informed");
+        // (Discovery, Task) => TriggeredBy — "the discovery triggered the task"
+        assert_eq!(CausalRelation::TriggeredBy.description(), "triggered");
+        // (Decision, Decision) => SupersededBy, from = the earlier decision —
+        // "the older decision was superseded by the newer one"
+        assert_eq!(
+            CausalRelation::SupersededBy.description(),
+            "was superseded by"
+        );
+        // Branch anchoring writes from = pivot, to = origin
+        assert_eq!(CausalRelation::BranchedFrom.description(), "branched from");
+        assert_eq!(CausalRelation::RelatedTo.description(), "is related to");
+    }
+
+    /// `from` is the EARLIER memory, and the inferred relation must agree.
+    ///
+    /// Pins the convention the verbs above depend on: `infer_relation(a, b)`
+    /// treats `a` as the cause-side memory. If that ever flips, the sentences
+    /// become wrong even though every individual verb is still "correct".
+    #[test]
+    fn inference_reads_the_earlier_memory_as_the_source() {
+        let (graph, _dir) = create_test_graph();
+
+        let learning = create_test_memory(ExperienceType::Learning, vec!["auth", "login"]);
+        let mut decision = create_test_memory(ExperienceType::Decision, vec!["auth", "login"]);
+        decision.created_at = learning.created_at + Duration::days(1);
+
+        let (relation, _) = graph
+            .infer_relation(&learning, &decision)
+            .expect("learning → decision is a known type pair");
+        assert_eq!(relation, CausalRelation::InformedBy);
+        // The whole sentence, as a client would render it.
+        assert_eq!(
+            format!("learning {} decision", relation.description()),
+            "learning informed decision"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Three defects found while acting on the MCP agent's report. Two are the same bug in different files.

## `InformedBy` described itself backwards

`infer_by_types(from_type, to_type)` takes its tuple in from→to order and writes `(Learning, Decision) => InformedBy` — from is the learning that *informed* the decision. Confirmed three ways before touching it: the signature, the table's own comment ("observation informed a decision"), and the existing tests' convention that `from` is the earlier memory. `description()` returned "was informed by", which inverts the causal arrow for every client that renders it.

It now reads **"informed"**, consistent with `TriggeredBy` already reading "triggered" — the "-By" in a variant name is a label, not the sentence.

I checked the siblings for the same class of error rather than assuming it was isolated: `Caused`, `ResolvedBy`, `SupersededBy` ("older was superseded by newer", from = earlier) and `BranchedFrom` all read correctly.

**Why it drifted:** `description()` has zero callers inside this crate. It is rendered by clients, so a wrong verb is invisible in-tree and wrong everywhere else. Two tests now pin it — each relation read as a sentence with its endpoints substituted in, and the earlier-memory-is-source convention the verbs depend on. 31 lineage tests pass.

## `list_edges` sorted *after* truncating

"Newest first" actually meant newest among an arbitrary storage-order prefix: an edge created a minute ago sat invisible behind `limit` older ones that happened to key earlier, and a caller asking for the ten most recent got ten that were merely recent among the first ten found.

It now ranks the scanned set and then cuts. The scan is capped separately at 10,000 — the same bound `stats()` already uses for the same trade-off — because the caller's limit and the scan cap answer different questions: how many edges you want, versus how much of the store we will read to rank them.

## `entities/all` never ranked at all

`take(limit)` straight off storage order, so "the 100 entities" meant 100 arbitrary ones and the graph's most important entity could sit outside the page for no reason the caller could observe. Now ordered by **salience** — the ranking the graph already computes for exactly this question — with mention count and then name breaking ties, so the order is total and the same request twice returns the same page.

Its `name_embedding` is now **opt-in** via `include_embeddings`. At ~3KB of JSON per entity, a 500-entity listing shipped about 3MB that every known caller discarded on arrival; the only in-repo consumers are one test and the MCP tools, which drop it. Still available for a caller that wants to compute similarity itself.

Both endpoint fixes remove the client-side ranking workaround the new MCP tools had to carry.