### PR TITLE
feat(mcp): annotations that are true, and structured output — plus the reason read tools were writing

### DIFF
--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -37,6 +37,12 @@ import { renderContent, MEMORY_PREVIEW_MAX } from "./memory-format";
 import { ShodhIpcClient, type WindowsIpcHelper } from "./ipc-client";
 import { DrainController } from "./drain";
 import {
+  decorateTool,
+  isReadOnlyTool,
+  TOOL_OUTPUT_SCHEMAS,
+  type ToolDefinition,
+} from "./tool-metadata";
+import {
   shodhDataRoot,
   loadOrCreatePersistedApiKey,
   publishSharedApiKey,
@@ -552,6 +558,96 @@ function getType(m: Memory): string {
   return m.memory_type || m.experience?.memory_type || m.experience?.experience_type || 'Observation';
 }
 
+// =============================================================================
+// STRUCTURED OUTPUT HELPERS
+//
+// These build the `structuredContent` payloads that accompany (never replace)
+// the formatted text, matching the schemas declared in ./tool-metadata.ts.
+// Undefined-valued keys are dropped so the payload carries only what the
+// backend actually returned rather than a wall of nulls.
+// =============================================================================
+
+/** Drop undefined-valued keys so optional schema fields stay genuinely absent. */
+function compact(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined && v !== null) out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Structured form of a memory, matching the MEMORY_ITEM schema fragment.
+ *
+ * `full` mirrors the tool's own full_content flag so the structured body is
+ * exactly the body the text rendered — a consumer reading structuredContent
+ * must not silently get a different amount of text than the human-readable
+ * channel. `content_truncated` states which it is, so a consumer never has to
+ * guess whether it holds the whole memory.
+ */
+function structuredMemory(m: Memory, full: boolean = false): Record<string, unknown> {
+  const body = getContent(m);
+  const truncated = !full && body.length > MEMORY_PREVIEW_MAX;
+  return compact({
+    id: m.id,
+    content: truncated ? body.slice(0, MEMORY_PREVIEW_MAX) : body,
+    content_truncated: truncated,
+    memory_type: getType(m),
+    tags: m.experience?.tags,
+    score: m.score,
+    importance: m.importance,
+    created_at: m.created_at,
+    tier: m.tier,
+  });
+}
+
+/** Wire shape of a todo as returned by /api/todos/* — only the fields projected. */
+interface TodoWire {
+  id?: string;
+  seq_num?: number;
+  project_prefix?: string | null;
+  project?: string | null;
+  content?: string;
+  status?: string;
+  priority?: string;
+  due_date?: string | null;
+  created_at?: string;
+  score?: number;
+  similarity_score?: number | null;
+}
+
+/**
+ * Structured form of a todo, matching the TODO_ITEM schema fragment.
+ *
+ * This is a PROJECTION, not a pass-through: the wire todo carries the full
+ * embedding vector (hundreds of floats) and the entire comment thread, and
+ * echoing those into structuredContent would dwarf the text channel it is
+ * meant to complement.
+ *
+ * `short_id` mirrors `Todo::short_id()` in src/memory/types.rs exactly —
+ * "{project_prefix|SHO}-{seq_num}" when seq_num > 0, otherwise "SHO-{first 4
+ * chars of the uuid}".
+ */
+function structuredTodo(t: TodoWire): Record<string, unknown> {
+  const shortId =
+    t.seq_num && t.seq_num > 0
+      ? `${t.project_prefix || "SHO"}-${t.seq_num}`
+      : t.id
+        ? `SHO-${t.id.slice(0, 4)}`
+        : undefined;
+  return compact({
+    id: t.id,
+    short_id: shortId,
+    content: t.content,
+    status: t.status,
+    priority: t.priority,
+    project: t.project ?? undefined,
+    score: t.score ?? t.similarity_score ?? undefined,
+    created_at: t.created_at,
+    due_date: t.due_date ?? undefined,
+  });
+}
+
 // Helper: Sleep for retry delays
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -645,6 +741,14 @@ function formatSurfacedMemories(memories: SurfacedMemory[]): string {
 function streamToolCall(toolName: string, args: Record<string, unknown>, resultText: string): void {
   // Skip ingesting memory management tools to avoid noise
   if (["remember", "recall", "forget", "list_memories"].includes(toolName)) return;
+
+  // Tools annotated readOnlyHint:true must not modify the store, and this path
+  // fires on EVERY call (tool output is essentially always over the streaming
+  // minimum), so without the gate every read tool would write a "Tool: X /
+  // Result: ..." memory. That is also circular by this function's own stated
+  // intent — recording what the store already knows back into the store.
+  // Conversation capture stays the job of proactive_context and the hooks.
+  if (isReadOnlyTool(toolName)) return;
 
   const argsStr = JSON.stringify(args, null, 2);
   const content = `Tool: ${toolName}\nInput: ${argsStr}\nResult: ${resultText.slice(0, 1000)}${resultText.length > 1000 ? "..." : ""}`;
@@ -740,6 +844,26 @@ interface LineageEdgeWire {
   branch_id: string | null;
   created_at: string;
   reinforcement_count: number;
+}
+
+/**
+ * Structured form of a lineage edge, matching the LINEAGE_EDGE schema fragment.
+ *
+ * The wire calls the identifier `id`; both the formatted text and
+ * validate_causal_link's parameter call it `edge_id`, so the structured channel
+ * follows the surface rather than the wire.
+ */
+function structuredLineageEdge(edge: LineageEdgeWire): Record<string, unknown> {
+  return {
+    edge_id: edge.id,
+    from: edge.from,
+    to: edge.to,
+    relation: edge.relation,
+    confidence: edge.confidence,
+    source: edge.source,
+    created_at: edge.created_at,
+    reinforcement_count: edge.reinforcement_count,
+  };
 }
 
 function formatLineageEdge(
@@ -849,10 +973,13 @@ const server = new Server(
   }
 );
 
-// List available tools
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return {
-    tools: [
+// Tool definitions. Behavioural annotations (readOnlyHint/destructiveHint/
+// idempotentHint/openWorldHint, plus a display title) and output schemas are
+// NOT written inline here — they live in ./tool-metadata.ts as a single source
+// of truth, because the read-only set also gates ambient memory ingestion
+// (see autoStreamContext / streamToolCall). decorateTool() merges them in and
+// throws if a tool is missing an entry, so the two can never drift.
+const TOOL_DEFINITIONS: ToolDefinition[] = [
       {
         name: "remember",
         description: "Store a memory for future recall. Use this to remember important information, decisions, user preferences, project context, or anything you want to recall later.",
@@ -2051,14 +2178,23 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ["memory_ids", "outcome"],
         },
       },
-    ],
-  };
+];
+
+// List available tools, decorated with annotations and output schemas.
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return { tools: TOOL_DEFINITIONS.map(decorateTool) };
 });
 
 // Auto-stream context from tool arguments (captures conversation intent)
 function autoStreamContext(toolName: string, args: Record<string, unknown>): void {
   // Skip tools that already handle their own streaming or are meta/diagnostic
   if (["proactive_context", "streaming_status", "token_status", "reset_token_session"].includes(toolName)) return;
+
+  // Tools annotated readOnlyHint:true must not modify the store. Streaming a
+  // memory here would make that annotation false — a client auto-approving
+  // "safe" tools would then silently write on every read. The annotation is the
+  // contract; this gate is what makes it true.
+  if (isReadOnlyTool(toolName)) return;
 
   // Extract meaningful context from tool arguments
   let context = "";
@@ -2112,7 +2248,19 @@ const handleCallTool = async (request: CallToolRequest) => {
   }
 
   // Result type for tool responses
-  type ToolResult = { content: { type: string; text: string }[]; isError?: boolean };
+  // Result type for tool responses.
+  //
+  // `structuredContent` is the machine-readable channel that accompanies the
+  // formatted text; `content` is always populated as well (the MCP spec expects
+  // it for backwards compatibility, and the formatted text reads better inline
+  // for small results). Any tool declaring an outputSchema MUST set this on
+  // every non-error return — the SDK client throws when an outputSchema is
+  // declared and structuredContent is absent on a successful call.
+  type ToolResult = {
+    content: { type: string; text: string }[];
+    isError?: boolean;
+    structuredContent?: Record<string, unknown>;
+  };
 
   // Inner function to execute tool logic - allows us to capture result for auto-ingest
   const executeTool = async (): Promise<ToolResult> => {
@@ -2239,6 +2387,7 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         return {
           content: [{ type: "text", text: response }],
+          structuredContent: { id: result.id, memory_type: type, tags },
         };
       }
 
@@ -2382,6 +2531,33 @@ const handleCallTool = async (request: CallToolRequest) => {
         const stats = result.retrieval_stats;
         const lineage = result.lineage || [];
 
+        // Structured payload for both the empty and non-empty paths. A tool
+        // that declares an outputSchema must emit structuredContent on EVERY
+        // successful return, including "nothing found" — the SDK client rejects
+        // a schema'd success result that omits it.
+        const recallStructured = (): Record<string, unknown> => ({
+          query,
+          mode,
+          memories: memories.map((m) => structuredMemory(m, full_content)),
+          todos: todos.map((t) =>
+            compact({
+              id: t.id,
+              short_id: t.short_id,
+              content: t.content,
+              status: t.status,
+              priority: t.priority,
+              project: t.project,
+              score: t.score,
+              created_at: t.created_at,
+            }),
+          ),
+          lineage: lineage.map((e) =>
+            compact({ from: e.from, to: e.to, relation: e.relation, confidence: e.confidence }),
+          ),
+          memory_count: memories.length,
+          todo_count: todos.length,
+        });
+
         if (memories.length === 0 && todos.length === 0) {
           return {
             content: [
@@ -2390,6 +2566,7 @@ const handleCallTool = async (request: CallToolRequest) => {
                 text: `🐘 No memories or todos found for: "${query}"\n   Mode: ${mode}`,
               },
             ],
+            structuredContent: recallStructured(),
           };
         }
 
@@ -2550,6 +2727,7 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         return {
           content: [{ type: "text", text: response }],
+          structuredContent: recallStructured(),
         };
       }
 
@@ -2572,9 +2750,16 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         const tagMemories = tagResult.memories || [];
 
+        const tagStructured = (): Record<string, unknown> => ({
+          tags,
+          memories: tagMemories.map((m) => structuredMemory(m, full_content)),
+          count: tagMemories.length,
+        });
+
         if (tagMemories.length === 0) {
           return {
             content: [{ type: "text", text: `No memories found matching tags: ${tags.join(", ")}` }],
+            structuredContent: tagStructured(),
           };
         }
 
@@ -2592,6 +2777,7 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         return {
           content: [{ type: "text", text: tagResponse.trimEnd() }],
+          structuredContent: tagStructured(),
         };
       }
 
