### PR TITLE
fix(front/ui): preselect a model and hide non-corpus profiles

### DIFF
--- a/front/ui/src/features/chat/NewConversation.tsx
+++ b/front/ui/src/features/chat/NewConversation.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { MessageSquarePlus } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import { createConversation } from "@/lib/seat/client";
+import { createConversation, listModels } from "@/lib/seat/client";
 import type { SeatModelInfo } from "@/lib/seat/types";
 import { useSession } from "@/stores/session";
 import { Button } from "@/components/ui/button";
@@ -49,6 +49,34 @@ export function NewConversation({
   const setProfile = useSession((s) => s.setProfile);
   const [model, setModel] = useState<SeatModelInfo | null>(null);
   const [newProfile, setNewProfile] = useState("");
+
+  // Preselect a model so the page opens ready to converse. Starting at `null`
+  // left "Start conversation" disabled with no visible reason — the control
+  // reads "Choose model" and the button is simply dead until you find it,
+  // which is a dead end rather than a choice.
+  //
+  // The pick is still the user's: this only fills the first frame, and the
+  // ModelPicker below (and the swap control mid-conversation) override it
+  // freely. Preference order is the most capable configured Anthropic model,
+  // then any configured model at all, so a seat with only a local runtime
+  // still lands on something real rather than nothing.
+  const { data: catalog } = useQuery({
+    queryKey: ["seat-models", "default-pick"],
+    queryFn: ({ signal }) => listModels(false, signal),
+    staleTime: 60_000,
+  });
+  useEffect(() => {
+    if (model !== null) return;
+    const all = catalog?.models ?? [];
+    if (all.length === 0) return;
+    const anthropic = all.filter((m) => m.provider === "anthropic");
+    const preferred =
+      anthropic.find((m) => m.id === "claude-opus-4-5") ??
+      anthropic.find((m) => m.id.startsWith("claude-opus")) ??
+      anthropic[0] ??
+      all[0];
+    if (preferred) setModel(preferred);
+  }, [catalog, model]);
 
   const fresh = profiles.length === 0;
   const effectiveProfile = fresh ? newProfile.trim() : profile;

--- a/front/ui/src/lib/api/health.ts
+++ b/front/ui/src/lib/api/health.ts
@@ -24,7 +24,23 @@ import { api, ApiError, NetworkError } from "./client";
  * fresh session could silently open ON the harness scope and read machinery
  * as memory.
  */
-export const isHumanProfile = (profile: string): boolean => !profile.endsWith(".seat-harness");
+/**
+ * `/api/users` returns every directory in the store, which includes machinery
+ * that is not a corpus anyone wants to look at. Left unfiltered the app opens
+ * on whichever of those sorts first — `.mcp-shims` — and then every surface
+ * truthfully reports an empty profile: graph fails to load, geo has no
+ * coordinates, tasks answers 400. That reads as a broken product when nothing
+ * is wrong except the selection.
+ *
+ * Excluded: seat-harness scratch profiles, anything dot-prefixed (internal
+ * directories, never user data), and test fixtures left behind by PR work.
+ */
+export const isHumanProfile = (profile: string): boolean =>
+  !profile.endsWith(".seat-harness") &&
+  !profile.startsWith(".") &&
+  profile !== "test" &&
+  !profile.startsWith("test-") &&
+  !profile.endsWith("-test");
 
 export type Reachability =
   | { state: "online"; profiles: string[] }


### PR DESCRIPTION
Two dead ends that read as a broken product when nothing is broken except the selection.

**Model preselect.** `NewConversation` opened with `model === null`, leaving "Start conversation" disabled with no visible reason — the control says "Choose model" and the button is simply inert until you find it. The first frame is now filled from the catalogue: most capable configured Anthropic model, then any configured model, so a seat with only a local runtime still lands on something real. The pick stays the user's — ModelPicker and the mid-conversation swap override it freely.

**Profile filter.** `isHumanProfile` only excluded `.seat-harness`, so `/api/users` returned every directory in the store and the app opened on whichever sorted first — `.mcp-shims`. Every surface then truthfully reported an empty profile: graph failed to load, geo had no coordinates, tasks answered 400. Now also excludes dot-prefixed internal directories and leftover test fixtures.

2 files, +48/-4.

**Known gap:** no tests. Both functions were already on the untested list flagged by `detect-changes`; this PR does not close that.