### PR TITLE
feat(seat): memory mechanisms take agent accuracy 60% to 88.1% (p = 0.0012)

### DIFF
--- a/seat/eval/memory-guidance-ab.mjs
+++ b/seat/eval/memory-guidance-ab.mjs
@@ -111,6 +111,33 @@ const CASE_FILTER = argOf("--cases")?.split(",").map((s) => s.trim());
 const USER_ARG = argOf("--user");
 const LABEL_ARG = argOf("--label"); // results subdir for this chunk, e.g. A1 / B2
 const GUIDANCE_ARG = argOf("--guidance"); // "on" | "off" for --phase run
+/**
+ * Memory-mechanism preset for --phase run (seat MemoryMechanisms, all-ON by
+ * default server-side):
+ *   off     — every mechanism disabled: byte-identical to the pre-mechanism
+ *             seat; the control arm.
+ *   on      — server defaults (all mechanisms on): the ship-candidate arm.
+ *   framing — proactive sample-framing only (single-factor attribution arm).
+ * Arms: mech/guidance off → A; anything treated → B.
+ */
+const MECH_ARG = argOf("--mech"); // "off" | "on" | "framing"
+const MECH_PRESETS = {
+  off: {
+    guidance: false,
+    proactive_framing: false,
+    recall_lineage: false,
+    verify_loop: false,
+    mcp_memory_tool_filter: false,
+  },
+  on: undefined, // omit the field — server defaults are the ship configuration
+  framing: {
+    guidance: false,
+    proactive_framing: true,
+    recall_lineage: false,
+    verify_loop: false,
+    mcp_memory_tool_filter: false,
+  },
+};
 const usingFixture = PROVIDER === "lmstudio" && MODEL === "fixture-deterministic-v1";
 
 const API_KEY = "guidance-ab-key";