@@ -2718,12 +2904,18 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         const memories = (result.memories || []).slice(0, limit);
 
+        const listStructured = (): Record<string, unknown> => ({
+          memories: memories.map((m) => structuredMemory(m)),
+          count: memories.length,
+        });
+
         if (memories.length === 0) {
           let response = `🐘 Memory List\n`;
           response += `━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`;
           response += `No memories stored yet.`;
           return {
             content: [{ type: "text", text: response }],
+            structuredContent: listStructured(),
           };
         }
 
@@ -2765,6 +2957,7 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         return {
           content: [{ type: "text", text: response.trimEnd() }],
+          structuredContent: listStructured(),
         };
       }
 
@@ -2783,16 +2976,24 @@ const handleCallTool = async (request: CallToolRequest) => {
       }
 
       case "memory_stats": {
+        // Wire shape of GET /api/users/{id}/stats. The tier counts and
+        // total_retrievals are returned by the current backend but were missing
+        // from this interface; they are declared here because the structured
+        // payload passes them through.
         interface MemoryStats {
           total_memories: number;
-          memory_types: Record<string, number>;
-          total_importance: number;
-          avg_importance: number;
-          average_importance: number; // API uses this name
+          memory_types?: Record<string, number>;
+          total_importance?: number;
+          avg_importance?: number;
+          average_importance?: number; // API uses this name
           graph_nodes: number;
           graph_edges: number;
-          indexed_vectors: number;
-          vector_index_count: number; // API uses this name
+          indexed_vectors?: number;
+          vector_index_count?: number; // API uses this name
+          working_memory_count?: number;
+          session_memory_count?: number;
+          long_term_memory_count?: number;
+          total_retrievals?: number;
         }
 
         const result = await apiCall<MemoryStats>(`/api/users/${encodeURIComponent(USER_ID)}/stats`, "GET");
@@ -2835,6 +3036,18 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         return {
           content: [{ type: "text", text: response.trimEnd() }],
+          structuredContent: compact({
+            total_memories: result.total_memories ?? 0,
+            working_memory_count: result.working_memory_count,
+            session_memory_count: result.session_memory_count,
+            long_term_memory_count: result.long_term_memory_count,
+            vector_index_count: indexedCount,
+            average_importance: avgImportance,
+            total_retrievals: result.total_retrievals,
+            graph_nodes: result.graph_nodes,
+            graph_edges: result.graph_edges,
+            memory_types: result.memory_types,
+          }),
         };
       }
 
@@ -2869,6 +3082,13 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         return {
           content: [{ type: "text", text: response }],
+          structuredContent: {
+            is_healthy: result.is_healthy,
+            total_storage: result.total_storage,
+            total_indexed: result.total_indexed,
+            orphaned_count: result.orphaned_count,
+            orphaned_ids: result.orphaned_ids || [],
+          },
         };
       }
 
@@ -3006,6 +3226,20 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         return {
           content: [{ type: "text", text: response.trimEnd() }],
+          structuredContent: {
+            backups: (result.backups || []).map((b) =>
+              compact({
+                backup_id: b.backup_id,
+                created_at: b.created_at,
+                backup_type: b.backup_type,
+                size_bytes: b.size_bytes,
+                memory_count: b.memory_count,
+                checksum: b.checksum,
+                sequence_number: b.sequence_number,
+              }),
+            ),
+            count: result.count ?? (result.backups || []).length,
+          },
         };
       }
 
@@ -3199,8 +3433,20 @@ const handleCallTool = async (request: CallToolRequest) => {
         // including <task-notification> XML which overwhelms BM25 and embedding.
         const cleanedContext = stripSystemNoise(context).slice(0, MAX_CONTEXT_LENGTH);
         if (cleanedContext.length < PROACTIVE_MIN_CONTEXT_LENGTH) {
+          // Returns before the backend call, so nothing was surfaced and
+          // nothing was ingested regardless of the auto_ingest argument.
           return {
             content: [{ type: "text", text: "No relevant memories surfaced (context too short after cleaning).\n\n[Latency: 0.0ms]" }],
+            structuredContent: {
+              memories: [],
+              detected_entities: [],
+              todos: [],
+              facts: [],
+              count: 0,
+              // Returns before the backend call, so nothing could be ingested
+              // whatever the argument said.
+              ingest_requested: false,
+            },
           };
         }
 
@@ -3249,6 +3495,53 @@ const handleCallTool = async (request: CallToolRequest) => {
         const entities = result.detected_entities || [];
 
         const facts = result.relevant_facts || [];
+
+        // Shared by the "nothing surfaced" and the fully-populated returns.
+        //
+        // `ingest_requested` echoes the argument rather than claiming an
+        // outcome. The backend spawns the ingest in a background task and waits
+        // only 50ms to read the id back (handlers/recall.rs), so
+        // `ingested_memory_id` is frequently absent for contexts that WERE
+        // stored — deriving a boolean "auto_ingested" from it would report
+        // false while a memory was being written.
+        const proactiveStructured = (): Record<string, unknown> => ({
+          memories: memories.map((m) => {
+            const body = m.content ?? "";
+            const truncated = !full_content && body.length > MEMORY_PREVIEW_MAX;
+            return compact({
+              id: m.id,
+              content: truncated ? body.slice(0, MEMORY_PREVIEW_MAX) : body,
+              content_truncated: truncated,
+              memory_type: m.memory_type,
+              score: m.score,
+              importance: m.importance,
+              tags: m.tags,
+              relevance_reason: m.relevance_reason,
+              matched_entities: m.matched_entities,
+              created_at: m.created_at,
+            });
+          }),
+          detected_entities: entities.map((e) => compact({ name: e.name, entity_type: e.entity_type })),
+          todos: (result.relevant_todos || []).map((t) =>
+            compact({
+              id: t.id,
+              short_id: t.short_id,
+              content: t.content,
+              status: t.status,
+              priority: t.priority,
+              project: t.project ?? undefined,
+              score: t.similarity_score ?? undefined,
+            }),
+          ),
+          facts: facts.map((f) =>
+            compact({ id: f.id, fact: f.fact, confidence: f.confidence, support_count: f.support_count }),
+          ),
+          count: memories.length,
+          ingest_requested: auto_ingest,
+          ...(result.ingested_memory_id ? { ingested_memory_id: result.ingested_memory_id } : {}),
+          ...(result.latency_ms !== undefined ? { latency_ms: result.latency_ms } : {}),
+        });
+
         if (memories.length === 0 && result.reminder_count === 0 && result.todo_count === 0 && facts.length === 0) {
           const entityList = entities.length > 0
             ? `\n\nDetected entities: ${entities.map(e => `"${e.name}" (${e.entity_type})`).join(', ')}`
@@ -3266,6 +3559,7 @@ const handleCallTool = async (request: CallToolRequest) => {
 
           return {
             content: [{ type: "text", text: emptyText }],
+            structuredContent: proactiveStructured(),
           };
         }
 
@@ -3417,6 +3711,7 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         return {
           content: [{ type: "text", text: responseText }],
+          structuredContent: proactiveStructured(),
         };
       }
 
@@ -3972,9 +4267,27 @@ const handleCallTool = async (request: CallToolRequest) => {
           status: status === "all" ? null : status,
         });
 
+        const remindersStructured = (): Record<string, unknown> => ({
+          status_filter: status,
+          reminders: (result.reminders || []).map((r) =>
+            compact({
+              id: r.id,
+              content: r.content,
+              status: r.status,
+              trigger_type: r.trigger_type,
+              due_at: r.due_at ?? undefined,
+              created_at: r.created_at,
+              priority: r.priority,
+              overdue_seconds: r.overdue_seconds ?? undefined,
+            }),
+          ),
+          count: result.count ?? (result.reminders || []).length,
+        });
+
         if (result.count === 0) {
           return {
             content: [{ type: "text", text: `No ${status === "all" ? "" : status + " "}reminders found.` }],
+            structuredContent: remindersStructured(),
           };
         }
 
@@ -3998,6 +4311,7 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         return {
           content: [{ type: "text", text: response }],
+          structuredContent: remindersStructured(),
         };
       }
 
@@ -4090,6 +4404,7 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         return {
           content: [{ type: "text", text: result.formatted }],
+          structuredContent: structuredTodo(result.todo as TodoWire),
         };
       }
 
@@ -4119,7 +4434,7 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         interface ListTodosResponse {
           success: boolean;
-          todos: unknown[];
+          todos: TodoWire[];
           projects: unknown[];
           formatted: string;
           count: number;
@@ -4139,6 +4454,11 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         return {
           content: [{ type: "text", text: result.formatted }],
+          structuredContent: {
+            todos: (result.todos || []).map(structuredTodo),
+            count: (result.todos || []).length,
+            ...(result.count !== undefined ? { total: result.count } : {}),
+          },
         };
       }
 
