### PR TITLE
ci: enable Dependabot, grouped weekly and capped

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,79 @@
+version: 2
+
+# Grouped, weekly, and capped. Ungrouped daily updates across five manifests
+# produce more PRs than a merge train under branch protection can absorb —
+# every merge re-stales the rest — so each ecosystem opens at most a couple of
+# PRs a week and patch/minor bumps travel together.
+#
+# Security advisories bypass `open-pull-requests-limit` and are raised
+# individually and immediately; that is the behaviour we actually want on.
+
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    groups:
+      cargo-patch-and-minor:
+        update-types:
+          - patch
+          - minor
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: npm
+    directory: /mcp-server
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2
+    groups:
+      npm-patch-and-minor:
+        update-types:
+          - patch
+          - minor
+    commit-message:
+      prefix: "deps(mcp-server)"
+
+  - package-ecosystem: npm
+    directory: /seat
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2
+    groups:
+      npm-patch-and-minor:
+        update-types:
+          - patch
+          - minor
+    commit-message:
+      prefix: "deps(seat)"
+
+  - package-ecosystem: npm
+    directory: /front/ui
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2
+    groups:
+      npm-patch-and-minor:
+        update-types:
+          - patch
+          - minor
+    commit-message:
+      prefix: "deps(front)"


### PR DESCRIPTION
Adds `.github/dependabot.yml` covering all five manifests: cargo, github-actions, and npm in `mcp-server/`, `seat/`, and `front/ui/`.

Patch and minor bumps are grouped per ecosystem with open-PR limits of 2-3. Ungrouped daily updates across five manifests would open more PRs than a merge train under branch protection can absorb — every merge re-stales the rest.

Security advisories bypass `open-pull-requests-limit` and are raised individually and immediately. That is the behaviour this change is actually for; the grouped routine bumps are the part that needed rate-limiting.

This is the first half of a two-part security-hygiene change. The second half — removing `continue-on-error: true` and `cargo audit ... || true` from the Security Audit job, which together make it structurally incapable of failing — lands with #416, since flipping the gate before the open advisories are cleared would turn every PR red.