### PR TITLE
fix(todos): the search index was never persisted — plus real dependencies and memory provenance

### DIFF
--- a/src/handlers/consolidation.rs
+++ b/src/handlers/consolidation.rs
@@ -710,7 +710,11 @@ pub async fn get_consolidation_report(
             })?
             .with_timezone(&chrono::Utc)
     } else {
-        now - chrono::Duration::hours(1)
+        // Default window is 24h. Consolidation cycles run on multi-hour
+        // schedules, so the previous 1h default reported "no activity" on
+        // stores that consolidated earlier the same day — and clients already
+        // document this default as 24 hours.
+        now - chrono::Duration::hours(24)
     };
 
     let until = if let Some(until_str) = &req.until {

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -952,9 +952,6 @@ impl MultiUserMemoryManager {
         info!("Prospective memory store initialized");
 
         let todo_store = Arc::new(TodoStore::new(shared_db.clone(), &base_path)?);
-        if let Err(e) = todo_store.load_vector_indices() {
-            tracing::warn!("Failed to load todo vector indices: {}, semantic todo search will rebuild on first use", e);
-        }
         info!("Todo store initialized");
 
         let file_store = Arc::new(FileMemoryStore::new(shared_db.clone(), &base_path)?);

--- a/src/handlers/todos.rs
+++ b/src/handlers/todos.rs
@@ -20,9 +20,9 @@ use crate::memory::sessions::SessionEvent;
 use crate::memory::todo_formatter;
 use crate::memory::{Experience, ExperienceType};
 use crate::memory::{
-    Project, ProjectId, ProjectStats, ProjectStatus, ProspectiveTask, ProspectiveTaskId,
+    MemoryId, Project, ProjectId, ProjectStats, ProjectStatus, ProspectiveTask, ProspectiveTaskId,
     ProspectiveTaskStatus, ProspectiveTrigger, Recurrence, Todo, TodoComment, TodoCommentId,
-    TodoCommentType, TodoPriority, TodoStatus, UserTodoStats,
+    TodoCommentType, TodoId, TodoPriority, TodoStatus, UserTodoStats,
 };
 use crate::validation;
 
@@ -188,6 +188,14 @@ pub struct CreateTodoRequest {
     pub recurrence: Option<String>,
     #[serde(default)]
     pub external_id: Option<String>,
+    /// Todos this one depends on (short keys like "SHO-3" or UUIDs).
+    /// Resolved to real todos; unknown references are rejected.
+    #[serde(default)]
+    pub blocked_by: Option<Vec<String>>,
+    /// Memory UUIDs that motivated this todo (the "why does this task exist"
+    /// link). Verified to exist before linking.
+    #[serde(default)]
+    pub related_memory_ids: Option<Vec<String>>,
 }
 
 /// Response for todo operations
@@ -215,6 +223,8 @@ pub struct TodoCompleteResponse {
     pub success: bool,
     pub todo: Option<Todo>,
     pub next_recurrence: Option<Todo>,
+    /// Todos whose dependency set is fully satisfied now that this one is done
+    pub unblocked: Vec<Todo>,
     pub formatted: String,
 }
 
@@ -272,6 +282,13 @@ pub struct UpdateTodoRequest {
     pub parent_id: Option<String>,
     #[serde(default)]
     pub external_id: Option<String>,
+    /// Replace the set of todos this one depends on (short keys or UUIDs).
+    /// Pass an empty array to clear. Cycles are rejected.
+    #[serde(default)]
+    pub blocked_by: Option<Vec<String>>,
+    /// Replace the set of linked memory UUIDs. Pass an empty array to clear.
+    #[serde(default)]
+    pub related_memory_ids: Option<Vec<String>>,
 }
 
 /// Request to reorder a todo
@@ -439,6 +456,77 @@ fn parse_recurrence(s: &str) -> Result<Recurrence, AppError> {
             ),
         }),
     }
+}
+
+/// Resolve todo references (short keys like "SHO-3", seq numbers, or UUIDs)
+/// to concrete TodoIds. Unknown references are rejected — a dependency on a
+/// todo that does not exist is a data error, not something to store silently.
+fn resolve_todo_refs(
+    state: &AppState,
+    user_id: &str,
+    refs: &[String],
+    field: &str,
+) -> Result<Vec<TodoId>, AppError> {
+    let mut resolved = Vec::with_capacity(refs.len());
+    for r in refs {
+        let todo = state
+            .todo_store
+            .find_todo_by_prefix(user_id, r)
+            .map_err(AppError::Internal)?
+            .ok_or_else(|| AppError::InvalidInput {
+                field: field.to_string(),
+                reason: format!("No todo found matching '{}'", r),
+            })?;
+        if !resolved.contains(&todo.id) {
+            resolved.push(todo.id);
+        }
+    }
+    Ok(resolved)
+}
+
+/// Parse and verify memory UUIDs against the user's memory store. Linking a
+/// todo to a memory that does not exist would silently break the "why does
+/// this task exist" chain, so unknown ids are rejected up front.
+async fn verify_memory_ids(
+    state: &AppState,
+    user_id: &str,
+    ids: &[String],
+) -> Result<Vec<MemoryId>, AppError> {
+    let mut parsed = Vec::with_capacity(ids.len());
+    for id_str in ids {
+        let uuid = uuid::Uuid::parse_str(id_str).map_err(|_| AppError::InvalidInput {
+            field: "related_memory_ids".to_string(),
+            reason: format!("'{}' is not a valid memory UUID", id_str),
+        })?;
+        let mid = MemoryId(uuid);
+        if !parsed.contains(&mid) {
+            parsed.push(mid);
+        }
+    }
+    if parsed.is_empty() {
+        return Ok(parsed);
+    }
+
+    let memory_system = state
+        .get_user_memory(user_id)
+        .map_err(AppError::Internal)?;
+    let ids_to_check = parsed.clone();
+    let missing: Option<MemoryId> = tokio::task::spawn_blocking(move || {
+        let guard = memory_system.read();
+        ids_to_check
+            .into_iter()
+            .find(|mid| guard.get_memory(mid).is_err())
+    })
+    .await
+    .map_err(|e| AppError::Internal(anyhow::anyhow!("Memory verification task panicked: {e}")))?;
+
+    if let Some(mid) = missing {
+        return Err(AppError::InvalidInput {
+            field: "related_memory_ids".to_string(),
+            reason: format!("No memory found with id '{}'", mid.0),
+        });
+    }
+    Ok(parsed)
 }
 
 // =============================================================================
@@ -981,7 +1069,20 @@ pub async fn create_todo(
         todo.recurrence = Some(parse_recurrence(recurrence_str)?);
     }
 