@@ -4270,9 +4590,29 @@ const handleCallTool = async (request: CallToolRequest) => {
       }
 
       case "list_projects": {
+        // `projects` arrives as (Project, ProjectStats) tuples — see
+        // handlers/todos.rs list_projects — hence the pair type.
+        interface ProjectWire {
+          id?: string;
+          name?: string;
+          prefix?: string | null;
+          description?: string | null;
+          status?: string;
+          parent_id?: string | null;
+        }
+        interface ProjectStatsWire {
+          total?: number;
+          backlog?: number;
+          todo?: number;
+          in_progress?: number;
+          blocked?: number;
+          done?: number;
+          cancelled?: number;
+        }
         interface ListProjectsResponse {
           success: boolean;
-          projects: unknown[];
+          count?: number;
+          projects: [ProjectWire, ProjectStatsWire][];
           formatted: string;
         }
 
@@ -4280,8 +4620,24 @@ const handleCallTool = async (request: CallToolRequest) => {
           user_id: USER_ID,
         });
 
+        const projectPairs = result.projects || [];
+
         return {
           content: [{ type: "text", text: result.formatted }],
+          structuredContent: {
+            projects: projectPairs.map(([p, stats]) =>
+              compact({
+                id: p?.id,
+                name: p?.name,
+                prefix: p?.prefix ?? undefined,
+                description: p?.description ?? undefined,
+                status: p?.status,
+                parent_id: p?.parent_id ?? undefined,
+                stats: stats ? compact({ ...stats }) : undefined,
+              }),
+            ),
+            count: result.count ?? projectPairs.length,
+          },
         };
       }
 
@@ -4324,8 +4680,10 @@ const handleCallTool = async (request: CallToolRequest) => {
       }
 
       case "todo_stats": {
+        // Flat status counts (UserTodoStats), passed through as-is rather than
+        // reshaped — a renaming layer would drift from the backend.
         interface TodoStatsResponse {
-          stats: unknown;
+          stats: Record<string, number>;
           formatted: string;
         }
 
@@ -4335,6 +4693,7 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         return {
           content: [{ type: "text", text: result.formatted }],
+          structuredContent: { total: 0, ...(result.stats || {}) },
         };
       }
 
@@ -4343,7 +4702,7 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         interface ListSubtasksResponse {
           success: boolean;
-          todos: unknown[];
+          todos: TodoWire[];
           formatted: string;
         }
 
@@ -4352,8 +4711,15 @@ const handleCallTool = async (request: CallToolRequest) => {
           "GET"
         );
 
+        const subtasks = result.todos || [];
+
         return {
           content: [{ type: "text", text: result.formatted }],
+          structuredContent: {
+            parent_id,
+            subtasks: subtasks.map(structuredTodo),
+            count: subtasks.length,
+          },
         };
       }
 
@@ -4388,10 +4754,18 @@ const handleCallTool = async (request: CallToolRequest) => {
       case "list_todo_comments": {
         const { todo_id } = args as { todo_id: string };
 
+        interface CommentWire {
+          id?: string;
+          content?: string;
+          author?: string;
+          comment_type?: string;
+          created_at?: string;
+          updated_at?: string | null;
+        }
         interface CommentListResponse {
           success: boolean;
           count: number;
-          comments: unknown[];
+          comments: CommentWire[];
           formatted: string;
         }
 
@@ -4400,8 +4774,23 @@ const handleCallTool = async (request: CallToolRequest) => {
           "GET"
         );
 
+        const comments = result.comments || [];
+
         return {
           content: [{ type: "text", text: result.formatted }],
+          structuredContent: {
+            todo_id,
+            comments: comments.map((c) =>
+              compact({
+                id: c.id,
+                content: c.content,
+                author: c.author,
+                comment_type: c.comment_type,
+                created_at: c.created_at,
+              }),
+            ),
+            count: result.count ?? comments.length,
+          },
         };
       }
 
@@ -4492,8 +4881,11 @@ const handleCallTool = async (request: CallToolRequest) => {
         }
 
         if (!memory) {
+          // Reported as a successful call rather than an error (unchanged
+          // behaviour); the structured payload says so explicitly.
           return {
             content: [{ type: "text", text: `Memory not found: ${memory_id}` }],
+            structuredContent: { found: false, id: memory_id },
           };
         }
 
@@ -4519,6 +4911,21 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         return {
           content: [{ type: "text", text: response }],
+          structuredContent: compact({
+            found: true,
+            id: memory.id,
+            // read_memory's whole purpose is the untruncated body, so the
+            // structured channel carries it in full too.
+            content: memory.experience.content,
+            memory_type: memory.experience.experience_type,
+            entities: memory.experience.entities,
+            created_at: memory.created_at,
+            importance: memory.importance,
+            tier: memory.tier,
+            parent_id: memory.parent_id,
+            children_ids: memory.children_ids,
+            children_count: memory.children_count,
+          }),
         };
       }
 
@@ -4579,6 +4986,20 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         const edges = trace.edges || [];
 
+        // The text render caps how many edges it prints; the structured payload
+        // deliberately does not — a consumer parsing it should see the whole
+        // traced chain, not the display subset.
+        const traceStructured = (): Record<string, unknown> =>
+          compact({
+            memory_id: trace.root ?? resolvedId,
+            direction,
+            root_cause_id: rootCause?.root_cause_id ?? undefined,
+            edges: edges.map(structuredLineageEdge),
+            path: trace.path,
+            depth_reached: trace.depth,
+            edge_count: edges.length,
+          });
+
         if (edges.length === 0) {
           const hint = direction === "both"
             ? "This memory has no causal edges at all yet."
@@ -4588,6 +5009,7 @@ const handleCallTool = async (request: CallToolRequest) => {
               type: "text",
               text: `🔗 No causal edges found ${direction} from ${resolvedId} (depth ${depth}).\n${hint}\nEdges are inferred automatically at ingest from type + entity overlap + temporal order, or recorded explicitly with add_causal_link.`,
             }],
+            structuredContent: traceStructured(),
           };
         }
 
@@ -4625,7 +5047,7 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         response += `\nUse read_memory for full content, validate_causal_link (edge_id + confirm/reject) to curate an edge.`;
 
