### PR TITLE
ci(deps): keep the ort release candidate out of the auto-merge group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,16 @@ updates:
         update-types:
           - patch
           - minor
+        # `ort` is a release candidate (2.0.0-rc.x). Cargo classifies rc-to-rc
+        # as a patch bump, but a release candidate makes no API-stability
+        # promise, so it does not belong in a group whose whole premise is
+        # "safe to merge on green". rc.11 -> rc.13 made `ort::Error` generic
+        # and broke every `anyhow::Context` call on a session builder
+        # (src/embeddings/gliner.rs, src/embeddings/minilm.rs) — it takes the
+        # entire embedding and NER stack down with it. Excluded so it arrives
+        # as its own reviewable PR with the migration attached.
+        exclude-patterns:
+          - "ort"
     commit-message:
       prefix: "deps"
 


### PR DESCRIPTION
`ort` 2.0.0-rc.11 → rc.13 arrived inside `cargo-patch-and-minor` because Cargo classifies an rc-to-rc move as a patch bump. That group's whole premise is that its contents are safe to merge on green, and a release candidate makes no API-stability promise.

The bump made `ort::Error` generic — `Result<SessionBuilder, ort::Error<SessionBuilder>>` — so the `anyhow::Context` trait bounds stopped being satisfied at `src/embeddings/gliner.rs:175` and `src/embeddings/minilm.rs:78`. Since `ort` is the ONNX runtime behind GLiNER and MiniLM, that takes the entire embedding and NER stack down: #487 failed all three builds, Clippy, the L1 recall gate, and every test tier on exactly this.

Excluding `ort` keeps the rest of the group mergeable and makes the runtime bump arrive as its own PR, where the two-call-site migration can be reviewed alongside it.

This is a fix to the config I added in #474 — I grouped by update-type without accounting for pre-1.0 and pre-release crates, where the update-type says nothing about API stability.