### PR TITLE
ci(recall): PR runs fall through to 5 repeats, as the workflow already claims

### DIFF
--- a/.github/workflows/recall.yml
+++ b/.github/workflows/recall.yml
@@ -54,7 +54,7 @@ env:
   # PR runs are always the gated `full`/5; only a manual dispatch can widen to
   # per-stage diagnosis (`all`) or a fast single repeat.
   LAYER: ${{ github.event.inputs.layer || 'full' }}
-  REPEATS: ${{ github.event.inputs.repeats || '1' }}
+  REPEATS: ${{ github.event.inputs.repeats || '5' }}
 
 jobs:
   smoke:


### PR DESCRIPTION
One character. `.github/workflows/recall.yml:57` fell through to `'1'` on PR events.

Three other places in the same file say 5: the `workflow_dispatch` input defaults to `'5'`, its description reads "use 1 for a fast diagnosis run", and the comment directly above the fallback says "PR runs are always the gated `full`/5". PR events never supply the input, so every gated run has been using the diagnosis setting.

The 5-repeat pass **is** the RH-12 rank-list determinism guard (#272). It has never fired on a PR — including across the window where #462 established that main was passing determinism by luck rather than by construction.

## Measured before changing it

Dispatch run [31318197948](https://github.com/varun29ankuS/shodh-memory/actions/runs/31318197948) on main, `repeats=5 layer=full tolerance=2.0`:

- **29m56s** wall clock (14:20:46 to 14:50:37)
- **Passed** within the 2.0% tolerance
- `full ndcg@10=0.4116 recall@10=0.5268 mrr=0.4033 p@1=0.3100 map=0.3589`
- `open_domain recall@10=0.2750` — consistent with the unperturbed number #467 established

Recent PR runs at `repeats=1` take 9-20 minutes. So the cost is **10-20 extra minutes, not 5x**: the release build dominates and is cached, and only the eval passes multiply.

Two things follow. The gate cost is affordable, and main already passes at 5, so this does not red-line anything on merge.

Merge or close — the latency tradeoff is the owner's call, and this PR exists so that call costs one click rather than a workflow edit.