-        return { content: [{ type: "text", text: response }] };
+        return { content: [{ type: "text", text: response }], structuredContent: traceStructured() };
       }
 
       case "list_causal_edges": {
@@ -4657,12 +5079,21 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         const edges = edgesResult.edges || [];
 
+        const edgesStructured = (): Record<string, unknown> =>
+          compact({
+            edges: edges.map(structuredLineageEdge),
+            count: edges.length,
+            total: stats?.total_edges,
+            stats: stats ? { ...stats } : undefined,
+          });
+
         if (edges.length === 0) {
           return {
             content: [{
               type: "text",
               text: `🔗 The causal lineage graph is empty.\nEdges are inferred automatically at ingest (memory type + entity overlap + temporal order) and can be added explicitly with add_causal_link.`,
             }],
+            structuredContent: edgesStructured(),
           };
         }
 
@@ -4697,7 +5128,9 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         response += `Use trace_lineage(memory_id) for the chain around one memory; validate_causal_link(edge_id, verdict) to confirm or reject an inferred edge.`;
 
-        return { content: [{ type: "text", text: response }] };
+        // `edges` has been sorted and truncated to edgeLimit above, so the
+        // structured payload carries exactly the edges the text lists.
+        return { content: [{ type: "text", text: response }], structuredContent: edgesStructured() };
       }
 
       case "add_causal_link": {
@@ -4839,8 +5272,19 @@ const handleCallTool = async (request: CallToolRequest) => {
         } catch (e) {
           const msg = e instanceof Error ? e.message : String(e);
           if (msg.includes("API error 404")) {
+            // Reported as a successful call rather than an error (unchanged
+            // behaviour); `found: false` carries that in the structured channel.
             return {
               content: [{ type: "text", text: `Entity not found in the knowledge graph: "${entity_name}" (no exact, case-insensitive, stemmed, or substring match). Use list_entities to see what the graph knows.` }],
+              structuredContent: {
+                query: entity_name,
+                found: false,
+                max_depth: depth,
+                entities: [],
+                relationships: [],
+                entity_count: 0,
+                relationship_count: 0,
+              },
             };
           }
           throw e;
@@ -4916,7 +5360,47 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         response += `\nUse explore_entity on a neighbor to keep walking, or recall to read the memories behind a relationship's context.`;
 
-        return { content: [{ type: "text", text: response }] };
+        // The text render caps entities at 30 and typed relationships at 20;
+        // the structured payload carries the full traversal so a consumer is
+        // not silently handed a display subset.
+        return {
+          content: [{ type: "text", text: response }],
+          structuredContent: compact({
+            query: entity_name,
+            found: true,
+            matched_entity: origin?.name,
+            max_depth: depth,
+            entities: sortedEntities.map((t) =>
+              compact({
+                id: t.entity.uuid,
+                name: t.entity.name,
+                entity_type: t.entity.fine_type || t.entity.labels.join("/") || "Concept",
+                labels: t.entity.labels,
+                salience: t.entity.salience,
+                mention_count: t.entity.mention_count,
+                kb_id: t.entity.kb_id ?? undefined,
+                hop_distance: t.hop_distance,
+              }),
+            ),
+            relationships: liveRels.map((r) => {
+              const relType = formatRelationType(r.relation_type);
+              return compact({
+                id: r.uuid,
+                from: nameById.get(r.from_entity) || r.from_entity,
+                to: nameById.get(r.to_entity) || r.to_entity,
+                from_id: r.from_entity,
+                to_id: r.to_entity,
+                relation_type: relType,
+                strength: r.strength,
+                context: r.context || undefined,
+                typed: !GENERIC_TYPES.has(relType),
+              });
+            }),
+            entity_count: entities.length,
+            relationship_count: liveRels.length,
+            invalidated_count: invalidatedCount,
+          }),
+        };
       }
 
       case "list_entities": {
@@ -4948,6 +5432,7 @@ const handleCallTool = async (request: CallToolRequest) => {
         if (all.length === 0) {
           return {
             content: [{ type: "text", text: `🕸 The knowledge graph has no entities yet.\nEntities are extracted automatically as memories are stored — remember something first.` }],
+            structuredContent: { entities: [], count: 0, total: 0 },
           };
         }
 
@@ -4962,7 +5447,27 @@ const handleCallTool = async (request: CallToolRequest) => {
         }
         response += `\nUse explore_entity(entity_name) to walk any of these.`;
 
-        return { content: [{ type: "text", text: response }] };
+        return {
+          content: [{ type: "text", text: response }],
+          structuredContent: {
+            entities: ranked.map((e) =>
+              compact({
+                id: e.uuid,
+                name: e.name,
+                entity_type: e.fine_type || e.labels.join("/") || "Concept",
+                labels: e.labels,
+                salience: e.salience,
+                mention_count: e.mention_count,
+              }),
+            ),
+            count: ranked.length,
+            // Entities seen in this page. The server truncates at
+            // SERVER_FETCH_LIMIT before ordering, so when `all` is exactly that
+            // size the real graph may hold more — same caveat the text renders
+            // as a trailing "+".
+            total: all.length,
+          },
+        };
       }
 
       // =======================================================================
@@ -4997,13 +5502,35 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         const anomalies = result.anomalies || [];
 
+        const anomaliesStructured = (): Record<string, unknown> => ({
+          min_sigma: result.min_sigma,
+          anomalies: anomalies.map((a) =>
+            compact({
+              memory_id: a.memory_id,
+              content_preview: a.content_preview,
+              max_abs_z: a.max_abs_z,
+              flagged: a.flagged,
+              explanation: a.explanation || undefined,
+              entities: a.entities,
+              created_at: a.created_at,
+            }),
+          ),
+          count: anomalies.length,
+          flagged_count: anomalies.filter((a) => a.flagged).length,
+          episodes_scored: result.episodes_scored,
+          baseline_window: result.baseline_window,
+        });
+
         if (anomalies.length === 0) {
           // The endpoint returns an empty feed (not z-scores against noise)
           // below its minimum baseline of scored episodes.
           const reason = result.episodes_scored < 10
             ? `Only ${result.episodes_scored} scored episode(s) exist — deviation needs a baseline of at least 10 before z-scores mean anything.`
             : `${result.episodes_scored} episodes scored against a window of ${result.baseline_window}; none deviate from the baseline.`;
-          return { content: [{ type: "text", text: `📈 No anomalies.\n${reason}` }] };
+          return {
+            content: [{ type: "text", text: `📈 No anomalies.\n${reason}` }],
+            structuredContent: anomaliesStructured(),
+          };
         }
 
         const flaggedCount = anomalies.filter((a) => a.flagged).length;
@@ -5028,7 +5555,10 @@ const handleCallTool = async (request: CallToolRequest) => {
 
         response += `Use read_memory(memory_id) for full content, trace_lineage(memory_id) to see what an anomalous memory caused or was caused by.`;
 
-        return { content: [{ type: "text", text: response.trimEnd() }] };
+        return {
+          content: [{ type: "text", text: response.trimEnd() }],
+          structuredContent: anomaliesStructured(),
+        };
       }
 
       case "search_facts": {
@@ -5072,12 +5602,32 @@ const handleCallTool = async (request: CallToolRequest) => {
         const result = await apiCall<{ facts: FactWire[]; total: number }>(endpoint, "POST", body);
         const facts = result.facts || [];
 
+        const factsStructured = (): Record<string, unknown> =>
+          compact({
+            query: query && query.trim().length > 0 ? query.trim() : undefined,
+            entity: entity && entity.trim().length > 0 ? entity.trim() : undefined,
+            facts: facts.map((f) =>
+              compact({
+                id: f.id,
+                fact: f.fact,
+                fact_type: f.fact_type,
+                confidence: f.confidence,
+                support_count: f.support_count,
+                related_entities: f.related_entities,
+                created_at: f.created_at,
+                invalidated_at: f.invalidated_at ?? undefined,
+              }),
+            ),
+            count: facts.length,
+          });
+
         if (facts.length === 0) {
           return {
             content: [{
               type: "text",
               text: `📚 No ${heading}.\nSemantic facts distill out of episodic memories during consolidation — a young or recently imported corpus may have none yet. Try recall for the underlying episodic memories, or fact_narratives for topic clusters.`,
             }],
+            structuredContent: factsStructured(),
           };
         }
 
@@ -5095,7 +5645,10 @@ const handleCallTool = async (request: CallToolRequest) => {
         }
         response += `Facts are confidence-scored distillations; use recall to read the episodic memories behind them.`;
 
-        return { content: [{ type: "text", text: response.trimEnd() }] };
+        return {
+          content: [{ type: "text", text: response.trimEnd() }],
+          structuredContent: factsStructured(),
+        };
       }
 
       // =======================================================================
@@ -5205,6 +5758,17 @@ const handleCallTool = async (request: CallToolRequest) => {
       const percentUsed = Math.round(tokenStatus.percent * 100);
       const warning = `⚠️ CONTEXT ALERT: ${percentUsed}% of token budget used (${tokenStatus.tokens.toLocaleString()}/${tokenStatus.budget.toLocaleString()}). Consider starting a new session or running consolidation.\n\n`;
       result.content[0].text = warning + result.content[0].text;
+    }
+
+    // A tool that declares an outputSchema must return structuredContent on
+    // every successful path — the SDK client rejects the result otherwise, and
+    // the error it raises names the schema, not the code path that skipped it.
+    // Log the tool name here so the cause is obvious in the server's stderr.
+    if (TOOL_OUTPUT_SCHEMAS[name] && !result.isError && !result.structuredContent) {
+      console.error(
+        `[shodh-memory] BUG: tool "${name}" declares an outputSchema but returned no structuredContent. ` +
+          `Clients validating structured output will reject this result.`,
+      );
     }
 
     // Add _meta with token status to response

--- a/mcp-server/tests/tool-metadata.test.ts
+++ b/mcp-server/tests/tool-metadata.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import {
+  TOOL_ANNOTATIONS,
+  TOOL_OUTPUT_SCHEMAS,
+  READ_ONLY_TOOLS,
+  isReadOnlyTool,
+  decorateTool,
+  type ToolDefinition,
+} from "../tool-metadata";
+
+const def = (name: string): ToolDefinition => ({
+  name,
+  description: "d",
+  inputSchema: { type: "object", properties: {} },
+});
+
+describe("tool annotations", () => {
+  it("covers every tool exactly once", () => {
+    // The server declares 51 tools; decorateTool throws for anything missing,
+    // so this count is the tripwire for a tool added without a judgement call.
+    expect(Object.keys(TOOL_ANNOTATIONS)).toHaveLength(51);
+  });
+
+  it("gives every tool a display title", () => {
+    for (const [name, ann] of Object.entries(TOOL_ANNOTATIONS)) {
+      expect(ann.title, `${name} has no title`).toBeTruthy();
+    }
+  });
+
+  it("closes the world for every tool", () => {
+    // The memory store is local and closed. The spec default is TRUE, so this
+    // must be set explicitly everywhere or clients assume external reach.
+    for (const [name, ann] of Object.entries(TOOL_ANNOTATIONS)) {
+      expect(ann.openWorldHint, `${name} should be closed-world`).toBe(false);
+    }
+  });
+
+  it("sets destructive and idempotent explicitly on every mutating tool", () => {
+    // destructiveHint defaults to TRUE when absent, so an unset hint on an
+    // additive tool would wrongly mark it dangerous.
+    for (const [name, ann] of Object.entries(TOOL_ANNOTATIONS)) {
+      if (ann.readOnlyHint) continue;
+      expect(typeof ann.destructiveHint, `${name} destructiveHint`).toBe("boolean");
+      expect(typeof ann.idempotentHint, `${name} idempotentHint`).toBe("boolean");
+    }
+  });
+
+  it("omits destructive/idempotent on read-only tools", () => {
+    // The spec defines both as meaningful only when readOnlyHint is false.
+    for (const [name, ann] of Object.entries(TOOL_ANNOTATIONS)) {
+      if (!ann.readOnlyHint) continue;
+      expect(ann.destructiveHint, `${name} destructiveHint`).toBeUndefined();
+      expect(ann.idempotentHint, `${name} idempotentHint`).toBeUndefined();
+    }
+  });
+
+  it("keeps isReadOnlyTool in sync with the annotations", () => {
+    for (const [name, ann] of Object.entries(TOOL_ANNOTATIONS)) {
+      expect(isReadOnlyTool(name)).toBe(Boolean(ann.readOnlyHint));
+    }
+    expect(READ_ONLY_TOOLS.size).toBe(
+      Object.values(TOOL_ANNOTATIONS).filter((a) => a.readOnlyHint).length,
+    );
+  });
+});
+
+describe("data-loss hazard tools are never marked safe", () => {
+  // Regression guard. A client that auto-approves readOnlyHint:true tools must
+  // never be handed one of these. Flipping any of them to read-only is a
+  // data-loss hazard, not a refactor.
+  const mustBeDestructive = [
+    "forget",
+    "purge_facts",
+    "delete_todo",
+    "delete_project",
+    "delete_todo_comment",
+    "backup_purge",
+    "backup_restore",
+    "validate_causal_link",
+    "update_todo",
+    "update_todo_comment",
+  ];
+
+  for (const name of mustBeDestructive) {
+    it(`${name} is destructive and not read-only`, () => {
+      const ann = TOOL_ANNOTATIONS[name];
+      expect(ann).toBeDefined();
+      expect(ann.readOnlyHint).toBe(false);
+      expect(ann.destructiveHint).toBe(true);
+      expect(isReadOnlyTool(name)).toBe(false);
+    });
+  }
+
+  // Names that read like queries but write. Verified against the handlers:
+  // proactive_context defaults to auto_ingest:true, reset_token_session
+  // persists a session-digest Context memory, repair_index re-indexes.
+  const writesDespiteName = ["proactive_context", "reset_token_session", "repair_index"];
+
+  for (const name of writesDespiteName) {
+    it(`${name} writes despite its name`, () => {
+      expect(TOOL_ANNOTATIONS[name].readOnlyHint).toBe(false);
+      expect(isReadOnlyTool(name)).toBe(false);
+    });
+  }
+
+  it("marks non-idempotent writers honestly", () => {
+    // complete_todo re-completes and spawns another recurrence + memory;
+    // add_project mints a fresh UUID; add_causal_link reinforces on repeat;
+    // reinforce_memories compounds boosts.
+    for (const name of ["complete_todo", "add_project", "add_causal_link", "reinforce_memories", "backup_create"]) {
+      expect(TOOL_ANNOTATIONS[name].idempotentHint, name).toBe(false);
+    }
+  });
+});
+
+describe("output schemas", () => {
+  it("declares an object at the root, as the spec requires", () => {
+    for (const [name, schema] of Object.entries(TOOL_OUTPUT_SCHEMAS)) {
+      expect(schema.type, `${name} root type`).toBe("object");
+      expect(schema.properties, `${name} properties`).toBeTruthy();
+    }
+  });
+
+  it("only lists required keys that the schema declares", () => {
+    for (const [name, schema] of Object.entries(TOOL_OUTPUT_SCHEMAS)) {
+      for (const key of schema.required ?? []) {
+        expect(Object.keys(schema.properties ?? {}), `${name}.${key}`).toContain(key);
+      }
+    }
+  });
+
+  it("only schemas tools that exist", () => {
+    for (const name of Object.keys(TOOL_OUTPUT_SCHEMAS)) {
+      expect(TOOL_ANNOTATIONS[name], `${name} has a schema but no annotation`).toBeDefined();
+    }
+  });
+});
+
+describe("decorateTool", () => {
+  it("attaches annotations", () => {
+    const decorated = decorateTool(def("recall"));
+    expect(decorated.annotations.readOnlyHint).toBe(true);
+    expect(decorated.annotations.title).toBe("Recall Memories & Todos");
+  });
+
+  it("attaches an outputSchema only where one is declared", () => {
+    expect(decorateTool(def("recall")).outputSchema).toBeDefined();
+    // A one-line confirmation gains nothing from a schema.
+    expect(decorateTool(def("forget")).outputSchema).toBeUndefined();
+  });
+
+  it("throws for an unannotated tool rather than defaulting silently", () => {
+    // A silent default would ship the spec defaults (destructive + open world)
+    // AND would leave the tool outside the ambient-ingestion gate.
+    expect(() => decorateTool(def("brand_new_tool"))).toThrow(/no entry in TOOL_BEHAVIOUR/);
+  });
+
+  it("does not mutate the input definition", () => {
+    const original = def("recall");
+    decorateTool(original);
+    expect("annotations" in original).toBe(false);
+  });
+});

--- a/mcp-server/tool-metadata.ts
+++ b/mcp-server/tool-metadata.ts
@@ -1,0 +1,844 @@
+/**
+ * MCP tool annotations and output schemas — single source of truth.
+ *
+ * Two protocol affordances live here:
+ *
+ * 1. `annotations` (MCP `ToolAnnotations`): behavioural hints a client uses to
+ *    decide what may be auto-approved. `forget`, `purge_facts`, `delete_todo`,
+ *    `backup_restore` and friends must be distinguishable from `recall` and
+ *    `memory_stats`, or a harness has to choose between prompting on
+ *    everything (friction) or running everything (data-loss hazard).
+ *
+ * 2. `outputSchema` (MCP `Tool.outputSchema`): a machine-readable channel next
+ *    to the emoji-formatted text, so a model does not have to scrape layout to
+ *    get a memory id or a score. Text is NOT replaced — the spec expects
+ *    `content` to stay populated, and the formatted text is genuinely better
+ *    for a small result read inline.
+ *
+ * IMPORTANT — the read-only set is enforced, not merely asserted.
+ * `index.ts` gates its two ambient-ingestion paths (`autoStreamContext` and
+ * `streamToolCall`) on `isReadOnlyTool()`. Without that gate every tool call
+ * with a >=50-char argument or result streams a memory to the backend, which
+ * would make `readOnlyHint: true` a lie on every read tool. Adding a tool to
+ * READ_ONLY here is therefore a behavioural commitment: that tool will not
+ * ambient-ingest. Verify the handler before moving a tool into it.
+ *
+ * Spec defaults that bite (per @modelcontextprotocol/sdk `ToolAnnotations`):
+ *   - `destructiveHint` defaults to TRUE when absent
+ *   - `openWorldHint`  defaults to TRUE when absent
+ * so both are set explicitly on every tool. The memory store is a closed local
+ * world, so `openWorldHint` is false everywhere.
+ */
+
+/** MCP `ToolAnnotations` — mirrors the SDK interface (sdk/spec.types.d.ts). */
+export interface ToolAnnotations {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+/** MCP `Tool.outputSchema` — JSON Schema, restricted to an object at the root. */
+export interface JsonSchemaObject {
+  type: "object";
+  properties?: Record<string, unknown>;
+  required?: string[];
+  [key: string]: unknown;
+}
+
+/** Minimal shape of a tool definition in the `tools/list` literal. */
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: { type: "object"; properties?: Record<string, unknown>; required?: string[] };
+}
+
+/** A tool definition decorated with its protocol affordances. */
+export interface DecoratedTool extends ToolDefinition {
+  annotations: ToolAnnotations;
+  outputSchema?: JsonSchemaObject;
+}
+
+// =============================================================================
+// ANNOTATIONS
+// =============================================================================
+
+type BehaviourSpec =
+  | { title: string; readOnly: true }
+  | { title: string; readOnly: false; destructive: boolean; idempotent: boolean };
+
+/**
+ * Per-tool behaviour, verified against the handler in `index.ts` and the Rust
+ * route it calls. Reasoning is recorded inline only where the honest answer
+ * differs from what the tool name suggests.
+ */
+const TOOL_BEHAVIOUR: Record<string, BehaviourSpec> = {
+  // ---------------------------------------------------------------------
+  // Core memory
+  // ---------------------------------------------------------------------
+  remember: { title: "Store Memory", readOnly: false, destructive: false, idempotent: false },
+  recall: { title: "Recall Memories & Todos", readOnly: true },
+  recall_by_tags: { title: "Recall by Tags", readOnly: true },
+  context_summary: { title: "Session Context Summary", readOnly: true },
+  list_memories: { title: "List Memories", readOnly: true },
+  read_memory: { title: "Read Full Memory", readOnly: true },
+  // Deletes a memory. Repeating with the same id leaves the store in the same
+  // state (the second call 404s without further effect) => idempotent.
+  forget: { title: "Delete Memory", readOnly: false, destructive: true, idempotent: true },
+  memory_stats: { title: "Memory Statistics", readOnly: true },
+
+  // ---------------------------------------------------------------------
+  // Index integrity
+  // ---------------------------------------------------------------------
+  // POST, but `verify_index_integrity` (src/handlers/…) takes a read lock and
+  // returns a report — no mutation. POST is transport, not semantics.
+  verify_index: { title: "Verify Vector Index", readOnly: true },
+  // Re-indexes orphaned memories: adds missing index entries, removes nothing.
+  // Running it again once healthy is a no-op.
+  repair_index: { title: "Repair Vector Index", readOnly: false, destructive: false, idempotent: true },
+
+  // ---------------------------------------------------------------------
+  // Backup & restore
+  // ---------------------------------------------------------------------
+  // Each call writes a new backup artifact => not idempotent, but additive.
+  backup_create: { title: "Create Backup", readOnly: false, destructive: false, idempotent: false },
+  backup_list: { title: "List Backups", readOnly: true },
+  // Checksum comparison only.
+  backup_verify: { title: "Verify Backup Integrity", readOnly: true },
+  backup_purge: { title: "Purge Old Backups", readOnly: false, destructive: true, idempotent: true },
+  // Replaces all current user data with the backup contents.
+  backup_restore: { title: "Restore Backup", readOnly: false, destructive: true, idempotent: true },
+
+  // ---------------------------------------------------------------------
+  // Consolidation / session / facts
+  // ---------------------------------------------------------------------
+  consolidation_report: { title: "Consolidation Report", readOnly: true },
+  // NOT read-only despite reading like a query: `auto_ingest` defaults to true,
+  // so the default call stores the supplied context as a Conversation memory.
+  proactive_context: { title: "Surface Proactive Context", readOnly: false, destructive: false, idempotent: false },
+  token_status: { title: "MCP Token Throughput", readOnly: true },
+  // NOT read-only despite the name: POST /api/sessions/context-compressed
+  // persists a session-digest Context memory on every call (sessions.rs
+  // `context_compressed` -> `build_active_digest` -> store).
+  reset_token_session: { title: "Reset Token Session Counter", readOnly: false, destructive: false, idempotent: false },
+  session_digest: { title: "Session Digest", readOnly: true },
+  session_history: { title: "Session History", readOnly: true },
+  fact_narratives: { title: "Fact Narratives", readOnly: true },
+  // dry_run=true is read-only, but annotations are static per tool, so the
+  // hint describes the worst case: the default (dry_run=false) deletes facts.
+  purge_facts: { title: "Purge Facts by Pattern", readOnly: false, destructive: true, idempotent: true },
+
+  // ---------------------------------------------------------------------
+  // Reminders
+  // ---------------------------------------------------------------------
+  set_reminder: { title: "Set Reminder", readOnly: false, destructive: false, idempotent: false },
+  list_reminders: { title: "List Reminders", readOnly: true },
+  // Status transition pending -> dismissed; re-dismissing changes nothing.
+  dismiss_reminder: { title: "Dismiss Reminder", readOnly: false, destructive: false, idempotent: true },
+
+  // ---------------------------------------------------------------------
+  // Todos & projects
+  // ---------------------------------------------------------------------
+  add_todo: { title: "Add Todo", readOnly: false, destructive: false, idempotent: false },
+  list_todos: { title: "List / Search Todos", readOnly: true },
+  // Overwrites existing field values rather than only appending => destructive
+  // in the spec's "not purely additive" sense; same args converge on one state.
+  update_todo: { title: "Update Todo", readOnly: false, destructive: true, idempotent: true },
+  // NOT idempotent: `TodoStore::complete_todo` re-completes unconditionally,
+  // and each call spawns another recurrence occurrence plus another completion
+  // memory and activity entry (src/memory/todos.rs, src/handlers/todos.rs).
+  complete_todo: { title: "Complete Todo", readOnly: false, destructive: false, idempotent: false },
+  delete_todo: { title: "Delete Todo", readOnly: false, destructive: true, idempotent: true },
+  // Each call shifts the todo one more position => repeating has further effect.
+  reorder_todo: { title: "Reorder Todo", readOnly: false, destructive: false, idempotent: false },
+  // `create_project` mints a fresh UUID per call with no name dedup, so calling
+  // twice yields two projects.
+  add_project: { title: "Add Project", readOnly: false, destructive: false, idempotent: false },
+  list_projects: { title: "List Projects", readOnly: true },
+  // Hides but preserves; restorable => not destructive.
+  archive_project: { title: "Archive Project", readOnly: false, destructive: false, idempotent: true },
+  delete_project: { title: "Delete Project", readOnly: false, destructive: true, idempotent: true },
+  todo_stats: { title: "Todo Statistics", readOnly: true },
+  list_subtasks: { title: "List Subtasks", readOnly: true },
+  add_todo_comment: { title: "Add Todo Comment", readOnly: false, destructive: false, idempotent: false },
+  list_todo_comments: { title: "List Todo Comments", readOnly: true },
+  update_todo_comment: { title: "Update Todo Comment", readOnly: false, destructive: true, idempotent: true },
+  delete_todo_comment: { title: "Delete Todo Comment", readOnly: false, destructive: true, idempotent: true },
+
+  // ---------------------------------------------------------------------
+  // Causal lineage / knowledge graph / anomalies / facts
+  // ---------------------------------------------------------------------
+  trace_lineage: { title: "Trace Causal Lineage", readOnly: true },
+  list_causal_edges: { title: "Survey Causal Edges", readOnly: true },
+  // Deduped server-side, but a repeat call `reinforce()`s the existing edge's
+  // confidence (src/memory/lineage.rs `add_explicit_edge`) => further effect.
+  add_causal_link: { title: "Add Causal Link", readOnly: false, destructive: false, idempotent: false },
+  // verdict="reject" deletes the edge, so the tool may destroy graph structure.
+  validate_causal_link: { title: "Confirm or Reject Causal Link", readOnly: false, destructive: true, idempotent: true },
+  explore_entity: { title: "Explore Entity Neighbourhood", readOnly: true },
+  list_entities: { title: "List Graph Entities", readOnly: true },
+  list_anomalies: { title: "List Statistical Anomalies", readOnly: true },
+  search_facts: { title: "Search Distilled Facts", readOnly: true },
+  // Adjusts importance weights and association strengths in a designed feedback
+  // loop; nothing is deleted and "helpful" reverses "misleading", so it is not
+  // destructive. Boosts compound across calls, so it is not idempotent.
+  reinforce_memories: { title: "Reinforce Memories (Hebbian Feedback)", readOnly: false, destructive: false, idempotent: false },
+};
+
+/** Fully-resolved annotations per tool, with spec defaults made explicit. */
+export const TOOL_ANNOTATIONS: Record<string, ToolAnnotations> = Object.fromEntries(
+  Object.entries(TOOL_BEHAVIOUR).map(([name, spec]): [string, ToolAnnotations] => {
+    if (spec.readOnly) {
+      return [
+        name,
+        {
+          title: spec.title,
+          readOnlyHint: true,
+          // destructiveHint/idempotentHint are defined by the spec to be
+          // meaningful only when readOnlyHint is false, so they are omitted.
+          openWorldHint: false,
+        },
+      ];
+    }
+    return [
+      name,
+      {
+        title: spec.title,
+        readOnlyHint: false,
+        destructiveHint: spec.destructive,
+        idempotentHint: spec.idempotent,
+        openWorldHint: false,
+      },
+    ];
+  }),
+);
+
+/** The set of tools that do not modify the memory store. */
+export const READ_ONLY_TOOLS: ReadonlySet<string> = new Set(
+  Object.entries(TOOL_BEHAVIOUR)
+    .filter(([, spec]) => spec.readOnly)
+    .map(([name]) => name),
+);
+
+/**
+ * True when the tool is annotated `readOnlyHint: true`.
+ *
+ * Ambient ingestion in `index.ts` is gated on this so the annotation is true by
+ * construction rather than by assertion.
+ */
+export function isReadOnlyTool(name: string): boolean {
+  return READ_ONLY_TOOLS.has(name);
+}
+
+// =============================================================================
+// OUTPUT SCHEMAS
+// =============================================================================
+
+// Reusable fragments. Every schema keeps `additionalProperties` open by
+// omission so a backend field added later does not fail client-side validation
+// (the SDK client validates structuredContent against these with Ajv).
+
+const MEMORY_ITEM = {
+  type: "object",
+  properties: {
+    id: { type: "string", description: "Memory UUID" },
+    content: { type: "string", description: "Memory body; a preview unless full_content was requested" },
+    content_truncated: { type: "boolean", description: "True when `content` is a truncated preview" },
+    memory_type: { type: "string", description: "Observation | Decision | Learning | Error | ..." },
+    tags: { type: "array", items: { type: "string" } },
+    score: { type: "number", description: "Retrieval score, when the tool ranks results" },
+    importance: { type: "number" },
+    created_at: { type: "string", description: "ISO 8601 timestamp" },
+    tier: { type: "string", description: "working | session | long_term" },
+  },
+  required: ["id", "content"],
+} as const;
+
+const TODO_ITEM = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    short_id: { type: "string", description: "Human-facing prefix id, e.g. SHO-1a2b" },
+    content: { type: "string" },
+    status: { type: "string" },
+    priority: { type: "string" },
+    project: { type: "string" },
+    score: { type: "number", description: "Present only for semantic todo search" },
+    created_at: { type: "string" },
+    due_date: { type: "string" },
+  },
+  required: ["id", "content", "status"],
+} as const;
+
+// `edge_id` rather than the wire's `id`: the formatted text has always labelled
+// it "edge_id", and validate_causal_link's own parameter is named edge_id, so
+// the structured channel uses the name the rest of the surface already uses.
+const LINEAGE_EDGE = {
+  type: "object",
+  properties: {
+    edge_id: { type: "string", description: "Pass to validate_causal_link" },
+    from: { type: "string", description: "Cause / origin memory id" },
+    to: { type: "string", description: "Effect memory id" },
+    relation: {
+      type: "string",
+      description: "Caused | ResolvedBy | InformedBy | SupersededBy | TriggeredBy | BranchedFrom | RelatedTo",
+    },
+    confidence: { type: "number" },
+    source: { type: "string", description: "Inferred | Confirmed | Explicit" },
+    created_at: { type: "string" },
+    reinforcement_count: { type: "number" },
+  },
+  required: ["edge_id", "from", "to", "relation"],
+} as const;
+
+// Knowledge-graph entity. `name_embedding` is on the wire but deliberately
+// never surfaced — it is a vector, not information for a reader.
+const GRAPH_ENTITY = {
+  type: "object",
+  properties: {
+    id: { type: "string", description: "Entity UUID" },
+    name: { type: "string", description: "Pass to explore_entity" },
+    entity_type: { type: "string", description: "fine_type when known, else the labels, else Concept" },
+    labels: { type: "array", items: { type: "string" } },
+    salience: { type: "number", description: "Learned importance" },
+    mention_count: { type: "number" },
+    kb_id: { type: "string", description: "Knowledge-base identifier when the entity is linked" },
+    hop_distance: { type: "number", description: "Hops from the starting entity (explore_entity only)" },
+  },
+  required: ["name"],
+} as const;
+
+const arrayOf = (item: unknown, description: string) => ({
+  type: "array",
+  items: item,
+  description,
+});
+
+/**
+ * Tools that return data worth parsing get a schema. Tools that return a
+ * one-line confirmation ("Memory deleted", "Backup restored") or a prose
+ * narrative deliberately do not — a schema there buys nothing and has to be
+ * maintained forever.
+ */
+export const TOOL_OUTPUT_SCHEMAS: Record<string, JsonSchemaObject> = {
+  remember: {
+    type: "object",
+    properties: {
+      id: { type: "string", description: "UUID of the stored memory" },
+      memory_type: { type: "string" },
+      tags: { type: "array", items: { type: "string" } },
+    },
+    required: ["id"],
+  },
+
+  recall: {
+    type: "object",
+    properties: {
+      query: { type: "string" },
+      mode: { type: "string" },
+      memories: arrayOf(MEMORY_ITEM, "Matching memories, best first"),
+      todos: arrayOf(TODO_ITEM, "Matching todos, best first"),
+      lineage: arrayOf(
+        {
+          type: "object",
+          properties: {
+            from: { type: "string" },
+            to: { type: "string" },
+            relation: { type: "string" },
+            confidence: { type: "number" },
+          },
+          required: ["from", "to", "relation"],
+        },
+        "Causal edges connecting the recalled memories",
+      ),
+      memory_count: { type: "number" },
+      todo_count: { type: "number" },
+    },
+    required: ["query", "mode", "memories", "todos", "memory_count", "todo_count"],
+  },
+
+  recall_by_tags: {
+    type: "object",
+    properties: {
+      tags: { type: "array", items: { type: "string" }, description: "Tags that were searched" },
+      memories: arrayOf(MEMORY_ITEM, "Memories matching ANY of the tags"),
+      count: { type: "number" },
+    },
+    required: ["tags", "memories", "count"],
+  },
+
+  list_memories: {
+    type: "object",
+    properties: {
+      memories: arrayOf(MEMORY_ITEM, "Stored memories, most recent first"),
+      count: { type: "number" },
+    },
+    required: ["memories", "count"],
+  },
+
+  // `found` exists so the "memory not found" path — which the tool reports as a
+  // successful call, not an error — still has an honest structured form. Only
+  // `found` and the requested `id` are guaranteed; everything else is present
+  // only when the lookup succeeded.
+  read_memory: {
+    type: "object",
+    properties: {
+      found: { type: "boolean" },
+      id: { type: "string", description: "Resolved memory id, or the id that was requested when not found" },
+      content: { type: "string", description: "Complete, untruncated memory body" },
+      memory_type: { type: "string" },
+      entities: { type: "array", items: { type: "string" }, description: "Entities extracted from this memory" },
+      created_at: { type: "string" },
+      importance: { type: "number" },
+      tier: { type: "string" },
+      parent_id: { type: "string" },
+      children_ids: { type: "array", items: { type: "string" } },
+      children_count: { type: "number" },
+    },
+    required: ["found", "id"],
+  },
+
+  memory_stats: {
+    type: "object",
+    properties: {
+      total_memories: { type: "number" },
+      working_memory_count: { type: "number" },
+      session_memory_count: { type: "number" },
+      long_term_memory_count: { type: "number" },
+      vector_index_count: { type: "number" },
+      average_importance: { type: "number" },
+      total_retrievals: { type: "number" },
+      graph_nodes: { type: "number" },
+      graph_edges: { type: "number" },
+      memory_types: {
+        type: "object",
+        description: "Count keyed by memory type, when the backend reports the breakdown",
+        additionalProperties: { type: "number" },
+      },
+    },
+    required: ["total_memories"],
+  },
+
+  // Field names mirror the backend `IndexIntegrityReport` wire shape rather
+  // than inventing prettier ones — a renaming layer would drift the moment the
+  // report changes.
+  verify_index: {
+    type: "object",
+    properties: {
+      is_healthy: { type: "boolean" },
+      total_storage: { type: "number", description: "Memories in storage" },
+      total_indexed: { type: "number", description: "Vectors in the search index" },
+      orphaned_count: { type: "number", description: "Stored but not searchable" },
+      orphaned_ids: { type: "array", items: { type: "string" } },
+    },
+    required: ["is_healthy", "total_storage", "total_indexed", "orphaned_count"],
+  },
+
+  list_reminders: {
+    type: "object",
+    properties: {
+      status_filter: { type: "string" },
+      reminders: arrayOf(
+        {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            content: { type: "string" },
+            status: { type: "string", description: "pending | triggered | dismissed" },
+            trigger_type: { type: "string", description: "time | duration | context" },
+            due_at: { type: "string", description: "ISO 8601, for time/duration triggers" },
+            created_at: { type: "string" },
+            priority: { type: "number", description: "1-5, 5 = highest" },
+            overdue_seconds: { type: "number" },
+          },
+          required: ["id", "content"],
+        },
+        "Reminders matching the status filter",
+      ),
+      count: { type: "number" },
+    },
+    required: ["reminders", "count"],
+  },
+
+  // Same projection as the todo items inside list_todos, so a caller can hand
+  // the created todo straight back to update_todo / add_todo_comment.
+  add_todo: {
+    type: "object",
+    properties: TODO_ITEM.properties,
+    required: ["id"],
+  },
+
+  list_todos: {
+    type: "object",
+    properties: {
+      todos: arrayOf(TODO_ITEM, "Todos matching the filters or semantic query"),
+      count: { type: "number", description: "Number of todos in this page" },
+      total: { type: "number", description: "Total matching todos before pagination" },
+    },
+    required: ["todos", "count"],
+  },
+
+  list_subtasks: {
+    type: "object",
+    properties: {
+      parent_id: { type: "string" },
+      subtasks: arrayOf(TODO_ITEM, "Direct children of the parent todo"),
+      count: { type: "number" },
+    },
+    required: ["subtasks", "count"],
+  },
+
+  list_todo_comments: {
+    type: "object",
+    properties: {
+      todo_id: { type: "string" },
+      comments: arrayOf(
+        {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            content: { type: "string" },
+            author: { type: "string" },
+            comment_type: { type: "string" },
+            created_at: { type: "string" },
+          },
+          required: ["id", "content"],
+        },
+        "Comments and activity entries, oldest first",
+      ),
+      count: { type: "number" },
+    },
+    required: ["comments", "count"],
+  },
+
+  // Flat status counts, mirroring the backend `UserTodoStats` wire shape.
+  todo_stats: {
+    type: "object",
+    properties: {
+      total: { type: "number" },
+      backlog: { type: "number" },
+      todo: { type: "number" },
+      in_progress: { type: "number" },
+      blocked: { type: "number" },
+      done: { type: "number" },
+      cancelled: { type: "number" },
+      overdue: { type: "number" },
+      due_today: { type: "number" },
+      projects: { type: "number", description: "Number of projects" },
+    },
+    required: ["total"],
+  },
+
+  // The backend returns `projects` as (Project, ProjectStats) tuples; the
+  // structured payload flattens each pair into one object so consumers do not
+  // have to index into a two-element array.
+  list_projects: {
+    type: "object",
+    properties: {
+      projects: arrayOf(
+        {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            name: { type: "string" },
+            prefix: { type: "string", description: "Todo id prefix, e.g. BOLT" },
+            description: { type: "string" },
+            status: { type: "string", description: "active | archived" },
+            parent_id: { type: "string" },
+            stats: {
+              type: "object",
+              description: "Todo counts for this project",
+              properties: {
+                total: { type: "number" },
+                backlog: { type: "number" },
+                todo: { type: "number" },
+                in_progress: { type: "number" },
+                blocked: { type: "number" },
+                done: { type: "number" },
+                cancelled: { type: "number" },
+              },
+            },
+          },
+          required: ["id", "name"],
+        },
+        "Projects with their todo counts",
+      ),
+      count: { type: "number" },
+    },
+    required: ["projects", "count"],
+  },
+
+  backup_list: {
+    type: "object",
+    properties: {
+      backups: arrayOf(
+        {
+          type: "object",
+          properties: {
+            backup_id: { type: "number", description: "Pass to backup_verify / backup_restore" },
+            created_at: { type: "string" },
+            backup_type: { type: "string" },
+            size_bytes: { type: "number" },
+            memory_count: { type: "number" },
+            checksum: { type: "string" },
+            sequence_number: { type: "number" },
+          },
+          required: ["backup_id"],
+        },
+        "Available backups, newest first",
+      ),
+      count: { type: "number" },
+    },
+    required: ["backups", "count"],
+  },
+
+  proactive_context: {
+    type: "object",
+    properties: {
+      memories: arrayOf(
+        {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            content: { type: "string" },
+            content_truncated: { type: "boolean" },
+            memory_type: { type: "string" },
+            score: { type: "number", description: "Relevance score for this context" },
+            importance: { type: "number" },
+            tags: { type: "array", items: { type: "string" } },
+            relevance_reason: { type: "string", description: "Why the engine surfaced this memory" },
+            matched_entities: { type: "array", items: { type: "string" } },
+            created_at: { type: "string" },
+          },
+          required: ["id", "content"],
+        },
+        "Memories surfaced as relevant to the supplied context",
+      ),
+      detected_entities: arrayOf(
+        {
+          type: "object",
+          properties: { name: { type: "string" }, entity_type: { type: "string" } },
+          required: ["name"],
+        },
+        "Entities extracted from the supplied context",
+      ),
+      todos: arrayOf(TODO_ITEM, "Todos judged relevant to the context"),
+      facts: arrayOf(
+        {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            fact: { type: "string" },
+            confidence: { type: "number" },
+            support_count: { type: "number" },
+          },
+          required: ["fact"],
+        },
+        "Distilled facts judged relevant to the context",
+      ),
+      count: { type: "number", description: "Number of surfaced memories" },
+      // Deliberately NOT a boolean "was it ingested". The backend spawns the
+      // ingest as a background task and only waits 50ms to read the id back
+      // (handlers/recall.rs), so a missing id routinely accompanies a write
+      // that did happen. Reporting that as `auto_ingested: false` would be a
+      // false negative — the exact wrong signal for a capture path.
+      ingest_requested: {
+        type: "boolean",
+        description:
+          "Whether ingestion of the supplied context was requested (the auto_ingest argument, default true). The backend applies its own filters (duplicate, length, bare-question, noise), so this is the request, not a guarantee.",
+      },
+      ingested_memory_id: {
+        type: "string",
+        description:
+          "Id of the stored context memory when the backend returned one in time. ABSENCE IS NOT PROOF OF NO WRITE: the ingest runs in the background and the id is only awaited briefly.",
+      },
+      latency_ms: { type: "number" },
+    },
+    required: ["memories", "detected_entities", "todos", "facts", "count", "ingest_requested"],
+  },
+
+  trace_lineage: {
+    type: "object",
+    properties: {
+      memory_id: { type: "string", description: "Resolved full UUID of the traced memory" },
+      direction: { type: "string", enum: ["backward", "forward", "both"] },
+      root_cause_id: {
+        type: "string",
+        description: "Oldest ancestor. Absent when tracing forward, or when the memory starts its own chain.",
+      },
+      edges: arrayOf(LINEAGE_EDGE, "Causal edges on the traced chain — ALL of them, not the display-capped subset"),
+      path: { type: "array", items: { type: "string" }, description: "Memory ids along the traced path" },
+      depth_reached: { type: "number" },
+      edge_count: { type: "number" },
+    },
+    required: ["memory_id", "direction", "edges", "edge_count"],
+  },
+
+  list_causal_edges: {
+    type: "object",
+    properties: {
+      edges: arrayOf(LINEAGE_EDGE, "Highest-confidence edges, up to the requested limit"),
+      count: { type: "number", description: "Edges returned here" },
+      total: { type: "number", description: "Total edges in the lineage graph" },
+      stats: {
+        type: "object",
+        description: "Graph-wide totals. Absent when the stats endpoint is unavailable.",
+        properties: {
+          total_edges: { type: "number" },
+          inferred_edges: { type: "number" },
+          confirmed_edges: { type: "number" },
+          explicit_edges: { type: "number" },
+          total_branches: { type: "number" },
+          active_branches: { type: "number" },
+          avg_confidence: { type: "number" },
+          edges_by_relation: { type: "object", additionalProperties: { type: "number" } },
+        },
+      },
+    },
+    required: ["edges", "count"],
+  },
+
+  explore_entity: {
+    type: "object",
+    properties: {
+      query: { type: "string", description: "Entity name exactly as supplied" },
+      found: { type: "boolean", description: "False when no entity matched the name" },
+      matched_entity: {
+        type: "string",
+        description: "Name the fuzzy match actually resolved to — may differ from `query`",
+      },
+      max_depth: { type: "number" },
+      entities: arrayOf(GRAPH_ENTITY, "Connected entities, nearest hop and highest salience first"),
+      relationships: arrayOf(
+        {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            from: { type: "string", description: "Source entity name" },
+            to: { type: "string", description: "Target entity name" },
+            from_id: { type: "string" },
+            to_id: { type: "string" },
+            relation_type: { type: "string", description: "Causes | Triggers | DependsOn | CoOccurs | custom" },
+            strength: { type: "number" },
+            context: { type: "string", description: "Sentence the relation was extracted from" },
+            typed: {
+              type: "boolean",
+              description: "False for bulk co-occurrence edges (CoOccurs / RelatedTo)",
+            },
+          },
+          required: ["from", "to", "relation_type"],
+        },
+        "Live relationships between the returned entities; invalidated edges are excluded",
+      ),
+      entity_count: { type: "number" },
+      relationship_count: { type: "number", description: "Live relationships" },
+      invalidated_count: { type: "number", description: "Relationships excluded because they were invalidated" },
+    },
+    required: ["query", "found", "entities", "relationships", "entity_count", "relationship_count"],
+  },
+
+  list_entities: {
+    type: "object",
+    properties: {
+      entities: arrayOf(GRAPH_ENTITY, "Entities ranked by salience"),
+      count: { type: "number" },
+      total: { type: "number", description: "Total entities in the graph" },
+    },
+    required: ["entities", "count"],
+  },
+
+  list_anomalies: {
+    type: "object",
+    properties: {
+      min_sigma: { type: "number", description: "Threshold the backend actually applied" },
+      anomalies: arrayOf(
+        {
+          type: "object",
+          properties: {
+            memory_id: { type: "string" },
+            content_preview: { type: "string" },
+            max_abs_z: { type: "number", description: "Largest absolute z-score across components" },
+            flagged: { type: "boolean", description: "True when max_abs_z >= min_sigma" },
+            explanation: { type: "string", description: "Deterministic reason the entry deviates" },
+            entities: arrayOf(
+              {
+                type: "object",
+                properties: { id: { type: "string" }, name: { type: "string" } },
+                required: ["name"],
+              },
+              "Entities in the anomalous memory",
+            ),
+            created_at: { type: "string" },
+          },
+          required: ["memory_id", "max_abs_z", "flagged"],
+        },
+        "Memories ranked by deviation from the user's own rolling baseline",
+      ),
+      count: { type: "number" },
+      flagged_count: { type: "number" },
+      episodes_scored: {
+        type: "number",
+        description: "Scored episodes available. Below 10 the feed is empty by design, not because nothing deviates.",
+      },
+      baseline_window: { type: "number", description: "Size of the rolling baseline window" },
+    },
+    required: ["anomalies", "count", "episodes_scored"],
+  },
+
+  search_facts: {
+    type: "object",
+    properties: {
+      query: { type: "string", description: "Echoed when keyword search was used" },
+      entity: { type: "string", description: "Echoed when entity lookup was used" },
+      facts: arrayOf(
+        {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            fact: { type: "string", description: "The distilled statement" },
+            fact_type: { type: "string" },
+            confidence: { type: "number" },
+            support_count: { type: "number", description: "Memories supporting this fact" },
+            related_entities: { type: "array", items: { type: "string" } },
+            created_at: { type: "string" },
+            invalidated_at: {
+              type: "string",
+              description: "Set when the fact was superseded but retained for audit",
+            },
+          },
+          required: ["fact"],
+        },
+        "Distilled semantic facts",
+      ),
+      count: { type: "number" },
+    },
+    required: ["facts", "count"],
+  },
+};
+
+// =============================================================================
+// DECORATION
+// =============================================================================
+
+/**
+ * Attach annotations (and an outputSchema where one is declared) to a tool
+ * definition.
+ *
+ * Throws when a tool has no entry in TOOL_BEHAVIOUR. That is deliberate: a
+ * silent default would mean a newly added tool ships with the spec defaults
+ * (`destructiveHint: true`, `openWorldHint: true`) and, worse, would be treated
+ * as non-read-only by the ambient-ingestion gate without anyone deciding so.
+ * Failing at startup forces the judgement call to be made once, here.
+ */
+export function decorateTool(def: ToolDefinition): DecoratedTool {
+  const annotations = TOOL_ANNOTATIONS[def.name];
+  if (!annotations) {
+    throw new Error(
+      `Tool "${def.name}" has no entry in TOOL_BEHAVIOUR (mcp-server/tool-metadata.ts). ` +
+        `Add one — annotations are not optional, and the read-only set gates ambient ingestion.`,
+    );
+  }
+  const outputSchema = TOOL_OUTPUT_SCHEMAS[def.name];
+  return outputSchema ? { ...def, annotations, outputSchema } : { ...def, annotations };
+}