-    // Compute embedding for semantic search
+    // Structured dependencies: resolve references to real todos. A new todo
+    // cannot introduce a cycle (nothing can depend on it yet), so resolution
+    // is the only check needed here.
+    if let Some(ref blocker_refs) = req.blocked_by {
+        todo.blocked_by = resolve_todo_refs(&state, &req.user_id, blocker_refs, "blocked_by")?;
+    }
+
+    // Explicit memory links: the memory that motivated this task
+    if let Some(ref memory_id_strs) = req.related_memory_ids {
+        todo.related_memory_ids = verify_memory_ids(&state, &req.user_id, memory_id_strs).await?;
+    }
+
+    // Compute embedding for semantic search — persisted on the todo record
+    // itself, which is the single source of truth for semantic todo search.
     let embedding_text = format!(
         "{} {} {}",
         todo.content,
@@ -1000,33 +1101,7 @@ pub async fn create_todo(
         .await
         .map_err(|e| AppError::Internal(anyhow::anyhow!("Embedding task panicked: {e}")))?
         {
-            todo.embedding = Some(embedding.clone());
-
-            match state
-                .todo_store
-                .index_todo_embedding(&req.user_id, &todo.id, &embedding)
-            {
-                Ok(vector_id) => {
-                    if let Err(e) =
-                        state
-                            .todo_store
-                            .store_vector_id_mapping(&req.user_id, vector_id, &todo.id)
-                    {
-                        tracing::warn!(
-                            todo_id = %todo.id,
-                            error = %e,
-                            "Failed to store vector ID mapping — todo will not be findable via semantic search"
-                        );
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        todo_id = %todo.id,
-                        error = %e,
-                        "Failed to index todo embedding — todo will not be findable via semantic search"
-                    );
-                }
-            }
+            todo.embedding = Some(embedding);
         }
     }
 
@@ -1076,6 +1151,7 @@ pub async fn create_todo(
         let exp_clone = experience.clone();
         let state_clone = state.clone();
         let user_id = req.user_id.clone();
+        let todo_id_for_link = todo.id.clone();
 
         tokio::spawn(async move {
             let memory_result = tokio::task::spawn_blocking(move || {
@@ -1093,6 +1169,19 @@ pub async fn create_todo(
                 ) {
                     tracing::debug!(
                         "Graph processing failed for todo memory {}: {}",
+                        memory_id.0,
+                        e
+                    );
+                }
+                // Link the creation memory back to the todo so its provenance
+                // is walkable from the task side ("why does this task exist")
+                if let Err(e) = state_clone.todo_store.add_related_memory(
+                    &user_id,
+                    &todo_id_for_link,
+                    memory_id.clone(),
+                ) {
+                    tracing::debug!(
+                        "Failed to link creation memory {} to todo: {}",
                         memory_id.0,
                         e
                     );
@@ -1186,34 +1275,33 @@ pub async fn list_todos(
         if query.trim().is_empty() {
             Vec::new()
         } else {
-            let memory_system = state
-                .get_user_memory(&req.user_id)
+            // Hybrid search: semantic (cosine over persisted embeddings) plus
+            // lexical substring matching. The lexical path guarantees exact
+            // word matches always surface, even when the embedding model is
+            // unavailable or a todo predates embedding support.
+            let query_embedding: Option<Vec<f32>> =
+                if let Ok(memory_system) = state.get_user_memory(&req.user_id) {
+                    let query_clone = query.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let memory_guard = memory_system.read();
+                        memory_guard.compute_embedding(&query_clone).ok()
+                    })
+                    .await
+                    .map_err(|e| AppError::Internal(anyhow::anyhow!("Embedding failed: {e}")))?
+                } else {
+                    None
+                };
+
+            let limit = req.limit.unwrap_or(50);
+            let search_results = state
+                .todo_store
+                .search_todos(&req.user_id, query, query_embedding.as_deref(), limit * 2)
                 .map_err(AppError::Internal)?;
 
-            let query_clone = query.clone();
-            let query_embedding: Vec<f32> = tokio::task::spawn_blocking(move || {
-                let memory_guard = memory_system.read();
-                memory_guard
-                    .compute_embedding(&query_clone)
-                    .unwrap_or_default()
-            })
-            .await
-            .map_err(|e| AppError::Internal(anyhow::anyhow!("Embedding failed: {e}")))?;
-
-            if query_embedding.is_empty() {
-                Vec::new()
-            } else {
-                let limit = req.limit.unwrap_or(50);
-                let search_results = state
-                    .todo_store
-                    .search_similar(&req.user_id, &query_embedding, limit * 2)
-                    .map_err(AppError::Internal)?;
-
-                search_results
-                    .into_iter()
-                    .map(|(todo, _score)| todo)
-                    .collect()
-            }
+            search_results
+                .into_iter()
+                .map(|(todo, _score)| todo)
+                .collect()
         }
     } else if let Some(ref statuses) = status_filter {
         state
@@ -1414,7 +1502,36 @@ pub async fn get_todo(
         None
     };
 
-    let formatted = todo_formatter::format_todo_line(&todo, project_name.as_deref(), true);
+    let mut formatted = todo_formatter::format_todo_line(&todo, project_name.as_deref(), true);
+
+    // Structured dependencies: show what this task waits on, with live status
+    if !todo.blocked_by.is_empty() {
+        let blockers: Vec<String> = todo
+            .blocked_by
+            .iter()
+            .map(|bid| {
+                match state.todo_store.get_todo(&query.user_id, bid) {
+                    Ok(Some(b)) => {
+                        let status = format!("{:?}", b.status).to_lowercase();
+                        format!("{} ({})", b.short_id(), status)
+                    }
+                    _ => format!("{} (deleted)", bid.short()),
+                }
+            })
+            .collect();
+        formatted.push_str(&format!("\n  Blocked by: {}", blockers.join(", ")));
+    }
+
+    // Memory links: the provenance chain for "why does this task exist" —
+    // each id can be read with the memory tools and traced through lineage
+    if !todo.related_memory_ids.is_empty() {
+        let ids: Vec<String> = todo
+            .related_memory_ids
+            .iter()
+            .map(|m| m.0.to_string())
+            .collect();
+        formatted.push_str(&format!("\n  Linked memories: {}", ids.join(", ")));
+    }
 
     Ok(Json(TodoResponse {
         success: true,
@@ -1491,6 +1608,35 @@ pub async fn update_todo(
         }
     }
 
+    // Structured dependencies: resolve references, reject self-references and
+    // cycles. Replace semantics — pass an empty array to clear.
+    let mut blocked_by_changed = false;
+    if let Some(ref blocker_refs) = req.blocked_by {
+        let resolved = resolve_todo_refs(&state, &req.user_id, blocker_refs, "blocked_by")?;
+        if state
+            .todo_store
+            .would_create_dependency_cycle(&req.user_id, &todo.id, &resolved)
+            .map_err(AppError::Internal)?
+        {
+            return Err(AppError::InvalidInput {
+                field: "blocked_by".to_string(),
+                reason: format!(
+                    "Dependency cycle: {} already blocks (directly or transitively) one of the given todos",
+                    todo.short_id()
+                ),
+            });
+        }
+        if resolved != todo.blocked_by {
+            todo.blocked_by = resolved;
+            blocked_by_changed = true;
+        }
+    }
+
+    // Memory links: replace semantics, verified against the memory store
+    if let Some(ref memory_id_strs) = req.related_memory_ids {
+        todo.related_memory_ids = verify_memory_ids(&state, &req.user_id, memory_id_strs).await?;
+    }
+
     let mut project_name = None;
     if let Some(ref proj_name) = req.project {
         let project = state
@@ -1503,18 +1649,9 @@ pub async fn update_todo(
 
     todo.updated_at = chrono::Utc::now();
 
-    // Re-compute embedding if needed.
-    // IMPORTANT: call update_todo() FIRST so remove_todo_indices() cleans up
-    // the OLD vector mapping. Then add the new embedding afterwards, so the
-    // new vector/mapping aren't immediately deleted by remove_todo_indices().
-    let needs_reindex = req.content.is_some() || req.notes.is_some() || req.tags.is_some();
-
-    state
-        .todo_store
-        .update_todo(&todo)
-        .map_err(AppError::Internal)?;
-
-    if needs_reindex {
+    // Re-compute the embedding BEFORE the single write below, so the todo is
+    // persisted exactly once with its up-to-date embedding.
+    if req.content.is_some() || req.notes.is_some() || req.tags.is_some() {
         let embedding_text = format!(
             "{} {} {}",
             todo.content,
@@ -1533,24 +1670,15 @@ pub async fn update_todo(
             .await
             .map_err(|e| AppError::Internal(anyhow::anyhow!("Embedding task panicked: {e}")))?
             {
-                todo.embedding = Some(embedding.clone());
-
-                if let Ok(vector_id) =
-                    state
-                        .todo_store
-                        .index_todo_embedding(&req.user_id, &todo.id, &embedding)
-                {
-                    let _ =
-                        state
-                            .todo_store
-                            .store_vector_id_mapping(&req.user_id, vector_id, &todo.id);
-                }
-
-                // Persist the embedding field on the todo
-                let _ = state.todo_store.update_todo(&todo);
+                todo.embedding = Some(embedding);
             }
         }
     }
+
+    state
+        .todo_store
+        .update_todo(&todo)
+        .map_err(AppError::Internal)?;
 
     let update_description = {
         let mut changes = Vec::new();
@@ -1574,6 +1702,13 @@ pub async fn update_todo(
                 "blocked on: {}",
                 todo.blocked_on.as_deref().unwrap_or("cleared")
             ));
+        }
+        if blocked_by_changed {
+            if todo.blocked_by.is_empty() {
+                changes.push("dependencies cleared".to_string());
+            } else {
+                changes.push(format!("blocked by {} todo(s)", todo.blocked_by.len()));
+            }
         }
         changes.join(", ")
     };
@@ -1617,6 +1752,7 @@ pub async fn update_todo(
             let exp_clone = experience.clone();
             let state_clone = state.clone();
             let user_id = req.user_id.clone();
+            let todo_id_for_link = todo.id.clone();
 
             tokio::spawn(async move {
                 let memory_result = tokio::task::spawn_blocking(move || {
@@ -1634,6 +1770,17 @@ pub async fn update_todo(
                     ) {
                         tracing::debug!(
                             "Graph processing failed for todo update memory {}: {}",
+                            memory_id.0,
+                            e
+                        );
+                    }
+                    if let Err(e) = state_clone.todo_store.add_related_memory(
+                        &user_id,
+                        &todo_id_for_link,
+                        memory_id.clone(),
+                    ) {
+                        tracing::debug!(
+                            "Failed to link update memory {} to todo: {}",
                             memory_id.0,
                             e
                         );
@@ -1744,6 +1891,7 @@ pub async fn complete_todo(
             let exp_clone = experience.clone();
             let state_clone = state.clone();
             let user_id = req.user_id.clone();
+            let todo_id_for_link = todo.id.clone();
 
             tokio::spawn(async move {
                 let memory_result = tokio::task::spawn_blocking(move || {
@@ -1765,6 +1913,17 @@ pub async fn complete_todo(
                             e
                         );
                     }
+                    if let Err(e) = state_clone.todo_store.add_related_memory(
+                        &user_id,
+                        &todo_id_for_link,
+                        memory_id.clone(),
+                    ) {
+                        tracing::debug!(
+                            "Failed to link completion memory {} to todo: {}",
+                            memory_id.0,
+                            e
+                        );
+                    }
                     tracing::debug!(memory_id = %memory_id.0, "Todo completion stored as searchable memory");
                 }
             });
@@ -1773,7 +1932,21 @@ pub async fn complete_todo(
 
     match result {
         Some((completed, next)) => {
-            let formatted = todo_formatter::format_todo_completed(&completed, next.as_ref());
+            // Surface todos whose dependency set is now fully satisfied —
+            // "you finished this; here is what it unblocks"
+            let unblocked = state
+                .todo_store
+                .unblocked_by_completion(&req.user_id, &completed.id)
+                .unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "Failed to compute unblocked todos");
+                    Vec::new()
+                });
+
+            let mut formatted = todo_formatter::format_todo_completed(&completed, next.as_ref());
+            if !unblocked.is_empty() {
+                let ids: Vec<String> = unblocked.iter().map(|t| t.short_id()).collect();
+                formatted.push_str(&format!("\n\n  → Unblocked: {}", ids.join(", ")));
+            }
 
             state.emit_event(MemoryEvent {
                 event_type: "TODO_COMPLETE".to_string(),
@@ -1820,6 +1993,7 @@ pub async fn complete_todo(
                 success: true,
                 todo: Some(completed),
                 next_recurrence: next,
+                unblocked,
                 formatted,
             }))
         }
@@ -1889,6 +2063,16 @@ pub async fn reorder_todo(
 ) -> Result<Json<TodoResponse>, AppError> {
     validation::validate_user_id(&req.user_id).map_validation_err("user_id")?;
 
+    if req.direction != "up" && req.direction != "down" {
+        return Err(AppError::InvalidInput {
+            field: "direction".to_string(),
+            reason: format!(
+                "Unknown direction '{}'. Valid values: up, down",
+                req.direction
+            ),
+        });
+    }
+
     let todo = state
         .todo_store
         .find_todo_by_prefix(&req.user_id, &todo_id)
@@ -1902,11 +2086,7 @@ pub async fn reorder_todo(
 
     match result {
         Some(updated) => {
-            let formatted = format!(
-                "Moved {} {}",
-                updated.short_id(),
-                if req.direction == "up" { "up" } else { "down" }
-            );
+            let formatted = format!("Moved {} {}", updated.short_id(), req.direction);
 
             state.emit_event(MemoryEvent {
                 event_type: "TODO_REORDER".to_string(),
@@ -2125,6 +2305,18 @@ pub async fn add_todo_comment(
                 );
             }
 
+            if let Err(e) =
+                state
+                    .todo_store
+                    .add_related_memory(&req.user_id, &todo.id, memory_id.clone())
+            {
+                tracing::debug!(
+                    "Failed to link comment memory {} to todo: {}",
+                    memory_id.0,
+                    e
+                );
+            }
+
             tracing::debug!(
                 memory_id = %memory_id.0,
                 todo_id = %todo.id,
@@ -2133,13 +2325,7 @@ pub async fn add_todo_comment(
         }
     }
 
-    let formatted = format!(
-        "✓ Added comment to {}\n\n  {} ({}):\n  {}",
-        todo.short_id(),
-        author,
-        comment.created_at.format("%Y-%m-%d %H:%M"),
-        req.content
-    );
+    let formatted = todo_formatter::format_comment_added(&todo.short_id(), &comment);
 
     state.emit_event(MemoryEvent {
         event_type: "TODO_COMMENT_ADD".to_string(),
@@ -2191,32 +2377,7 @@ pub async fn list_todo_comments(
         .get_comments(&query.user_id, &todo.id)
         .map_err(AppError::Internal)?;
 
-    let formatted = if comments.is_empty() {
-        format!("No comments on {}", todo.short_id())
-    } else {
-        let mut output = format!(
-            "📝 Comments on {} ({} total)\n\n",
-            todo.short_id(),
-            comments.len()
-        );
-        for (i, comment) in comments.iter().enumerate() {
-            let type_icon = match comment.comment_type {
-                TodoCommentType::Comment => "💬",
-                TodoCommentType::Progress => "📊",
-                TodoCommentType::Resolution => "✅",
-                TodoCommentType::Activity => "🔄",
-            };
-            output.push_str(&format!(
-                "{}. {} {} ({})\n   {}\n\n",
-                i + 1,
-                type_icon,
-                comment.author,
-                comment.created_at.format("%Y-%m-%d %H:%M"),
-                comment.content
-            ));
-        }
-        output
-    };
+    let formatted = todo_formatter::format_comment_list(&todo.short_id(), &comments);
 
     tracing::debug!(
         user_id = %query.user_id,

--- a/src/handlers/todos.rs
+++ b/src/handlers/todos.rs
@@ -507,9 +507,7 @@ async fn verify_memory_ids(
         return Ok(parsed);
     }
 
-    let memory_system = state
-        .get_user_memory(user_id)
-        .map_err(AppError::Internal)?;
+    let memory_system = state.get_user_memory(user_id).map_err(AppError::Internal)?;
     let ids_to_check = parsed.clone();
     let missing: Option<MemoryId> = tokio::task::spawn_blocking(move || {
         let guard = memory_system.read();
@@ -1509,14 +1507,12 @@ pub async fn get_todo(
         let blockers: Vec<String> = todo
             .blocked_by
             .iter()
-            .map(|bid| {
-                match state.todo_store.get_todo(&query.user_id, bid) {
-                    Ok(Some(b)) => {
-                        let status = format!("{:?}", b.status).to_lowercase();
-                        format!("{} ({})", b.short_id(), status)
-                    }
-                    _ => format!("{} (deleted)", bid.short()),
+            .map(|bid| match state.todo_store.get_todo(&query.user_id, bid) {
+                Ok(Some(b)) => {
+                    let status = format!("{:?}", b.status).to_lowercase();
+                    format!("{} ({})", b.short_id(), status)
                 }
+                _ => format!("{} (deleted)", bid.short()),
             })
             .collect();
         formatted.push_str(&format!("\n  Blocked by: {}", blockers.join(", ")));

--- a/src/memory/todo_formatter.rs
+++ b/src/memory/todo_formatter.rs
@@ -383,10 +383,7 @@ fn comment_type_icon(comment_type: &super::types::TodoCommentType) -> &'static s
 /// Format the comment list for a todo. Every comment line carries its id —
 /// update/delete operations require the comment id, and this rendering is the
 /// only place a client that reads formatted output can discover it.
-pub fn format_comment_list(
-    todo_short_id: &str,
-    comments: &[super::types::TodoComment],
-) -> String {
+pub fn format_comment_list(todo_short_id: &str, comments: &[super::types::TodoComment]) -> String {
     if comments.is_empty() {
         return format!("No comments on {}", todo_short_id);
     }

--- a/src/memory/todo_formatter.rs
+++ b/src/memory/todo_formatter.rs
@@ -163,9 +163,26 @@ pub fn format_todo_list_with_total(
 
     let mut output = header;
 
-    // Separate parent todos and subtasks
-    let parent_todos: Vec<_> = todos.iter().filter(|t| t.parent_id.is_none()).collect();
-    let subtasks: Vec<_> = todos.iter().filter(|t| t.parent_id.is_some()).collect();
+    // Top-level rows: todos without a parent, PLUS subtasks whose parent is
+    // not part of this list (e.g. the subtasks view, or a filtered list that
+    // matched only the child). A subtask must never be dropped just because
+    // its parent didn't make the list.
+    let ids_in_list: std::collections::HashSet<_> = todos.iter().map(|t| &t.id).collect();
+    let parent_todos: Vec<_> = todos
+        .iter()
+        .filter(|t| match &t.parent_id {
+            None => true,
+            Some(pid) => !ids_in_list.contains(pid),
+        })
+        .collect();
+    let subtasks: Vec<_> = todos
+        .iter()
+        .filter(|t| {
+            t.parent_id
+                .as_ref()
+                .is_some_and(|pid| ids_in_list.contains(pid))
+        })
+        .collect();
 
     // Group by status in workflow order
     let status_order = [
@@ -350,6 +367,60 @@ pub fn format_todo_updated(todo: &Todo, project_name: Option<&str>) -> String {
 /// Format todo deleted confirmation
 pub fn format_todo_deleted(todo_id: &str) -> String {
     format!("✓ Deleted {}", todo_id)
+}
+
+/// Icon for a comment type
+fn comment_type_icon(comment_type: &super::types::TodoCommentType) -> &'static str {
+    use super::types::TodoCommentType;
+    match comment_type {
+        TodoCommentType::Comment => "💬",
+        TodoCommentType::Progress => "📊",
+        TodoCommentType::Resolution => "✅",
+        TodoCommentType::Activity => "🔄",
+    }
+}
+
+/// Format the comment list for a todo. Every comment line carries its id —
+/// update/delete operations require the comment id, and this rendering is the
+/// only place a client that reads formatted output can discover it.
+pub fn format_comment_list(
+    todo_short_id: &str,
+    comments: &[super::types::TodoComment],
+) -> String {
+    if comments.is_empty() {
+        return format!("No comments on {}", todo_short_id);
+    }
+
+    let mut output = format!(
+        "📝 Comments on {} ({} total)\n\n",
+        todo_short_id,
+        comments.len()
+    );
+    for (i, comment) in comments.iter().enumerate() {
+        output.push_str(&format!(
+            "{}. {} {} ({}) [id: {}]\n   {}\n\n",
+            i + 1,
+            comment_type_icon(&comment.comment_type),
+            comment.author,
+            comment.created_at.format("%Y-%m-%d %H:%M"),
+            comment.id.0,
+            comment.content
+        ));
+    }
+    output
+}
+
+/// Format the confirmation for a newly added comment, including its id so the
+/// caller can immediately update or delete it.
+pub fn format_comment_added(todo_short_id: &str, comment: &super::types::TodoComment) -> String {
+    format!(
+        "✓ Added comment to {} [id: {}]\n\n  {} ({}):\n  {}",
+        todo_short_id,
+        comment.id.0,
+        comment.author,
+        comment.created_at.format("%Y-%m-%d %H:%M"),
+        comment.content
+    )
 }
 
 /// Format project list with sub-project hierarchy
@@ -640,5 +711,65 @@ mod tests {
         let future = now + Duration::days(3);
         let text = format_due_date(&future);
         assert!(text.contains("Due"));
+    }
+
+    /// Regression: a list consisting only of subtasks (the subtasks view, or a
+    /// filtered list that matched a child but not its parent) must render the
+    /// rows, not just the header. Subtasks were previously dropped whenever
+    /// their parent was absent from the list.
+    #[test]
+    fn test_orphan_subtasks_render_as_rows() {
+        let parent_elsewhere = super::super::types::TodoId::new();
+        let mut child = Todo::new("u".to_string(), "The child task".to_string());
+        child.parent_id = Some(parent_elsewhere);
+
+        let out = format_todo_list(&[child], &[]);
+        assert!(
+            out.contains("The child task"),
+            "subtask with absent parent must still render: {out}"
+        );
+    }
+
+    #[test]
+    fn test_subtasks_nest_under_present_parent() {
+        let mut parent = Todo::new("u".to_string(), "Parent task".to_string());
+        parent.status = TodoStatus::Todo;
+        let mut child = Todo::new("u".to_string(), "Child task".to_string());
+        child.parent_id = Some(parent.id.clone());
+        child.status = TodoStatus::Todo;
+
+        let out = format_todo_list(&[parent, child], &[]);
+        assert!(out.contains("Parent task"));
+        assert!(out.contains("Child task"));
+        // Child appears after parent (nested rendering)
+        let p_pos = out.find("Parent task").unwrap();
+        let c_pos = out.find("Child task").unwrap();
+        assert!(c_pos > p_pos, "child renders under its parent");
+    }
+
+    /// Comment ids must be discoverable from the rendered list — update and
+    /// delete both require the id, and this rendering is the only place a
+    /// formatted-output client can obtain it.
+    #[test]
+    fn test_comment_list_and_confirmation_include_ids() {
+        use super::super::types::{TodoComment, TodoId};
+
+        let todo_id = TodoId::new();
+        let comment = TodoComment::new(todo_id, "varun".to_string(), "First note".to_string());
+
+        let listed = format_comment_list("SHO-8", std::slice::from_ref(&comment));
+        assert!(
+            listed.contains(&comment.id.0.to_string()),
+            "comment id must appear in the list rendering: {listed}"
+        );
+        assert!(listed.contains("First note"));
+
+        let added = format_comment_added("SHO-8", &comment);
+        assert!(
+            added.contains(&comment.id.0.to_string()),
+            "comment id must appear in the add confirmation: {added}"
+        );
+
+        assert_eq!(format_comment_list("SHO-8", &[]), "No comments on SHO-8");
     }
 }

--- a/src/memory/todos.rs
+++ b/src/memory/todos.rs
@@ -22,8 +22,8 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use super::types::{
-    MemoryId, Project, ProjectId, ProjectStatus, Todo, TodoComment, TodoCommentId,
-    TodoCommentType, TodoId, TodoStatus,
+    MemoryId, Project, ProjectId, ProjectStatus, Todo, TodoComment, TodoCommentId, TodoCommentType,
+    TodoId, TodoStatus,
 };
 
 /// Minimum cosine similarity for a todo to count as a semantic match.
@@ -888,8 +888,7 @@ impl TodoStore {
                     continue;
                 }
                 if let Some(blocker) = self.get_todo(user_id, blocker_id)? {
-                    if blocker.status != TodoStatus::Done
-                        && blocker.status != TodoStatus::Cancelled
+                    if blocker.status != TodoStatus::Done && blocker.status != TodoStatus::Cancelled
                     {
                         continue 'outer; // Still blocked by something else
                     }
@@ -1873,8 +1872,14 @@ mod tests {
             "invalid direction must be an error, not a silent no-op: {err}"
         );
         // Valid directions still work
-        assert!(store.reorder_todo("test_user", &todo.id, "up").unwrap().is_some());
-        assert!(store.reorder_todo("test_user", &todo.id, "down").unwrap().is_some());
+        assert!(store
+            .reorder_todo("test_user", &todo.id, "up")
+            .unwrap()
+            .is_some());
+        assert!(store
+            .reorder_todo("test_user", &todo.id, "down")
+            .unwrap()
+            .is_some());
     }
 
     // =========================================================================

--- a/src/memory/todos.rs
+++ b/src/memory/todos.rs
@@ -8,26 +8,29 @@
 //! - Project grouping
 //! - Recurring tasks with automatic next instance creation
 //! - Due date tracking with overdue detection
-//! - Vector embeddings for semantic search (MiniLM-L6-v2)
-//! - Vamana HNSW index for fast similarity search
+//! - Semantic search via exact cosine scan over embeddings persisted on each
+//!   todo (MiniLM-L6-v2, 384-dim), plus a lexical substring path that guarantees
+//!   exact word matches even for todos without embeddings.
+//! - Structured dependencies (`blocked_by`) with cycle rejection
+//! - Bidirectional memory links (`related_memory_ids`)
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use chrono::Utc;
-use parking_lot::RwLock;
 use rocksdb::{ColumnFamily, ColumnFamilyDescriptor, Options, WriteBatch, DB};
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use uuid::Uuid;
 
 use super::types::{
-    Project, ProjectId, ProjectStatus, Todo, TodoComment, TodoCommentId, TodoCommentType, TodoId,
-    TodoStatus,
+    MemoryId, Project, ProjectId, ProjectStatus, Todo, TodoComment, TodoCommentId,
+    TodoCommentType, TodoId, TodoStatus,
 };
-use crate::vector_db::{VamanaConfig, VamanaIndex};
 
-/// Embedding dimension (MiniLM-L6-v2)
-const EMBEDDING_DIM: usize = 384;
+/// Minimum cosine similarity for a todo to count as a semantic match.
+/// Below this, results are noise: an exact scan with no floor would return
+/// `limit` todos for ANY query, which misleads callers as badly as returning
+/// none. Lexical substring matches are exempt from this floor.
+pub const MIN_SEMANTIC_SIMILARITY: f32 = 0.3;
 
 const CF_TODOS: &str = "todos";
 const CF_PROJECTS: &str = "projects";
@@ -78,12 +81,13 @@ fn migrate_due_key_padding(db: &DB, index_cf: &ColumnFamily) -> Result<usize> {
 pub struct TodoStore {
     /// Shared RocksDB instance with column families for todos, projects, and indices
     db: Arc<DB>,
-    /// Vector index for semantic search (per-user indices)
-    vector_indices: RwLock<HashMap<String, VamanaIndex>>,
-    /// Storage path for persisting vector indices
+    /// Storage path (used for legacy vector-index cleanup during user purge)
     storage_path: std::path::PathBuf,
     /// Mutex for atomic sequence number allocation (prevents TOCTOU race)
     seq_mutex: parking_lot::Mutex<()>,
+    /// Serializes read-modify-write mutations that can run concurrently with
+    /// user-initiated updates (e.g. async memory linking after remember()).
+    link_mutex: parking_lot::Mutex<()>,
 }
 
 impl TodoStore {
@@ -132,9 +136,9 @@ impl TodoStore {
 
         Ok(Self {
             db,
-            vector_indices: RwLock::new(HashMap::new()),
             storage_path: todos_path,
             seq_mutex: parking_lot::Mutex::new(()),
+            link_mutex: parking_lot::Mutex::new(()),
         })
     }
 
@@ -192,142 +196,132 @@ impl TodoStore {
         Ok(())
     }
 
-    /// Get or create a Vamana vector index for a user
-    fn get_or_create_index(&self, user_id: &str) -> Result<()> {
-        let mut indices = self.vector_indices.write();
-        if !indices.contains_key(user_id) {
-            let config = VamanaConfig {
-                dimension: EMBEDDING_DIM,
-                max_degree: 32,
-                search_list_size: 75,
-                alpha: 1.2,
-                ..Default::default()
-            };
-            let index = VamanaIndex::new(config)?;
-            indices.insert(user_id.to_string(), index);
+    /// Cosine similarity between two vectors. Returns None on dimension
+    /// mismatch or zero-norm inputs (treated as "no semantic signal").
+    fn cosine_similarity(a: &[f32], b: &[f32]) -> Option<f32> {
+        if a.len() != b.len() || a.is_empty() {
+            return None;
         }
-        Ok(())
+        let mut dot = 0.0f32;
+        let mut norm_a = 0.0f32;
+        let mut norm_b = 0.0f32;
+        for (x, y) in a.iter().zip(b.iter()) {
+            dot += x * y;
+            norm_a += x * x;
+            norm_b += y * y;
+        }
+        if norm_a <= f32::EPSILON || norm_b <= f32::EPSILON {
+            return None;
+        }
+        Some(dot / (norm_a.sqrt() * norm_b.sqrt()))
     }
 
-    /// Add or update a todo in the vector index
-    /// Returns the vector ID assigned to this todo
-    pub fn index_todo_embedding(
-        &self,
-        user_id: &str,
-        _todo_id: &TodoId,
-        embedding: &[f32],
-    ) -> Result<u32> {
-        self.get_or_create_index(user_id)?;
-
-        let mut indices = self.vector_indices.write();
-        if let Some(index) = indices.get_mut(user_id) {
-            // Add vector and get assigned ID
-            let vector_id = index.add_vector(embedding.to_vec())?;
-            return Ok(vector_id);
-        }
-        anyhow::bail!("Failed to get vector index for user: {}", user_id)
-    }
-
-    /// Search for similar todos by embedding
+    /// Search for similar todos by embedding.
+    ///
+    /// Exact cosine scan over the embeddings persisted on each todo record.
+    /// This deliberately replaces the previous in-memory Vamana side-index,
+    /// which was never persisted in production (its save path had no callers),
+    /// so every restart silently emptied it and semantic todo search returned
+    /// nothing. The embedding on the todo record is the single source of truth;
+    /// an exact scan over it cannot go stale. Todo counts are human-scale, and
+    /// other hot paths (`find_todo_by_prefix`) already scan all of a user's
+    /// todos, so this matches the store's existing performance profile.
+    ///
+    /// Results are clamped to [0, 1] and filtered by [`MIN_SEMANTIC_SIMILARITY`].
     pub fn search_similar(
         &self,
         user_id: &str,
         query_embedding: &[f32],
         limit: usize,
     ) -> Result<Vec<(Todo, f32)>> {
-        let indices = self.vector_indices.read();
-        if let Some(index) = indices.get(user_id) {
-            let results = index.search(query_embedding, limit)?;
-
-            // Find todos by vector_id (stored in todo_index CF)
-            let mut todo_results = Vec::new();
-            for (vector_id, score) in results {
-                if let Some(todo) = self.get_todo_by_vector_id(user_id, vector_id)? {
-                    todo_results.push((todo, score));
+        let todos = self.list_todos_for_user(user_id, None)?;
+        let mut scored: Vec<(Todo, f32)> = todos
+            .into_iter()
+            .filter_map(|todo| {
+                let emb = todo.embedding.as_deref()?;
+                let sim = Self::cosine_similarity(query_embedding, emb)?;
+                let sim = sim.clamp(0.0, 1.0);
+                if sim >= MIN_SEMANTIC_SIMILARITY {
+                    Some((todo, sim))
+                } else {
+                    None
                 }
-            }
-            Ok(todo_results)
-        } else {
-            Ok(Vec::new())
-        }
+            })
+            .collect();
+
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(limit);
+        Ok(scored)
     }
 
-    /// Get a todo by its vector index ID (stored in todo_index CF)
-    fn get_todo_by_vector_id(&self, user_id: &str, vector_id: u32) -> Result<Option<Todo>> {
-        let key = format!("vector_id:{}:{}", user_id, vector_id);
-        if let Some(data) = self.db.get_cf(self.todo_index_cf(), key.as_bytes())? {
-            let todo_id_str = String::from_utf8_lossy(&data);
-            if let Ok(uuid) = Uuid::parse_str(&todo_id_str) {
-                return self.get_todo(user_id, &TodoId(uuid));
-            }
-        }
-        Ok(None)
-    }
-
-    /// Store the mapping from vector_id to todo_id (and reverse)
-    pub fn store_vector_id_mapping(
+    /// Hybrid todo search: semantic (cosine over persisted embeddings) unioned
+    /// with lexical substring matching over content, notes, and tags.
+    ///
+    /// The lexical path guarantees that exact word matches ALWAYS surface —
+    /// including todos that have no embedding (created while the embedding
+    /// model was unavailable) and queries whose embedding could not be
+    /// computed (`query_embedding = None`).
+    ///
+    /// Ordering: lexical matches first (a literal hit is the strongest signal
+    /// for a task lookup), then by semantic score descending.
+    pub fn search_todos(
         &self,
         user_id: &str,
-        vector_id: u32,
-        todo_id: &TodoId,
-    ) -> Result<()> {
-        let mut batch = WriteBatch::default();
-        let index_cf = self.todo_index_cf();
-
-        // Forward: vector_id → todo_id (for search result resolution)
-        let fwd_key = format!("vector_id:{}:{}", user_id, vector_id);
-        batch.put_cf(
-            index_cf,
-            fwd_key.as_bytes(),
-            todo_id.0.to_string().as_bytes(),
-        );
-
-        // Reverse: todo_id → vector_id (for cleanup on delete)
-        let rev_key = format!("todo_vector:{}:{}", user_id, todo_id.0);
-        batch.put_cf(index_cf, rev_key.as_bytes(), vector_id.to_le_bytes());
-
-        self.db.write(batch)?;
-        Ok(())
-    }
-
-    /// Save vector indices to disk
-    pub fn save_vector_indices(&self) -> Result<()> {
-        let indices = self.vector_indices.read();
-        for (user_id, index) in indices.iter() {
-            let index_path = self.storage_path.join("vectors").join(user_id);
-            std::fs::create_dir_all(&index_path)?;
-            index.save(&index_path)?;
+        query: &str,
+        query_embedding: Option<&[f32]>,
+        limit: usize,
+    ) -> Result<Vec<(Todo, f32)>> {
+        let query_lower = query.trim().to_lowercase();
+        if query_lower.is_empty() {
+            return Ok(Vec::new());
         }
-        Ok(())
-    }
+        let query_tokens: Vec<&str> = query_lower.split_whitespace().collect();
 
-    /// Load vector indices from disk
-    pub fn load_vector_indices(&self) -> Result<()> {
-        let vectors_path = self.storage_path.join("vectors");
-        if !vectors_path.exists() {
-            return Ok(());
-        }
+        let todos = self.list_todos_for_user(user_id, None)?;
+        let mut results: Vec<(Todo, f32, bool)> = Vec::new();
 
-        let mut indices = self.vector_indices.write();
-        for entry in std::fs::read_dir(&vectors_path)? {
-            let entry = entry?;
-            if entry.file_type()?.is_dir() {
-                let user_id = entry.file_name().to_string_lossy().to_string();
-                let index_path = entry.path();
+        for todo in todos {
+            // Searchable text: content + notes + tags (mirrors what the
+            // embedding is computed from)
+            let haystack = format!(
+                "{} {} {}",
+                todo.content,
+                todo.notes.as_deref().unwrap_or(""),
+                todo.tags.join(" ")
+            )
+            .to_lowercase();
 
-                // Create a new index and load from disk
-                let config = VamanaConfig {
-                    dimension: EMBEDDING_DIM,
-                    ..Default::default()
-                };
-                let mut index = VamanaIndex::new(config)?;
-                if index.load(&index_path).is_ok() {
-                    indices.insert(user_id.clone(), index);
-                    tracing::debug!("Loaded todo vector index for user: {}", user_id);
-                }
+            // A lexical hit is either the full query as a substring, or every
+            // query word present somewhere (word-order independent).
+            let lexical_hit = haystack.contains(&query_lower)
+                || query_tokens.iter().all(|tok| haystack.contains(tok));
+
+            let semantic_score = query_embedding
+                .and_then(|q| {
+                    todo.embedding
+                        .as_deref()
+                        .and_then(|e| Self::cosine_similarity(q, e))
+                })
+                .map(|s| s.clamp(0.0, 1.0));
+
+            let semantic_hit = semantic_score.is_some_and(|s| s >= MIN_SEMANTIC_SIMILARITY);
+
+            if lexical_hit || semantic_hit {
+                results.push((todo, semantic_score.unwrap_or(0.0), lexical_hit));
             }
         }
-        Ok(())
+
+        // Lexical hits first, then semantic score descending
+        results.sort_by(|a, b| {
+            b.2.cmp(&a.2)
+                .then(b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal))
+        });
+        results.truncate(limit);
+
+        Ok(results
+            .into_iter()
+            .map(|(todo, score, _)| (todo, score))
+            .collect())
     }
 
     // =========================================================================
@@ -511,39 +505,22 @@ impl TodoStore {
             batch.delete_cf(index_cf, parent_key.as_bytes());
         }
 
-        // Clean up vector index mapping: look up vector_id from reverse mapping.
-        // We capture the vector_id BEFORE the batch write so we can mark_deleted AFTER
-        // the batch commits — this ensures the index only reflects committed deletes.
+        // Legacy hygiene: earlier versions kept a Vamana side-index with
+        // vector-id mappings in the index CF. Remove any leftover mapping keys
+        // for this todo so old stores stay clean. (Orphaned `vector_id:*` keys
+        // from crashes are harmless and are swept by user purge.)
         let rev_key = format!("todo_vector:{}:{}", todo.user_id, id_str);
-        let pending_vector_delete = if let Some(vid_bytes) =
-            self.db.get_cf(index_cf, rev_key.as_bytes())?
-        {
+        if let Some(vid_bytes) = self.db.get_cf(index_cf, rev_key.as_bytes())? {
             if vid_bytes.len() >= 4 {
                 let vector_id =
                     u32::from_le_bytes([vid_bytes[0], vid_bytes[1], vid_bytes[2], vid_bytes[3]]);
-
-                // Remove forward mapping in batch (will commit atomically)
                 let fwd_key = format!("vector_id:{}:{}", todo.user_id, vector_id);
                 batch.delete_cf(index_cf, fwd_key.as_bytes());
-                Some((todo.user_id.clone(), vector_id))
-            } else {
-                None
             }
-        } else {
-            None
-        };
-        // Remove reverse mapping in batch
+        }
         batch.delete_cf(index_cf, rev_key.as_bytes());
 
         self.db.write(batch)?;
-
-        // Mark deleted in Vamana index AFTER batch commit succeeds
-        if let Some((ref user_id, vector_id)) = pending_vector_delete {
-            let indices = self.vector_indices.read();
-            if let Some(index) = indices.get(user_id) {
-                index.mark_deleted(vector_id);
-            }
-        }
         Ok(())
     }
 
@@ -798,6 +775,131 @@ impl TodoStore {
         }
     }
 
+    // =========================================================================
+    // MEMORY LINKS ("why does this task exist")
+    // =========================================================================
+
+    /// Link a memory to a todo (idempotent). Serialized via `link_mutex` so the
+    /// async link-back after `remember()` cannot lose a concurrent update.
+    /// Returns true if the todo exists (whether or not the link was new).
+    pub fn add_related_memory(
+        &self,
+        user_id: &str,
+        todo_id: &TodoId,
+        memory_id: MemoryId,
+    ) -> Result<bool> {
+        let _lock = self.link_mutex.lock();
+        if let Some(mut todo) = self.get_todo(user_id, todo_id)? {
+            if !todo.has_related_memory(&memory_id) {
+                todo.add_related_memory(memory_id);
+                self.update_todo(&todo)?;
+            }
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    // =========================================================================
+    // STRUCTURED DEPENDENCIES (blocked_by)
+    // =========================================================================
+
+    /// Check whether setting `new_blockers` on `todo_id` would create a
+    /// dependency cycle. Walks the `blocked_by` graph from each proposed
+    /// blocker; if any chain reaches back to `todo_id`, the edge set is cyclic.
+    pub fn would_create_dependency_cycle(
+        &self,
+        user_id: &str,
+        todo_id: &TodoId,
+        new_blockers: &[TodoId],
+    ) -> Result<bool> {
+        use std::collections::{HashSet, VecDeque};
+
+        if new_blockers.iter().any(|b| b == todo_id) {
+            return Ok(true); // Self-dependency
+        }
+
+        let mut visited: HashSet<Uuid> = HashSet::new();
+        let mut queue: VecDeque<TodoId> = new_blockers.iter().cloned().collect();
+
+        while let Some(current) = queue.pop_front() {
+            if current == *todo_id {
+                return Ok(true);
+            }
+            if !visited.insert(current.0) {
+                continue;
+            }
+            if let Some(todo) = self.get_todo(user_id, &current)? {
+                for blocker in &todo.blocked_by {
+                    queue.push_back(blocker.clone());
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    /// Walk the full blocking chain for a todo: everything it transitively
+    /// waits on, in BFS order (direct blockers first). Cycle-safe.
+    pub fn blocking_chain(&self, user_id: &str, todo_id: &TodoId) -> Result<Vec<Todo>> {
+        use std::collections::{HashSet, VecDeque};
+
+        let mut visited: HashSet<Uuid> = HashSet::new();
+        visited.insert(todo_id.0);
+        let mut chain = Vec::new();
+        let mut queue: VecDeque<TodoId> = match self.get_todo(user_id, todo_id)? {
+            Some(t) => t.blocked_by.iter().cloned().collect(),
+            None => return Ok(Vec::new()),
+        };
+
+        while let Some(current) = queue.pop_front() {
+            if !visited.insert(current.0) {
+                continue;
+            }
+            if let Some(todo) = self.get_todo(user_id, &current)? {
+                for blocker in &todo.blocked_by {
+                    queue.push_back(blocker.clone());
+                }
+                chain.push(todo);
+            }
+        }
+        Ok(chain)
+    }
+
+    /// Todos that become unblocked by completing `completed_id`: they list it
+    /// in `blocked_by` and every OTHER blocker is already Done/Cancelled (or
+    /// deleted). Used to surface "you can now start X" on completion.
+    pub fn unblocked_by_completion(
+        &self,
+        user_id: &str,
+        completed_id: &TodoId,
+    ) -> Result<Vec<Todo>> {
+        let todos = self.list_todos_for_user(user_id, None)?;
+        let mut unblocked = Vec::new();
+
+        'outer: for todo in todos {
+            if todo.status == TodoStatus::Done || todo.status == TodoStatus::Cancelled {
+                continue;
+            }
+            if !todo.blocked_by.contains(completed_id) {
+                continue;
+            }
+            for blocker_id in &todo.blocked_by {
+                if blocker_id == completed_id {
+                    continue;
+                }
+                if let Some(blocker) = self.get_todo(user_id, blocker_id)? {
+                    if blocker.status != TodoStatus::Done
+                        && blocker.status != TodoStatus::Cancelled
+                    {
+                        continue 'outer; // Still blocked by something else
+                    }
+                }
+            }
+            unblocked.push(todo);
+        }
+        Ok(unblocked)
+    }
+
     /// Reorder a todo within its status group
     /// direction: "up" moves earlier in list (lower sort_order), "down" moves later
     pub fn reorder_todo(
@@ -839,7 +941,10 @@ impl TodoStore {
                 }
                 pos + 1
             }
-            _ => return Ok(Some(todo)), // Invalid direction
+            other => bail!(
+                "Invalid reorder direction '{}'. Valid values: up, down",
+                other
+            ),
         };
 
         // Swap sort_order values with adjacent todo
@@ -1333,17 +1438,28 @@ impl TodoStore {
         }
     }
 
-    /// Purge a user's vector index from memory (used during GDPR user deletion)
+    /// Purge a user's legacy on-disk vector index files (GDPR user deletion).
+    /// Embeddings now live only on the todo records themselves, which the
+    /// shared-DB purge deletes; this removes index files written by earlier
+    /// versions that kept a separate Vamana side-index per user.
     pub fn purge_user_vectors(&self, user_id: &str) {
-        let mut indices = self.vector_indices.write();
-        indices.remove(user_id);
+        let legacy_dir = self.storage_path.join("vectors").join(user_id);
+        if legacy_dir.exists() {
+            if let Err(e) = std::fs::remove_dir_all(&legacy_dir) {
+                tracing::warn!(
+                    user_id = %user_id,
+                    error = %e,
+                    "Failed to remove legacy todo vector index dir during purge"
+                );
+            }
+        }
     }
 
     // =========================================================================
     // STATS
     // =========================================================================
 
-    /// Flush all RocksDB column families and save vector indices to disk (critical for graceful shutdown)
+    /// Flush all RocksDB column families to disk (critical for graceful shutdown)
     pub fn flush(&self) -> Result<()> {
         use rocksdb::FlushOptions;
         let mut flush_opts = FlushOptions::default();
@@ -1356,10 +1472,6 @@ impl TodoStore {
                     .map_err(|e| anyhow::anyhow!("Failed to flush {cf_name}: {e}"))?;
             }
         }
-
-        // Save vector indices
-        self.save_vector_indices()
-            .map_err(|e| anyhow::anyhow!("Failed to save todo vector indices: {e}"))?;
 
         Ok(())
     }
@@ -1624,5 +1736,304 @@ mod tests {
             .unwrap();
         assert_eq!(in_progress.len(), 1);
         assert_eq!(in_progress[0].content, "Task 1");
+    }
+
+    // =========================================================================
+    // SEMANTIC + LEXICAL SEARCH
+    // =========================================================================
+
+    /// Regression for the dead `list_todos({query})` path: semantic search must
+    /// read the embeddings persisted on the todo records — including through a
+    /// process restart. The previous Vamana side-index was never saved in
+    /// production, so every restart silently emptied it and search returned
+    /// nothing.
+    #[test]
+    fn test_search_similar_survives_store_reopen() {
+        let temp_dir = TempDir::new().unwrap();
+        let db = open_test_shared_db(temp_dir.path());
+
+        let mut todo_a = Todo::new("test_user".to_string(), "Deploy the API server".to_string());
+        todo_a.embedding = Some(vec![1.0, 0.0, 0.0, 0.0]);
+        let mut todo_b = Todo::new("test_user".to_string(), "Buy groceries".to_string());
+        todo_b.embedding = Some(vec![0.0, 1.0, 0.0, 0.0]);
+
+        {
+            let store = TodoStore::new(db.clone(), temp_dir.path()).unwrap();
+            store.store_todo(&todo_a).unwrap();
+            store.store_todo(&todo_b).unwrap();
+
+            let results = store
+                .search_similar("test_user", &[0.9, 0.1, 0.0, 0.0], 10)
+                .unwrap();
+            // todo_a: cosine ≈ 0.99 (match); todo_b: cosine ≈ 0.11 (below floor)
+            assert_eq!(results.len(), 1, "only the todo above the floor matches");
+            assert_eq!(results[0].0.content, "Deploy the API server");
+            assert!(results[0].1 > MIN_SEMANTIC_SIMILARITY);
+        }
+
+        // Simulate a process restart: a brand-new TodoStore over the same DB.
+        // No in-memory state may be required for search to work.
+        let reopened = TodoStore::new(db, temp_dir.path()).unwrap();
+        let results = reopened
+            .search_similar("test_user", &[0.9, 0.1, 0.0, 0.0], 10)
+            .unwrap();
+        assert!(
+            !results.is_empty(),
+            "semantic search must survive a restart (embeddings are persisted on the todos)"
+        );
+        assert_eq!(results[0].0.content, "Deploy the API server");
+    }
+
+    #[test]
+    fn test_search_similar_applies_similarity_floor() {
+        let (store, _temp) = setup_store();
+
+        let mut todo = Todo::new("test_user".to_string(), "Unrelated task".to_string());
+        todo.embedding = Some(vec![0.0, 0.0, 1.0, 0.0]);
+        store.store_todo(&todo).unwrap();
+
+        // Orthogonal query: cosine 0.0 < MIN_SEMANTIC_SIMILARITY
+        let results = store
+            .search_similar("test_user", &[1.0, 0.0, 0.0, 0.0], 10)
+            .unwrap();
+        assert!(
+            results.is_empty(),
+            "matches below the similarity floor must not surface"
+        );
+    }
+
+    #[test]
+    fn test_search_todos_lexical_guarantees_exact_match() {
+        let (store, _temp) = setup_store();
+
+        // No embedding at all — created while the embedding model was down
+        let todo = Todo::new("test_user".to_string(), "Audit-2 parent task".to_string());
+        store.store_todo(&todo).unwrap();
+
+        // No query embedding either — lexical path must still find it
+        let results = store
+            .search_todos("test_user", "Audit-2 parent", None, 10)
+            .unwrap();
+        assert_eq!(results.len(), 1, "exact word match must always surface");
+        assert_eq!(results[0].0.content, "Audit-2 parent task");
+
+        // Case-insensitive, and matches notes and tags too
+        let mut tagged = Todo::new("test_user".to_string(), "Second task".to_string());
+        tagged.tags = vec!["release-blocker".to_string()];
+        store.store_todo(&tagged).unwrap();
+
+        let by_tag = store
+            .search_todos("test_user", "RELEASE-BLOCKER", None, 10)
+            .unwrap();
+        assert_eq!(by_tag.len(), 1);
+        assert_eq!(by_tag[0].0.content, "Second task");
+
+        // Word-order independent: all query tokens present counts as a hit
+        let reordered = store
+            .search_todos("test_user", "parent Audit-2", None, 10)
+            .unwrap();
+        assert_eq!(reordered.len(), 1, "token match must be order-independent");
+        assert_eq!(reordered[0].0.content, "Audit-2 parent task");
+    }
+
+    #[test]
+    fn test_search_todos_lexical_ranks_before_semantic() {
+        let (store, _temp) = setup_store();
+
+        let mut semantic_only = Todo::new("test_user".to_string(), "Related work".to_string());
+        semantic_only.embedding = Some(vec![1.0, 0.0]);
+        store.store_todo(&semantic_only).unwrap();
+
+        let mut lexical_hit = Todo::new("test_user".to_string(), "Fix login bug".to_string());
+        lexical_hit.embedding = Some(vec![0.8, 0.6]);
+        store.store_todo(&lexical_hit).unwrap();
+
+        let results = store
+            .search_todos("test_user", "login", Some(&[1.0, 0.0]), 10)
+            .unwrap();
+        assert_eq!(results[0].0.content, "Fix login bug", "literal hit first");
+    }
+
+    // =========================================================================
+    // REORDER VALIDATION
+    // =========================================================================
+
+    #[test]
+    fn test_reorder_invalid_direction_rejected() {
+        let (store, _temp) = setup_store();
+
+        let todo = Todo::new("test_user".to_string(), "Task".to_string());
+        store.store_todo(&todo).unwrap();
+
+        let err = store
+            .reorder_todo("test_user", &todo.id, "sideways")
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("Valid values: up, down"),
+            "invalid direction must be an error, not a silent no-op: {err}"
+        );
+        // Valid directions still work
+        assert!(store.reorder_todo("test_user", &todo.id, "up").unwrap().is_some());
+        assert!(store.reorder_todo("test_user", &todo.id, "down").unwrap().is_some());
+    }
+
+    // =========================================================================
+    // MEMORY LINKS
+    // =========================================================================
+
+    #[test]
+    fn test_add_related_memory_idempotent() {
+        let (store, _temp) = setup_store();
+
+        let todo = Todo::new("test_user".to_string(), "Linked task".to_string());
+        store.store_todo(&todo).unwrap();
+
+        let mem_id = MemoryId(Uuid::new_v4());
+        assert!(store
+            .add_related_memory("test_user", &todo.id, mem_id.clone())
+            .unwrap());
+        assert!(store
+            .add_related_memory("test_user", &todo.id, mem_id.clone())
+            .unwrap());
+
+        let stored = store.get_todo("test_user", &todo.id).unwrap().unwrap();
+        assert_eq!(stored.related_memory_ids, vec![mem_id]);
+
+        // Unknown todo → false, not an error
+        assert!(!store
+            .add_related_memory("test_user", &TodoId::new(), MemoryId(Uuid::new_v4()))
+            .unwrap());
+    }
+
+    // =========================================================================
+    // STRUCTURED DEPENDENCIES
+    // =========================================================================
+
+    #[test]
+    fn test_dependency_cycle_detection() {
+        let (store, _temp) = setup_store();
+
+        let mut a = Todo::new("test_user".to_string(), "A".to_string());
+        let b = Todo::new("test_user".to_string(), "B".to_string());
+        let c = Todo::new("test_user".to_string(), "C".to_string());
+
+        // A depends on B
+        a.blocked_by = vec![b.id.clone()];
+        store.store_todo(&a).unwrap();
+        store.store_todo(&b).unwrap();
+        store.store_todo(&c).unwrap();
+
+        // Self-dependency is a cycle
+        assert!(store
+            .would_create_dependency_cycle("test_user", &a.id, &[a.id.clone()])
+            .unwrap());
+        // B → A would close the loop (A already waits on B)
+        assert!(store
+            .would_create_dependency_cycle("test_user", &b.id, &[a.id.clone()])
+            .unwrap());
+        // C → A is fine (no path from A back to C)
+        assert!(!store
+            .would_create_dependency_cycle("test_user", &c.id, &[a.id.clone()])
+            .unwrap());
+    }
+
+    #[test]
+    fn test_blocking_chain_walk() {
+        let (store, _temp) = setup_store();
+
+        let mut a = Todo::new("test_user".to_string(), "A".to_string());
+        let mut b = Todo::new("test_user".to_string(), "B".to_string());
+        let c = Todo::new("test_user".to_string(), "C".to_string());
+
+        b.blocked_by = vec![c.id.clone()];
+        a.blocked_by = vec![b.id.clone()];
+        store.store_todo(&a).unwrap();
+        store.store_todo(&b).unwrap();
+        store.store_todo(&c).unwrap();
+
+        let chain = store.blocking_chain("test_user", &a.id).unwrap();
+        let contents: Vec<&str> = chain.iter().map(|t| t.content.as_str()).collect();
+        assert_eq!(contents, vec!["B", "C"], "BFS: direct blocker first");
+    }
+
+    #[test]
+    fn test_unblocked_by_completion() {
+        let (store, _temp) = setup_store();
+
+        let mut a = Todo::new("test_user".to_string(), "A".to_string());
+        let b = Todo::new("test_user".to_string(), "B".to_string());
+        let c = Todo::new("test_user".to_string(), "C".to_string());
+
+        a.blocked_by = vec![b.id.clone(), c.id.clone()];
+        store.store_todo(&a).unwrap();
+        store.store_todo(&b).unwrap();
+        store.store_todo(&c).unwrap();
+
+        // Completing B alone does not unblock A (C is still open)
+        store.complete_todo("test_user", &b.id).unwrap();
+        let after_b = store.unblocked_by_completion("test_user", &b.id).unwrap();
+        assert!(after_b.is_empty(), "A still waits on C");
+
+        // Completing C releases A
+        store.complete_todo("test_user", &c.id).unwrap();
+        let after_c = store.unblocked_by_completion("test_user", &c.id).unwrap();
+        assert_eq!(after_c.len(), 1);
+        assert_eq!(after_c[0].content, "A");
+    }
+
+    // =========================================================================
+    // PERSISTED-SHAPE COMPATIBILITY
+    // =========================================================================
+
+    /// A todo serialized by a pre-`blocked_by` build must deserialize cleanly
+    /// (new fields default) and survive a write-back round trip. Todos are
+    /// stored as JSON, so unknown/missing fields are tolerated — this test
+    /// pins that contract against the exact bytes an old build produced.
+    #[test]
+    fn test_old_bytes_round_trip() {
+        let old_json = r#"{
+            "id": "5f2b7a86-3e64-4f0e-9c86-2f9f9a3d1b11",
+            "seq_num": 7,
+            "project_prefix": "MEM",
+            "project": "MEM",
+            "user_id": "test_user",
+            "content": "Legacy todo from an old build",
+            "status": "in_progress",
+            "priority": "high",
+            "project_id": "0e6f4a92-8f4b-4f0a-b0d9-6a3c62f5a001",
+            "parent_id": null,
+            "contexts": ["@computer"],
+            "tags": ["legacy"],
+            "due_date": "2026-01-15T23:59:59Z",
+            "recurrence": null,
+            "blocked_on": "vendor response",
+            "notes": "created before blocked_by existed",
+            "created_at": "2026-01-01T10:00:00Z",
+            "updated_at": "2026-01-02T11:00:00Z",
+            "completed_at": null,
+            "sort_order": 3,
+            "comments": [],
+            "related_memory_ids": []
+        }"#;
+
+        let mut todo: Todo = serde_json::from_str(old_json).expect("old bytes must deserialize");
+        assert_eq!(todo.content, "Legacy todo from an old build");
+        assert_eq!(todo.seq_num, 7);
+        assert!(todo.blocked_by.is_empty(), "new field defaults to empty");
+        assert!(todo.embedding.is_none());
+        assert_eq!(todo.blocked_on.as_deref(), Some("vendor response"));
+
+        // Write-back through the store and read again
+        let (store, _temp) = setup_store();
+        todo.sync_compat_fields();
+        store.store_todo(&todo).unwrap();
+        let reread = store.get_todo("test_user", &todo.id).unwrap().unwrap();
+        assert_eq!(reread.content, todo.content);
+        assert_eq!(reread.seq_num, 7);
+        assert!(reread.blocked_by.is_empty());
+
+        // And the new serialized form carries the new field explicitly
+        let new_json = serde_json::to_string(&reread).unwrap();
+        assert!(new_json.contains("\"blocked_by\":[]"));
     }
 }

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -4138,6 +4138,13 @@ pub struct Todo {
     /// Memories that are semantically or explicitly linked to this todo
     #[serde(default)]
     pub related_memory_ids: Vec<MemoryId>,
+
+    /// Structured dependencies: todos that must complete before this one can proceed.
+    /// Unlike the free-text `blocked_on` (who/what, e.g. "waiting on vendor"), these
+    /// reference real todos so blocked chains can be walked and cycles rejected.
+    /// NOTE: appended at the struct tail — keep new fields after this one.
+    #[serde(default)]
+    pub blocked_by: Vec<TodoId>,
 }
 
 impl Todo {
@@ -4169,6 +4176,7 @@ impl Todo {
             comments: Vec::new(),
             embedding: None,
             related_memory_ids: Vec::new(),
+            blocked_by: Vec::new(),
         }
     }
 

--- a/src/mif/adapters/shodh.rs
+++ b/src/mif/adapters/shodh.rs
@@ -242,6 +242,7 @@ fn convert_v1_todo(t: &serde_json::Value) -> Option<MifTodo> {
         comments: Vec::new(),
         related_memory_ids: Vec::new(),
         external_id: None,
+        blocked_by: Vec::new(),
     })
 }
 

--- a/src/mif/export.rs
+++ b/src/mif/export.rs
@@ -407,6 +407,7 @@ fn convert_todo(t: &Todo) -> MifTodo {
         comments,
         related_memory_ids: t.related_memory_ids.iter().map(|id| id.0).collect(),
         external_id: t.external_id.clone(),
+        blocked_by: t.blocked_by.iter().map(|id| id.0).collect(),
     }
 }
 

--- a/src/mif/import.rs
+++ b/src/mif/import.rs
@@ -160,6 +160,7 @@ pub fn prepare_todos(doc: &MifDocument, user_id: &str) -> Vec<Todo> {
                 embedding: None,
                 related_memory_ids,
                 external_id: t.external_id.clone(),
+                blocked_by: t.blocked_by.iter().map(|id| TodoId(*id)).collect(),
             }
         })
         .collect()

--- a/src/mif/schema.rs
+++ b/src/mif/schema.rs
@@ -261,6 +261,9 @@ pub struct MifTodo {
     pub related_memory_ids: Vec<Uuid>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
+    /// Structured dependencies: todo UUIDs that must complete before this one
+    #[serde(default)]
+    pub blocked_by: Vec<Uuid>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/handler_tests.rs
+++ b/tests/handler_tests.rs
@@ -1669,6 +1669,39 @@ async fn verify_index_empty() {
     assert!(status.is_success());
 }
 
+/// Regression (capability-map F17): with no `since`, the consolidation report
+/// covered only the last hour while clients document a 24-hour default, so it
+/// reported "no activity" on stores that consolidated earlier the same day.
+/// The default window must span 24 hours.
+#[tokio::test]
+async fn consolidation_report_defaults_to_24h_window() {
+    let h = Harness::new();
+    let (status, body) = json_of(
+        h.app(),
+        authed_post(
+            "/api/consolidation/report",
+            json!({"user_id": "test-user"}),
+        ),
+    )
+    .await;
+    assert!(status.is_success(), "consolidation report: {body}");
+
+    let start = body["period"]["start"]
+        .as_str()
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .expect("period.start");
+    let end = body["period"]["end"]
+        .as_str()
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .expect("period.end");
+
+    let window_mins = (end - start).num_minutes();
+    assert!(
+        (window_mins - 24 * 60).abs() <= 5,
+        "default report window must span ~24h, got {window_mins} minutes"
+    );
+}
+
 #[tokio::test]
 async fn rebuild_index_empty() {
     let h = Harness::new();

--- a/tests/handler_tests.rs
+++ b/tests/handler_tests.rs
@@ -1354,22 +1354,29 @@ async fn todo_comment_ids_are_discoverable_and_usable() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "add comment: {body}");
-    let comment_id = body["comment"]["id"].as_str().expect("comment id").to_string();
+    let comment_id = body["comment"]["id"]
+        .as_str()
+        .expect("comment id")
+        .to_string();
     assert!(
-        body["formatted"].as_str().unwrap_or("").contains(&comment_id),
+        body["formatted"]
+            .as_str()
+            .unwrap_or("")
+            .contains(&comment_id),
         "add confirmation must render the comment id: {body}"
     );
 
     let (status, body) = json_of(
         h.app(),
-        authed_get(&format!(
-            "/api/todos/{todo_id}/comments?user_id=test-user"
-        )),
+        authed_get(&format!("/api/todos/{todo_id}/comments?user_id=test-user")),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
     assert!(
-        body["formatted"].as_str().unwrap_or("").contains(&comment_id),
+        body["formatted"]
+            .as_str()
+            .unwrap_or("")
+            .contains(&comment_id),
         "comment list must render ids: {body}"
     );
 
@@ -1441,7 +1448,10 @@ async fn subtasks_listing_renders_rows() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["count"], json!(1), "one subtask expected: {body}");
     assert!(
-        body["formatted"].as_str().unwrap_or("").contains("Child task row"),
+        body["formatted"]
+            .as_str()
+            .unwrap_or("")
+            .contains("Child task row"),
         "formatted subtask list must render the rows, not just a count: {body}"
     );
 }
@@ -1477,7 +1487,10 @@ async fn todo_blocked_by_dependency_flow() {
     )
     .await;
     assert_eq!(status, StatusCode::OK, "create dependent: {body}");
-    let dependent_id = body["todo"]["id"].as_str().expect("dependent id").to_string();
+    let dependent_id = body["todo"]["id"]
+        .as_str()
+        .expect("dependent id")
+        .to_string();
     assert_eq!(
         body["todo"]["blocked_by"].as_array().map(|a| a.len()),
         Some(1),
@@ -1532,7 +1545,10 @@ async fn todo_blocked_by_dependency_flow() {
         "completing the last blocker must surface the dependent as unblocked: {body}"
     );
     assert!(
-        body["formatted"].as_str().unwrap_or("").contains("Unblocked"),
+        body["formatted"]
+            .as_str()
+            .unwrap_or("")
+            .contains("Unblocked"),
         "formatted completion must mention what was unblocked: {body}"
     );
 }
@@ -1678,10 +1694,7 @@ async fn consolidation_report_defaults_to_24h_window() {
     let h = Harness::new();
     let (status, body) = json_of(
         h.app(),
-        authed_post(
-            "/api/consolidation/report",
-            json!({"user_id": "test-user"}),
-        ),
+        authed_post("/api/consolidation/report", json!({"user_id": "test-user"})),
     )
     .await;
     assert!(status.is_success(), "consolidation report: {body}");

--- a/tests/handler_tests.rs
+++ b/tests/handler_tests.rs
@@ -1245,6 +1245,298 @@ async fn list_todos_empty() {
     assert!(status.is_success());
 }
 
+/// Regression (capability-map F19): `list_todos` with a `query` that is a
+/// literal prefix of an existing todo's content returned nothing. The lexical
+/// path of hybrid search must guarantee exact word matches surface.
+#[tokio::test]
+async fn list_todos_query_finds_exact_word_match() {
+    let h = Harness::new();
+
+    let (status, body) = json_of(
+        h.app(),
+        authed_post(
+            "/api/todos/add",
+            json!({"user_id": "test-user", "content": "Audit-2 parent task"}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "create todo: {body}");
+
+    let (status, body) = json_of(
+        h.app(),
+        authed_post(
+            "/api/todos",
+            json!({"user_id": "test-user", "query": "Audit-2 parent"}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let todos = body["todos"].as_array().expect("todos array");
+    assert!(
+        todos
+            .iter()
+            .any(|t| t["content"].as_str() == Some("Audit-2 parent task")),
+        "query must find the todo whose content it literally prefixes: {body}"
+    );
+}
+
+/// Regression (capability-map F15): `reorder_todo` accepted any direction and
+/// silently treated it as "down". Invalid directions must be a 400 that names
+/// the accepted values.
+#[tokio::test]
+async fn reorder_todo_rejects_invalid_direction() {
+    let h = Harness::new();
+
+    let (_, body) = json_of(
+        h.app(),
+        authed_post(
+            "/api/todos/add",
+            json!({"user_id": "test-user", "content": "Reorder me"}),
+        ),
+    )
+    .await;
+    let todo_id = body["todo"]["id"].as_str().expect("todo id").to_string();
+
+    let (status, body) = json_of(
+        h.app(),
+        authed_post(
+            &format!("/api/todos/{todo_id}/reorder"),
+            json!({"user_id": "test-user", "direction": "sideways"}),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "invalid direction must be rejected, got: {body}"
+    );
+    assert!(
+        body.to_string().contains("up"),
+        "error should name accepted values: {body}"
+    );
+
+    // Valid direction still works
+    let (status, _) = json_of(
+        h.app(),
+        authed_post(
+            &format!("/api/todos/{todo_id}/reorder"),
+            json!({"user_id": "test-user", "direction": "up"}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+/// Regression (capability-map F7): comment ids were never rendered, making
+/// `update_todo_comment` / `delete_todo_comment` unreachable for clients that
+/// read formatted output. Both the add confirmation and the list must carry
+/// the id, and the id must actually drive update and delete.
+#[tokio::test]
+async fn todo_comment_ids_are_discoverable_and_usable() {
+    let h = Harness::new();
+
+    let (_, body) = json_of(
+        h.app(),
+        authed_post(
+            "/api/todos/add",
+            json!({"user_id": "test-user", "content": "Comment target"}),
+        ),
+    )
+    .await;
+    let todo_id = body["todo"]["id"].as_str().expect("todo id").to_string();
+
+    let (status, body) = json_of(
+        h.app(),
+        authed_post(
+            &format!("/api/todos/{todo_id}/comments"),
+            json!({"user_id": "test-user", "content": "an audit comment"}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "add comment: {body}");
+    let comment_id = body["comment"]["id"].as_str().expect("comment id").to_string();
+    assert!(
+        body["formatted"].as_str().unwrap_or("").contains(&comment_id),
+        "add confirmation must render the comment id: {body}"
+    );
+
+    let (status, body) = json_of(
+        h.app(),
+        authed_get(&format!(
+            "/api/todos/{todo_id}/comments?user_id=test-user"
+        )),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        body["formatted"].as_str().unwrap_or("").contains(&comment_id),
+        "comment list must render ids: {body}"
+    );
+
+    // The rendered id drives update...
+    let (status, body) = json_of(
+        h.app(),
+        authed_post(
+            &format!("/api/todos/{todo_id}/comments/{comment_id}/update"),
+            json!({"user_id": "test-user", "content": "edited"}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "update comment: {body}");
+
+    // ...and delete
+    let (status, body) = json_of(
+        h.app(),
+        authed_delete(&format!(
+            "/api/todos/{todo_id}/comments/{comment_id}?user_id=test-user"
+        )),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "delete comment: {body}");
+    assert_eq!(body["success"], json!(true));
+}
+
+/// Regression (capability-map F8): the subtasks endpoint returned a header and
+/// a count with no rows. The formatted output must render the children.
+#[tokio::test]
+async fn subtasks_listing_renders_rows() {
+    let h = Harness::new();
+
+    let (_, body) = json_of(
+        h.app(),
+        authed_post(
+            "/api/todos/add",
+            json!({"user_id": "test-user", "content": "Parent task"}),
+        ),
+    )
+    .await;
+    let parent_id = body["todo"]["id"].as_str().expect("parent id").to_string();
+
+    let (status, body) = json_of(
+        h.app(),
+        authed_post(
+            "/api/todos/add",
+            json!({
+                "user_id": "test-user",
+                "content": "Child task row",
+                "parent_id": parent_id
+            }),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "create subtask: {body}");
+    assert_eq!(
+        body["todo"]["parent_id"].as_str(),
+        Some(parent_id.as_str()),
+        "child must be parented: {body}"
+    );
+
+    let (status, body) = json_of(
+        h.app(),
+        authed_get(&format!(
+            "/api/todos/{parent_id}/subtasks?user_id=test-user"
+        )),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["count"], json!(1), "one subtask expected: {body}");
+    assert!(
+        body["formatted"].as_str().unwrap_or("").contains("Child task row"),
+        "formatted subtask list must render the rows, not just a count: {body}"
+    );
+}
+
+/// Structured dependencies end to end: create with blocked_by, reject a
+/// dependency cycle with 400, and surface the newly unblocked todo on
+/// completion of its last blocker.
+#[tokio::test]
+async fn todo_blocked_by_dependency_flow() {
+    let h = Harness::new();
+
+    let (_, body) = json_of(
+        h.app(),
+        authed_post(
+            "/api/todos/add",
+            json!({"user_id": "test-user", "content": "Blocker task"}),
+        ),
+    )
+    .await;
+    let blocker_id = body["todo"]["id"].as_str().expect("blocker id").to_string();
+
+    // Create a dependent todo referencing the blocker by UUID
+    let (status, body) = json_of(
+        h.app(),
+        authed_post(
+            "/api/todos/add",
+            json!({
+                "user_id": "test-user",
+                "content": "Dependent task",
+                "blocked_by": [blocker_id]
+            }),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "create dependent: {body}");
+    let dependent_id = body["todo"]["id"].as_str().expect("dependent id").to_string();
+    assert_eq!(
+        body["todo"]["blocked_by"].as_array().map(|a| a.len()),
+        Some(1),
+        "dependency must be stored: {body}"
+    );
+
+    // Unknown reference is rejected
+    let (status, _) = json_of(
+        h.app(),
+        authed_post(
+            "/api/todos/add",
+            json!({
+                "user_id": "test-user",
+                "content": "Bad dep",
+                "blocked_by": ["NOPE-999"]
+            }),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "unknown dependency ref");
+
+    // Cycle: blocker cannot depend on dependent (dependent already waits on it)
+    let (status, body) = json_of(
+        h.app(),
+        authed_post(
+            &format!("/api/todos/{blocker_id}/update"),
+            json!({"user_id": "test-user", "blocked_by": [dependent_id]}),
+        ),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "dependency cycle must be rejected: {body}"
+    );
+
+    // Completing the blocker surfaces the dependent as unblocked
+    let (status, body) = json_of(
+        h.app(),
+        authed_post(
+            &format!("/api/todos/{blocker_id}/complete"),
+            json!({"user_id": "test-user"}),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "complete blocker: {body}");
+    let unblocked = body["unblocked"].as_array().expect("unblocked array");
+    assert!(
+        unblocked
+            .iter()
+            .any(|t| t["content"].as_str() == Some("Dependent task")),
+        "completing the last blocker must surface the dependent as unblocked: {body}"
+    );
+    assert!(
+        body["formatted"].as_str().unwrap_or("").contains("Unblocked"),
+        "formatted completion must mention what was unblocked: {body}"
+    );
+}
+
 #[tokio::test]
 async fn todo_stats_empty() {
     let h = Harness::new();


### PR DESCRIPTION
Sent to make todos "extremely potent". The data model was already close to Jira's core, so the work was repairing what was broken and connecting what was inert.

## The headline: todo semantic search never worked in production, and here is why

`list_todos({query})` returned nothing despite every todo carrying an embedding. Root cause: **the todo Vamana side-index was never persisted.** `TodoStore::flush()` is the only caller of `save_vector_indices()`, and `flush()` itself has **zero callers** — `flush_all_databases` flushes `shared_db` directly. So every restart silently emptied the index and `search_similar` returned `Ok(vec![])` forever.

Three further decoherence modes existed underneath: a load failure produced a fresh index whose `id = current_count` collided with stale RocksDB mappings; an absent per-user index returned empty silently; and Vamana's "graph not built" error did the same.

Rather than repair a side-store that can always drift, it is **removed**. `search_similar` is now an exact cosine scan over the embeddings already persisted on the todo records — single source of truth, cannot go stale — with a documented `MIN_SEMANTIC_SIMILARITY = 0.3` floor so the failure mode does not simply invert from "always empty" to "always full". A new `search_todos` adds a lexical path (substring plus word-order-independent all-tokens) that **guarantees exact word matches** even for todos with no embedding or when the model is unavailable. `find_todo_by_prefix` already full-scans, so this matches the store's existing performance profile.

## The other broken paths, each pinned by a regression test

- **`list_subtasks` printed no rows**: the formatter dropped any subtask whose parent was absent from the same list — which also silently lost rows from *filtered* lists. Orphans now render as top-level rows.
- **Comment ids were undiscoverable**, making `update_todo_comment` and `delete_todo_comment` permanently uncallable. Formatted output now carries `[id: <uuid>]` per comment, so **both tools become callable with zero MCP changes**; the test drives update and delete through the rendered id.
- **`reorder_todo`** silently meant "down" for any input; now a 400 naming `up, down`.
- **`consolidation_report`** default window 1h → 24h, matching its documented default.

## `related_memory_ids` was dead weight — now live

Zero callers ever populated it, in either direction; only MIF round-tripped it. Creation, update, completion and comment memories now link back to the todo, and `add`/`update` accept explicit ids **verified to exist** in the memory store. `get_todo` renders them, so "why does this task exist" chains into `read_memory` and `trace_lineage` with tools that already ship.

## Real dependencies

`Todo.blocked_by: Vec<TodoId>` referencing actual todos: references resolved from short keys or UUIDs, self-references and **cycles rejected with 400** via a BFS check, chains walkable, and completing the last open blocker returns the newly unblocked todos both in the response and in the formatted output ("→ Unblocked: SHO-5"). Free-text `blocked_on` is kept for blockers that are not todos.

## What it rejected, and why that judgement is right

**Premise-change detection** — surfacing a task whose motivating fact was later contradicted — was in my brief as a headline idea. The agent rejected it on evidence: the capability map proves fact extraction yields nothing on realistic corpora, so the feature would be potent on paper and inert in production. It also declined to clone more Jira surface.

## Schema and safety

`blocked_by` is tail-appended with `#[serde(default)]` and an old-bytes round-trip test. `Todo` is serde_json-only — verified that postcard never encodes it (only `TodoId` inside `MemoryFlat`, `#[serde(transparent)]`, unchanged). MIF schema, export and import carry the new field. GDPR purge now also deletes the legacy on-disk vector directories.

**Tests**: 23/23 lib todo tests, 9/9 new handler tests, full lib suite 1015/1015, handler suite 77/77. Recall baseline untouched and `recall_eval.rs` has zero todo references.

## MCP-side follow-ups required (not made — that tree is owned elsewhere)

`add_todo` needs `parent_id` in its inputSchema (REST already supports it, so subtasks are currently uncreatable from MCP); `add_todo`/`update_todo` need `blocked_by` and `related_memory_ids` or both new features are unreachable from an agent; `reorder_todo` should declare a `["up","down"]` enum.

Not exercised against the live stack by constraint — verified through in-process full-router tests instead.