@@ -299,18 +326,28 @@ const CASES = [
     mustMatch: [/dolphin/i],
   },
   {
-    // The one approximate rule in the suite, documented as such: PASS iff the
-    // answer carries ZERO [mem:] citations — nothing in the corpus concerns
-    // rail strikes, so citing memory as support here is the failure mode
-    // (fabricated relevance). A model that cites adjacent-but-irrelevant
-    // memories fails; that strictness is symmetric across arms.
+    // SCORING RULE FIXED 2026-08-09 (rule 2 provision: a documented-approximate
+    // rule misfired on correct answers). The original rule — PASS iff ZERO
+    // [mem:] citations — was measured to fail 13 transcripts that answered
+    // honestly ("no records of rail strikes...") while citing REAL adjacent
+    // memories as context; over-citation is not the fabricated-relevance
+    // failure this case exists to catch. The fixed rule is still deterministic:
+    // PASS iff (a) the answer asserts the absence in words (absenceAssert
+    // regex must match near the topic), (b) every cited id is real — seeded
+    // corpus or written this run — so fabricated ids still fail, and (c) no
+    // full-UUID contract violations. Known residual hole, accepted and
+    // symmetric across arms: an answer claiming rail strikes DID occur would
+    // pass if it also contained an absence-assertion sentence; models have no
+    // incentive toward that shape and no transcript exhibits it. Both rules'
+    // numbers are reported by rescore (pass vs pass_strict_nocite).
     id: "absence-honesty",
     stratum: "absence",
     question: "Have any rail strikes affected port operations recently?",
     gold: [],
     minGoldCited: 0,
     mustMatch: [],
-    requireNoCitations: true,
+    absenceAssert:
+      /(\bno\b|\bnot\b|n't|\bnone\b|\bnothing\b|\bzero\b|\bhaven't\b|\bdon't\b)[^.!?]{0,120}rail[ -]?strike|rail[ -]?strike[^.!?]{0,160}(\bno records?\b|\bnot (?:been )?(?:recorded|found|mentioned|affected)\b|\bnothing\b)/i,
   },
   {
     id: "write-capture",
@@ -547,8 +584,21 @@ async function phaseRun() {
     process.exit(2);
   }
   const { corpus_ids: corpusIds } = JSON.parse(readFileSync(idsFile, "utf-8"));
+  if (MECH_ARG !== undefined && !(MECH_ARG in MECH_PRESETS)) {
+    console.error(`--mech must be one of: ${Object.keys(MECH_PRESETS).join(", ")}`);
+    process.exit(2);
+  }
+  // Mechanisms wire MEMORY_GUIDANCE themselves; injecting it via system_prompt
+  // on top would double the block, so the combination is rejected. Without
+  // --mech, runs stay byte-identical to the legacy arms (all mechanisms off).
+  if (GUIDANCE_ARG === "on" && MECH_ARG === "on") {
+    console.error("--guidance on with --mech on would inject MEMORY_GUIDANCE twice (mech 'on' wires it); use --guidance off");
+    process.exit(2);
+  }
   const guidance = GUIDANCE_ARG === "on" ? await loadGuidance() : undefined;
-  const arm = GUIDANCE_ARG === "on" ? "B" : "A";
+  const mechanisms = MECH_PRESETS[MECH_ARG ?? "off"];
+  const treated = GUIDANCE_ARG === "on" || (MECH_ARG !== undefined && MECH_ARG !== "off");
+  const arm = treated ? "B" : "A";
   const scratch = path.join(scratchRoot, `scratch-run-${LABEL_ARG}-${Date.now()}`);
   mkdirSync(scratch, { recursive: true });
 
@@ -563,7 +613,7 @@ async function phaseRun() {
   const scores = await withSeat(`run-${LABEL_ARG}`, USER_ARG, scratch, undefined, async (seatHandle) => {
     const out = [];
     for (const testCase of cases) {
-      const raw = await runCase(seatHandle.base, USER_ARG, arm, testCase, guidance);
+      const raw = await runCase(seatHandle.base, USER_ARG, arm, testCase, guidance, mechanisms);
       persistRecord(RESULTS_ARG, LABEL_ARG, raw, corpusIds);
       const score = scoreCase(raw, testCase, corpusIds);
       score.repeat = LABEL_ARG;
@@ -681,7 +731,7 @@ async function launchSeat(runName, runUser, scratch, fixturePort) {
  *  candidate models inside one invocation. */
 const MODEL_STATE = { model: MODEL };
 
-async function createConversation(seatBase, userId, systemPrompt) {
+async function createConversation(seatBase, userId, systemPrompt, mechanisms) {
   const res = await fetch(`${seatBase}/v1/conversations`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -691,6 +741,9 @@ async function createConversation(seatBase, userId, systemPrompt) {
       model: MODEL_STATE.model,
       harness_learning: false,
       ...(systemPrompt ? { system_prompt: systemPrompt } : {}),
+      // undefined → field omitted → the seat's ship defaults (all mechanisms
+      // on); an explicit preset pins the arm regardless of seat defaults.
+      ...(mechanisms ? { memory_mechanisms: mechanisms } : {}),
     }),
   });
   if (!res.ok) throw new Error(`create conversation: ${res.status} ${await res.text()}`);
@@ -721,11 +774,13 @@ async function sendMessage(seatBase, conversationId, text) {
   return { events, ms: Date.now() - started };
 }
 
-/** Run one case on one seat; retries once on an error turn (rate limits). */
-async function runCase(seatBase, runUser, arm, testCase, systemPrompt) {
+/** Run one case on one seat; retries once on an error turn (rate limits).
+ *  `mechanisms` undefined = seat ship defaults; legacy phases pass the off
+ *  preset so their arms stay byte-identical to the pre-mechanism seat. */
+async function runCase(seatBase, runUser, arm, testCase, systemPrompt, mechanisms) {
   let retries = 0;
   for (;;) {
-    const conversationId = await createConversation(seatBase, runUser, systemPrompt);
+    const conversationId = await createConversation(seatBase, runUser, systemPrompt, mechanisms);
     let events;
     let ms;
     let transportError;
@@ -797,25 +852,31 @@ function scoreCase(recordObj, testCase, corpusIds) {
   }
   const nativeRecallIds = new Set();
   const recallCalls = [];
+  const writtenIds = new Set();
   for (const event of events) {
     if (event.type === "memory_recall" && event.scope === "user") {
       const returned = (event.memories ?? []).map((memory) => memory.id);
       for (const id of returned) nativeRecallIds.add(id);
       recallCalls.push({ query: event.query, returned });
     }
+    if (event.type === "memory_write") writtenIds.add(event.memory_id);
   }
   const toolCalls = events.filter((event) => event.type === "tool_call_start");
   const toolCounts = {};
   for (const call of toolCalls) toolCounts[call.tool_name] = (toolCounts[call.tool_name] ?? 0) + 1;
 
-  // Provenance per cited short-id: proactive > native recall > mcp (in corpus
-  // but surfaced by neither seat channel) > fabricated (not a corpus id).
+  // Provenance per cited short-id: proactive > native recall > self-written
+  // (the model citing a memory it just stored — legitimate, previously
+  // mislabeled fabricated) > mcp (in corpus but surfaced by neither seat
+  // channel) > fabricated (an id that exists nowhere).
   const proactiveShort = new Set([...proactiveIds].map(shortId));
   const nativeShort = new Set([...nativeRecallIds].map(shortId));
-  const provenance = { proactive: 0, native_recall: 0, mcp_or_other: 0, fabricated: 0 };
+  const writtenShort = new Set([...writtenIds].map(shortId));
+  const provenance = { proactive: 0, native_recall: 0, self_written: 0, mcp_or_other: 0, fabricated: 0 };
   for (const citedId of cited) {
     if (proactiveShort.has(citedId)) provenance.proactive += 1;
     else if (nativeShort.has(citedId)) provenance.native_recall += 1;
+    else if (writtenShort.has(citedId)) provenance.self_written += 1;
     else if (corpusShort.has(citedId)) provenance.mcp_or_other += 1;
     else provenance.fabricated += 1;
   }
@@ -827,12 +888,16 @@ function scoreCase(recordObj, testCase, corpusIds) {
   ).length;
 
   const goldCited = [...cited].filter((citedId) => goldShort.has(citedId)).length;
-  const citationOk = testCase.requireNoCitations
-    ? cited.size === 0 && fullUuidCitations === 0
+  // Absence rule (see the absence-honesty case comment): honesty in words plus
+  // no fabricated ids. The superseded zero-citation rule is still computed so
+  // rescore reports both numbers.
+  const citationOk = testCase.absenceAssert
+    ? provenance.fabricated === 0 && fullUuidCitations === 0
     : goldCited >= (testCase.minGoldCited ?? 1);
   const contentOk =
     (testCase.mustMatch ?? []).every((re) => new RegExp(re.source ?? re, re.flags ?? "").test(answer)) &&
-    !(testCase.mustNotMatch ?? []).some((re) => new RegExp(re.source ?? re, re.flags ?? "").test(answer));
+    !(testCase.mustNotMatch ?? []).some((re) => new RegExp(re.source ?? re, re.flags ?? "").test(answer)) &&
+    (!testCase.absenceAssert || testCase.absenceAssert.test(answer));
 
   let toolOk = true;
   if (testCase.requireToolCall) {
@@ -863,6 +928,16 @@ function scoreCase(recordObj, testCase, corpusIds) {
     citations_total: cited.size,
     full_uuid_citations: fullUuidCitations,
     fabricated_citations: provenance.fabricated,
+    // Superseded strict absence rule, reproduced exactly as originally scored
+    // (zero citations; no content requirement) so rescore reports both
+    // numbers for the absence case; null elsewhere.
+    pass_strict_nocite: testCase.absenceAssert
+      ? cited.size === 0 &&
+        fullUuidCitations === 0 &&
+        toolOk &&
+        !recordObj.transport_error &&
+        turnEnd?.stop_reason !== "error"
+      : null,
     provenance,
     proactive_injected: proactiveIds.size,
     proactive_gold_hits: [...proactiveIds].filter((id) => goldIds.includes(id)).length,
@@ -1078,7 +1153,7 @@ async function runArmRepeat(arm, repeat, dir, systemPrompt, seatHandle, corpusId
   const runName = `${arm}${repeat}`;
   const scores = [];
   for (const testCase of cases) {
-    const raw = await runCase(seatHandle.base, seatHandle.user, arm, testCase, systemPrompt);
+    const raw = await runCase(seatHandle.base, seatHandle.user, arm, testCase, systemPrompt, MECH_PRESETS.off);
     persistRecord(dir, runName, raw, corpusIds);
     const score = scoreCase(raw, testCase, corpusIds);
     score.repeat = `${arm}${repeat}`;
@@ -1166,7 +1241,7 @@ async function phaseSmoke() {
         const out = [];
         for (const caseId of smokeCases) {
           const testCase = CASES.find((candidate) => candidate.id === caseId);
-          const raw = await runCase(seatHandle.base, user, "A", testCase, undefined);
+          const raw = await runCase(seatHandle.base, user, "A", testCase, undefined, MECH_PRESETS.off);
           persistRecord(dir, `smoke-${modelId}`, raw, corpusIds);
           const score = scoreCase(raw, testCase, corpusIds);
           score.repeat = modelId;
@@ -1258,6 +1333,17 @@ async function phaseRescore() {
   }
   if (scoresByArm.A.length) printAggregate("ARM A (rescored)", aggregate(scoresByArm.A, activeCases()));
   if (scoresByArm.B.length) printAggregate("ARM B (rescored)", aggregate(scoresByArm.B, activeCases()));
+  // Dual reporting for the fixed absence rule: current rule vs the superseded
+  // strict zero-citation rule, per arm (rule 2: report both numbers).
+  for (const arm of ["A", "B"]) {
+    const absence = scoresByArm[arm].filter((score) => score.pass_strict_nocite !== null);
+    if (absence.length === 0) continue;
+    const fixed = absence.filter((score) => score.pass).length;
+    const strict = absence.filter((score) => score.pass_strict_nocite).length;
+    console.log(
+      `  absence rule, arm ${arm}: fixed ${fixed}/${absence.length} · superseded strict-nocite ${strict}/${absence.length}`,
+    );
+  }
   perCaseTable(scoresByArm.A, scoresByArm.B, activeCases());
   if (scoresByArm.A.length && scoresByArm.B.length) {
     const test = permutationTest(scoresByArm.A, scoresByArm.B, activeCases());
@@ -1329,8 +1415,20 @@ async function main() {
   process.exit(failed.length === 0 ? 0 : 1);
 }
 
-main().catch((err) => {
-  console.error("memory-guidance-ab crashed:", err);
-  for (const child of children) child.kill();
-  process.exit(2);
-});
+/** Importable surface: analysis tooling must use THIS scorer, never a
+ *  reimplementation — decomposition numbers and rescore numbers have to come
+ *  from one implementation. resolveGoldIndices() must be called once before
+ *  scoreCase. The CLI behaviour runs only when this file is the entry point
+ *  (same pattern as seed-demo-corpus.mjs). */
+export { CASES, resolveGoldIndices, scoreCase, aggregate, permutationTest, MECH_PRESETS };
+
+const isEntryPoint =
+  process.argv[1] && import.meta.url === (await import("node:url")).pathToFileURL(process.argv[1]).href;
+
+if (isEntryPoint) {
+  main().catch((err) => {
+    console.error("memory-guidance-ab crashed:", err);
+    for (const child of children) child.kill();
+    process.exit(2);
+  });
+}

--- a/seat/eval/memory-guidance-ab.mjs
+++ b/seat/eval/memory-guidance-ab.mjs
@@ -697,6 +697,14 @@ async function launchSeat(runName, runUser, scratch, fixturePort) {
               SHODH_USER_ID: runUser,
               SHODH_NO_AUTO_SPAWN: "true",
               SHODH_ALLOW_HTTP: "true",
+              // The MCP server's background capture (streamToolCall,
+              // mcp-server/index.ts) ingests a "Tool: <name>\nInput: …" memory
+              // on ANY bridged tool call. Measured in ab1 AND mech1: that junk
+              // entered eval stores (106 and 33 proactive injections of
+              // non-corpus memories respectively) and displaced real memories
+              // from proactive slots. An evaluation store must contain exactly
+              // the seeded corpus plus the model's own deliberate writes.
+              SHODH_STREAM: "false",
             },
           },
         ],

--- a/seat/src/conversation.ts
+++ b/seat/src/conversation.ts
@@ -42,6 +42,7 @@ import {
 	OVERLAP_USED_THRESHOLD,
 } from "./feedback.js";
 import type { LearningLedger } from "./ledger.js";
+import { MEMORY_GUIDANCE } from "./memory-guidance.js";
 import { createMemoryTools } from "./memory-tools.js";
 import type { ModelRegistry } from "./models-registry.js";
 
@@ -60,6 +61,87 @@ const MAX_TOOL_ERROR_CAPTURES = 5;
  * the backend's pending-feedback set contains only memories the model actually
  * saw — otherwise the implicit loop penalizes memories that were never shown. */
 const PROACTIVE_MAX_RESULTS = 3;
+
+/**
+ * Memory-behaviour mechanisms, each measured by seat/eval/memory-guidance-ab.mjs.
+ * All default ON — this is the ship configuration. Per-mechanism switches exist
+ * for exactly one reason: an A/B evaluation needs a control arm reproducing the
+ * pre-mechanism behaviour, and factored arms need single-mechanism attribution
+ * (same rationale as ConversationOptions.harnessLearning).
+ */
+export interface MemoryMechanisms {
+	/** Append MEMORY_GUIDANCE (memory-guidance.ts) to the base system prompt. */
+	guidance: boolean;
+	/**
+	 * Frame the proactive block as a partial sample of a larger store instead
+	 * of a bare list. Measured failure it targets: the model treated the
+	 * 3-memory injected block as the whole of memory (recall_memory called 0
+	 * times across 63 baseline cases) and declared facts "not recorded"
+	 * without ever searching.
+	 */
+	proactiveFraming: boolean;
+	/** Proactive memories surfaced+injected per turn (owner hypothesis: 3 vs 5). */
+	proactiveMax: number;
+	/**
+	 * Render causal lineage edges in recall_memory results. The backend
+	 * returns them on every recall; before this mechanism they were dropped
+	 * before the model saw any structure (measured: chain-tracing cases
+	 * failed 16/16 with the chain present in the store).
+	 */
+	recallLineage: boolean;
+	/**
+	 * Deterministic post-draft verification with one bounded revision pass:
+	 * malformed/unknown/unsupported [mem:] citations and absence claims made
+	 * without having searched are fed back to the model once.
+	 */
+	verifyLoop: boolean;
+	/**
+	 * Exclude bridged MCP tools that duplicate the seat's native memory
+	 * surface (recall/remember/proactive_context/quick_recall). Measured
+	 * defects of the duplicates: relevance-percentage output the citation
+	 * contract cannot parse (models cited "[mem:95%]"), writes that bypass
+	 * the ledger, recalls that bypass the reinforcement loop, and MCP
+	 * proactive_context auto-ingesting conversation fragments as junk
+	 * memories mid-conversation.
+	 */
+	mcpMemoryToolFilter: boolean;
+}
+
+export const DEFAULT_MEMORY_MECHANISMS: MemoryMechanisms = {
+	guidance: true,
+	proactiveFraming: true,
+	proactiveMax: PROACTIVE_MAX_RESULTS,
+	recallLineage: true,
+	verifyLoop: true,
+	mcpMemoryToolFilter: true,
+};
+
+/**
+ * MCP tool base names (suffix after mcp__<server>__) that duplicate native
+ * seat memory tools. Everything else — graph/lineage/entity/todo/fact tools —
+ * stays bridged: none of those write memories or auto-ingest (verified against
+ * mcp-server/index.ts: proactive_context is the only auto_ingest tool;
+ * remember is the only general memory write).
+ */
+const REDUNDANT_MCP_MEMORY_TOOLS = new Set(["recall", "quick_recall", "proactive_context", "remember"]);
+
+/** Hard cap on verification passes per turn: one revision, never a loop. */
+const MAX_VERIFY_PASSES = 1;
+
+/** Citation-shaped tokens that are NOT the contract's [mem:<8 hex>] form
+ *  (e.g. "[mem:95%]", "[mem:<full-uuid>]"). */
+const MALFORMED_CITATION_RE = /\[mem:(?![0-9a-fA-F]{8}\])[^\]]{1,80}\]/g;
+
+/** Conservative floor for the misattribution check: fire only when a cited
+ *  memory's content shares essentially no tokens with the answer — the
+ *  measured failure shape is citing an unrelated id for content that came
+ *  from a different memory entirely. OVERLAP_USED_THRESHOLD (0.1) is NOT
+ *  reused here: it calibrates "was this memory used", the opposite question. */
+const MISATTRIBUTION_OVERLAP_FLOOR = 0.05;
+
+/** Deterministic detector for "this is absent from memory" claims. */
+const ABSENCE_CLAIM_RE =
+	/\b(?:no|any)\s+(?:specific\s+)?(?:records?|memor(?:y|ies)|mentions?|information|evidence)\b|\bnot\s+(?:recorded|captured|included|specified|mentioned)\b|\bisn't\s+(?:recorded|captured|included|mentioned)\b|\bdon't\s+have\s+(?:any\s+)?(?:records?|memor|information)|\bnothing\s+in\s+(?:my\s+)?memor/i;
 /** Matches the thresholds the existing callers use (mcp-server/index.ts, hooks/memory-hook.ts). */
 const PROACTIVE_SEMANTIC_THRESHOLD = 0.6;
 
@@ -121,6 +203,12 @@ export interface ConversationOptions {
 	 * substrate, not a treatment under test.
 	 */
 	harnessLearning?: boolean;
+	/**
+	 * Per-mechanism overrides of DEFAULT_MEMORY_MECHANISMS. Absent fields keep
+	 * their (ON) defaults; like harnessLearning, overrides exist for A/B
+	 * evaluation arms and are not persisted across restarts.
+	 */
+	memoryMechanisms?: Partial<MemoryMechanisms>;
 	/**
 	 * Rehydration state for a conversation reopened from the store: identity,
 	 * transcript, and the turn counter continue exactly where they stopped.
@@ -185,6 +273,7 @@ export class Conversation {
 	readonly userId: string;
 	readonly harnessUserId: string;
 	readonly harnessLearning: boolean;
+	readonly mechanisms: MemoryMechanisms;
 	readonly createdAt: Date;
 
 	private readonly deps: ConversationDeps;
@@ -203,6 +292,12 @@ export class Conversation {
 	/** Ids surfaced by proactive_context this run — owned by the backend's
 	 * implicit-feedback loop, excluded from the seat's explicit reinforcement. */
 	private proactiveIds = new Set<string>();
+	/** Content of proactively injected memories this run (verify-loop misattribution check). */
+	private proactiveContents = new Map<string, string>();
+	/** Memory ids written this run (remember/seat-learning) — citable, never "unknown". */
+	private writtenIds = new Set<string>();
+	/** User-scope recall_memory calls this run (verify-loop absence check). */
+	private userRecallCount = 0;
 	/** Previous run's proactive ids — excluded from explicit negative-followup
 	 * penalties because the implicit loop applies its own followup penalty. */
 	private prevProactiveIds = new Set<string>();
@@ -233,9 +328,11 @@ export class Conversation {
 			this.turn = options.restore.turn;
 			this.lastAssistantText = options.restore.lastAssistantText;
 		}
-		this.baseSystemPrompt = options.systemPrompt?.trim()
-			? `${BASE_SYSTEM_PROMPT}\n\n${options.systemPrompt.trim()}`
-			: BASE_SYSTEM_PROMPT;
+		this.mechanisms = { ...DEFAULT_MEMORY_MECHANISMS, ...options.memoryMechanisms };
+		const promptBlocks = [BASE_SYSTEM_PROMPT];
+		if (this.mechanisms.guidance) promptBlocks.push(MEMORY_GUIDANCE);
+		if (options.systemPrompt?.trim()) promptBlocks.push(options.systemPrompt.trim());
+		this.baseSystemPrompt = promptBlocks.join("\n\n");
 
 		const memoryTools = createMemoryTools({
 			backend: deps.backend,
@@ -253,14 +350,22 @@ export class Conversation {
 				this.weakRecalls.push({ query, resultCount, bestFinalScore });
 			},
 			ledger: deps.ledger,
+			renderLineage: this.mechanisms.recallLineage,
 		});
+
+		const mcpTools = this.mechanisms.mcpMemoryToolFilter
+			? deps.mcpTools.filter((tool) => {
+					const baseName = tool.name.startsWith("mcp__") ? tool.name.split("__").slice(2).join("__") : tool.name;
+					return !REDUNDANT_MCP_MEMORY_TOOLS.has(baseName);
+				})
+			: deps.mcpTools;
 
 		this.agent = new Agent({
 			initialState: {
 				systemPrompt: this.baseSystemPrompt,
 				model: options.model,
 				thinkingLevel: "off",
-				tools: [...memoryTools, ...deps.mcpTools],
+				tools: [...memoryTools, ...mcpTools],
 				// Restored transcripts were produced by this same agent and
 				// persisted verbatim (store.ts) — the cast re-labels what the
 				// agent itself serialized.
@@ -285,6 +390,10 @@ export class Conversation {
 	}
 
 	private emit(event: SeatEvent): void {
+		// Verify-loop bookkeeping, kept here so every emitter (native tools,
+		// proactive pass) feeds it without additional plumbing.
+		if (event.type === "memory_write") this.writtenIds.add(event.memory_id);
+		if (event.type === "memory_recall" && event.scope === "user") this.userRecallCount += 1;
 		if (this.currentSink) {
 			this.currentSink(event);
 		} else {
@@ -362,6 +471,9 @@ export class Conversation {
 		this.surfaced = new Map();
 		this.prevProactiveIds = this.proactiveIds;
 		this.proactiveIds = new Set();
+		this.proactiveContents = new Map();
+		this.writtenIds = new Set();
+		this.userRecallCount = 0;
 		this.weakRecalls = [];
 		this.toolErrors = [];
 		this.assistantTexts = [];
@@ -384,6 +496,8 @@ export class Conversation {
 				.join("\n\n");
 
 			await this.agent.prompt(text);
+
+			if (this.mechanisms.verifyLoop) await this.runVerificationPass();
 
 			await this.closeLearningLoops();
 			this.lastAssistantText = this.assistantTexts.join("\n") || undefined;
@@ -471,7 +585,7 @@ export class Conversation {
 			const response = await this.deps.backend.proactiveContext({
 				userId: this.userId,
 				context: userText,
-				maxResults: PROACTIVE_MAX_RESULTS,
+				maxResults: this.mechanisms.proactiveMax,
 				semanticThreshold: PROACTIVE_SEMANTIC_THRESHOLD,
 				autoIngest: false,
 				previousResponse: sendFeedback ? this.lastAssistantText : undefined,
@@ -481,6 +595,7 @@ export class Conversation {
 
 			for (const memory of response.memories) {
 				this.proactiveIds.add(memory.id);
+				this.proactiveContents.set(memory.id, memory.content);
 			}
 
 			// The implicit leg just applied real learning updates server-side
@@ -515,7 +630,18 @@ export class Conversation {
 				(memory) =>
 					`- [mem:${memoryShortId(memory.id)}] (${memory.memory_type}) ${memory.content.slice(0, 400)}`,
 			);
-			return `## Possibly relevant memories (auto-surfaced — cite [mem:id] if used)\n${lines.join("\n")}`;
+			if (!this.mechanisms.proactiveFraming) {
+				return `## Possibly relevant memories (auto-surfaced — cite [mem:id] if used)\n${lines.join("\n")}`;
+			}
+			// Sample framing: the measured failure mode is the model treating
+			// this block as the whole of memory — answering "not recorded" or
+			// stopping a chain because the next link was not in these few lines.
+			return (
+				`## Memory sample (auto-surfaced — cite [mem:id] if used)\n` +
+				`These are only the ${response.memories.length} closest matches to the current message; the persistent store holds far more, and details relevant to the question may not be shown here. ` +
+				`Search it with recall_memory before concluding anything is missing, and before answering questions whose evidence these lines do not fully cover.\n` +
+				lines.join("\n")
+			);
 		} catch (error) {
 			// Momentum loop is an enhancement; its failure must not block the turn.
 			// Un-drained tool actions stay queued for the next attempt.
@@ -528,6 +654,80 @@ export class Conversation {
 		} finally {
 			if (feedbackAllowed) proactiveFeedbackInFlight.delete(this.userId);
 		}
+	}
+
+	/**
+	 * Deterministic answer verification with ONE bounded revision pass.
+	 *
+	 * Memory answers are checkable without any judge model: every [mem:] token
+	 * must be the 8-hex contract form; every cited id must have actually been
+	 * shown to the model this run (proactive block, recall result, or its own
+	 * write); a cited memory must share at least minimal vocabulary with the
+	 * answer (misattribution check, conservative floor); and a claim that
+	 * something is absent from memory is only creditable after memory was
+	 * actually searched. When any check fires, the specific findings are fed
+	 * back to the model exactly once and it revises; the `verification` event
+	 * records what fired so evaluations can attribute revisions.
+	 */
+	private async runVerificationPass(): Promise<void> {
+		for (let pass = 0; pass < MAX_VERIFY_PASSES; pass += 1) {
+			const issues = this.verifyDraft();
+			if (issues.length === 0) return;
+			this.emit({ type: "verification", issues, nudged: true });
+			const nudge =
+				`[automated answer verification — not the user] Issues detected in your draft answer:\n` +
+				issues.map((issue) => `- ${issue}`).join("\n") +
+				`\nRevise now: cite memories as [mem:<8-hex id>] exactly as shown in recall results or the surfaced-memories block, citing only memories that support the sentence they follow. ` +
+				`If you stated that something is not in memory, first search with recall_memory using concrete alternative terms (names, identifiers, short forms); then either use what you find or confirm the absence. ` +
+				`Reply with the corrected, complete answer.`;
+			await this.agent.prompt(nudge);
+		}
+	}
+
+	/** Pure checks over this run's draft answer and memory events. */
+	private verifyDraft(): string[] {
+		const answer = this.assistantTexts.join("\n");
+		if (!answer.trim()) return [];
+		const issues: string[] = [];
+
+		const malformed = answer.match(MALFORMED_CITATION_RE) ?? [];
+		if (malformed.length > 0) {
+			issues.push(
+				`Malformed citation token(s) ${[...new Set(malformed)].slice(0, 4).join(", ")} — the contract is [mem:<8 hex chars>]; for a long id use its first 8 characters.`,
+			);
+		}
+
+		const knownShort = new Map<string, string>(); // shortId -> content ("" when unknown)
+		for (const [memoryId, memory] of this.surfaced) knownShort.set(memoryShortId(memoryId), memory.content);
+		for (const [memoryId, content] of this.proactiveContents) knownShort.set(memoryShortId(memoryId), content);
+		for (const memoryId of this.writtenIds) knownShort.set(memoryShortId(memoryId), "");
+
+		const cited = extractCitations(answer);
+		const unknown = [...cited].filter((shortId) => !knownShort.has(shortId));
+		if (unknown.length > 0) {
+			issues.push(
+				`Cited memory id(s) ${unknown.map((shortId) => `[mem:${shortId}]`).join(", ")} were never surfaced in this conversation — cite only ids shown to you, or search for the memory first.`,
+			);
+		}
+
+		const answerTokens = extractTokens(answer);
+		for (const shortId of cited) {
+			const content = knownShort.get(shortId);
+			if (!content) continue; // unknown handled above; written ids have no content here
+			if (memoryOverlap(content, answerTokens) < MISATTRIBUTION_OVERLAP_FLOOR) {
+				issues.push(
+					`[mem:${shortId}] does not contain the content it is cited for — re-check which surfaced memory actually supports that sentence.`,
+				);
+			}
+		}
+
+		if (this.userRecallCount === 0 && ABSENCE_CLAIM_RE.test(answer)) {
+			issues.push(
+				`The answer claims something is not in memory, but memory was never searched this turn — only the auto-surfaced sample was consulted.`,
+			);
+		}
+
+		return issues;
 	}
 
 	/**

--- a/seat/src/conversation.ts
+++ b/seat/src/conversation.ts
@@ -614,34 +614,38 @@ export class Conversation {
 				});
 			}
 
+			const lines = response.memories.map(
+				(memory) =>
+					`- [mem:${memoryShortId(memory.id)}] (${memory.memory_type}) ${memory.content.slice(0, 400)}`,
+			);
+			let block: string | undefined;
+			if (response.memories.length > 0) {
+				block = this.mechanisms.proactiveFraming
+					? // Sample framing: the measured failure mode is the model treating
+						// this block as the whole of memory — answering "not recorded" or
+						// stopping a chain because the next link was not in these few lines.
+						`## Memory sample (auto-surfaced — cite [mem:id] if used)\n` +
+						`These are only the ${response.memories.length} closest matches to the current message; the persistent store holds far more, and details relevant to the question may not be shown here. ` +
+						`Search it with recall_memory before concluding anything is missing, and before answering questions whose evidence these lines do not fully cover.\n` +
+						lines.join("\n")
+					: `## Possibly relevant memories (auto-surfaced — cite [mem:id] if used)\n${lines.join("\n")}`;
+			}
+
 			this.emit({
 				type: "proactive_context",
 				scope: "user",
 				query: userText,
 				memories: response.memories,
 				injected_memory_ids: response.memories.map((memory) => memory.id),
+				// The block verbatim: what the model was actually shown must be
+				// inspectable, not reconstructable.
+				injected_block: block ?? null,
 				feedback: response.feedback_processed ?? null,
 				temporal_credits_applied: response.temporal_credits_applied ?? null,
 				took_ms: Date.now() - startedAt,
 			});
 
-			if (response.memories.length === 0) return undefined;
-			const lines = response.memories.map(
-				(memory) =>
-					`- [mem:${memoryShortId(memory.id)}] (${memory.memory_type}) ${memory.content.slice(0, 400)}`,
-			);
-			if (!this.mechanisms.proactiveFraming) {
-				return `## Possibly relevant memories (auto-surfaced — cite [mem:id] if used)\n${lines.join("\n")}`;
-			}
-			// Sample framing: the measured failure mode is the model treating
-			// this block as the whole of memory — answering "not recorded" or
-			// stopping a chain because the next link was not in these few lines.
-			return (
-				`## Memory sample (auto-surfaced — cite [mem:id] if used)\n` +
-				`These are only the ${response.memories.length} closest matches to the current message; the persistent store holds far more, and details relevant to the question may not be shown here. ` +
-				`Search it with recall_memory before concluding anything is missing, and before answering questions whose evidence these lines do not fully cover.\n` +
-				lines.join("\n")
-			);
+			return block;
 		} catch (error) {
 			// Momentum loop is an enhancement; its failure must not block the turn.
 			// Un-drained tool actions stay queued for the next attempt.

--- a/seat/src/events.ts
+++ b/seat/src/events.ts
@@ -98,6 +98,9 @@ export type SeatEvent =
 			query: string;
 			memories: ProactiveSurfacedMemory[];
 			injected_memory_ids: string[];
+			/** The system-prompt block verbatim as injected this turn (null when
+			 * nothing surfaced) — what the model saw must be inspectable. */
+			injected_block: string | null;
 			feedback: FeedbackProcessed | null;
 			temporal_credits_applied: number | null;
 			took_ms: number;

--- a/seat/src/events.ts
+++ b/seat/src/events.ts
@@ -103,6 +103,17 @@ export type SeatEvent =
 			took_ms: number;
 	  }
 	| { type: "harness_learning_applied"; memories: { id: string; content: string; score: number }[] }
+	| {
+			/**
+			 * Deterministic post-draft verification (conversation.ts verify loop):
+			 * the issues found in the drafted answer and whether a bounded
+			 * revision pass was run. Emitted only when at least one issue fired,
+			 * so rescoring can count trigger rates and attribute revisions.
+			 */
+			type: "verification";
+			issues: string[];
+			nudged: boolean;
+	  }
 	| { type: "model_changed"; model: ModelRef }
 	| { type: "usage"; model: ModelRef; usage: UsagePayload }
 	| { type: "turn_end"; turn: number; stop_reason: string; error_message?: string }

--- a/seat/src/memory-guidance.ts
+++ b/seat/src/memory-guidance.ts
@@ -24,29 +24,34 @@
  * The A/B harness injects this text verbatim as the treatment arm, so what is
  * measured is byte-identical to what would ship.
  *
- * ── A/B VERDICT (claude-haiku-4-5, 8 repeats/arm, 168 trials/arm, interleaved,
- *    fresh seeded user per run, paired permutation test) ──────────────────────
+ * ── A/B VERDICT 1 — guidance alone (claude-haiku-4-5, 8 repeats/arm,
+ *    168 trials/arm, interleaved, paired permutation test) ───────────────────
  *
- *   control 60.7% ± 9.4pp · guidance 67.9% ± 6.1pp · +7.1pp, p = 0.167
- *   needle stratum (retrieval-only evidence): 52.1% → 68.8% (z = 1.67)
- *   native recall_memory usage: 0.02 → 0.35 calls/case (citations sourced
- *   from native recall: 3 → 78); full-UUID citation-contract violations 1 → 0
- *   REGRESSION (nuanced): the absence case fell 2/8 → 0/8 under the suite's
- *   strict zero-citation rule, but the arm-B transcripts all answer honestly
- *   ("no records of rail strikes…") while citing REAL adjacent memories as
- *   context — over-citation, not fabrication. The fabricated-citations
- *   counter (7 → 14) is dominated in BOTH arms by the model echoing the id
- *   of a memory it has just written (write-capture), which the corpus-
- *   membership check mislabels; genuinely unexplained ids: ~2 vs ~8.
+ *   Under the original scoring: control 60.7% ± 9.4pp · guidance 67.9% ±
+ *   6.1pp · +7.1pp, p = 0.167 — below the pre-registered bar, so guidance
+ *   alone stayed unwired. After the absence-rule scoring fix (the rule was
+ *   measured misfiring on honest "nothing recorded" answers that cited real
+ *   adjacent memories as context; see the absence-honesty case in
+ *   memory-guidance-ab.mjs), the same transcripts rescore to 63.7% ± 10.5pp
+ *   vs 72.6% ± 6.1pp (+8.9pp, p = 0.065) — still short of the bar.
  *
- * NOT WIRED into BASE_SYSTEM_PROMPT: the pre-registered bar was a measured
- * improvement, and p = 0.167 does not clear it. The effect is directionally
- * positive and the mechanism (the model actually searching memory instead of
- * treating the 3-memory proactive block as the whole store) demonstrably
- * moved, but establishing a ~7pp effect at this variance needs roughly 30+
- * repeats per arm. Anyone revisiting: sharpen the citation-restraint line
- * (or the absence rule) against contextual over-citation, then re-run
- * seat/eval/memory-guidance-ab.mjs before wiring this in.
+ * ── A/B VERDICT 2 — mechanism bundle, "mech1" (control ×4 vs bundle ×6
+ *    repeats, interleaved, fresh seeded user per run, pinned backend,
+ *    paired permutation test) ────────────────────────────────────────────────
+ *
+ *   This guidance is now WIRED via MemoryMechanisms.guidance
+ *   (conversation.ts) as one of five mechanisms measured as a single
+ *   ship-candidate bundle: guidance + proactive sample framing + recall
+ *   lineage rendering + deterministic verify loop + MCP redundant-tool
+ *   filter. Bundle verdict: control 66.7% ± 6.7pp · bundle 88.1% ± 4.0pp ·
+ *   mean per-case delta +21.4pp, p = 0.0012 — clears the pre-registered
+ *   p < 0.05 bar. Mechanism movement: native recall 0.02 → 1.09 calls/case,
+ *   mcp-recall bypass calls 15 → 0, full-UUID contract violations 2 → 0.
+ *   Per-mechanism attribution is deliberately NOT factored (one bundle arm
+ *   vs one control arm); the control is byte-identical to the pre-mechanism
+ *   seat. Residual failures concentrate in the two causal-chain cases —
+ *   bounded by the inferred graph substrate (the drift→strike edge was
+ *   absent in 7 of 7 probed user graphs), not by prompt or seat mechanics.
  */
 export const MEMORY_GUIDANCE = `Working memory effectively:
 - The auto-surfaced memory block is a starting point, not the whole of memory. Never say something is absent from memory until recall_memory has searched for it and come back empty.

--- a/seat/src/memory-tools.ts
+++ b/seat/src/memory-tools.ts
@@ -9,7 +9,7 @@
 
 import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import { Type } from "@earendil-works/pi-ai";
-import type { MemoryType, RecallMemory, RecallMode, ShodhBackend } from "./backend.js";
+import type { MemoryType, RecallLineageEdge, RecallMemory, RecallMode, ShodhBackend } from "./backend.js";
 import type { MemoryScope, SeatEvent } from "./events.js";
 import type { LearningLedger } from "./ledger.js";
 
@@ -27,6 +27,8 @@ export interface MemoryToolContext {
 	/** A recall came back empty — candidate harness learning. */
 	onWeakRecall(query: string, resultCount: number, bestFinalScore: number): void;
 	ledger: LearningLedger;
+	/** Render causal lineage edges in recall results (MemoryMechanisms.recallLineage). */
+	renderLineage: boolean;
 }
 
 /** Absolute fusion-score floor under which a recall counts as a miss for
@@ -88,6 +90,58 @@ const seatLearningParameters = Type.Object({
 
 function shortId(memoryId: string): string {
 	return memoryId.replace(/-/g, "").slice(0, 8);
+}
+
+/**
+ * Prose for a causal relation read from→to. The edge's `from` is always the
+ * earlier memory (cause/origin/evidence), `to` the later one; InformedBy
+ * therefore reads "from informed to", not the enum's to-perspective name —
+ * same semantics as mcp-server/index.ts CAUSAL_RELATION_PROSE (post-#468).
+ * RelatedTo is deliberately absent: co-occurrence edges are not causal
+ * structure and would dilute the chain signal this block exists to carry.
+ */
+const LINEAGE_RELATION_PROSE: Record<string, string> = {
+	Caused: "caused",
+	ResolvedBy: "was resolved by",
+	InformedBy: "informed",
+	SupersededBy: "was superseded by",
+	TriggeredBy: "triggered",
+	BranchedFrom: "branched from",
+};
+
+/** Cap on rendered edges: every line is context on every recall. */
+const LINEAGE_RENDER_CAP = 8;
+
+/**
+ * Render the causal edges among the returned memories, plus a bounded hint at
+ * how many causal links lead OUTSIDE the result set — the outside count is an
+ * invitation to keep tracing (recall again or use a lineage tool), which the
+ * measured chain-case failures never did.
+ */
+function formatLineage(edges: RecallLineageEdge[], returned: RecallMemory[]): string[] {
+	const returnedIds = new Set(returned.map((memory) => memory.id));
+	const causal = edges.filter((edge) => LINEAGE_RELATION_PROSE[edge.relation] !== undefined);
+	const inside = causal
+		.filter((edge) => returnedIds.has(edge.from) && returnedIds.has(edge.to))
+		.sort((a, b) => b.confidence - a.confidence)
+		.slice(0, LINEAGE_RENDER_CAP);
+	const outsideCount = causal.filter(
+		(edge) => returnedIds.has(edge.from) !== returnedIds.has(edge.to),
+	).length;
+
+	const lines: string[] = [];
+	if (inside.length > 0) {
+		lines.push("Causal links among these memories (earlier → later):");
+		for (const edge of inside) {
+			lines.push(`- [mem:${shortId(edge.from)}] ${LINEAGE_RELATION_PROSE[edge.relation]} [mem:${shortId(edge.to)}]`);
+		}
+	}
+	if (outsideCount > 0) {
+		lines.push(
+			`${outsideCount} causal link${outsideCount === 1 ? "" : "s"} lead beyond these results — recall the linked topic or use a lineage tool to follow the chain.`,
+		);
+	}
+	return lines;
 }
 
 function formatMemoryForModel(memory: RecallMemory, index: number): string {
@@ -172,6 +226,9 @@ export function createMemoryTools(context: MemoryToolContext): AgentTool<any>[] 
 
 			const lines: string[] = [`Found ${response.memories.length} memories:`];
 			response.memories.forEach((memory, index) => lines.push(formatMemoryForModel(memory, index)));
+			if (context.renderLineage && response.lineage && response.lineage.length > 0) {
+				lines.push(...formatLineage(response.lineage, response.memories));
+			}
 			if (response.facts && response.facts.length > 0) {
 				lines.push("Related facts:");
 				for (const fact of response.facts.slice(0, 5)) {

--- a/seat/src/memory-tools.ts
+++ b/seat/src/memory-tools.ts
@@ -113,10 +113,17 @@ const LINEAGE_RELATION_PROSE: Record<string, string> = {
 const LINEAGE_RENDER_CAP = 8;
 
 /**
- * Render the causal edges among the returned memories, plus a bounded hint at
- * how many causal links lead OUTSIDE the result set — the outside count is an
- * invitation to keep tracing (recall again or use a lineage tool), which the
- * measured chain-case failures never did.
+ * Render the causal edges among the returned memories.
+ *
+ * Within-results only, and deliberately so: /api/recall's lineage payload
+ * contains exclusively edges whose BOTH endpoints are in the returned set
+ * (verified empirically against a seeded store — every edge across 20+
+ * recalls had both endpoints among the results), so there is no
+ * outside-the-results information here to expand. Chain links that fall
+ * outside the result set need the lineage trace endpoints; on the probed
+ * corpus the binding constraint was the inferred graph itself (the
+ * drift→strike edge was absent in 7 of 7 user graphs), which no seat-side
+ * rendering can repair.
  */
 function formatLineage(edges: RecallLineageEdge[], returned: RecallMemory[]): string[] {
 	const returnedIds = new Set(returned.map((memory) => memory.id));
@@ -125,9 +132,6 @@ function formatLineage(edges: RecallLineageEdge[], returned: RecallMemory[]): st
 		.filter((edge) => returnedIds.has(edge.from) && returnedIds.has(edge.to))
 		.sort((a, b) => b.confidence - a.confidence)
 		.slice(0, LINEAGE_RENDER_CAP);
-	const outsideCount = causal.filter(
-		(edge) => returnedIds.has(edge.from) !== returnedIds.has(edge.to),
-	).length;
 
 	const lines: string[] = [];
 	if (inside.length > 0) {
@@ -135,11 +139,6 @@ function formatLineage(edges: RecallLineageEdge[], returned: RecallMemory[]): st
 		for (const edge of inside) {
 			lines.push(`- [mem:${shortId(edge.from)}] ${LINEAGE_RELATION_PROSE[edge.relation]} [mem:${shortId(edge.to)}]`);
 		}
-	}
-	if (outsideCount > 0) {
-		lines.push(
-			`${outsideCount} causal link${outsideCount === 1 ? "" : "s"} lead beyond these results — recall the linked topic or use a lineage tool to follow the chain.`,
-		);
 	}
 	return lines;
 }

--- a/seat/src/server.ts
+++ b/seat/src/server.ts
@@ -31,7 +31,13 @@ import * as http from "node:http";
 import type { AuthInteraction, AuthPrompt } from "@earendil-works/pi-ai";
 import type { ShodhBackend } from "./backend.js";
 import type { SeatConfig } from "./config.js";
-import { Conversation, ConversationBusyError, type ConversationDeps, UnknownModelError } from "./conversation.js";
+import {
+	Conversation,
+	ConversationBusyError,
+	type ConversationDeps,
+	type MemoryMechanisms,
+	UnknownModelError,
+} from "./conversation.js";
 import type { SeatEvent } from "./events.js";
 import { LedgerError, type LearningLedger } from "./ledger.js";
 import type { McpHost } from "./mcp.js";
@@ -59,6 +65,31 @@ interface CreateConversationBody {
 	model?: string;
 	system_prompt?: string;
 	harness_learning?: boolean;
+	/** Per-mechanism overrides (A/B evaluation arms); absent fields keep their ON defaults. */
+	memory_mechanisms?: {
+		guidance?: boolean;
+		proactive_framing?: boolean;
+		proactive_max?: number;
+		recall_lineage?: boolean;
+		verify_loop?: boolean;
+		mcp_memory_tool_filter?: boolean;
+	};
+}
+
+/** Map the wire's snake_case mechanism overrides onto MemoryMechanisms fields. */
+function parseMechanisms(body: CreateConversationBody): Partial<MemoryMechanisms> | undefined {
+	const wire = body.memory_mechanisms;
+	if (!wire || typeof wire !== "object") return undefined;
+	const overrides: Partial<MemoryMechanisms> = {};
+	if (typeof wire.guidance === "boolean") overrides.guidance = wire.guidance;
+	if (typeof wire.proactive_framing === "boolean") overrides.proactiveFraming = wire.proactive_framing;
+	if (typeof wire.proactive_max === "number" && Number.isInteger(wire.proactive_max) && wire.proactive_max >= 1 && wire.proactive_max <= 10) {
+		overrides.proactiveMax = wire.proactive_max;
+	}
+	if (typeof wire.recall_lineage === "boolean") overrides.recallLineage = wire.recall_lineage;
+	if (typeof wire.verify_loop === "boolean") overrides.verifyLoop = wire.verify_loop;
+	if (typeof wire.mcp_memory_tool_filter === "boolean") overrides.mcpMemoryToolFilter = wire.mcp_memory_tool_filter;
+	return Object.keys(overrides).length > 0 ? overrides : undefined;
 }
 
 class HttpError extends Error {
@@ -412,6 +443,7 @@ export class SeatServer {
 				// Default true; `harness_learning: false` exists for A/B evaluation
 				// control arms only (see ConversationOptions.harnessLearning).
 				harnessLearning: body.harness_learning !== false,
+				memoryMechanisms: parseMechanisms(body),
 			});
 		} catch (error) {
 			throw new HttpError(400, error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
Answers the standing directive to raise agent-level accuracy. It clears the pre-registered bar; it does **not** reach 90, and the remaining 1.9pp is characterised rather than hand-waved.

All numbers are `claude-haiku-4-5`, deterministic citation-anchored scoring, **no LLM judge anywhere**. Frozen 21-case set, unchanged throughout. Fresh seeded user per run, pinned backend exe, sequential seats, interleaved arms.

| Arm | Accuracy | Repeats |
|---|---|---|
| Baseline, original scoring | 60.3-60.7% ± 9.4pp | 8 |
| Baseline, fixed scoring | 63.7% ± 10.5pp / 66.7% ± 6.7pp | 8 / 4 |
| Guidance text alone | 72.6% ± 6.1pp, p = 0.065 | 8 |
| **Mechanism bundle** | **88.1% ± 4.0pp, Δ +21.4pp, p = 0.0012** | **6** |

Guidance text alone stayed below the bar and remains unwired on its own, consistent with #472. The bundle is what moved.

## What ships

All in `seat/**`. `MemoryMechanisms` defaults ON; per-mechanism off-switches exist only so the A/B arms could be constructed.

1. **Proactive block reframed as a sample that invites search.** The diagnosis in #472 was over-reliance, not neglect — the model treated three injected memories as the whole store and called `recall_memory` 0.02x per case. Native recalls are now 1.09x per case.
2. **Causal lineage rendered in recall results**, short ids, direction-correct prose per post-#468 semantics. Lineage was fetched into the structured payload and never rendered into the text the model reads.
3. **Deterministic cite-and-verify with one bounded revision.** Malformed, unknown, or unsupported citations and absence-claims-without-search are fed back exactly once. Fired on 11/210 trials, every one catching a real bad citation.
4. **MCP tools duplicating native memory ops are no longer bridged** (`recall`/`quick_recall`/`proactive_context`/`remember`). Graph, lineage and todo tools stay. Two mechanism-level reasons: MCP recall bypasses `onSurfaced` so its citations are invisible to reinforcement, and it emits uncitable output — models were literally citing `[mem:95%]`.
5. **MEMORY_GUIDANCE wired via the bundle.**

Also: `injected_block` in proactive events, so what the model actually saw is now inspectable.

**The bundle is cheaper than the control** — 24.7K vs 29.4K tokens per trial. MCP round-trips cost more than native recalls plus the occasional verify turn.

## Failure decomposition

The deliverable that mattered regardless of the delta. Across 336 baseline trials / 120 failures:

- **Over-reliance, no search: 62** — the dominant class, and the one the bundle targets.
- **Systemic pipeline: 37** — uncitable MCP output, reinforcement bypass, and pre-#470 tool-transcript pollution.
- **Measurement error: 13** — the absence rule failed honest "no records of X" answers that cited real adjacent memories. The **rule** was fixed, persisted streams re-scored, and both the superseded and corrected numbers are reported.
- **Search-miss: 5.** Uncited-but-surfaced: 3.
- **Retrieval unreachability: zero.** Every failing case's golds rank ≤20 for at least one sane query, most ≤10. 90% is not arithmetically out of reach on this case set.

In the bundle arm, pipeline and uncited failures both drop to **0** as measured categories.

## Why not 90, with evidence

The gap is two cases: forward-trace (1/6) and propulsion-chain (2/6). At the ~8/12 those need, everything else at measured rates lands near 92%. Three blockers, none in `seat/`:

- The inferred causal graph lacks the drift→strike edge in **7 of 7 probed user graphs** (all edges Inferred, mean confidence 0.24) — a `src/memory/lineage.rs` inference gap.
- Recall ranking puts the strike memory below the limit-10 cut for cause-phrased queries.
- `/api/recall` lineage contains only edges among returned results, capping seat-side chain assistance.

Outside-edge neighbour expansion was built, smoke-tested, failed (the payload never carries outside edges), and reverted with the reason documented in code.

## Disclosures

Control ran 4 repeats, not 8. The 3-vs-5 proactive count arm was dropped and the framing-only attribution arm was skipped once the bundle cleared decisively — **per-mechanism attribution is therefore unavailable**. Only `claude-haiku-4-5` was measured. Raw records are re-scorable via `--phase rescore` without re-running.

One correction to the agent's own report: it flagged `streamToolCall` as still polluting user stores. That was measured on a pre-#470 build. On current main both `streamToolCall` and `autoStreamContext` return early for `isReadOnlyTool`, so the path is closed. Item 4 above stands on its own merits regardless.