### PR TITLE
ci: deny clippy correctness lints, keep the rest at warn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,20 @@ jobs:
       - name: Run Clippy
         run: |
           set -o pipefail
-          # clippy runs -W: 30 pre-existing lints tracked for cleanup; flip to -D when cleared (see repo issue)
-          cargo clippy --all-targets -- -W clippy::all 2>&1 | tee clippy-output.txt
+          # The ~30 pre-existing lints tracked for cleanup are style/complexity,
+          # so clippy::all stays at -W until they are cleared.
+          #
+          # clippy::correctness is different and is denied here. Those lints are
+          # deny-by-default upstream because they flag code that is almost
+          # certainly wrong, and a blanket -W clippy::all was silently
+          # downgrading them: two assertions in tests/adaptive_memory_tests.rs
+          # compared unsigned counts >= 0, so they could never fail, and they
+          # kept passing while the subsystem they cover went inert (#489).
+          # A test that cannot fail is invisible to a failing-test sweep — this
+          # lint is the only thing that finds that class.
+          #
+          # -D comes AFTER -W so the deny wins for the correctness subset.
+          cargo clippy --all-targets -- -W clippy::all -D clippy::correctness 2>&1 | tee clippy-output.txt
           WARNINGS=$(grep -c "warning:" clippy-output.txt || true)
           WARNINGS=${WARNINGS:-0}
           echo "### Clippy Results" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
`clippy::correctness` is deny-by-default upstream because those lints flag code that is almost certainly wrong. CI's blanket `-W clippy::all` was downgrading that group along with everything else.

Not hypothetical — it cost us something real. Two assertions in `tests/adaptive_memory_tests.rs` compared **unsigned** counts against `>= 0`:

```rust
assert!(graph_stats.node_count > 0 || graph_stats.edge_count >= 0);
assert!(stats.node_count >= 0);
```

Neither could ever fail. Both kept passing while the memory↔memory coactivation subsystem they cover went inert (it has been dead since 2026-07-10). The earlier sweep that found **14** tests asserting that subsystem's pre-flip contract could not find these two, because it searched for *failing* tests — and an assertion that cannot fail isn't a broken test, it's an **absent** one. `absurd_extreme_comparisons` is the only instrument that surfaces that class, and CI was muting it. See #489.

## Scope

The ~30 pre-existing lints tracked for cleanup are style and complexity, so `clippy::all` **stays at `-W`** — this does not front-load that work or red-line unrelated PRs. Only the correctness subset is denied. `-D` is placed after `-W` so the deny wins for that subset.

**This PR's own Clippy job is the evidence** that nothing else in the correctness group is currently hiding. I could not run it locally — two eval agents are saturating the machine. If it comes back red, that is a genuine finding and the right response is to look at what it caught, not to loosen the flag.