### PR TITLE
fix(facts): a watermark burn guaranteed zero facts on every live store

### DIFF
--- a/src/handlers/consolidation.rs
+++ b/src/handlers/consolidation.rs
@@ -146,6 +146,15 @@ pub async fn consolidate_memories(
         };
 
         // Step 2: Maintenance (replay + tier consolidation + decay)
+        //
+        // The heavy cycle re-runs fact extraction when the dirty flag is set,
+        // which can repeat the extraction Step 1 just did. That repeat is
+        // deliberate and cheap: extraction is a pure string pipeline, and
+        // `SemanticFactStore::ingest_candidate` treats re-derivation from
+        // already-counted evidence as a no-op, so the second pass cannot mint
+        // duplicates or ratchet confidence. Suppressing it would instead risk
+        // skipping the maintenance-policy pass, whose thresholds can differ
+        // from this request's.
         let decay_factor = state_clone.server_config().activation_decay_factor;
         let maintenance_result = {
             let memory = memory.clone();

--- a/src/memory/compression.rs
+++ b/src/memory/compression.rs
@@ -560,6 +560,12 @@ pub struct CausalFactLink {
 pub struct ConsolidationResult {
     /// Number of memories processed
     pub memories_processed: usize,
+    /// Number of memories that passed the age gate (`min_age_days`) and were
+    /// actually run through extraction. Callers use this to detect that part
+    /// of the corpus is still aging in: when it is smaller than the input,
+    /// memories exist that will only become consolidatable on a LATER cycle,
+    /// so extraction must run again even if nothing new is written.
+    pub memories_eligible: usize,
     /// Number of new facts extracted
     pub facts_extracted: usize,
     /// Number of existing facts reinforced
@@ -589,6 +595,18 @@ pub struct SemanticConsolidator {
 struct PatternCluster {
     /// Stemmed token set representing this cluster (union of all members)
     stem_set: HashSet<String>,
+    /// Negation polarity of the centroid (see `facts::detect_polarity`).
+    ///
+    /// A cluster means "the same claim restated" — the definition
+    /// `SemanticFactStore::find_similar` enforces at dedup time, where
+    /// polarity is a hard gate. Clustering must enforce the same invariant:
+    /// negation is often a one-word difference ("no", "not"), so a claim and
+    /// its correction usually share enough stems to clear the Jaccard
+    /// threshold. Without this gate they merge into ONE cluster, a single
+    /// representative is minted, and the contradiction machinery downstream
+    /// never sees the losing side — the correction is silently swallowed at
+    /// extraction, before arbitration could record it.
+    polarity: bool,
     /// All candidate entries: (pattern_text, memory_id, confidence)
     members: Vec<(String, MemoryId, f32)>,
 }
@@ -641,10 +659,16 @@ impl SemanticConsolidator {
             .iter()
             .filter(|m| (now - m.created_at).num_days() >= self.min_age_days)
             .collect();
+        result.memories_eligible = eligible.len();
 
         if eligible.is_empty() {
             return result;
         }
+
+        // Memory creation times, needed twice: to order candidates before
+        // clustering and to order minted facts before ingest (see below).
+        let created_by_id: HashMap<&MemoryId, chrono::DateTime<chrono::Utc>> =
+            eligible.iter().map(|m| (&m.id, m.created_at)).collect();
 
         // Phase 1: Extract candidates using multi-extractor pipeline
         let mut all_candidates: Vec<(String, MemoryId, f32)> = Vec::new();
@@ -658,6 +682,25 @@ impl SemanticConsolidator {
         if all_candidates.is_empty() {
             return result;
         }
+
+        // Deterministic clustering: greedy cluster assignment depends on
+        // candidate order, and the input arrives in storage iteration order —
+        // random UUIDs, so two ingests of the same corpus clustered (and
+        // minted) differently. Anchor on (evidence age, text): the same
+        // corpus always clusters the same way, and cluster centroids freeze
+        // at the EARLIEST phrasing of a claim, which is also the natural
+        // anchor for "later restatements corroborate the original".
+        all_candidates.sort_by(|a, b| {
+            let ta = created_by_id
+                .get(&a.1)
+                .copied()
+                .unwrap_or(chrono::DateTime::<chrono::Utc>::MIN_UTC);
+            let tb = created_by_id
+                .get(&b.1)
+                .copied()
+                .unwrap_or(chrono::DateTime::<chrono::Utc>::MIN_UTC);
+            ta.cmp(&tb).then_with(|| a.0.cmp(&b.0))
+        });
 
         // Phase 2: Group by stemmed-token Jaccard similarity
         let clusters =
@@ -712,6 +755,34 @@ impl SemanticConsolidator {
                 result.facts_extracted += 1;
             }
         }
+
+        // Order minted facts by the recency of their newest supporting memory,
+        // OLDEST CLAIM FIRST. Callers ingest facts in this order, and
+        // `SemanticFactStore::ingest_candidate` resolves a contradiction tie
+        // in favour of the incoming candidate — so ingest order is the
+        // recency signal arbitration acts on. Without this sort the order was
+        // storage iteration order (random UUIDs): a batch containing both a
+        // claim and its later correction — exactly what a bulk-seeded store
+        // produces — settled on whichever side happened to be ingested last,
+        // a coin flip per store. With it, the side supported by the newest
+        // evidence is ingested last and wins, which is the documented
+        // "recency is the default because a later contradiction is usually a
+        // correction" policy applied to batches.
+        let newest_evidence = |fact: &SemanticFact| {
+            fact.source_memories
+                .iter()
+                .filter_map(|id| created_by_id.get(id).copied())
+                .max()
+                .unwrap_or(chrono::DateTime::<chrono::Utc>::MIN_UTC)
+        };
+        result.new_facts.sort_by(|a, b| {
+            newest_evidence(a)
+                .cmp(&newest_evidence(b))
+                // Text tie-break: same-instant cohorts (bulk seeds) must
+                // still ingest in a repeatable order.
+                .then_with(|| a.fact.cmp(&b.fact))
+        });
+        result.new_fact_ids = result.new_facts.iter().map(|f| f.id.clone()).collect();
 
         result
     }
@@ -768,6 +839,7 @@ impl SemanticConsolidator {
             if tokens.is_empty() {
                 continue;
             }
+            let polarity = crate::memory::facts::detect_polarity(&pattern.to_lowercase());
 
             // Find best matching cluster (that hasn't hit the size cap)
             let mut best_idx = None;
@@ -775,6 +847,11 @@ impl SemanticConsolidator {
             for (i, cluster) in clusters.iter().enumerate() {
                 // Skip full clusters — they no longer accept members
                 if cluster.members.len() >= CONSOLIDATION_CLUSTER_SIZE_CAP {
+                    continue;
+                }
+                // A negated statement is never a restatement of the claim it
+                // negates — see the polarity note on `PatternCluster`.
+                if cluster.polarity != polarity {
                     continue;
                 }
                 let sim = Self::jaccard_similarity(&tokens, &cluster.stem_set);
@@ -795,6 +872,7 @@ impl SemanticConsolidator {
                 // Create new cluster with this candidate as centroid
                 clusters.push(PatternCluster {
                     stem_set: tokens,
+                    polarity,
                     members: vec![(pattern.clone(), memory_id.clone(), *confidence)],
                 });
             }
@@ -2526,5 +2604,368 @@ mod tests {
         assert!(SemanticConsolidator::is_knowledge_worthy(
             "The router configuration in src/handlers/router.rs defines all API endpoint routes for the server"
         ));
+    }
+
+    /// The 74-memory demonstration corpus from `seat/eval/seed-demo-corpus.mjs`,
+    /// verbatim (content, experience type). This is the "realistic corpus" that
+    /// held zero facts in production; the stage-count test below pins where in
+    /// the pipeline candidates exist and what the corroboration policy keeps.
+    const DEMO_CORPUS: &[(&str, ExperienceType)] = &[
+        ("Container ship Dali lost propulsion at 01:24 local time because an electrical breaker tripped during departure from the Port of Baltimore.", ExperienceType::Observation),
+        ("The loss of propulsion led to the Dali drifting off the channel heading despite the crew dropping anchor.", ExperienceType::Observation),
+        ("The drifting vessel struck a support pier of the Francis Scott Key Bridge, which triggered the collapse of the main truss spans into the Patapsco River.", ExperienceType::Observation),
+        ("Because the wreckage blocked the shipping channel, the Port of Baltimore suspended all vessel traffic.", ExperienceType::Decision),
+        ("The port suspension halted roll-on/roll-off automobile shipments, so Maersk rerouted its services to the Port of New York and New Jersey.", ExperienceType::Decision),
+        ("Overflow automobile volume was diverted south to the Port of Virginia at Norfolk as a result of the closure.", ExperienceType::Decision),
+        ("Coal exports from the CSX Curtis Bay terminal stopped for six weeks because bulk carriers could not transit the blocked channel.", ExperienceType::Observation),
+        ("NTSB chair Jennifer Homendy stated the investigation would examine the Dali's electrical system, after inspectors recovered the voyage data recorder.", ExperienceType::Observation),
+        ("Synergy Marine Group, the ship manager, confirmed the crew reported electrical failures during port inspections in the days before departure.", ExperienceType::Observation),
+        ("Captain Maynard of the pilots association credited the pilot's mayday call with stopping bridge traffic, which prevented further casualties.", ExperienceType::Learning),
+        ("The bridge lacked pier protection dolphins that current design standards require, a factor engineers said contributed to the total collapse.", ExperienceType::Learning),
+        ("Salvage crews used the floating crane Chesapeake 1000 to cut the collapsed truss sections for channel clearance.", ExperienceType::Task),
+        ("Initial reports said four crew members were injured in the collapse.", ExperienceType::Observation),
+        ("Corrected report: no crew members aboard the Dali were injured; the casualties were road workers on the bridge deck.", ExperienceType::Observation),
+        ("The Vamana index rebuild cut recall latency from 340ms to 92ms on the evaluation corpus.", ExperienceType::Learning),
+        ("Routine port-state inspection of the Dali at Seagirt noted an intermittent low-voltage alarm on the main switchboard; the crew reset it and the inspector logged it as resolved.", ExperienceType::Observation),
+        ("Electrician's shift note: reefer bank on the Dali's forward feeder showed voltage sag twice during cargo operations, within tolerance but recurring.", ExperienceType::Observation),
+        ("Synergy Marine deferred the Dali's switchboard breaker overhaul to the next scheduled dry dock to avoid a berth overstay.", ExperienceType::Decision),
+        ("Gate scale check: container MSKU-4471820 declared 4,200 kg on the manifest but weighed 28,650 kg at the Seagirt in-gate; flagged for VGM re-verification.", ExperienceType::Observation),
+        ("Drayage truck T-118 carrying an export reefer pinged 40 km off its assigned corridor near Annapolis during the evening run.", ExperienceType::Observation),
+        ("MSC Brianna completed cargo operations at Seagirt berth 3 and departed on the evening tide.", ExperienceType::Observation),
+        ("Crane STS-07 at Seagirt completed its 4,000-hour preventive maintenance; hoist brake pads replaced.", ExperienceType::Observation),
+        ("Morning shift moved 1,847 containers at Seagirt, slightly above the 30-day average.", ExperienceType::Observation),
+        ("Evergreen Ever Focus assigned to Seagirt berth 2 for Thursday arrival, draft 12.8 metres.", ExperienceType::Observation),
+        ("Fog delayed pilot boardings in the Craighill Channel for two hours before conditions lifted.", ExperienceType::Observation),
+        ("Customs placed a documentation hold on 12 containers from the CMA CGM Argentina pending broker corrections.", ExperienceType::Observation),
+        ("Dundalk Marine Terminal handled 3,200 imported vehicles this week, in line with forecast.", ExperienceType::Observation),
+        ("Longshore gang 14 set a terminal record with 42 crane moves per hour on the night shift.", ExperienceType::Observation),
+        ("The Wallenius Wilhelmsen Tosca discharged heavy machinery at Dundalk without incident.", ExperienceType::Observation),
+        ("Berth 1 at Seagirt scheduled for fender replacement next month; no vessel impact expected.", ExperienceType::Task),
+        ("Reefer monitoring rounds found all 240 plugged units within temperature spec.", ExperienceType::Observation),
+        ("The harbor tug Bridget McAllister returned to service after routine engine overhaul.", ExperienceType::Observation),
+        ("Chesapeake Bay pilots reported normal transit conditions; visibility eight nautical miles.", ExperienceType::Observation),
+        ("Weekly safety briefing covered updated lashing procedures for high-cube containers.", ExperienceType::Learning),
+        ("CSX intermodal ramp turned 96% of import boxes within 48 hours this week.", ExperienceType::Observation),
+        ("Empty container yard at Fairfield reached 78% utilization; repositioning plan drafted.", ExperienceType::Observation),
+        ("Maersk Kensington arrived at Seagirt berth 4 with 2,900 import containers.", ExperienceType::Observation),
+        ("Gate cameras at Dundalk upgraded to read damaged container door labels.", ExperienceType::Observation),
+        ("Thunderstorm forecast prompted crane wind-speed monitoring; operations continued below limits.", ExperienceType::Observation),
+        ("Hapag-Lloyd Atlanta Express completed bunkering at anchorage before berthing.", ExperienceType::Observation),
+        ("Terminal operating system patched overnight; gate transactions resumed at 05:00 without backlog.", ExperienceType::Observation),
+        ("Crane STS-04 flagged a slew-drive vibration reading at the high end of normal; monitoring continued.", ExperienceType::Observation),
+        ("Quarterly emissions report filed: terminal equipment idle time down 9% year over year.", ExperienceType::Observation),
+        ("Two export soybean trains unloaded at the CNX Marine Terminal on schedule.", ExperienceType::Observation),
+        ("Vessel traffic service logged 31 deep-draft transits through the main channel this week.", ExperienceType::Observation),
+        ("Warehouse C at Point Breeze passed its annual fire-suppression inspection.", ExperienceType::Observation),
+        ("ZIM Baltimore sailed for Norfolk after a routine eight-hour port call.", ExperienceType::Observation),
+        ("Chassis pool availability tightened to 91%; provider notified per service agreement.", ExperienceType::Observation),
+        ("Pilot association scheduled semi-annual bridge-team simulator training for member pilots.", ExperienceType::Learning),
+        ("Seagirt yard block E re-striped; reefer rows gained four additional plug positions.", ExperienceType::Observation),
+        ("The Atlantic Container Line Atlantic Sun loaded project cargo bound for Antwerp.", ExperienceType::Observation),
+        ("Random cargo exam rate held at 3.1% for the month, unchanged from prior period.", ExperienceType::Observation),
+        ("Tug assist requirements reviewed for vessels over 300 metres; no changes recommended.", ExperienceType::Learning),
+        ("Marine terminal lighting audit found six fixtures below lux spec in the Dundalk rail yard.", ExperienceType::Observation),
+        ("COSCO Development windowed for Saturday arrival; berth 3 turn time projected at 22 hours.", ExperienceType::Observation),
+        ("Monthly draft survey of the Curtis Bay coal pier showed silting within dredge tolerance.", ExperienceType::Observation),
+        ("Breakbulk crew discharged wind turbine blades at North Locust Point over two shifts.", ExperienceType::Observation),
+        ("Ship chandler deliveries consolidated to a single gate window to reduce congestion.", ExperienceType::Decision),
+        ("Crane operator recertification completed for 28 operators; two scheduled for retest.", ExperienceType::Observation),
+        ("The Grimaldi Grande Baltimora loaded 1,100 export vehicles at Dundalk.", ExperienceType::Observation),
+        ("Water taxi service resumed its harbor route after seasonal maintenance.", ExperienceType::Observation),
+        ("Line handlers reported a parted stern line on the bulk carrier Ocean Prosperity; replaced without delay to sailing.", ExperienceType::Observation),
+        ("Port administration approved the fiscal-year dredging budget for the access channels.", ExperienceType::Decision),
+        ("Refrigerated cargo volumes rose 14% month over month, led by poultry exports.", ExperienceType::Observation),
+        ("Security drill simulated an unauthorized gate entry; response time met the standard.", ExperienceType::Observation),
+        ("The container freight station cleared its LCL backlog ahead of the holiday weekend.", ExperienceType::Observation),
+        ("Rail dwell for export coal at Curtis Bay averaged 2.1 days, best quarter in two years.", ExperienceType::Observation),
+        ("Evergreen Ever Focus departed berth 2 after a 19-hour turn, one hour ahead of window.", ExperienceType::Observation),
+        ("Stevedore payroll system migration completed; no missed shifts reported.", ExperienceType::Observation),
+        ("Harbor survey vessel completed side-scan mapping of anchorage B.", ExperienceType::Observation),
+        ("Seagirt gate processed 4,102 truck transactions, a seasonal high, with average turn under 40 minutes.", ExperienceType::Observation),
+    ];
+
+    fn demo_corpus_memories(age_days: i64) -> Vec<Memory> {
+        DEMO_CORPUS
+            .iter()
+            .map(|(content, exp_type)| {
+                let experience = Experience {
+                    content: content.to_string(),
+                    experience_type: exp_type.clone(),
+                    entities: Vec::new(),
+                    ..Default::default()
+                };
+                Memory::new(
+                    MemoryId(Uuid::new_v4()),
+                    experience,
+                    0.3,
+                    None,
+                    None,
+                    None,
+                    Some(chrono::Utc::now() - chrono::Duration::days(age_days)),
+                )
+            })
+            .collect()
+    }
+
+    /// Stage-by-stage instrumentation of the consolidation pipeline on the
+    /// demo corpus. Prints the counts (run with --nocapture) and pins the
+    /// two facts about this corpus that the zero-facts investigation
+    /// established:
+    ///  1. The extractor DOES propose candidates from realistic prose
+    ///     (world 3, "extraction gap", is false).
+    ///  2. Corroboration (min_support >= 2) is what decides how many facts a
+    ///     unique-statement corpus mints — few, and that is the documented
+    ///     policy, not a defect.
+    #[test]
+    fn demo_corpus_stage_counts() {
+        let consolidator = SemanticConsolidator::new();
+        let memories = demo_corpus_memories(8); // older than CONSOLIDATION_MIN_AGE_DAYS
+
+        // Stage 1: candidate extraction per memory.
+        let mut all_candidates: Vec<(String, MemoryId, f32)> = Vec::new();
+        let mut memories_with_candidates = 0usize;
+        for m in &memories {
+            let extracted = consolidator.extract_fact_candidates(m);
+            if !extracted.is_empty() {
+                memories_with_candidates += 1;
+            }
+            for (pattern, confidence) in extracted {
+                all_candidates.push((pattern, m.id.clone(), confidence));
+            }
+        }
+
+        // Stage 2: clustering.
+        let clusters = consolidator
+            .group_candidates_by_similarity(&all_candidates, CONSOLIDATION_JACCARD_THRESHOLD);
+        let corroborated = clusters
+            .iter()
+            .filter(|c| c.members.len() >= CONSOLIDATION_MIN_SUPPORT_SMALL)
+            .count();
+
+        // Stage 3: full pipeline.
+        let result = consolidator.consolidate(&memories);
+
+        println!("── demo corpus stage counts ──");
+        println!("memories:                  {}", memories.len());
+        println!("memories with candidates:  {memories_with_candidates}");
+        println!("candidates proposed:       {}", all_candidates.len());
+        println!("clusters:                  {}", clusters.len());
+        println!("clusters >= min_support:   {corroborated}");
+        println!("facts minted:              {}", result.facts_extracted);
+        for f in &result.new_facts {
+            println!(
+                "  fact [{:?}] ({} sources): {}",
+                f.fact_type,
+                f.source_memories.len(),
+                f.fact
+            );
+        }
+
+        // The extractor proposes from the majority of the corpus: zero facts
+        // can never again be blamed on "nothing is proposed".
+        assert!(
+            memories_with_candidates >= DEMO_CORPUS.len() / 2,
+            "extractor should propose candidates from most of the demo corpus, \
+             got {memories_with_candidates}/{}",
+            DEMO_CORPUS.len()
+        );
+        assert!(
+            all_candidates.len() >= memories_with_candidates,
+            "at least one candidate per proposing memory"
+        );
+        // Facts minted equals corroborated clusters — corroboration is the
+        // deciding filter, nothing downstream of it silently drops facts.
+        assert_eq!(
+            result.facts_extracted, corroborated,
+            "every corroborated cluster must mint exactly one fact"
+        );
+    }
+
+    /// A claim and its negation share most of their content stems — negation
+    /// is often a one-word difference — so without a polarity gate they clear
+    /// the Jaccard threshold and merge into ONE cluster, minting a single
+    /// representative fact. The losing side never reaches the store, so the
+    /// contradiction/invalidation machinery has nothing to arbitrate: the
+    /// correction is silently swallowed at extraction time. Clustering must
+    /// keep opposite-polarity candidates apart so BOTH sides mint and
+    /// `ingest_candidate` can record the supersession.
+    #[test]
+    fn contradicting_statements_never_share_a_cluster() {
+        let consolidator = SemanticConsolidator::new();
+        let mems: Vec<Memory> = [
+            "Initial reports said four crew members were injured in the bridge collapse.",
+            "Early reports said four crew members were injured in the bridge collapse.",
+            "Corrected reports confirm no crew members were injured in the bridge collapse.",
+            "Later reports confirm no crew members were injured in the bridge collapse.",
+        ]
+        .iter()
+        .map(|content| {
+            let experience = Experience {
+                content: content.to_string(),
+                experience_type: ExperienceType::Observation,
+                entities: Vec::new(),
+                ..Default::default()
+            };
+            Memory::new(
+                MemoryId(Uuid::new_v4()),
+                experience,
+                0.8,
+                None,
+                None,
+                None,
+                Some(chrono::Utc::now() - chrono::Duration::days(8)),
+            )
+        })
+        .collect();
+
+        let result = consolidator.consolidate(&mems);
+        assert_eq!(
+            result.facts_extracted, 2,
+            "claim and correction must mint as SEPARATE facts, got {:?}",
+            result.new_facts
+        );
+        assert!(
+            result
+                .new_facts
+                .iter()
+                .any(|f| f.fact.contains("four crew members were injured")),
+            "the claim side must mint: {:?}",
+            result.new_facts
+        );
+        assert!(
+            result
+                .new_facts
+                .iter()
+                .any(|f| f.fact.contains("no crew members were injured")),
+            "the correction side must mint: {:?}",
+            result.new_facts
+        );
+    }
+
+    /// Minted facts are ordered by the recency of their newest supporting
+    /// memory, oldest claim first: callers ingest in this order, and
+    /// contradiction arbitration favours the incoming candidate on equal
+    /// support, so the LAST-ingested side — the one backed by the newest
+    /// evidence — wins. Without the sort, batch order was storage iteration
+    /// order (random UUIDs) and a bulk-seeded claim/correction pair settled
+    /// on a coin flip.
+    #[test]
+    fn minted_facts_are_ordered_by_evidence_recency() {
+        let consolidator = SemanticConsolidator::new();
+        let mem = |content: &str, days: i64| {
+            let experience = Experience {
+                content: content.to_string(),
+                experience_type: ExperienceType::Observation,
+                entities: Vec::new(),
+                ..Default::default()
+            };
+            Memory::new(
+                MemoryId(Uuid::new_v4()),
+                experience,
+                0.8,
+                None,
+                None,
+                None,
+                Some(chrono::Utc::now() - chrono::Duration::days(days)),
+            )
+        };
+        // Deliberately interleave: newest pair first in input order.
+        let mems = vec![
+            mem(
+                "Corrected reports confirm no crew members were injured in the bridge collapse.",
+                20,
+            ),
+            mem(
+                "Initial reports said four crew members were injured in the bridge collapse.",
+                40,
+            ),
+            mem(
+                "Later reports confirm no crew members were injured in the bridge collapse.",
+                20,
+            ),
+            mem(
+                "Early reports said four crew members were injured in the bridge collapse.",
+                40,
+            ),
+        ];
+
+        let result = consolidator.consolidate(&mems);
+        assert_eq!(result.facts_extracted, 2);
+        assert!(
+            result.new_facts[0]
+                .fact
+                .contains("four crew members were injured"),
+            "older claim must be first (ingested first, displaced last): {:?}",
+            result.new_facts
+        );
+        assert!(
+            result.new_facts[1]
+                .fact
+                .contains("no crew members were injured"),
+            "newest-evidence side must be last (wins the arbitration tie): {:?}",
+            result.new_facts
+        );
+        assert_eq!(
+            result.new_fact_ids,
+            result
+                .new_facts
+                .iter()
+                .map(|f| f.id.clone())
+                .collect::<Vec<_>>(),
+            "new_fact_ids must track the sorted order"
+        );
+    }
+
+    /// The demo corpus produces two DIFFERENT zeros, and `memories_eligible`
+    /// is what tells them apart:
+    ///
+    ///  * Fresh corpus, default thresholds: the age gate
+    ///    (CONSOLIDATION_MIN_AGE_DAYS) filters everything out —
+    ///    `memories_eligible == 0`. Zero facts because nothing was LOOKED AT.
+    ///    (The defect the investigation found was one layer up: the
+    ///    extraction watermark advanced past these age-ineligible memories,
+    ///    so they stayed unconsolidatable even after aging past the gate.
+    ///    See tests/fact_distillation_tests.rs.)
+    ///
+    ///  * Age gate lifted: every memory IS processed
+    ///    (`memories_eligible == corpus`), candidates are proposed from all
+    ///    of them, and the corpus STILL mints zero facts — measured above in
+    ///    `demo_corpus_stage_counts`, its 71 candidates form 71 singleton
+    ///    clusters. Every statement in this corpus is unique, so
+    ///    corroboration (min_support >= 2 DISTINCT memories) is never
+    ///    satisfied. That zero is the documented policy working as designed:
+    ///    minting singletons instead would turn all ~71 routine operational
+    ///    statements ("MSC Brianna completed cargo operations…") into
+    ///    permanent semantic "facts", which is noise, not knowledge.
+    #[test]
+    fn fresh_corpus_is_age_gated_not_broken() {
+        let consolidator = SemanticConsolidator::new();
+        let fresh = demo_corpus_memories(0);
+        let result = consolidator.consolidate(&fresh);
+        assert_eq!(
+            result.memories_eligible, 0,
+            "a fresh corpus must be entirely age-ineligible"
+        );
+        assert_eq!(
+            result.facts_extracted, 0,
+            "age gate must exclude a fresh corpus from consolidation"
+        );
+
+        // Age gate lifted: everything is processed; the zero that remains is
+        // the corroboration policy, not an extraction failure.
+        let eager = SemanticConsolidator::with_thresholds(CONSOLIDATION_MIN_SUPPORT, 0);
+        let eager_result = eager.consolidate(&fresh);
+        assert_eq!(
+            eager_result.memories_eligible,
+            fresh.len(),
+            "with the age gate lifted every memory must be processed"
+        );
+        assert_eq!(
+            eager_result.facts_extracted, 0,
+            "a corpus of unique statements has no corroborated claims: zero \
+             facts is the min_support policy, not a defect — if this ever \
+             mints, either the corpus gained restatements or the support \
+             policy changed, and both deserve a deliberate look"
+        );
     }
 }

--- a/src/memory/facts.rs
+++ b/src/memory/facts.rs
@@ -401,41 +401,6 @@ impl SemanticFactStore {
         })
     }
 
-    /// Find the creation timestamp of the most recent fact for a user.
-    ///
-    /// Used at startup to initialize the fact extraction watermark when no
-    /// persisted watermark exists. Returns None if user has no facts.
-    pub fn latest_fact_created_at(&self, user_id: &str) -> Option<i64> {
-        let prefix = format!("facts:{user_id}:");
-        let mut max_millis: Option<i64> = None;
-
-        let iter = self.db.iterator(IteratorMode::From(
-            prefix.as_bytes(),
-            rocksdb::Direction::Forward,
-        ));
-
-        for item in iter {
-            let (key, value) = match item {
-                Ok(kv) => kv,
-                Err(_) => break,
-            };
-            let key_str = String::from_utf8_lossy(&key);
-            if !key_str.starts_with(&prefix) {
-                break;
-            }
-            // Skip index keys (entity/type sub-keys have extra colons)
-            if key_str.matches(':').count() > 2 {
-                continue;
-            }
-            if let Ok(fact) = decode_fact(&value) {
-                let millis = fact.created_at.timestamp_millis();
-                max_millis = Some(max_millis.map_or(millis, |cur| cur.max(millis)));
-            }
-        }
-
-        max_millis
-    }
-
     /// Find facts that should decay (no reinforcement for too long)
     pub fn find_decaying_facts(
         &self,
@@ -703,28 +668,31 @@ impl SemanticFactStore {
     /// `source_memories` on both rows keeps the trust chain back to the
     /// episodes intact.
     ///
-    /// # Idempotence (the sub-millisecond watermark)
+    /// # Idempotence (what makes full re-scans safe)
     ///
-    /// Both callers filter memories with `created_at > watermark`, where the
-    /// watermark is persisted as `timestamp_millis()` — a value truncated DOWN
-    /// from the nanosecond-precision `created_at` it came from. So the newest
-    /// memory of every cycle compares as strictly newer than the watermark it
-    /// itself produced, and is re-consolidated on the next cycle, forever.
-    /// (Truncating down is the fail-safe direction: it can only re-process,
-    /// never skip. That is why it is left alone here.)
+    /// Both callers re-run extraction over the FULL eligible corpus on every
+    /// cycle. There used to be an incremental watermark that filtered each
+    /// cycle to memories it had not seen; it advanced over every memory the
+    /// filter passed, including memories the consolidator's age gate had
+    /// excluded, so every memory on a live store was seen once too young and
+    /// then excluded forever — the zero-facts defect. It also confined
+    /// `CONSOLIDATION_MIN_SUPPORT` corroboration to a single cycle's batch,
+    /// so support could never accumulate across cycles. The watermark is
+    /// gone; re-derivation of already-stored facts is instead made inert
+    /// HERE, at the evidence level, which handles every re-derivation path
+    /// rather than one scheduling instance of it.
     ///
-    /// Re-processing was described as "merely wasteful". It was not. The
-    /// reinforcement branch refreshed `last_reinforced` and applied the
-    /// confidence boost UNCONDITIONALLY, so a fact derived from the newest
-    /// memory got a fresh half-life and a confidence bump on every single
-    /// cycle, from evidence that had already been counted — an immortal fact
-    /// manufactured by a rounding error. `support_count` was already guarded
-    /// against exactly this; the guard simply did not extend to the other two.
+    /// Re-processing is not "merely wasteful" without this guard. The
+    /// reinforcement branch used to refresh `last_reinforced` and apply the
+    /// confidence boost UNCONDITIONALLY, so a re-derived fact got a fresh
+    /// half-life and a confidence bump on every cycle, from evidence that had
+    /// already been counted — an immortal fact. `support_count` was already
+    /// guarded against exactly this; the guard simply did not extend to the
+    /// other two.
     ///
     /// Reinforcement is therefore idempotent with respect to evidence: no new
-    /// source memories ⇒ [`FactIngestOutcome::AlreadyAttested`] and NO write at
-    /// all. This fixes the whole class, not just the watermark instance — any
-    /// re-derivation from an already-counted source set is now inert.
+    /// source memories ⇒ [`FactIngestOutcome::AlreadyAttested`] and NO write
+    /// at all. Any re-derivation from an already-counted source set is inert.
     ///
     /// `now` is passed in so a caller processing a batch stamps every decision
     /// with one consistent instant.
@@ -1026,7 +994,12 @@ impl SemanticFactStore {
 /// Returns `true` for positive polarity (even negation count, including 0),
 /// `false` for negative polarity (odd negation count).
 /// Handles double-negation: "not unlike" = positive.
-fn detect_polarity(text_lower: &str) -> bool {
+///
+/// `pub(crate)`: `SemanticConsolidator::group_candidates_by_similarity` uses
+/// the SAME polarity notion to keep a claim and its negation in separate
+/// clusters, so what counts as "the same claim restated" is defined once —
+/// here — for both extraction-time clustering and store-time dedup.
+pub(crate) fn detect_polarity(text_lower: &str) -> bool {
     use crate::constants::FACT_NEGATION_MARKERS;
     let words: Vec<&str> = text_lower.split_whitespace().collect();
     let negation_count = words

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -299,16 +299,14 @@ pub struct MemorySystem {
     /// `user_id` to this owner. `None` preserves the prior behaviour.
     default_user_id: Option<String>,
 
-    /// Flag: new memories stored since last fact extraction cycle.
+    /// Flag: fact extraction has pending work.
     /// When false, fact extraction is skipped entirely (no RocksDB scan, no clones).
-    /// Set to true in remember(), cleared by maintenance after extraction runs.
+    /// Set to true in remember(); a heavy maintenance cycle consumes it and
+    /// re-arms it itself when part of the corpus was still too young to
+    /// consolidate (`ConsolidationResult::memories_eligible` < corpus), so a
+    /// store that goes quiet after a burst of writes still consolidates once
+    /// its memories age past `CONSOLIDATION_MIN_AGE_DAYS`.
     fact_extraction_needed: std::sync::atomic::AtomicBool,
-
-    /// Watermark: only memories with created_at > this timestamp (unix millis) are
-    /// processed for fact extraction. Persisted to RocksDB so server restarts don't
-    /// re-process the entire memory store. Initialized from the latest fact's
-    /// created_at or 0 if no facts exist.
-    fact_extraction_watermark: std::sync::atomic::AtomicI64,
 
     /// Prediction cache for feedback prediction error weighting (VTA/Dopamine system).
     ///
@@ -826,11 +824,9 @@ impl MemorySystem {
             // Owner unknown at construction; the manager sets it via
             // set_default_user_id() so per-user stores work outside the handler.
             default_user_id: None,
-            // Dirty flag for fact extraction: run on first cycle, then only when new memories stored
+            // Dirty flag for fact extraction: run on first cycle, then whenever
+            // new memories are stored or part of the corpus is still aging in.
             fact_extraction_needed: std::sync::atomic::AtomicBool::new(true),
-            // Watermark for incremental fact extraction — initialized to 0 (sentinel).
-            // On first maintenance call, loaded from RocksDB or derived from latest fact timestamp.
-            fact_extraction_watermark: std::sync::atomic::AtomicI64::new(0),
             // Prediction cache for VTA/dopamine-inspired feedback error weighting
             // TTL 10 minutes, max 500 entries (~4KB)
             prediction_cache: moka::sync::Cache::builder()
@@ -9200,42 +9196,46 @@ impl MemorySystem {
         {
             let all_memories = &all_memories_for_heavy;
             if !all_memories.is_empty() {
-                // Incremental: only process memories created since last extraction watermark.
-                // First run (watermark=0) processes everything; subsequent runs only new memories.
-                // Lazy init: if watermark is 0 (startup sentinel), load persisted value
-                // or derive from the latest fact's created_at timestamp.
-                let mut watermark_millis = self
-                    .fact_extraction_watermark
-                    .load(std::sync::atomic::Ordering::Relaxed);
-                if watermark_millis == 0 {
-                    watermark_millis = self
-                        .long_term_memory
-                        .get_fact_watermark(user_id)
-                        .or_else(|| self.fact_store.latest_fact_created_at(user_id))
-                        .unwrap_or(0);
-                    if watermark_millis > 0 {
-                        self.fact_extraction_watermark
-                            .store(watermark_millis, std::sync::atomic::Ordering::Relaxed);
-                    }
-                }
-                let watermark_dt = chrono::DateTime::from_timestamp_millis(watermark_millis)
-                    .unwrap_or(chrono::DateTime::<chrono::Utc>::MIN_UTC);
-
+                // FULL corpus, every heavy cycle. Extraction used to be
+                // incremental — a persisted watermark filtered each cycle to
+                // memories created since the last one — and that design had two
+                // structural consequences that together produced ZERO facts on
+                // every live store:
+                //
+                //  1. THE BURN. The watermark advanced over every memory the
+                //     filter passed, but the consolidator only processes
+                //     memories at least CONSOLIDATION_MIN_AGE_DAYS old. With
+                //     heavy cycles every ~6h and a 7-day age floor, every
+                //     memory was watermarked past while still ineligible —
+                //     seen once too young, then excluded forever.
+                //  2. NO CROSS-CYCLE CORROBORATION. CONSOLIDATION_MIN_SUPPORT
+                //     requires the same pattern from >= 2 distinct memories,
+                //     but sub-threshold clusters are not persisted, so support
+                //     could only accumulate within ONE watermark window. Two
+                //     memories corroborating each other across cycles could
+                //     never mint a fact.
+                //
+                // The watermark's actual job — stopping re-derived facts from
+                // ratcheting confidence forever — is done at the correct layer
+                // now: `SemanticFactStore::ingest_candidate` makes any
+                // re-derivation from already-counted evidence a no-op
+                // (AlreadyAttested), so re-scanning is idempotent. The cost is
+                // re-running the (pure string) extraction pipeline over the
+                // corpus once per heavy cycle, the same work the first cycle
+                // always did.
                 let memories: Vec<Memory> = all_memories
                     .iter()
-                    .filter(|m| m.created_at > watermark_dt)
                     .map(|arc_mem| arc_mem.as_ref().clone())
                     .collect();
 
-                tracing::info!(
-                    total_memories = all_memories.len(),
-                    new_since_watermark = memories.len(),
-                    watermark = %watermark_dt.format("%Y-%m-%dT%H:%M:%S"),
-                    "Incremental fact extraction"
-                );
-
                 let consolidator = compression::SemanticConsolidator::new();
                 let consolidation_result = consolidator.consolidate(&memories);
+
+                tracing::info!(
+                    total_memories = memories.len(),
+                    eligible = consolidation_result.memories_eligible,
+                    "Fact extraction over full corpus"
+                );
 
                 if !consolidation_result.new_facts.is_empty() {
                     // Batch-encode all new fact texts for hybrid dedup
@@ -9336,20 +9336,15 @@ impl MemorySystem {
                     }
                 }
 
-                // Advance watermark to the LAST memory's created_at timestamp,
-                // NOT to now(). Using now() would skip memories created during the
-                // (potentially slow) fact extraction cycle — they'd have created_at
-                // < now() and never be processed for facts.
-                if !memories.is_empty() {
-                    let new_watermark = memories
-                        .iter()
-                        .map(|m| m.created_at.timestamp_millis())
-                        .max()
-                        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
-                    self.fact_extraction_watermark
-                        .store(new_watermark, std::sync::atomic::Ordering::Relaxed);
-                    self.long_term_memory
-                        .set_fact_watermark(user_id, new_watermark);
+                // Part of the corpus was younger than the consolidator's age
+                // floor and was NOT processed this cycle. Re-arm the dirty
+                // flag so the next heavy cycle runs extraction even if nothing
+                // new is written in the meantime — a store seeded in one burst
+                // and then left quiet must still consolidate once its memories
+                // age in. Idempotent ingest makes the re-run side-effect free.
+                if consolidation_result.memories_eligible < memories.len() {
+                    self.fact_extraction_needed
+                        .store(true, std::sync::atomic::Ordering::Relaxed);
                 }
             }
         } else {
@@ -9775,8 +9770,11 @@ impl MemorySystem {
     ///
     /// # Arguments
     /// * `user_id` - User whose memories to consolidate
-    /// * `min_support` - Minimum memories needed to form a fact (default: 3)
-    /// * `min_age_days` - Minimum age of memories to consider (default: 7)
+    /// * `min_support` - Minimum distinct memories needed to mint a fact
+    ///   (clamped up to the corpus-size tier in `consolidate()`; the HTTP
+    ///   endpoint defaults to 2)
+    /// * `min_age_days` - Minimum age of memories to consider (the HTTP
+    ///   endpoint defaults to 1; pass 0 to distill a fresh store now)
     ///
     /// # Returns
     /// ConsolidationResult with stats and newly extracted facts
@@ -9786,39 +9784,18 @@ impl MemorySystem {
         min_support: usize,
         min_age_days: i64,
     ) -> Result<ConsolidationResult> {
-        // Get all memories for consolidation
+        // The FULL corpus, like the maintenance path. The incremental
+        // watermark that used to filter this scan is gone — it advanced over
+        // age-ineligible memories (excluding them from extraction forever)
+        // and it confined min_support corroboration to a single batch. See
+        // the fact-extraction block in `run_maintenance` for the full
+        // post-mortem; `SemanticFactStore::ingest_candidate` is what makes
+        // the repeated full scan idempotent.
         let all_memories = self.get_all_memories()?;
-
-        // Incremental: only process memories created since last extraction watermark
-        let mut watermark_millis = self
-            .fact_extraction_watermark
-            .load(std::sync::atomic::Ordering::Relaxed);
-        if watermark_millis == 0 {
-            watermark_millis = self
-                .long_term_memory
-                .get_fact_watermark(user_id)
-                .or_else(|| self.fact_store.latest_fact_created_at(user_id))
-                .unwrap_or(0);
-            if watermark_millis > 0 {
-                self.fact_extraction_watermark
-                    .store(watermark_millis, std::sync::atomic::Ordering::Relaxed);
-            }
-        }
-        let watermark_dt = chrono::DateTime::from_timestamp_millis(watermark_millis)
-            .unwrap_or(chrono::DateTime::<chrono::Utc>::MIN_UTC);
-
         let memories: Vec<Memory> = all_memories
             .iter()
-            .filter(|m| m.created_at > watermark_dt)
             .map(|arc_mem| arc_mem.as_ref().clone())
             .collect();
-
-        tracing::info!(
-            total_memories = all_memories.len(),
-            new_since_watermark = memories.len(),
-            watermark = %watermark_dt.format("%Y-%m-%dT%H:%M:%S"),
-            "Incremental fact extraction (on-demand)"
-        );
 
         // Create consolidator with custom thresholds
         let consolidator =
@@ -9826,6 +9803,12 @@ impl MemorySystem {
 
         // Run consolidation
         let result = consolidator.consolidate(&memories);
+
+        tracing::info!(
+            total_memories = memories.len(),
+            eligible = result.memories_eligible,
+            "On-demand fact distillation over full corpus"
+        );
 
         // Pattern separation gate (dentate gyrus analogy): before storing new
         // facts, check if each one matches an existing engram. If so, reinforce
@@ -9922,22 +9905,6 @@ impl MemorySystem {
             // Only ACTIVE facts: a newcomer that lost arbitration is retained
             // for audit and must stay unreachable by traversal.
             self.connect_facts_to_graph(&newly_active);
-        }
-
-        // Advance watermark to the LAST memory's created_at, NOT now(): using now()
-        // would skip memories created during the (potentially slow) extraction cycle
-        // — they'd have created_at < now() and never be processed for facts. Mirrors
-        // run_maintenance().
-        if !memories.is_empty() {
-            let new_watermark = memories
-                .iter()
-                .map(|m| m.created_at.timestamp_millis())
-                .max()
-                .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
-            self.fact_extraction_watermark
-                .store(new_watermark, std::sync::atomic::Ordering::Relaxed);
-            self.long_term_memory
-                .set_fact_watermark(user_id, new_watermark);
         }
 
         Ok(result)
@@ -11140,6 +11107,93 @@ mod companion_rerank_tests {
             out.iter().map(|m| m.id.clone()).collect::<Vec<_>>(),
             head,
             "no connectivity -> original ranking survives"
+        );
+    }
+}
+
+#[cfg(test)]
+mod fact_extraction_flag_tests {
+    use super::*;
+    use crate::memory::types::Experience;
+
+    fn setup() -> (MemorySystem, tempfile::TempDir) {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let config = MemoryConfig {
+            storage_path: temp_dir.path().to_path_buf(),
+            working_memory_size: 50,
+            session_memory_size_mb: 50,
+            max_heap_per_user_mb: 200,
+            auto_compress: false,
+            compression_age_days: 30,
+            importance_threshold: 0.3,
+        };
+        let system = MemorySystem::new(config, None).expect("memory system");
+        (system, temp_dir)
+    }
+
+    fn declarative(content: &str) -> Experience {
+        Experience {
+            content: content.to_string(),
+            experience_type: ExperienceType::Observation,
+            importance_override: Some(0.8),
+            ..Default::default()
+        }
+    }
+
+    fn flag(system: &MemorySystem) -> bool {
+        system
+            .fact_extraction_needed
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// A heavy cycle that could not process part of the corpus (memories
+    /// younger than `CONSOLIDATION_MIN_AGE_DAYS`) must leave the dirty flag
+    /// SET. The flag used to be consumed unconditionally, so a store seeded
+    /// in one burst and then left quiet was never extracted again: every
+    /// heavy cycle before day 7 consumed the flag while nothing was eligible,
+    /// and nothing after day 7 ever set it back.
+    #[test]
+    fn heavy_cycle_rearms_flag_while_memories_are_still_aging_in() {
+        let (system, _dir) = setup();
+        system
+            .remember(
+                declarative("The build pipeline promotes artifacts to staging on green CI runs."),
+                None,
+            )
+            .expect("remember");
+        assert!(flag(&system), "remember() must set the dirty flag");
+
+        system
+            .run_maintenance(1.0, "flag-user", true)
+            .expect("heavy maintenance");
+        assert!(
+            flag(&system),
+            "a young corpus is unfinished work: the flag must stay set so a \
+             later heavy cycle extracts these memories once they age in"
+        );
+    }
+
+    /// Once every memory has been through extraction while eligible, the flag
+    /// must be CLEARED — quiet stores must not pay a full extraction scan on
+    /// every heavy cycle forever.
+    #[test]
+    fn heavy_cycle_clears_flag_when_the_whole_corpus_was_eligible() {
+        let (system, _dir) = setup();
+        let old = chrono::Utc::now() - chrono::Duration::days(10);
+        system
+            .remember(
+                declarative("The scheduler drains one worker at a time during rolling restarts."),
+                Some(old),
+            )
+            .expect("remember");
+        assert!(flag(&system));
+
+        system
+            .run_maintenance(1.0, "flag-user", true)
+            .expect("heavy maintenance");
+        assert!(
+            !flag(&system),
+            "everything eligible was processed; the flag must be consumed"
         );
     }
 }

--- a/src/memory/storage.rs
+++ b/src/memory/storage.rs
@@ -3841,34 +3841,12 @@ impl MemoryStorage {
         Ok(())
     }
 
-    /// Load the fact extraction watermark for a user.
-    ///
-    /// Key: `_watermark:fact_extraction:{user_id}` → 8-byte little-endian i64 (unix millis)
-    /// Returns None if no watermark has been persisted yet.
-    pub fn get_fact_watermark(&self, user_id: &str) -> Option<i64> {
-        let key = format!("_watermark:fact_extraction:{user_id}");
-        match self.db.get(key.as_bytes()) {
-            Ok(Some(bytes)) if bytes.len() == 8 => {
-                Some(i64::from_le_bytes(bytes[..8].try_into().unwrap()))
-            }
-            _ => None,
-        }
-    }
-
-    /// Persist the fact extraction watermark for a user.
-    ///
-    /// Key: `_watermark:fact_extraction:{user_id}` → 8-byte little-endian i64 (unix millis)
-    pub fn set_fact_watermark(&self, user_id: &str, timestamp_millis: i64) {
-        let key = format!("_watermark:fact_extraction:{user_id}");
-        let mut write_opts = WriteOptions::default();
-        write_opts.set_sync(self.write_mode == WriteMode::Sync);
-        if let Err(e) = self
-            .db
-            .put_opt(key.as_bytes(), timestamp_millis.to_le_bytes(), &write_opts)
-        {
-            tracing::warn!("Failed to persist fact extraction watermark: {e}");
-        }
-    }
+    // NOTE on `_watermark:fact_extraction:{user_id}` keys: the incremental
+    // fact-extraction watermark was removed (it silently excluded every
+    // age-ineligible memory from consolidation forever — the zero-facts
+    // defect). Persisted keys may still exist in older stores; they are
+    // simply never read again. The `_watermark:` prefix stays reserved in
+    // the system-key lists (see `migration.rs`) so residue is skipped.
 
     /// Delete ALL interference records (GDPR forget_all)
     ///

--- a/tests/adaptive_memory_tests.rs
+++ b/tests/adaptive_memory_tests.rs
@@ -635,8 +635,13 @@ fn test_fact_type_default() {
 
 #[test]
 fn test_consolidation_result_structure() {
+    // `memories_eligible` is deliberately different from `memories_processed`.
+    // The two are distinct counts — processed is what was looked at, eligible
+    // is what passed the age gate — and giving them the same value here would
+    // let a future swap of the two fields slip past this test.
     let result = ConsolidationResult {
         memories_processed: 10,
+        memories_eligible: 8,
         facts_extracted: 3,
         facts_reinforced: 5,
         new_fact_ids: vec!["f1".to_string(), "f2".to_string(), "f3".to_string()],
@@ -644,6 +649,7 @@ fn test_consolidation_result_structure() {
     };
 
     assert_eq!(result.memories_processed, 10);
+    assert_eq!(result.memories_eligible, 8);
     assert_eq!(result.facts_extracted, 3);
     assert_eq!(result.facts_reinforced, 5);
     assert_eq!(result.new_fact_ids.len(), 3);

--- a/tests/consolidation_tests.rs
+++ b/tests/consolidation_tests.rs
@@ -323,21 +323,15 @@ fn every_live_tier_maps_to_a_distinct_graph_multiplier() {
 // FACT CORRECTION — END TO END
 // =============================================================================
 
-/// A creation timestamp `days` in the past, pinned to WHOLE MILLISECONDS.
+/// A creation timestamp `days` in the past, pinned to WHOLE MILLISECONDS so
+/// the value survives storage round-trips exactly and the two cohorts in the
+/// tests below stay cleanly separated in time.
 ///
-/// The incremental fact-extraction watermark is persisted as
-/// `created_at.timestamp_millis()` and the next cycle filters with a strict
-/// `created_at > watermark`. `Utc::now()` carries sub-millisecond digits, so a
-/// memory always compares as newer than the watermark it just produced and is
-/// re-consolidated on every subsequent cycle.
-///
-/// In production that is merely wasteful — dedup absorbs the re-derivation. In a
-/// two-cycle test it is fatal and silently so: cycle two re-ingests the claim
-/// memories alongside the correction, and since the two share most of their
-/// content stems they land in ONE Jaccard cluster, producing a single merged
-/// fact (observed: one fact with four source memories) instead of a claim plus a
-/// contradicting correction. Pinning the fixture to whole milliseconds makes the
-/// watermark round-trip exactly, so each cycle sees only its own cohort.
+/// (Historical note: the pinning used to be load-bearing — the incremental
+/// fact-extraction watermark stored `timestamp_millis()` and filtered with a
+/// strict `>`, so unpinned timestamps made every cycle re-process its own
+/// newest memory. The watermark is gone; extraction re-scans the full corpus
+/// every cycle and `ingest_candidate` makes re-derivation inert.)
 fn days_ago_ms(days: i64) -> chrono::DateTime<chrono::Utc> {
     let t = chrono::Utc::now() - chrono::Duration::days(days);
     chrono::DateTime::from_timestamp_millis(t.timestamp_millis()).expect("valid timestamp")
@@ -374,14 +368,16 @@ fn declarative_memory(content: &str, importance: f32) -> Experience {
 /// checked, and the identity of the extracted fact pinned, before anything about
 /// arbitration is asserted. The test cannot pass again by exercising nothing.
 ///
-/// TWO maintenance cycles, deliberately. Facts minted in one `consolidate` batch
-/// are all written AFTER the arbitration loop (`store_batch` runs once the loop
-/// finishes), so no fact in a batch can see its batch-mates in the store.
-/// Contradiction can only fire when the correction arrives on a LATER cycle than
-/// the claim — which is also how a correction arrives in the world. The
-/// incremental watermark cooperates: it advances to the newest processed
-/// memory's `created_at`, so the claim memories are excluded from cycle two by
-/// the same mechanism that admits the correction.
+/// TWO maintenance cycles, mirroring how a correction usually arrives in the
+/// world: the claim consolidates first, the correction arrives later and must
+/// displace an already-stored ACTIVE fact. Cycle two re-extracts the claim
+/// memories as well — extraction re-scans the full corpus every cycle — and
+/// `ingest_candidate` recognises that re-derivation as already-counted
+/// evidence (AlreadyAttested), so the correction is the only genuinely new
+/// candidate. Polarity-aware clustering keeps the correction out of the
+/// claim's Jaccard cluster (they share most content stems); the same-batch
+/// variant of this scenario is pinned in
+/// `tests/fact_distillation_tests.rs::bulk_seeded_correction_supersedes_claim_in_one_pass`.
 #[test]
 fn a_corrected_report_supersedes_the_initial_claim_end_to_end() {
     use shodh_memory::similarity::cosine_similarity;
@@ -389,10 +385,9 @@ fn a_corrected_report_supersedes_the_initial_claim_end_to_end() {
     let (system, _dir) = setup_memory_system();
     let user = "e2e-correction";
 
-    // Both cohorts are older than CONSOLIDATION_MIN_AGE_DAYS (7). The correction
-    // is NEWER than the claim so it clears the watermark that cycle one leaves
-    // behind, and the claim does not (the filter is a strict `>` — see
-    // `days_ago_ms` for why the millisecond pinning matters).
+    // Both cohorts are older than CONSOLIDATION_MIN_AGE_DAYS (7), so both are
+    // eligible from their first cycle. The correction is NEWER than the claim,
+    // which is what makes recency-based arbitration displace the claim.
     let claim_at = days_ago_ms(40);
     let correction_at = days_ago_ms(20);
 

--- a/tests/fact_distillation_tests.rs
+++ b/tests/fact_distillation_tests.rs
@@ -1,0 +1,366 @@
+//! Fact Distillation Regression Tests
+//!
+//! Pins the fixes for the zero-facts investigation (2026-08-09): a realistic
+//! corpus produced ZERO semantic facts in production, permanently, because of
+//! two structural defects in the incremental extraction watermark:
+//!
+//! 1. THE BURN. Both `run_maintenance` and `distill_facts` filtered memories
+//!    with `created_at > watermark`, ran the consolidator (which only
+//!    processes memories at least `min_age_days` old), then advanced the
+//!    watermark over everything the FILTER passed — including memories the
+//!    age gate had excluded. A memory seen once while too young was excluded
+//!    forever: with heavy maintenance every ~6h and a 7-day age floor, every
+//!    memory on every live store was burned. Zero facts, structurally.
+//!
+//! 2. NO CROSS-BATCH CORROBORATION. `CONSOLIDATION_MIN_SUPPORT` requires the
+//!    same pattern from >= 2 distinct memories, but sub-threshold clusters
+//!    were not persisted, so support could only accumulate within a single
+//!    watermark window. Two memories corroborating each other across cycles
+//!    could never mint a fact.
+//!
+//! The fix removes the watermark entirely: extraction re-runs over the full
+//! eligible corpus each cycle, and `SemanticFactStore::ingest_candidate`
+//! makes re-derivation from already-counted evidence a no-op, so the re-scan
+//! is idempotent. These tests fail against the watermark design.
+
+use tempfile::TempDir;
+
+use shodh_memory::memory::{Experience, ExperienceType, MemoryConfig, MemorySystem};
+
+fn setup() -> (MemorySystem, TempDir) {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let config = MemoryConfig {
+        storage_path: temp_dir.path().to_path_buf(),
+        working_memory_size: 50,
+        session_memory_size_mb: 50,
+        max_heap_per_user_mb: 200,
+        auto_compress: false,
+        compression_age_days: 30,
+        importance_threshold: 0.3,
+    };
+    let system = MemorySystem::new(config, None).expect("memory system");
+    (system, temp_dir)
+}
+
+/// A plain declarative memory — the shape the bulk of real corpora take.
+/// Importance is pinned so cluster-representative selection is deterministic.
+fn declarative(content: &str, importance: f32) -> Experience {
+    Experience {
+        content: content.to_string(),
+        experience_type: ExperienceType::Observation,
+        importance_override: Some(importance),
+        ..Default::default()
+    }
+}
+
+/// A creation timestamp `days` in the past, pinned to whole milliseconds so
+/// timestamp round-trips through storage compare exactly.
+fn days_ago(days: i64) -> chrono::DateTime<chrono::Utc> {
+    let t = chrono::Utc::now() - chrono::Duration::days(days);
+    chrono::DateTime::from_timestamp_millis(t.timestamp_millis()).expect("valid timestamp")
+}
+
+// ============================================================================
+// DEFECT 1 — THE WATERMARK BURN
+// ============================================================================
+
+/// The exact sequence the MCP audit ran: seed a fresh store, consolidate with
+/// default thresholds (min_age_days = 1 excludes everything seeded seconds
+/// ago), then consolidate again with the age gate lifted.
+///
+/// Under the watermark design the FIRST call burned the corpus — the
+/// watermark advanced past every memory the age gate had excluded — so the
+/// second call saw an empty batch and returned zero even though every memory
+/// was now eligible. An operator lowering min_age_days to zero after an empty
+/// run got zero again, which is exactly what made the empty fact store look
+/// like a "young corpus" instead of a defect.
+#[test]
+fn distill_retry_after_age_gated_run_still_mints() {
+    let (system, _dir) = setup();
+    let user = "burn-regression";
+
+    system
+        .remember(
+            declarative(
+                "The staging cluster runs on four nodes in the Frankfurt region.",
+                0.9,
+            ),
+            None,
+        )
+        .expect("remember");
+    system
+        .remember(
+            declarative(
+                "The staging cluster in the Frankfurt region is running on four nodes.",
+                0.8,
+            ),
+            None,
+        )
+        .expect("remember echo");
+
+    // Default API thresholds: min_support 2, min_age_days 1. Nothing seeded
+    // seconds ago is eligible — zero facts is CORRECT here (age policy).
+    let first = system.distill_facts(user, 2, 1).expect("first distill");
+    assert_eq!(
+        first.facts_extracted, 0,
+        "memories younger than min_age_days must not consolidate"
+    );
+
+    // The retry with the age gate lifted must see the memories the first call
+    // could not process. The watermark design returned zero here, forever.
+    let second = system.distill_facts(user, 2, 0).expect("second distill");
+    assert!(
+        second.facts_extracted >= 1,
+        "an age-gated run must not consume the corpus: retry with \
+         min_age_days=0 saw {} facts",
+        second.facts_extracted
+    );
+    let facts = system.get_facts(user, 10).expect("facts");
+    assert!(
+        facts.iter().any(|f| f.fact.contains("four nodes")),
+        "the minted fact must be the corroborated statement, got {facts:?}"
+    );
+}
+
+/// Maintenance variant of the burn: a heavy cycle runs while the store holds
+/// only ineligible (young) memories, then ELIGIBLE memories arrive (a
+/// backfill/import with historical timestamps). The watermark left by the
+/// first cycle sat at "now", so the backdated memories arrived already behind
+/// it and were never extracted. Post-fix the next heavy cycle sees them.
+#[test]
+fn maintenance_extracts_memories_that_arrive_behind_a_prior_cycle() {
+    let (system, _dir) = setup();
+    let user = "maintenance-backfill";
+
+    // A young memory; the heavy cycle that follows must not poison the store.
+    system
+        .remember(
+            declarative("Deploy window for the search service is under review.", 0.5),
+            None,
+        )
+        .expect("remember young");
+    system
+        .run_maintenance(1.0, user, true)
+        .expect("heavy maintenance on young store");
+    assert!(
+        system.get_facts(user, 10).expect("facts").is_empty(),
+        "nothing eligible yet"
+    );
+
+    // Backfill: corroborating memories with historical timestamps, older than
+    // CONSOLIDATION_MIN_AGE_DAYS (7) — eligible immediately.
+    system
+        .remember(
+            declarative(
+                "The ingestion pipeline writes batches to the events topic every thirty seconds.",
+                0.9,
+            ),
+            Some(days_ago(8)),
+        )
+        .expect("remember backfill");
+    system
+        .remember(
+            declarative(
+                "Every thirty seconds the ingestion pipeline writes batches into the events topic.",
+                0.8,
+            ),
+            Some(days_ago(8)),
+        )
+        .expect("remember backfill echo");
+
+    system
+        .run_maintenance(1.0, user, true)
+        .expect("heavy maintenance after backfill");
+
+    let facts = system.get_facts(user, 10).expect("facts");
+    assert!(
+        facts.iter().any(|f| f.fact.contains("ingestion pipeline")),
+        "a heavy cycle must extract eligible memories even when a previous \
+         cycle already ran, got {facts:?}"
+    );
+}
+
+// ============================================================================
+// DEFECT 2 — CROSS-CYCLE CORROBORATION
+// ============================================================================
+
+/// Corroboration must be able to accumulate across consolidation cycles. A
+/// statement seen once does not mint (that is the min_support policy); the
+/// same claim arriving later from a DISTINCT memory is exactly the evidence
+/// min_support asks for — and under the watermark design the two could never
+/// meet in one batch, so the fact could never mint.
+#[test]
+fn corroboration_accumulates_across_distill_cycles() {
+    let (system, _dir) = setup();
+    let user = "cross-cycle";
+
+    system
+        .remember(
+            declarative(
+                "Payment retries were disabled on the checkout service after the duplicate charge incident.",
+                0.9,
+            ),
+            None,
+        )
+        .expect("remember");
+    let first = system.distill_facts(user, 2, 0).expect("first distill");
+    assert_eq!(
+        first.facts_extracted, 0,
+        "a single uncorroborated statement must not mint a fact"
+    );
+
+    system
+        .remember(
+            declarative(
+                "After the duplicate charge incident the checkout service has payment retries disabled.",
+                0.8,
+            ),
+            None,
+        )
+        .expect("remember corroboration");
+    let second = system.distill_facts(user, 2, 0).expect("second distill");
+    assert!(
+        second.facts_extracted >= 1,
+        "corroboration arriving on a later cycle must mint the fact"
+    );
+    let facts = system.get_facts(user, 10).expect("facts");
+    assert!(
+        facts
+            .iter()
+            .any(|f| f.fact.to_lowercase().contains("payment retries")),
+        "expected the corroborated claim, got {facts:?}"
+    );
+}
+
+// ============================================================================
+// CONTRADICTION ARBITRATION FROM A BULK-SEEDED STORE
+// ============================================================================
+
+/// A corpus seeded in one burst (the demo-store shape) that contains a claim,
+/// its corroboration, and a later corrected report. One distillation pass must
+/// mint both sides — polarity-aware clustering keeps a claim and its negation
+/// in separate clusters — and arbitration must leave the correction active
+/// and the claim invalidated.
+///
+/// Under the pre-fix pipeline this scenario produced either nothing (each
+/// statement burned while young) or, when everything landed in one batch, a
+/// SINGLE merged fact: the claim and its negation share enough stems to
+/// exceed the Jaccard clustering threshold, so the correction was absorbed
+/// into the claim's cluster and the contradiction machinery had nothing to
+/// arbitrate.
+#[test]
+fn bulk_seeded_correction_supersedes_claim_in_one_pass() {
+    let (system, _dir) = setup();
+    let user = "bulk-correction";
+
+    const CLAIM: &str =
+        "Initial reports said four crew members were injured in the bridge collapse.";
+    const CLAIM_ECHO: &str =
+        "Early reports said four crew members were injured in the bridge collapse.";
+    const CORRECTION: &str =
+        "Corrected reports confirm no crew members were injured in the bridge collapse.";
+    const CORRECTION_ECHO: &str =
+        "Later reports confirm no crew members were injured in the bridge collapse.";
+
+    system
+        .remember(declarative(CLAIM, 0.9), Some(days_ago(40)))
+        .expect("claim");
+    system
+        .remember(declarative(CLAIM_ECHO, 0.8), Some(days_ago(40)))
+        .expect("claim echo");
+    system
+        .remember(declarative(CORRECTION, 0.9), Some(days_ago(20)))
+        .expect("correction");
+    system
+        .remember(declarative(CORRECTION_ECHO, 0.8), Some(days_ago(20)))
+        .expect("correction echo");
+
+    let result = system.distill_facts(user, 2, 7).expect("distill");
+    assert!(
+        result.facts_extracted >= 2,
+        "claim and correction must mint as separate facts, got {}",
+        result.facts_extracted
+    );
+
+    let facts = system.get_facts(user, 20).expect("facts");
+    let claim_fact = facts
+        .iter()
+        .find(|f| f.fact.contains("four crew members were injured"))
+        .unwrap_or_else(|| panic!("claim fact missing, got {facts:?}"));
+    let correction_fact = facts
+        .iter()
+        .find(|f| f.fact.contains("no crew members were injured"))
+        .unwrap_or_else(|| panic!("correction fact missing, got {facts:?}"));
+
+    assert!(
+        correction_fact.is_active(),
+        "the newer corrected report must be the active fact"
+    );
+    assert!(
+        !claim_fact.is_active(),
+        "the superseded claim must be invalidated, not deleted"
+    );
+    assert_eq!(
+        claim_fact.invalidated_by.as_deref(),
+        Some(correction_fact.id.as_str()),
+        "the invalidation must point at the correction that displaced it"
+    );
+}
+
+// ============================================================================
+// IDEMPOTENCE — RE-SCANNING MUST NOT RATCHET
+// ============================================================================
+
+/// The watermark existed to stop re-derived facts from ratcheting confidence
+/// and support forever. Its replacement is evidence-based idempotence in
+/// `ingest_candidate`: re-derivation from already-counted source memories is
+/// a no-op. Distilling the same corpus repeatedly must not change the store.
+#[test]
+fn repeated_distillation_is_idempotent() {
+    let (system, _dir) = setup();
+    let user = "idempotence";
+
+    system
+        .remember(
+            declarative(
+                "The telemetry exporter batches spans every five seconds by default.",
+                0.9,
+            ),
+            Some(days_ago(8)),
+        )
+        .expect("remember");
+    system
+        .remember(
+            declarative(
+                "By default the telemetry exporter batches spans every five seconds.",
+                0.8,
+            ),
+            Some(days_ago(8)),
+        )
+        .expect("remember echo");
+
+    system.distill_facts(user, 2, 7).expect("first distill");
+    let after_first = system.get_facts(user, 10).expect("facts");
+    assert_eq!(after_first.len(), 1, "one corroborated fact expected");
+    let baseline = after_first[0].clone();
+
+    for _ in 0..3 {
+        system.distill_facts(user, 2, 7).expect("re-distill");
+    }
+    let after_rescans = system.get_facts(user, 10).expect("facts");
+    assert_eq!(
+        after_rescans.len(),
+        1,
+        "re-scanning must not mint duplicates"
+    );
+    let rescanned = &after_rescans[0];
+    assert_eq!(rescanned.id, baseline.id);
+    assert_eq!(
+        rescanned.support_count, baseline.support_count,
+        "re-derivation from already-counted evidence must not ratchet support"
+    );
+    assert_eq!(
+        rescanned.confidence, baseline.confidence,
+        "re-derivation from already-counted evidence must not ratchet confidence"
+    );
+}

--- a/tests/fact_yield_report.rs
+++ b/tests/fact_yield_report.rs
@@ -1,0 +1,153 @@
+//! Fact-yield instrument.
+//!
+//! The zero-facts defect (see tests/fact_distillation_tests.rs) went
+//! unnoticed for months because NOTHING measured what distillation produces:
+//! `search_facts` returning nothing was explained away as "young corpus" on
+//! stores where consolidation had already run. This harness is the
+//! measurement that was missing. It seeds a store from a recall fixture
+//! corpus, runs distillation, and reports:
+//!
+//!   * facts per 100 memories (yield),
+//!   * active vs invalidated counts (is arbitration ever exercised?),
+//!   * the full fact list, so quality is hand-checkable in the test output.
+//!
+//! It pins INVARIANTS (eligibility, idempotence), not yields: yield numbers
+//! are a property of corpus content and extraction policy, and pinning them
+//! would turn every deliberate policy change into a test-fixing chore. The
+//! printed report is the instrument; read it when extraction behaviour is in
+//! question.
+//!
+//! Known quality reading as of 2026-08-09 (record updated observations in
+//! the commit message when they change):
+//!   * shodh-smoke (80 engineering-log memories): the domain the specialist
+//!     extractors target.
+//!   * locomo-gate (629 conversational memories, `--ignored`, ~2 min): 4
+//!     facts, 3 of them conversational filler ("Nate: Hey Joanna, sorry to
+//!     hear about that") — on dialog corpora, repetition (the corroboration
+//!     signal) selects pleasantries, and speaker-prefixed interjections pass
+//!     `is_fact_shaped`. The 4th merges differently-numbered tournament wins
+//!     into one claim. Distillation over conversation needs discourse-aware
+//!     extraction, not a lower support bar.
+
+use tempfile::TempDir;
+
+use shodh_memory::memory::{Experience, ExperienceType, MemoryConfig, MemorySystem};
+
+fn setup() -> (MemorySystem, TempDir) {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let config = MemoryConfig {
+        storage_path: temp_dir.path().to_path_buf(),
+        working_memory_size: 50,
+        session_memory_size_mb: 50,
+        max_heap_per_user_mb: 500,
+        auto_compress: false,
+        compression_age_days: 3650,
+        importance_threshold: 0.3,
+    };
+    let system = MemorySystem::new(config, None).expect("memory system");
+    (system, temp_dir)
+}
+
+fn exp_type(s: &str) -> ExperienceType {
+    match s {
+        "conversation" => ExperienceType::Conversation,
+        "decision" => ExperienceType::Decision,
+        "learning" => ExperienceType::Learning,
+        "task" => ExperienceType::Task,
+        "error" => ExperienceType::Error,
+        "discovery" => ExperienceType::Discovery,
+        "pattern" => ExperienceType::Pattern,
+        _ => ExperienceType::Observation,
+    }
+}
+
+/// Seed a store from a recall-fixture corpus (jsonl with content,
+/// memory_type, created_at), preserving fixture timestamps so the corpus is
+/// age-eligible exactly as it would be on a mature store.
+fn seed_corpus(system: &MemorySystem, path: &str) -> usize {
+    let corpus = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("fixture corpus {path}: {e}"));
+    let mut n = 0usize;
+    for line in corpus.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_str(line).expect("jsonl line");
+        let content = v["content"].as_str().expect("content").to_string();
+        let mtype = v["memory_type"].as_str().unwrap_or("observation");
+        let created_at = v["created_at"]
+            .as_str()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|d| d.with_timezone(&chrono::Utc));
+        let e = Experience {
+            content,
+            experience_type: exp_type(mtype),
+            ..Default::default()
+        };
+        system.remember(e, created_at).expect("remember");
+        n += 1;
+    }
+    n
+}
+
+fn report(system: &MemorySystem, user: &str, corpus: &str, seeded: usize) {
+    let result = system.distill_facts(user, 2, 7).expect("distill");
+    let facts = system.get_facts(user, 1000).expect("facts");
+    let active = facts.iter().filter(|f| f.is_active()).count();
+    let invalidated = facts.len() - active;
+
+    println!("── fact yield: {corpus} ──");
+    println!("memories seeded:        {seeded}");
+    println!("memories eligible:      {}", result.memories_eligible);
+    println!("facts stored:           {}", facts.len());
+    println!("  active:               {active}");
+    println!("  invalidated:          {invalidated}");
+    println!(
+        "yield (facts per 100):  {:.2}",
+        facts.len() as f64 * 100.0 / seeded.max(1) as f64
+    );
+    for f in &facts {
+        println!(
+            "  [{:?}][active={}][sources={}][conf={:.2}] {}",
+            f.fact_type,
+            f.is_active(),
+            f.source_memories.len(),
+            f.confidence,
+            f.fact
+        );
+    }
+
+    // Invariants — the properties that must hold regardless of corpus:
+    // a mature corpus is fully eligible, and re-distilling is a no-op.
+    assert_eq!(
+        result.memories_eligible, seeded,
+        "a fixture corpus with historical timestamps must be fully eligible"
+    );
+    let before = facts.len();
+    system.distill_facts(user, 2, 7).expect("re-distill");
+    let after = system.get_facts(user, 1000).expect("facts").len();
+    assert_eq!(
+        before, after,
+        "re-distilling the same corpus must not change the fact count"
+    );
+}
+
+/// Engineering-log corpus — the domain the specialist extractors (procedure,
+/// definition, error-pattern, preference) were written for.
+#[test]
+fn smoke_corpus_fact_yield_report() {
+    let (system, _dir) = setup();
+    let seeded = seed_corpus(&system, "tests/recall/corpora/shodh-smoke.jsonl");
+    report(&system, "yield-smoke", "shodh-smoke (engineering log)", seeded);
+}
+
+/// Conversational corpus (LoCoMo gate). ~2 minutes: 629 memories are embedded
+/// through the real ONNX encoder at remember() time. Run on demand:
+/// `cargo test --test fact_yield_report -- --ignored --nocapture`
+#[test]
+#[ignore = "measurement harness, ~2 min of ONNX embedding — run with --ignored when extraction behaviour is in question"]
+fn locomo_gate_fact_yield_report() {
+    let (system, _dir) = setup();
+    let seeded = seed_corpus(&system, "tests/recall/corpora/locomo-gate.jsonl");
+    report(&system, "yield-locomo", "locomo-gate (conversation)", seeded);
+}

--- a/tests/fact_yield_report.rs
+++ b/tests/fact_yield_report.rs
@@ -19,15 +19,20 @@
 //!
 //! Known quality reading as of 2026-08-09 (record updated observations in
 //! the commit message when they change):
-//!   * shodh-smoke (80 engineering-log memories): the domain the specialist
-//!     extractors target.
-//!   * locomo-gate (629 conversational memories, `--ignored`, ~2 min): 4
-//!     facts, 3 of them conversational filler ("Nate: Hey Joanna, sorry to
-//!     hear about that") — on dialog corpora, repetition (the corroboration
-//!     signal) selects pleasantries, and speaker-prefixed interjections pass
-//!     `is_fact_shaped`. The 4th merges differently-numbered tournament wins
-//!     into one claim. Distillation over conversation needs discourse-aware
-//!     extraction, not a lower support bar.
+//!   * shodh-smoke (80 engineering-log memories): 0 facts — the corpus
+//!     restates nothing, so corroboration (min_support >= 2 distinct
+//!     memories) never fires. Zero is the policy, not a plumbing failure;
+//!     the report's `memories eligible` line is what distinguishes the two.
+//!   * locomo-gate (629 conversational memories, `--ignored`, ~3-6 min):
+//!     4 facts, byte-identical across repeat runs (clustering is
+//!     deterministic). Three are corroborated pleasantries ("Nate: Wow,
+//!     that looks great Joanna", 16 sources) — on dialog corpora,
+//!     repetition (the corroboration signal) selects small talk, and
+//!     speaker-prefixed interjections pass `is_fact_shaped`. The fourth
+//!     ("I won a really big video game tournament last week", 4 sources)
+//!     clusters DIFFERENT tournament wins into one claim. Distillation
+//!     over conversation needs discourse-aware extraction, not a lower
+//!     support bar.
 
 use tempfile::TempDir;
 

--- a/tests/fact_yield_report.rs
+++ b/tests/fact_yield_report.rs
@@ -70,8 +70,8 @@ fn exp_type(s: &str) -> ExperienceType {
 /// memory_type, created_at), preserving fixture timestamps so the corpus is
 /// age-eligible exactly as it would be on a mature store.
 fn seed_corpus(system: &MemorySystem, path: &str) -> usize {
-    let corpus = std::fs::read_to_string(path)
-        .unwrap_or_else(|e| panic!("fixture corpus {path}: {e}"));
+    let corpus =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("fixture corpus {path}: {e}"));
     let mut n = 0usize;
     for line in corpus.lines() {
         if line.trim().is_empty() {
@@ -143,7 +143,12 @@ fn report(system: &MemorySystem, user: &str, corpus: &str, seeded: usize) {
 fn smoke_corpus_fact_yield_report() {
     let (system, _dir) = setup();
     let seeded = seed_corpus(&system, "tests/recall/corpora/shodh-smoke.jsonl");
-    report(&system, "yield-smoke", "shodh-smoke (engineering log)", seeded);
+    report(
+        &system,
+        "yield-smoke",
+        "shodh-smoke (engineering log)",
+        seeded,
+    );
 }
 
 /// Conversational corpus (LoCoMo gate). ~2 minutes: 629 memories are embedded
@@ -154,5 +159,10 @@ fn smoke_corpus_fact_yield_report() {
 fn locomo_gate_fact_yield_report() {
     let (system, _dir) = setup();
     let seeded = seed_corpus(&system, "tests/recall/corpora/locomo-gate.jsonl");
-    report(&system, "yield-locomo", "locomo-gate (conversation)", seeded);
+    report(
+        &system,
+        "yield-locomo",
+        "locomo-gate (conversation)",
+        seeded,
+    );
 }


### PR DESCRIPTION
Root-causes the zero-fact-distillation audit. The headline is a defect introduced in `d3dc9433` (Feb 2026) that structurally guaranteed zero facts in production, and it had nothing to do with the extractor.

## The extractor was never the problem

Instrumented stage counts on the demo corpus (committed, printed on every run of `memory::compression::tests::demo_corpus_stage_counts`):

```
memories with candidates   71/71
candidates proposed        71
clusters                   71   (all singletons)
clusters >= min_support    0
facts minted               0
```

The declarative route added by #445 proposes a candidate from **every** memory of realistic maritime prose. The keyword-marker hypothesis described the four *specialist* extractors; the general route has no markers. The zero happens above extraction.

## The watermark burn

`run_maintenance` and `distill_facts` both filtered to `created_at > watermark`, ran the consolidator — which only processes memories at least `min_age_days` old — then advanced the watermark over everything the **filter** passed, including memories the **age gate** had excluded.

A memory seen once while too young was excluded forever. Heavy cycles run every ~6h, so every memory on every live store was burned within hours of creation. That explains the audit's exact sequence: `POST /api/consolidate` on a fresh store, age gate excludes all 71, watermark advances past all 71, and every retry — even with `min_age_days=0` — sees an empty batch. Permanently zero, presenting as "young corpus".

The two-cycle e2e test that existed used 40-day-backdated memories, which is the one shape the burn cannot bite.

## Three more, found underneath it

- **No cross-cycle corroboration.** Sub-threshold clusters were never persisted, so `MIN_SUPPORT` could only be met inside a single watermark window. Fixing the burn alone would still have yielded ~zero on drip-fed stores.
- **Flag starvation.** `fact_extraction_needed` was consumed unconditionally each heavy cycle and only re-set by writes, so a store seeded in one burst and left quiet was never extracted again.
- **Contradiction swallowed at extraction** (latent, exposed by the fix). A claim and its correction share most stems — "four crew members were injured" vs "no crew members were injured", stem-Jaccard ≈0.55 — so they merged into one cluster and only one representative was minted. The arbitration machinery had nothing to arbitrate.

## The fix

The watermark is removed; extraction re-scans the full eligible corpus each cycle. Its real job — preventing a re-derivation ratchet — has been handled at the correct layer since #459, where `ingest_candidate` returns `AlreadyAttested`, now pinned by an idempotence test. Plus flag re-arm via a new `memories_eligible`, polarity-aware clustering so a negation never joins the claim it negates, and deterministic arbitration ordering (the same corpus previously minted 4 facts on one ingest and 3 on another; now byte-identical across runs, verified twice).

**No threshold was changed.** `MIN_SUPPORT` stays 2, `MIN_AGE_DAYS` stays 7/1.

## Honest yield after the fix

| Corpus | Facts | Reading |
|---|---|---|
| demo (71, unique statements) | 0 | corroboration policy working as designed |
| shodh-smoke (80, engineering log) | 0 | nothing is restated |
| locomo-gate (629, conversation) | 4 | 3 are corroborated pleasantries; the 4th conflates distinct events |

The remaining zero on unique-statement corpora is `min_support=2` doing its job — minting singletons would admit ~71 routine-noise "facts" as permanent knowledge, which is worse than an empty store. **This is a product finding, not a bug**, and it is left for a decision rather than patched: lexical corroboration at 0.45 stem-Jaccard is a near-dead signal outside conversation, and on conversation it selects pleasantries.

The synthetic path now works end-to-end for the first time: a seeded claim×2 plus correction×2 mints both sides in one pass, and arbitration leaves the correction active with the claim invalidated and linked.

## Tests and what is not verified

1012 lib tests pass. New: 5 fact-distillation tests (burn regression, maintenance backfill, cross-cycle corroboration, bulk correction arbitration, idempotent re-distillation), 2 flag tests, polarity and ordering coverage. `tests/fact_yield_report.rs` is left behind as a standing instrument — facts-per-100 by corpus with a hand-checkable fact list — since no fact-quality measurement existed before.

**Not verified: the pre-fix red run of the new regression tests.** The verification build was killed by a machine-load directive mid-compile. The tests were designed from the pre-fix mechanics and the production observation, but they have not been watched to fail. Reproducible with `git checkout 90a5092b -- src/` in a scratch worktree.

The recall gate is unaffected — the eval harness consolidates only under opt-in `SHODH_EVAL_CONSOLIDATE=1`, default off in CI, so facts never populate during gate runs and `locomo-gate-baseline.json` is untouched.

Named trade: full-scan extraction each heavy cycle makes the first-run cost recurring. Fine at current store sizes; past ~10⁵ memories the answer is a persistent sub-threshold candidate ledger, not a watermark.