### PR DESCRIPTION
51 tools annotated, 22 given `outputSchema`. But the headline is what annotating honestly required.

## Every "read" tool was writing to the store

`readOnlyHint: true` would have been a lie on all 26 read tools. `autoStreamContext` (`index.ts:2071`) and `streamToolCall` (`index.ts:651`) fire on essentially every tool call, with `STREAM_ENABLED` defaulting to true (`index.ts:348`).

Measured before changing anything, on a disposable store: `recall` + `list_entities` + `memory_stats` + `search_facts` created **2 memories** — a `Query: …` from one path and a `Tool: list_entities … Result:` from the other. **Reading the memory was writing to it.**

Both paths are now gated on the read-only set, so the annotation is true by construction from a single table. Same call sequence after the change: **delta 0**.

**This is the reversible decision to confirm.** It changes runtime behaviour, not just metadata. `proactive_context`'s `auto_ingest` default is untouched and hook-based capture is unaffected — only the MCP server's own reflexive self-recording stops.

## Annotations: all 51, none missing

26 read-only, 25 writers. `openWorldHint: false` everywhere and `destructiveHint`/`idempotentHint` set explicitly on every writer — both spec defaults are *true*, so silence would have been the dangerous answer.

Each non-obvious call was verified in the handler rather than inferred from the name:

- **`proactive_context`** — `auto_ingest` defaults true; writes.
- **`reset_token_session`** — same class and initially missed: `context_compressed` persists a session digest via `build_active_digest`.
- **`verify_index`, `backup_verify`** — POST but genuinely read-only. POST is transport, not semantics.
- **`complete_todo`** — **not** idempotent: re-completing spawns another recurrence, memory and activity entry every call.
- **`add_causal_link`** — dedupes but `reinforce()`s on repeat, so not idempotent.
- **`archive_project`** is restorable (not destructive); **`update_todo`/`update_todo_comment`** overwrite fields (destructive).
- **`purge_facts`** — `dry_run` is read-only, but annotations are static, so the hint describes the deleting default.

## A field that would have lied, caught in verification

`auto_ingested` was first derived as `Boolean(ingested_memory_id)`. During verification the store count moved 2 → 3 while the field said `false`: `handlers/recall.rs:2567` spawns the ingest as a background task and waits only **50 ms** to read the id back, so a null id routinely accompanies a write that did happen. It is now `ingest_requested` (echoes the argument, actually knowable), with `ingested_memory_id` documented as *absence is not proof of no write*.

## Structured output: 22 schemas, additive only

Text output is unchanged everywhere. Every non-error path emits a payload including empty and not-found cases, because the SDK client rejects a schema'd success result without one. All 22 exercised through a real SDK client, whose Ajv validation makes a passing call genuine schema validation rather than a self-assessment.

Payloads are **projections, not pass-throughs** — todo wire objects carry full embedding vectors and comment threads that would dwarf the text channel. Collection payloads carry the *full* result rather than the display-capped subset the text renders.

Deliberately skipped: one-line confirmations (all `delete_*`, `forget`, backup operations, `reorder_todo`, …) and prose narratives (`context_summary`, `session_digest`, `fact_narratives`, `consolidation_report`, `token_status`). A schema there buys nothing and must be maintained forever.

## Verification

`bun build` clean; **200 tests pass** (173 existing + 27 new pinning the table), including a regression guard that fails if any data-loss tool is ever flipped to read-only, and a test that `decorateTool` **throws** rather than silently defaulting an unannotated tool. No new `tsc` errors (5 pre-existing before and after). Read-only sampling ran against the demo backend (still 74 memories, never restarted); every mutating call ran against a disposable store on another port.

**SDK**: declared `^1.24.0` resolves to installed **1.29.0**, which carries `ToolAnnotations`, `outputSchema` and client-side validation. No bump needed.

**Left alone and disclosed**: `recall` still increments server-side retrieval counters — retrieval bookkeeping rather than user-visible mutation, and fixing it means reaching into Rust.