### PR TITLE
fix(embeddings): silent 128-token truncation — token-aware chunking + sequence contract guard

### DIFF
--- a/src/embeddings/chunking.rs
+++ b/src/embeddings/chunking.rs
@@ -487,7 +487,10 @@ mod tests {
         // The oversized sentence must survive intact in ONE chunk — proof no
         // word-level hard split was needed to rescue an overlap overflow.
         assert!(
-            result.chunks.iter().any(|c| c.contains("w1 ") && c.contains("w20")),
+            result
+                .chunks
+                .iter()
+                .any(|c| c.contains("w1 ") && c.contains("w20")),
             "the budget-filling sentence was split apart: {:?}",
             result.chunks
         );
@@ -596,7 +599,10 @@ mod tests {
         // Every turn is <= budget, so no chunk may contain a partial turn:
         // each speaker prefix in a chunk starts at a line boundary.
         for chunk in &result.chunks {
-            for (i, _) in chunk.match_indices("Alice:").chain(chunk.match_indices("Bob:")) {
+            for (i, _) in chunk
+                .match_indices("Alice:")
+                .chain(chunk.match_indices("Bob:"))
+            {
                 assert!(
                     i == 0 || chunk.as_bytes()[i - 1] == b'\n',
                     "turn split mid-chunk: {chunk:?}"
@@ -626,8 +632,7 @@ mod tests {
     fn pathological_single_token_run_is_bisected() {
         let config = cfg(10, 2);
         // Counter that charges 1 token per 4 chars — a 400-char unbroken blob.
-        let char_counter =
-            |t: &str| t.chars().count().div_ceil(4) + SPECIAL_TOKEN_OVERHEAD;
+        let char_counter = |t: &str| t.chars().count().div_ceil(4) + SPECIAL_TOKEN_OVERHEAD;
         let blob = "x".repeat(400);
         let result = chunk_text(&blob, &config, &char_counter);
         for chunk in &result.chunks {

--- a/src/embeddings/chunking.rs
+++ b/src/embeddings/chunking.rs
@@ -313,11 +313,18 @@ fn pack_units(units: Vec<Unit>, config: &ChunkConfig, content_budget: usize) -> 
     for unit in units {
         let fits = current.is_empty() || current_tokens + unit.tokens <= content_budget;
         if !fits {
-            // Close the current chunk and start the next one.
+            // Close the current chunk and start the next one. The carried
+            // sentence must leave room for the unit that forced the split:
+            // without this check a 24-token overlap in front of a
+            // budget-sized unit overflows the window, and the verification
+            // pass would have to rescue it with a WORD-level hard split —
+            // destroying exactly the sentence boundaries this module exists
+            // to preserve. When it does not fit, correctness wins: drop the
+            // overlap, keep the boundary.
             let overlap = if unit.boundary == Boundary::Soft {
-                last_unit
-                    .take()
-                    .filter(|(_, t)| *t <= config.overlap_tokens)
+                last_unit.take().filter(|(_, t)| {
+                    *t <= config.overlap_tokens && *t + unit.tokens <= content_budget
+                })
             } else {
                 None
             };
@@ -444,6 +451,46 @@ mod tests {
         assert_eq!(result.chunks.len(), 1);
         assert!(!result.was_chunked);
         assert_eq!(result.chunks[0], "This is a short text.");
+    }
+
+    /// Regression: a small trailing sentence carried as overlap must never be
+    /// prepended to a unit that already fills the budget. Before the fits
+    /// check in `pack_units`, `overlap + unit` overflowed the window and the
+    /// verification pass rescued it with a WORD-level `hard_split`, cutting
+    /// mid-sentence — the one thing structural chunking must not do.
+    #[test]
+    fn overlap_never_overflows_and_never_forces_a_word_split() {
+        // max_tokens 22 => content budget 20; overlap allowance 8.
+        let config = cfg(22, 8);
+        // Three sentences: 12-token filler, a 4-token carry candidate, then a
+        // sentence that alone exactly fills the 20-token content budget.
+        // Carrying the 4-token sentence in front of it would need 24.
+        let filler = (1..=12)
+            .map(|i| format!("f{i}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let small = "Alpha beta gamma delta.";
+        let big = (1..=20)
+            .map(|i| format!("w{i}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let text = format!("{filler}. {small} {big}.");
+        let result = chunk_text(&text, &config, &word_counter);
+
+        for chunk in &result.chunks {
+            assert!(
+                word_counter(chunk) <= config.max_tokens,
+                "chunk exceeds budget: {} tokens: {chunk:?}",
+                word_counter(chunk)
+            );
+        }
+        // The oversized sentence must survive intact in ONE chunk — proof no
+        // word-level hard split was needed to rescue an overlap overflow.
+        assert!(
+            result.chunks.iter().any(|c| c.contains("w1 ") && c.contains("w20")),
+            "the budget-filling sentence was split apart: {:?}",
+            result.chunks
+        );
     }
 
     #[test]

--- a/src/embeddings/chunking.rs
+++ b/src/embeddings/chunking.rs
@@ -1,65 +1,111 @@
-//! Text Chunking for Long-Content Embeddings
+//! Token-aware, structure-aware text chunking for embeddings.
 //!
-//! MiniLM has a 256 token limit. Content beyond this is silently dropped,
-//! making long memories unsearchable by their later content.
+//! # Why token-aware
 //!
-//! This module implements two chunking strategies:
+//! The embedding window is enforced by the TOKENIZER, not by this module: the
+//! shipped MiniLM tokenizer.json truncates every sequence to
+//! [`MODEL_TOKEN_WINDOW`] (128) tokens including `[CLS]`/`[SEP]`. The previous
+//! chunker measured CHARACTERS and targeted ~800 chars ("~200 tokens"), so
+//! every full-size chunk exceeded the real window and silently lost its last
+//! ~35% of tokens before the model ever saw them. Chunk budgets are therefore
+//! expressed in REAL tokens, counted by the same tokenizer that feeds the
+//! model (`Embedder::count_tokens`), never by a chars/4 heuristic.
 //!
-//! ## 1. Fixed-Size Overlapping Chunking (`chunk_text`)
-//! - Split text into ~200 token chunks (leaving room for special tokens)
-//! - 50 token overlap between chunks for context continuity
-//! - Good for general prose and documents
+//! # Strategy: structural segmentation + token-budget packing
 //!
-//! ## 2. Semantic Chunking (`semantic_chunk_text`)
-//! - Splits on natural boundaries (paragraphs, dialogue turns, sections)
-//! - Preserves conversational context - never splits mid-turn
-//! - Better for dialogue, structured text, logs, and multi-speaker content
+//! 1. Segment on structure — dialogue turns (never split mid-turn), then
+//!    paragraphs, then sentences/lines. Splitting mid-sentence measurably
+//!    degrades sentence-embedding quality; boundaries follow the text's own
+//!    units.
+//! 2. Greedily pack segments into chunks whose full sequence length
+//!    (content + special tokens) fits `ChunkConfig::max_tokens`.
+//! 3. Overlap is a single trailing sentence, carried only across SOFT
+//!    (sentence) boundaries and only when it is at most
+//!    `ChunkConfig::overlap_tokens`. Rationale: with sentence-aligned
+//!    boundaries no fact is severed mid-clause, so the only residual boundary
+//!    loss is anaphora ("it", "she") whose antecedent is the previous
+//!    sentence. One sentence of carry-over restores that context; the old
+//!    fixed 25% char overlap inflated vector count without a measured recall
+//!    gain. Hard boundaries (paragraph / dialogue turn) carry no overlap —
+//!    those units are self-contained by construction.
+//! 4. A verification pass re-counts every emitted chunk with the real counter
+//!    and hard-splits any that still exceed the budget (defence against
+//!    non-additive tokenization edge cases), so no emitted chunk can exceed
+//!    the window.
 //!
-//! # Example (Fixed-Size)
+//! # Rejected alternatives (surveyed 2026-08)
 //!
-//! A 1000-token memory becomes ~6 chunks:
-//! ```text
-//! [0-200] [150-350] [300-500] [450-650] [600-800] [750-1000]
-//! ```
-//!
-//! # Example (Semantic)
-//!
-//! A dialogue becomes natural chunks preserving speaker turns:
-//! ```text
-//! [Alice: Hi / Bob: Hello] [Alice: How are you? / Bob: Great!]
-//! ```
+//! - **Late chunking** (embed long context once, pool per chunk): requires a
+//!   long-context token-embedding model; degenerate at a 128-token window.
+//! - **Embedding-distance semantic breakpoints**: needs per-sentence
+//!   embeddings at ingest (~Nx embed cost). At this window a memory yields
+//!   1–3 chunks and a breakpoint can move a boundary by at most a sentence —
+//!   the cost is not earned. Revisit only with an ingest-side ablation.
+//! - **Long-context embedder swap**: out of scope; our own bake-off found the
+//!   embedder is not the lever (one comparison bit-identical).
+//! - **Parent-document retrieval**: already present — chunk vectors map to the
+//!   parent memory id (`IdMapping::insert_chunks`), and retrieval returns the
+//!   whole memory.
 
 use regex::Regex;
 use std::sync::LazyLock;
+
+/// The real encoder sequence window, in tokens, INCLUDING the `[CLS]`/`[SEP]`
+/// special tokens. This is the single source of truth that the chunk budget,
+/// the tokenizer truncation (enforced at model load), and the ONNX tensor
+/// length are all validated against at startup
+/// (`MiniLMEmbedder::validate_sequence_contract`). The shipped MiniLM
+/// tokenizer.json truncates at exactly this length; content past it never
+/// reaches the model.
+pub const MODEL_TOKEN_WINDOW: usize = 128;
+
+/// Tokens consumed by `[CLS]` + `[SEP]` in a single-sequence BERT encode.
+pub const SPECIAL_TOKEN_OVERHEAD: usize = 2;
+
+/// Token counter contract: returns the FULL encoded sequence length of `text`
+/// as the model would see it — including special tokens, WITHOUT truncation.
+/// `MiniLMEmbedder` implements this with the real tokenizer; the default
+/// trait fallback uses the calibrated heuristic in `token_estimation`.
+pub type TokenCounter<'a> = dyn Fn(&str) -> usize + 'a;
 
 /// Pattern to detect dialogue turns (e.g., "Alice:", "User:", "Speaker 1:")
 static DIALOGUE_TURN_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?m)^([A-Z][a-zA-Z0-9_\- ]{0,30})\s*:").unwrap());
 
-/// Pattern to detect section headers or timestamps
-static SECTION_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?m)^(?:\[.*?\]|#{1,3}\s+\w|Session \d+|---+)").unwrap());
+/// Sentence terminator followed by whitespace (or end): `.`, `!`, `?` runs,
+/// optionally closed by quotes/brackets.
+static SENTENCE_END_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"[.!?]+["')\]]*(?:\s+|$)"#).unwrap());
 
-/// Chunk configuration for fixed-size chunking
+/// Chunk configuration, in REAL tokens (full sequence, including special
+/// tokens — the same unit the encoder window is measured in).
 pub struct ChunkConfig {
-    /// Target chunk size in characters (approximate tokens * 4)
-    pub chunk_size: usize,
-    /// Overlap between chunks in characters
-    pub overlap: usize,
-    /// Minimum chunk size (don't create tiny trailing chunks)
-    pub min_chunk_size: usize,
+    /// Maximum full-sequence tokens per chunk (content + special tokens).
+    /// MUST be ≤ the tokenizer truncation window or content is silently lost;
+    /// this invariant is asserted at embedder construction.
+    pub max_tokens: usize,
+    /// Maximum CONTENT tokens the trailing sentence of a chunk may have to be
+    /// carried into the next chunk as overlap.
+    pub overlap_tokens: usize,
 }
 
 impl Default for ChunkConfig {
     fn default() -> Self {
         Self {
-            // ~200 tokens * 4 chars/token = 800 chars
-            // Leave headroom for tokenizer differences
-            chunk_size: 800,
-            // ~50 tokens overlap for context continuity
-            overlap: 200,
-            // Don't create chunks smaller than ~50 tokens
-            min_chunk_size: 200,
+            max_tokens: MODEL_TOKEN_WINDOW,
+            overlap_tokens: 24,
+        }
+    }
+}
+
+impl ChunkConfig {
+    /// Config for an embedder-specific budget (e.g. reduced by an asymmetric
+    /// document instruction prefix). Clamped to a sane floor so a
+    /// misconfigured prefix can never produce degenerate one-word chunks.
+    pub fn for_budget(budget_tokens: usize) -> Self {
+        Self {
+            max_tokens: budget_tokens.max(32),
+            ..Self::default()
         }
     }
 }
@@ -69,251 +115,42 @@ impl Default for ChunkConfig {
 pub struct ChunkResult {
     /// The chunked text segments
     pub chunks: Vec<String>,
-    /// Original text length
+    /// Original text length in chars
     pub original_length: usize,
-    /// Whether chunking was needed (content exceeded single chunk)
+    /// Whether the text was split into more than one chunk
     pub was_chunked: bool,
 }
 
-impl ChunkResult {
-    /// Calculate content coverage ratio (1.0 = all content in single chunk)
-    pub fn coverage_ratio(&self) -> f32 {
-        if self.chunks.is_empty() {
-            return 0.0;
-        }
-        // With chunking, we cover everything
-        // Without chunking, we might truncate
-        1.0
-    }
+/// How a segment attaches to the segment before it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Boundary {
+    /// Paragraph or dialogue-turn start: self-contained unit, no overlap
+    /// carried across it, joined with a newline inside a chunk.
+    Hard,
+    /// Sentence/line continuation: overlap may be carried, joined with a
+    /// space inside a chunk.
+    Soft,
 }
 
-/// Find the nearest valid char boundary at or before the given byte index
-#[inline]
-fn floor_char_boundary(s: &str, index: usize) -> usize {
-    if index >= s.len() {
-        return s.len();
-    }
-    // Walk backwards to find a valid char boundary
-    let mut i = index;
-    while i > 0 && !s.is_char_boundary(i) {
-        i -= 1;
-    }
-    i
-}
-
-/// Find the nearest valid char boundary at or after the given byte index
-#[inline]
-fn ceil_char_boundary(s: &str, index: usize) -> usize {
-    if index >= s.len() {
-        return s.len();
-    }
-    // Walk forwards to find a valid char boundary
-    let mut i = index;
-    while i < s.len() && !s.is_char_boundary(i) {
-        i += 1;
-    }
-    i
-}
-
-/// Chunk text into overlapping segments for embedding
-///
-/// Uses sentence-aware splitting to avoid breaking mid-sentence when possible.
-pub fn chunk_text(text: &str, config: &ChunkConfig) -> ChunkResult {
-    let text = text.trim();
-    let original_length = text.len();
-
-    // If text fits in a single chunk, no need to split
-    if original_length <= config.chunk_size {
-        return ChunkResult {
-            chunks: vec![text.to_string()],
-            original_length,
-            was_chunked: false,
-        };
-    }
-
-    let mut chunks = Vec::new();
-    let mut start = 0;
-
-    while start < original_length {
-        // Calculate end position for this chunk, ensuring valid char boundary
-        let mut end = floor_char_boundary(text, (start + config.chunk_size).min(original_length));
-
-        // If we're not at the end, try to break at a sentence boundary
-        if end < original_length {
-            end = find_break_point(text, start, end, config.min_chunk_size);
-            // Ensure the break point is on a valid char boundary
-            end = floor_char_boundary(text, end);
-        }
-
-        // Ensure start is on a valid char boundary
-        start = ceil_char_boundary(text, start);
-
-        // Safety check: ensure we don't have start >= end
-        if start >= end {
-            break;
-        }
-
-        // Extract chunk (now safe - both start and end are valid char boundaries)
-        let chunk = text[start..end].trim();
-        if chunk.len() >= config.min_chunk_size || chunks.is_empty() {
-            chunks.push(chunk.to_string());
-        } else if let Some(last) = chunks.last_mut() {
-            // Append tiny trailing chunk to previous
-            last.push(' ');
-            last.push_str(chunk);
-        }
-
-        // Move start position, accounting for overlap
-        if end >= original_length {
-            break;
-        }
-        // Ensure new start is on a valid char boundary
-        start = ceil_char_boundary(text, end.saturating_sub(config.overlap));
-
-        // Ensure we make progress
-        if start <= chunks.len().saturating_sub(1) * (config.chunk_size - config.overlap) {
-            start = ceil_char_boundary(text, end);
-        }
-    }
-
-    ChunkResult {
-        chunks,
-        original_length,
-        was_chunked: true,
-    }
-}
-
-/// Find a good break point for chunking (sentence or word boundary)
-fn find_break_point(text: &str, start: usize, ideal_end: usize, min_size: usize) -> usize {
-    let chunk = &text[start..ideal_end];
-
-    // Try to find sentence boundary (. ! ?) followed by space or end
-    let sentence_boundaries: Vec<usize> = chunk
-        .char_indices()
-        .filter_map(|(byte_offset, c)| {
-            if (c == '.' || c == '!' || c == '?') && byte_offset >= min_size {
-                // Check if followed by space or end of chunk
-                let after = byte_offset + c.len_utf8();
-                let next_char = chunk[after..].chars().next();
-                if next_char.is_none_or(|nc| nc.is_whitespace()) {
-                    return Some(start + after);
-                }
-            }
-            None
-        })
-        .collect();
-
-    // Use the last sentence boundary if available
-    if let Some(&boundary) = sentence_boundaries.last() {
-        return boundary;
-    }
-
-    // Fall back to word boundary
-    let word_boundaries: Vec<usize> = chunk
-        .char_indices()
-        .filter_map(|(i, c)| {
-            if c.is_whitespace() && i >= min_size {
-                Some(start + i)
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    if let Some(&boundary) = word_boundaries.last() {
-        return boundary;
-    }
-
-    // No good boundary found, use ideal_end
-    ideal_end
-}
-
-/// Estimate token count for text (improved approximation)
-///
-/// Uses word-based estimation with adjustment for BPE subword tokenization.
-/// More accurate than simple character division for mixed content (prose, code, numbers).
-///
-/// Accuracy: ~85-90% for English prose, ~75-85% for code/mixed content.
-/// For exact counts, use a proper tokenizer like tiktoken.
-pub fn estimate_tokens(text: &str) -> usize {
-    if text.is_empty() {
-        return 0;
-    }
-
-    let words = text.split_whitespace().count();
-    if words == 0 {
-        // Text with no whitespace (e.g., single long token or CJK)
-        // Fall back to character-based estimate
-        return text.chars().count().div_ceil(4);
-    }
-
-    // BPE tokenization typically splits words into ~1.3 subword tokens on average
-    // Code and technical content have more splits (camelCase, snake_case, etc.)
-    let base_tokens = (words as f64 * 1.3).ceil() as usize;
-
-    // Add tokens for punctuation and special characters not attached to words
-    // These often become separate tokens
-    let special_chars = text
-        .chars()
-        .filter(|c| c.is_ascii_punctuation() || *c == '\n')
-        .count();
-    let punct_tokens = special_chars / 3; // ~3 punct chars per token on average
-
-    base_tokens + punct_tokens
-}
-
-/// Configuration for semantic chunking
-pub struct SemanticChunkConfig {
-    /// Target chunk size in characters
-    pub target_size: usize,
-    /// Maximum chunk size (hard limit)
-    pub max_size: usize,
-    /// Minimum chunk size (merge smaller segments)
-    pub min_size: usize,
-    /// Whether to preserve dialogue turns intact
-    pub preserve_dialogue_turns: bool,
-    /// Whether to split on paragraph boundaries
-    pub split_on_paragraphs: bool,
-}
-
-impl Default for SemanticChunkConfig {
-    fn default() -> Self {
-        Self {
-            target_size: 800,
-            max_size: 1200,
-            min_size: 100,
-            preserve_dialogue_turns: true,
-            split_on_paragraphs: true,
-        }
-    }
-}
-
-/// A semantic segment with metadata
-#[derive(Debug, Clone)]
-struct SemanticSegment {
+/// A structural unit with its pre-counted CONTENT token length.
+struct Unit {
     text: String,
-    #[allow(dead_code)]
-    segment_type: SegmentType,
+    boundary: Boundary,
+    /// Content tokens (full count minus special-token overhead).
+    tokens: usize,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-enum SegmentType {
-    DialogueTurn,
-    Paragraph,
-    Section,
-    Text,
-}
-
-/// Semantic chunking: splits text on natural boundaries (dialogue turns, paragraphs, sections)
-/// and groups related content together.
+/// Chunk `text` into segments that each fit the token budget.
 ///
-/// This is better for conversational content, logs, and structured text than fixed-size chunking.
-pub fn semantic_chunk_text(text: &str, config: &SemanticChunkConfig) -> ChunkResult {
+/// `counter` must implement the [`TokenCounter`] contract (full sequence
+/// length including specials, no truncation). Every returned chunk satisfies
+/// `counter(chunk) <= config.max_tokens`.
+pub fn chunk_text(text: &str, config: &ChunkConfig, counter: &TokenCounter) -> ChunkResult {
     let text = text.trim();
     let original_length = text.len();
 
-    // If text fits in a single chunk, no need to split
-    if original_length <= config.target_size {
+    // Fast path: the whole text fits the window.
+    if counter(text) <= config.max_tokens {
         return ChunkResult {
             chunks: vec![text.to_string()],
             original_length,
@@ -321,198 +158,29 @@ pub fn semantic_chunk_text(text: &str, config: &SemanticChunkConfig) -> ChunkRes
         };
     }
 
-    // Step 1: Split into semantic segments
-    let segments = split_into_segments(text, config);
+    let content_budget = config.max_tokens.saturating_sub(SPECIAL_TOKEN_OVERHEAD);
+    let units = split_units(text, content_budget, counter);
+    let mut chunks = pack_units(units, config, content_budget);
 
-    // Step 2: Group segments into chunks respecting size constraints
-    let chunks = group_segments_into_chunks(segments, config);
-
-    ChunkResult {
-        chunks,
-        original_length,
-        was_chunked: true,
-    }
-}
-
-/// Split text into semantic segments based on structure
-fn split_into_segments(text: &str, config: &SemanticChunkConfig) -> Vec<SemanticSegment> {
-    let mut segments = Vec::new();
-
-    // Check if this looks like dialogue (has speaker patterns)
-    let is_dialogue = config.preserve_dialogue_turns && DIALOGUE_TURN_PATTERN.is_match(text);
-
-    if is_dialogue {
-        // Split by dialogue turns
-        let turn_starts: Vec<usize> = DIALOGUE_TURN_PATTERN
-            .find_iter(text)
-            .map(|m| m.start())
-            .collect();
-
-        // Add any text before the first turn
-        if !turn_starts.is_empty() && turn_starts[0] > 0 {
-            let pre_text = text[..turn_starts[0]].trim();
-            if !pre_text.is_empty() {
-                segments.push(SemanticSegment {
-                    text: pre_text.to_string(),
-                    segment_type: SegmentType::Text,
-                });
-            }
-        }
-
-        for (i, &start) in turn_starts.iter().enumerate() {
-            let end = if i + 1 < turn_starts.len() {
-                turn_starts[i + 1]
-            } else {
-                text.len()
-            };
-
-            let turn_text = text[start..end].trim();
-            if !turn_text.is_empty() {
-                segments.push(SemanticSegment {
-                    text: turn_text.to_string(),
-                    segment_type: SegmentType::DialogueTurn,
-                });
-            }
-        }
-    } else if config.split_on_paragraphs {
-        // Split by paragraphs (double newlines) or section markers
-        let paragraph_pattern = Regex::new(r"\n\s*\n").unwrap();
-        let mut last_end = 0;
-
-        for mat in paragraph_pattern.find_iter(text) {
-            if mat.start() > last_end {
-                let para_text = text[last_end..mat.start()].trim();
-                if !para_text.is_empty() {
-                    let seg_type = if SECTION_PATTERN.is_match(para_text) {
-                        SegmentType::Section
-                    } else {
-                        SegmentType::Paragraph
-                    };
-                    segments.push(SemanticSegment {
-                        text: para_text.to_string(),
-                        segment_type: seg_type,
-                    });
-                }
-            }
-            last_end = mat.end();
-        }
-
-        // Add remaining text
-        if last_end < text.len() {
-            let remaining = text[last_end..].trim();
-            if !remaining.is_empty() {
-                segments.push(SemanticSegment {
-                    text: remaining.to_string(),
-                    segment_type: SegmentType::Paragraph,
-                });
-            }
-        }
-    } else {
-        // Fall back to sentence-based splitting
-        segments = split_by_sentences(text);
-    }
-
-    // If no segments found, treat entire text as one segment
-    if segments.is_empty() {
-        segments.push(SemanticSegment {
-            text: text.to_string(),
-            segment_type: SegmentType::Text,
-        });
-    }
-
-    segments
-}
-
-/// Split text by sentences for fallback
-fn split_by_sentences(text: &str) -> Vec<SemanticSegment> {
-    let sentence_pattern = Regex::new(r"[.!?]+\s+").unwrap();
-    let mut segments = Vec::new();
-    let mut last_end = 0;
-
-    for mat in sentence_pattern.find_iter(text) {
-        let sentence = text[last_end..mat.end()].trim();
-        if !sentence.is_empty() {
-            segments.push(SemanticSegment {
-                text: sentence.to_string(),
-                segment_type: SegmentType::Text,
-            });
-        }
-        last_end = mat.end();
-    }
-
-    // Add remaining text
-    if last_end < text.len() {
-        let remaining = text[last_end..].trim();
-        if !remaining.is_empty() {
-            segments.push(SemanticSegment {
-                text: remaining.to_string(),
-                segment_type: SegmentType::Text,
-            });
-        }
-    }
-
-    segments
-}
-
-/// Group segments into chunks respecting size constraints
-fn group_segments_into_chunks(
-    segments: Vec<SemanticSegment>,
-    config: &SemanticChunkConfig,
-) -> Vec<String> {
-    let mut chunks = Vec::new();
-    let mut current_chunk = String::new();
-
-    for segment in segments {
-        let segment_len = segment.text.len();
-
-        // If segment alone exceeds max size, we need to split it
-        if segment_len > config.max_size {
-            // Flush current chunk first
-            if !current_chunk.is_empty() {
-                chunks.push(current_chunk.trim().to_string());
-                current_chunk = String::new();
-            }
-
-            // Split the large segment using fixed-size chunking
-            let fixed_config = ChunkConfig {
-                chunk_size: config.target_size,
-                overlap: config.min_size / 2,
-                min_chunk_size: config.min_size,
-            };
-            let sub_chunks = chunk_text(&segment.text, &fixed_config);
-            chunks.extend(sub_chunks.chunks);
-            continue;
-        }
-
-        // Check if adding this segment would exceed target
-        let new_len = current_chunk.len() + segment_len + 1; // +1 for newline
-
-        if new_len > config.target_size && !current_chunk.is_empty() {
-            // Flush current chunk
-            chunks.push(current_chunk.trim().to_string());
-            current_chunk = String::new();
-        }
-
-        // Add segment to current chunk
-        if !current_chunk.is_empty() {
-            current_chunk.push('\n');
-        }
-        current_chunk.push_str(&segment.text);
-    }
-
-    // Flush remaining chunk
-    if !current_chunk.is_empty() {
-        let trimmed = current_chunk.trim().to_string();
-        // Merge tiny trailing chunk with previous if too small
-        if trimmed.len() < config.min_size && !chunks.is_empty() {
-            let last = chunks.pop().unwrap_or_default();
-            chunks.push(format!("{last}\n{trimmed}"));
+    // Verification pass: re-count each emitted chunk with the REAL counter.
+    // Wordpiece token counts are additive across whitespace joins for BERT
+    // tokenizers, but this module must hold its guarantee for ANY counter, so
+    // any chunk that still exceeds the budget is hard-split here.
+    let mut verified = Vec::with_capacity(chunks.len());
+    for chunk in chunks.drain(..) {
+        if counter(&chunk) > config.max_tokens {
+            verified.extend(hard_split(&chunk, content_budget, counter));
         } else {
-            chunks.push(trimmed);
+            verified.push(chunk);
         }
     }
 
-    chunks
+    let was_chunked = verified.len() > 1;
+    ChunkResult {
+        chunks: verified,
+        original_length,
+        was_chunked,
+    }
 }
 
 /// Detect if text appears to be dialogue/conversation format
@@ -520,252 +188,432 @@ pub fn is_dialogue_format(text: &str) -> bool {
     DIALOGUE_TURN_PATTERN.is_match(text)
 }
 
-/// Auto-select the best chunking strategy based on content
-pub fn auto_chunk_text(text: &str) -> ChunkResult {
-    if is_dialogue_format(text) {
-        semantic_chunk_text(text, &SemanticChunkConfig::default())
+/// Split text into structural units: dialogue turns > paragraphs > sentences.
+/// Any single unit larger than `content_budget` is word-split so every unit
+/// fits the budget on its own.
+fn split_units(text: &str, content_budget: usize, counter: &TokenCounter) -> Vec<Unit> {
+    let mut units = Vec::new();
+
+    // Top-level spans: dialogue turns when the text is a conversation,
+    // otherwise paragraphs (blank-line separated).
+    let spans: Vec<&str> = if is_dialogue_format(text) {
+        let starts: Vec<usize> = DIALOGUE_TURN_PATTERN
+            .find_iter(text)
+            .map(|m| m.start())
+            .collect();
+        let mut spans = Vec::with_capacity(starts.len() + 1);
+        if let Some(&first) = starts.first() {
+            if first > 0 {
+                spans.push(&text[..first]);
+            }
+        }
+        for (i, &start) in starts.iter().enumerate() {
+            let end = starts.get(i + 1).copied().unwrap_or(text.len());
+            spans.push(&text[start..end]);
+        }
+        if spans.is_empty() {
+            spans.push(text);
+        }
+        spans
     } else {
-        chunk_text(text, &ChunkConfig::default())
+        static PARAGRAPH_PATTERN: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"\n\s*\n").unwrap());
+        let mut spans = Vec::new();
+        let mut last = 0;
+        for m in PARAGRAPH_PATTERN.find_iter(text) {
+            if m.start() > last {
+                spans.push(&text[last..m.start()]);
+            }
+            last = m.end();
+        }
+        if last < text.len() {
+            spans.push(&text[last..]);
+        }
+        if spans.is_empty() {
+            spans.push(text);
+        }
+        spans
+    };
+
+    for span in spans {
+        let span = span.trim();
+        if span.is_empty() {
+            continue;
+        }
+        let mut first_in_span = true;
+        for sentence in split_sentences(span) {
+            let sentence = sentence.trim();
+            if sentence.is_empty() {
+                continue;
+            }
+            let boundary = if first_in_span {
+                Boundary::Hard
+            } else {
+                Boundary::Soft
+            };
+            first_in_span = false;
+
+            let tokens = counter(sentence).saturating_sub(SPECIAL_TOKEN_OVERHEAD);
+            if tokens > content_budget {
+                // Oversized single sentence (rare: log lines, minified blobs).
+                for (i, piece) in hard_split(sentence, content_budget, counter)
+                    .into_iter()
+                    .enumerate()
+                {
+                    let tokens = counter(&piece).saturating_sub(SPECIAL_TOKEN_OVERHEAD);
+                    units.push(Unit {
+                        text: piece,
+                        boundary: if i == 0 { boundary } else { Boundary::Soft },
+                        tokens,
+                    });
+                }
+            } else {
+                units.push(Unit {
+                    text: sentence.to_string(),
+                    boundary,
+                    tokens,
+                });
+            }
+        }
     }
+
+    units
+}
+
+/// Split a span into sentences; single newlines also terminate a unit so
+/// logs / lists / code lines segment on their natural lines.
+fn split_sentences(span: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    for line in span.split('\n') {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut last = 0;
+        for m in SENTENCE_END_PATTERN.find_iter(line) {
+            out.push(&line[last..m.end()]);
+            last = m.end();
+        }
+        if last < line.len() {
+            out.push(&line[last..]);
+        }
+    }
+    out
+}
+
+/// Greedily pack units into chunks that fit the content budget, carrying a
+/// single small trailing sentence as overlap across soft boundaries.
+fn pack_units(units: Vec<Unit>, config: &ChunkConfig, content_budget: usize) -> Vec<String> {
+    let mut chunks: Vec<(String, usize)> = Vec::new();
+    let mut current = String::new();
+    let mut current_tokens = 0usize;
+    // Trailing unit of `current`, kept for overlap carry-over.
+    let mut last_unit: Option<(String, usize)> = None;
+
+    for unit in units {
+        let fits = current.is_empty() || current_tokens + unit.tokens <= content_budget;
+        if !fits {
+            // Close the current chunk and start the next one.
+            let overlap = if unit.boundary == Boundary::Soft {
+                last_unit
+                    .take()
+                    .filter(|(_, t)| *t <= config.overlap_tokens)
+            } else {
+                None
+            };
+            chunks.push((std::mem::take(&mut current), current_tokens));
+            current_tokens = 0;
+            if let Some((text, tokens)) = overlap {
+                current.push_str(&text);
+                current_tokens = tokens;
+            }
+        }
+
+        if !current.is_empty() {
+            current.push(if unit.boundary == Boundary::Hard {
+                '\n'
+            } else {
+                ' '
+            });
+        }
+        current.push_str(&unit.text);
+        current_tokens += unit.tokens;
+        last_unit = Some((unit.text, unit.tokens));
+    }
+
+    if !current.is_empty() {
+        // NOTE: no minimum-size merge. Greedy packing guarantees a trailing
+        // fragment only becomes its own chunk when the previous chunk had no
+        // room for it — so any merge would overflow the budget and lose
+        // tokens. A small final chunk is correct; an overflowing one is not.
+        chunks.push((current, current_tokens));
+    }
+
+    chunks.into_iter().map(|(text, _)| text).collect()
+}
+
+/// Split text that exceeds the content budget at word boundaries, greedily
+/// packing words up to the budget. A single word larger than the budget
+/// (pathological: base64/minified blobs) is bisected at char boundaries.
+fn hard_split(text: &str, content_budget: usize, counter: &TokenCounter) -> Vec<String> {
+    let budget = content_budget.max(1);
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut current_tokens = 0usize;
+
+    let mut queue: std::collections::VecDeque<String> =
+        text.split_whitespace().map(str::to_string).collect();
+
+    while let Some(word) = queue.pop_front() {
+        let word_tokens = counter(&word).saturating_sub(SPECIAL_TOKEN_OVERHEAD);
+        if word_tokens > budget {
+            // Bisect the oversized word at a char boundary and re-queue.
+            let mid = word.len() / 2;
+            let mut split_at = mid;
+            while split_at > 0 && !word.is_char_boundary(split_at) {
+                split_at -= 1;
+            }
+            if split_at == 0 || split_at == word.len() {
+                // Cannot split further; emit as-is (tokenizer truncation is
+                // the final backstop for a single indivisible token run).
+                if !current.is_empty() {
+                    out.push(std::mem::take(&mut current));
+                    current_tokens = 0;
+                }
+                out.push(word);
+                continue;
+            }
+            let (a, b) = word.split_at(split_at);
+            queue.push_front(b.to_string());
+            queue.push_front(a.to_string());
+            continue;
+        }
+
+        if !current.is_empty() && current_tokens + word_tokens > budget {
+            out.push(std::mem::take(&mut current));
+            current_tokens = 0;
+        }
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(&word);
+        current_tokens += word_tokens;
+    }
+
+    if !current.is_empty() {
+        out.push(current);
+    }
+    if out.is_empty() {
+        out.push(text.to_string());
+    }
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_short_text_no_chunking() {
-        let config = ChunkConfig::default();
-        let result = chunk_text("This is a short text.", &config);
+    /// Heuristic counter matching the `Embedder::count_tokens` default:
+    /// whitespace-word based, plus special-token overhead. Deterministic and
+    /// additive across whitespace joins, like real wordpiece counts.
+    fn word_counter(text: &str) -> usize {
+        text.split_whitespace().count() + SPECIAL_TOKEN_OVERHEAD
+    }
 
+    fn cfg(max_tokens: usize, overlap: usize) -> ChunkConfig {
+        ChunkConfig {
+            max_tokens,
+            overlap_tokens: overlap,
+        }
+    }
+
+    #[test]
+    fn chunk_budget_never_exceeds_model_window() {
+        // The invariant the startup validation enforces; pinned here so a
+        // config drift fails the unit suite too, not only server startup.
+        assert!(ChunkConfig::default().max_tokens <= MODEL_TOKEN_WINDOW);
+    }
+
+    #[test]
+    fn short_text_single_chunk() {
+        let result = chunk_text(
+            "This is a short text.",
+            &ChunkConfig::default(),
+            &word_counter,
+        );
         assert_eq!(result.chunks.len(), 1);
         assert!(!result.was_chunked);
         assert_eq!(result.chunks[0], "This is a short text.");
     }
 
     #[test]
-    fn test_long_text_chunking() {
-        let config = ChunkConfig {
-            chunk_size: 100,
-            overlap: 20,
-            min_chunk_size: 30,
-        };
-
-        // Create text longer than chunk_size
-        let text = "This is sentence one. This is sentence two. This is sentence three. \
-                   This is sentence four. This is sentence five. This is sentence six. \
-                   This is sentence seven. This is sentence eight.";
-
-        let result = chunk_text(text, &config);
-
+    fn every_chunk_fits_token_budget() {
+        let config = cfg(30, 8);
+        let text = (1..=40)
+            .map(|i| format!("Sentence number {i} contains unique information."))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let result = chunk_text(&text, &config, &word_counter);
         assert!(result.was_chunked);
-        assert!(result.chunks.len() > 1);
-
-        // Verify each chunk has meaningful content
         for chunk in &result.chunks {
             assert!(
-                chunk.len() >= config.min_chunk_size,
-                "Chunk too small: '{}' (len={})",
-                chunk,
-                chunk.len()
-            );
-        }
-
-        // Verify total chunked content is at least as long as original (with overlaps)
-        let total_len: usize = result.chunks.iter().map(|c| c.len()).sum();
-        assert!(
-            total_len >= result.original_length,
-            "Total chunk length {} < original {}",
-            total_len,
-            result.original_length
-        );
-    }
-
-    #[test]
-    fn test_sentence_boundary_respected() {
-        let config = ChunkConfig {
-            chunk_size: 50,
-            overlap: 10,
-            min_chunk_size: 20,
-        };
-
-        let text = "First sentence here. Second sentence follows. Third sentence ends.";
-        let result = chunk_text(text, &config);
-
-        // Chunks should end at sentence boundaries when possible
-        for chunk in &result.chunks {
-            let trimmed = chunk.trim();
-            if !trimmed.is_empty() && result.chunks.len() > 1 {
-                // Most chunks should end with sentence-ending punctuation
-                let last_char = trimmed.chars().last().unwrap();
-                // Allow some flexibility - not all chunks will end at sentence boundary
-                assert!(
-                    last_char == '.'
-                        || last_char == '!'
-                        || last_char == '?'
-                        || chunk == result.chunks.last().unwrap(),
-                    "Chunk '{chunk}' doesn't end at sentence boundary"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_overlap_exists() {
-        let config = ChunkConfig {
-            chunk_size: 60,
-            overlap: 20,
-            min_chunk_size: 20,
-        };
-
-        let text = "AAAA BBBB CCCC DDDD EEEE FFFF GGGG HHHH IIII JJJJ KKKK LLLL MMMM";
-        let result = chunk_text(text, &config);
-
-        if result.chunks.len() >= 2 {
-            // Check that consecutive chunks have overlapping content
-            for i in 0..result.chunks.len() - 1 {
-                let chunk1 = &result.chunks[i];
-                let chunk2 = &result.chunks[i + 1];
-
-                // Find common words
-                let words1: std::collections::HashSet<_> = chunk1.split_whitespace().collect();
-                let words2: std::collections::HashSet<_> = chunk2.split_whitespace().collect();
-                let common: Vec<_> = words1.intersection(&words2).collect();
-
-                // Should have some overlap
-                assert!(
-                    !common.is_empty() || chunk1.len() < config.overlap,
-                    "No overlap between chunks {} and {}",
-                    i,
-                    i + 1
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_token_estimation() {
-        // Empty string
-        assert_eq!(estimate_tokens(""), 0);
-
-        // Single word: 1 * 1.3 = 2 (ceil)
-        assert_eq!(estimate_tokens("test"), 2);
-
-        // Two words: 2 * 1.3 = 3 (ceil)
-        assert_eq!(estimate_tokens("hello world"), 3);
-
-        // Sentence with punctuation: 5 words * 1.3 = 7 (ceil) + 1 punct token (3 punct chars / 3)
-        assert_eq!(estimate_tokens("Hello, world! How are you?"), 8);
-
-        // Code-like content with more punctuation
-        let code = "fn main() { println!(\"hello\"); }";
-        let tokens = estimate_tokens(code);
-        assert!(tokens >= 5 && tokens <= 15, "Code tokens: {}", tokens);
-
-        // No whitespace (falls back to char-based)
-        assert_eq!(estimate_tokens("abcdefgh"), 2); // 8 chars / 4 = 2
-    }
-
-    #[test]
-    fn test_very_long_content() {
-        let config = ChunkConfig::default();
-
-        // Create 10KB of content
-        let long_text = "This is a test sentence. ".repeat(400);
-        let result = chunk_text(&long_text, &config);
-
-        assert!(result.was_chunked);
-        assert!(result.chunks.len() > 10); // Should have many chunks
-        assert_eq!(result.coverage_ratio(), 1.0);
-
-        // Verify no chunk exceeds config size significantly
-        for chunk in &result.chunks {
-            assert!(
-                chunk.len() <= config.chunk_size + 100,
-                "Chunk too large: {} chars",
-                chunk.len()
+                word_counter(chunk) <= config.max_tokens,
+                "chunk exceeds token budget: {} tokens: {chunk:?}",
+                word_counter(chunk)
             );
         }
     }
 
     #[test]
-    fn test_chunking_quality_unique_content_searchable() {
-        let config = ChunkConfig::default();
+    fn coverage_no_content_lost() {
+        let config = cfg(30, 8);
+        let text = (1..=40)
+            .map(|i| format!("Sentence number {i} contains unique information."))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let result = chunk_text(&text, &config, &word_counter);
+        for i in 1..=40 {
+            let marker = format!("number {i} ");
+            let marker_end = format!("number {i} contains");
+            let found = result
+                .chunks
+                .iter()
+                .any(|c| c.contains(&marker) || c.contains(&marker_end));
+            assert!(found, "sentence {i} missing from all chunks");
+        }
+    }
 
-        // Create content with UNIQUE markers at beginning, middle, and end
-        // These markers should each appear in at least one chunk
+    #[test]
+    fn unique_markers_beginning_middle_end_searchable() {
+        let config = cfg(40, 8);
         let beginning = "ALPHA_BEGINNING_MARKER is a unique identifier at the start.";
-        let middle_padding = "This is filler content to push things apart. ".repeat(30);
+        let filler_a = "This is filler content to push things apart. ".repeat(20);
         let middle = "BETA_MIDDLE_MARKER represents content in the center of the document.";
-        let end_padding = "More filler content for separation between sections. ".repeat(30);
+        let filler_b = "More filler content for separation between sections. ".repeat(20);
         let end = "GAMMA_END_MARKER signifies the conclusion of this memory content.";
+        let text = format!("{beginning} {filler_a} {middle} {filler_b} {end}");
 
-        let full_text = format!("{beginning} {middle_padding} {middle} {end_padding} {end}");
+        let result = chunk_text(&text, &config, &word_counter);
+        assert!(result.was_chunked);
+        assert!(result.chunks.iter().any(|c| c.contains("ALPHA_BEGINNING")));
+        assert!(result.chunks.iter().any(|c| c.contains("BETA_MIDDLE")));
+        assert!(result.chunks.iter().any(|c| c.contains("GAMMA_END")));
+    }
 
-        let result = chunk_text(&full_text, &config);
-
-        // Content should be chunked
-        assert!(result.was_chunked, "Content should require chunking");
-        assert!(result.chunks.len() >= 3, "Should have multiple chunks");
-
-        // Verify each unique marker appears in at least one chunk
-        let has_alpha = result.chunks.iter().any(|c| c.contains("ALPHA_BEGINNING"));
-        let has_beta = result.chunks.iter().any(|c| c.contains("BETA_MIDDLE"));
-        let has_gamma = result.chunks.iter().any(|c| c.contains("GAMMA_END"));
-
-        assert!(has_alpha, "ALPHA marker (beginning) not found in any chunk");
-        assert!(has_beta, "BETA marker (middle) not found in any chunk");
-        assert!(has_gamma, "GAMMA marker (end) not found in any chunk");
-
-        // Log chunk info for debugging
-        println!("Total chunks: {}", result.chunks.len());
-        println!("Original length: {} chars", result.original_length);
-        for (i, chunk) in result.chunks.iter().enumerate() {
-            let markers: Vec<&str> = vec![
-                if chunk.contains("ALPHA") { "ALPHA" } else { "" },
-                if chunk.contains("BETA") { "BETA" } else { "" },
-                if chunk.contains("GAMMA") { "GAMMA" } else { "" },
-            ]
-            .into_iter()
-            .filter(|m| !m.is_empty())
-            .collect();
-            println!(
-                "  Chunk {}: {} chars {}",
-                i,
-                chunk.len(),
-                if markers.is_empty() {
-                    String::new()
-                } else {
-                    format!("[contains: {}]", markers.join(", "))
-                }
+    #[test]
+    fn sentence_boundaries_respected() {
+        let config = cfg(12, 2);
+        let text = "First sentence here. Second sentence follows on. Third sentence ends it. \
+                    Fourth sentence too. Fifth sentence closes.";
+        let result = chunk_text(&text, &config, &word_counter);
+        assert!(result.chunks.len() > 1);
+        for chunk in &result.chunks[..result.chunks.len() - 1] {
+            let last = chunk.trim_end().chars().last().unwrap();
+            assert!(
+                last == '.' || last == '!' || last == '?',
+                "chunk does not end at a sentence boundary: {chunk:?}"
             );
         }
     }
 
     #[test]
-    fn test_chunking_coverage_no_content_lost() {
-        let config = ChunkConfig {
-            chunk_size: 200,
-            overlap: 50,
-            min_chunk_size: 50,
-        };
-
-        // Create text with numbered sentences for easy tracking
-        let sentences: Vec<String> = (1..=20)
-            .map(|i| format!("Sentence number {i} contains unique information. "))
-            .collect();
-        let text = sentences.join("");
-
-        let result = chunk_text(&text, &config);
-
-        // Every sentence number should appear in at least one chunk
-        for i in 1..=20 {
-            let marker = format!("number {i}");
-            let found = result.chunks.iter().any(|c| c.contains(&marker));
+    fn overlap_carries_small_trailing_sentence() {
+        let config = cfg(20, 10);
+        // Sentences of 8 words each: two fit per 18-content-token chunk; the
+        // trailing sentence (8 tokens ≤ overlap 10) must be carried over.
+        let text = (1..=6)
+            .map(|i| format!("Overlap test sentence {i} has exactly eight words."))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let result = chunk_text(&text, &config, &word_counter);
+        assert!(result.chunks.len() >= 2);
+        for w in result.chunks.windows(2) {
+            let last_sentence = w[0].split(". ").last().unwrap_or("").trim();
             assert!(
-                found,
-                "Sentence {i} not found in any chunk! Coverage gap detected."
+                w[1].contains(last_sentence.trim_end_matches('.')),
+                "no overlap between consecutive chunks:\n prev: {:?}\n next: {:?}",
+                w[0],
+                w[1]
             );
         }
+    }
+
+    #[test]
+    fn dialogue_turns_not_split_when_they_fit() {
+        let config = cfg(25, 4);
+        let text = "Alice: I went to the market this morning and bought fresh vegetables.\n\
+                    Bob: That sounds great, did you find good tomatoes there?\n\
+                    Alice: Yes, and I also picked up some basil for the sauce.\n\
+                    Bob: Perfect, let us cook dinner together tonight then.";
+        let result = chunk_text(text, &config, &word_counter);
+        // Every turn is <= budget, so no chunk may contain a partial turn:
+        // each speaker prefix in a chunk starts at a line boundary.
+        for chunk in &result.chunks {
+            for (i, _) in chunk.match_indices("Alice:").chain(chunk.match_indices("Bob:")) {
+                assert!(
+                    i == 0 || chunk.as_bytes()[i - 1] == b'\n',
+                    "turn split mid-chunk: {chunk:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn oversized_single_sentence_is_word_split() {
+        let config = cfg(12, 2);
+        let text = "word ".repeat(100); // one 100-word "sentence", no terminator
+        let result = chunk_text(text.trim(), &config, &word_counter);
+        assert!(result.chunks.len() >= 10);
+        for chunk in &result.chunks {
+            assert!(word_counter(chunk) <= config.max_tokens);
+        }
+        let total_words: usize = result
+            .chunks
+            .iter()
+            .map(|c| c.split_whitespace().count())
+            .sum();
+        assert_eq!(total_words, 100, "hard split lost words");
+    }
+
+    #[test]
+    fn pathological_single_token_run_is_bisected() {
+        let config = cfg(10, 2);
+        // Counter that charges 1 token per 4 chars — a 400-char unbroken blob.
+        let char_counter =
+            |t: &str| t.chars().count().div_ceil(4) + SPECIAL_TOKEN_OVERHEAD;
+        let blob = "x".repeat(400);
+        let result = chunk_text(&blob, &config, &char_counter);
+        for chunk in &result.chunks {
+            assert!(char_counter(chunk) <= config.max_tokens);
+        }
+        let total: usize = result.chunks.iter().map(|c| c.len()).sum();
+        assert_eq!(total, 400, "bisection lost characters");
+    }
+
+    #[test]
+    fn trailing_fragment_never_lost_and_never_overflows() {
+        let config = cfg(20, 4);
+        // Two 9-word sentences fill a chunk to its 18-content-token budget;
+        // the 3-word tail cannot merge without overflowing, so it must stand
+        // alone rather than be dropped or force a lossy merge.
+        let text = "This first sentence is exactly nine words long okay.                     This second sentence is also exactly nine words long. Tiny tail here";
+        let result = chunk_text(text, &config, &word_counter);
+        assert!(
+            result.chunks.iter().any(|c| c.contains("Tiny tail here")),
+            "trailing fragment lost"
+        );
+        for chunk in &result.chunks {
+            assert!(
+                word_counter(chunk) <= config.max_tokens,
+                "chunk exceeds budget: {chunk:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_text_single_empty_chunk() {
+        let result = chunk_text("", &ChunkConfig::default(), &word_counter);
+        assert_eq!(result.chunks.len(), 1);
+        assert!(!result.was_chunked);
     }
 }

--- a/src/embeddings/circuit_breaker.rs
+++ b/src/embeddings/circuit_breaker.rs
@@ -304,6 +304,17 @@ impl Embedder for ResilientEmbedder {
         self.inner.dimension()
     }
 
+    /// Token counting is a pure tokenizer operation — no inference, no
+    /// circuit involved. Always forward to the inner embedder so chunk
+    /// budgets stay in real-tokenizer units even when the circuit is open.
+    fn count_tokens(&self, text: &str) -> usize {
+        self.inner.count_tokens(text)
+    }
+
+    fn chunk_budget_tokens(&self) -> usize {
+        self.inner.chunk_budget_tokens()
+    }
+
     fn encode_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
         // For batch operations, check circuit once and apply consistently
         if !self.should_allow_request() {

--- a/src/embeddings/minilm.rs
+++ b/src/embeddings/minilm.rs
@@ -43,6 +43,11 @@ pub fn pre_init_ort_runtime(offline_mode: bool) {
 struct LazyModel {
     session: Mutex<Session>,
     tokenizer: Tokenizer,
+    /// Truncation-free, padding-free clone of `tokenizer`, used ONLY for
+    /// counting true sequence lengths (`Embedder::count_tokens`). The main
+    /// tokenizer truncates at [`chunking::MODEL_TOKEN_WINDOW`], so it can
+    /// never report how long a text really is.
+    count_tokenizer: Tokenizer,
 }
 
 impl LazyModel {
@@ -92,14 +97,42 @@ impl LazyModel {
             .commit_from_file(&config.model_path)
             .context("Failed to load ONNX model")?;
 
-        let tokenizer = Tokenizer::from_file(&config.tokenizer_path)
+        let mut tokenizer = Tokenizer::from_file(&config.tokenizer_path)
             .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {e}"))?;
 
-        tracing::info!("MiniLM-L6-v2 model loaded successfully");
+        // Enforce the sequence window IN CODE rather than trusting whatever
+        // truncation the shipped tokenizer.json declares. The startup
+        // validation (`validate_sequence_contract`) has already hard-failed if
+        // the shipped truncation is tighter than the window; here we pin it to
+        // exactly MODEL_TOKEN_WINDOW so the chunk budget and the tokenizer can
+        // never disagree again. Params match the shipped MiniLM config
+        // (LongestFirst / stride 0 / right), so this is byte-identical for the
+        // stock tokenizer.
+        use crate::embeddings::chunking::MODEL_TOKEN_WINDOW;
+        tokenizer
+            .with_truncation(Some(tokenizers::TruncationParams {
+                max_length: MODEL_TOKEN_WINDOW,
+                ..Default::default()
+            }))
+            .map_err(|e| anyhow::anyhow!("Failed to set tokenizer truncation: {e}"))?;
+
+        // Second instance for TRUE length counting: no truncation, no padding.
+        let mut count_tokenizer = Tokenizer::from_file(&config.tokenizer_path)
+            .map_err(|e| anyhow::anyhow!("Failed to load counting tokenizer: {e}"))?;
+        count_tokenizer
+            .with_truncation(None)
+            .map_err(|e| anyhow::anyhow!("Failed to clear counting truncation: {e}"))?;
+        count_tokenizer.with_padding(None);
+
+        tracing::info!(
+            "MiniLM-L6-v2 model loaded successfully (sequence window: {} tokens)",
+            MODEL_TOKEN_WINDOW
+        );
 
         Ok(Self {
             session: Mutex::new(session),
             tokenizer,
+            count_tokenizer,
         })
     }
 }
@@ -491,6 +524,12 @@ impl MiniLMEmbedder {
             }
         }
 
+        // Startup guard: the chunk budget, the tokenizer's truncation window,
+        // and the ONNX tensor length must agree, or content silently vanishes
+        // past the tightest layer. Runs at construction (i.e. server startup)
+        // even under lazy loading, so the failure is loud and immediate.
+        Self::validate_sequence_contract(&config)?;
+
         let (query_prefix, doc_prefix) = embedder_prefixes();
         let (native_hidden, dimension) = embedder_dims();
         let embedder = Self {
@@ -513,6 +552,89 @@ impl MiniLMEmbedder {
         }
 
         Ok(embedder)
+    }
+
+    /// Validate the three-layer sequence-length contract at startup:
+    ///
+    /// ```text
+    /// chunk budget  ≤  tokenizer truncation window  ≤  ONNX tensor length
+    /// ```
+    ///
+    /// This is the guard for the defect class where the chunker sized chunks
+    /// for ~200 tokens while the shipped tokenizer.json silently truncated at
+    /// 128 — the last third of every full-size chunk never reached the model
+    /// and nothing logged it. Three rules:
+    ///
+    /// 1. `ChunkConfig::default().max_tokens` must be ≤ `MODEL_TOKEN_WINDOW`.
+    /// 2. `MODEL_TOKEN_WINDOW` must be ≤ `config.max_length` (tensor length).
+    /// 3. The truncation declared inside the shipped tokenizer.json must not
+    ///    be TIGHTER than `MODEL_TOKEN_WINDOW`. (Looser is tolerated with a
+    ///    warning — `LazyModel::new` pins truncation to the window at load.)
+    ///
+    /// Hard-fails on violation: a mis-sized window corrupts every embedding
+    /// written after it, so refusing to start is strictly cheaper.
+    fn validate_sequence_contract(config: &EmbeddingConfig) -> Result<()> {
+        use crate::embeddings::chunking::{ChunkConfig, MODEL_TOKEN_WINDOW};
+
+        let chunk_budget = ChunkConfig::default().max_tokens;
+        anyhow::ensure!(
+            chunk_budget <= MODEL_TOKEN_WINDOW,
+            "Sequence contract violated: chunk budget ({chunk_budget} tokens) exceeds the \
+             model token window ({MODEL_TOKEN_WINDOW}). Chunks would be silently truncated \
+             before embedding. Fix ChunkConfig::default() or MODEL_TOKEN_WINDOW."
+        );
+        anyhow::ensure!(
+            MODEL_TOKEN_WINDOW <= config.max_length,
+            "Sequence contract violated: model token window ({MODEL_TOKEN_WINDOW}) exceeds \
+             the ONNX tensor length ({}). Tokens past the tensor length would be dropped. \
+             Fix EmbeddingConfig::max_length or MODEL_TOKEN_WINDOW.",
+            config.max_length
+        );
+
+        // Inspect the truncation the shipped tokenizer.json declares. A window
+        // TIGHTER than the code assumes is exactly the silent-loss bug this
+        // guard exists for — refuse to start.
+        let raw = std::fs::read_to_string(&config.tokenizer_path).with_context(|| {
+            format!(
+                "Sequence contract check: cannot read tokenizer file {:?}",
+                config.tokenizer_path
+            )
+        })?;
+        let parsed: serde_json::Value = serde_json::from_str(&raw).with_context(|| {
+            format!(
+                "Sequence contract check: tokenizer file {:?} is not valid JSON",
+                config.tokenizer_path
+            )
+        })?;
+        if let Some(declared) = parsed
+            .get("truncation")
+            .and_then(|t| t.get("max_length"))
+            .and_then(|m| m.as_u64())
+        {
+            let declared = declared as usize;
+            anyhow::ensure!(
+                declared >= MODEL_TOKEN_WINDOW,
+                "Sequence contract violated: tokenizer.json at {:?} declares truncation at \
+                 {declared} tokens, tighter than the assumed model window \
+                 ({MODEL_TOKEN_WINDOW}). Content between {declared} and {MODEL_TOKEN_WINDOW} \
+                 tokens would silently never reach the model. Ship a tokenizer whose \
+                 truncation matches MODEL_TOKEN_WINDOW, or lower MODEL_TOKEN_WINDOW.",
+                config.tokenizer_path
+            );
+            if declared != MODEL_TOKEN_WINDOW {
+                tracing::warn!(
+                    "tokenizer.json declares truncation at {declared} tokens; the runtime \
+                     pins it to MODEL_TOKEN_WINDOW ({MODEL_TOKEN_WINDOW}) at load"
+                );
+            }
+        }
+
+        tracing::debug!(
+            "Sequence contract OK: chunk {chunk_budget} <= window {MODEL_TOKEN_WINDOW} <= \
+             tensor {}",
+            config.max_length
+        );
+        Ok(())
     }
 
     /// Ensure the model is loaded (thread-safe, idempotent)
@@ -745,10 +867,12 @@ impl MiniLMEmbedder {
         tracing::debug!("ONNX: session lock acquired, tokenizing...");
 
         // Tokenize input text
+        let t_tokenize = crate::stage_probe::start();
         let encoding = model
             .tokenizer
             .encode(text, true)
             .map_err(|e| anyhow::anyhow!("Tokenization failed: {e}"))?;
+        crate::stage_probe::record(t_tokenize, |p, d| p.tokenize += d);
 
         let tokens = encoding.get_ids();
         let attention_mask = encoding.get_attention_mask();
@@ -780,8 +904,11 @@ impl MiniLMEmbedder {
             .iter()
             .any(|i| i.name() == "token_type_ids");
 
-        // Run inference
+        // Run inference. Timed in isolation: `session.run` is the only part of
+        // this function that hardware acceleration could move, so it must be
+        // separable from tokenization, tensor construction, and mean pooling.
         tracing::debug!("ONNX: running inference...");
+        let t_forward = crate::stage_probe::start();
         let outputs = if wants_token_type {
             session.run(ort::inputs![
                 "input_ids" => &input_ids_value,
@@ -794,6 +921,10 @@ impl MiniLMEmbedder {
                 "attention_mask" => &attention_mask_value,
             ])?
         };
+        crate::stage_probe::record(t_forward, |p, d| {
+            p.onnx_forward += d;
+            p.forwards += 1;
+        });
         tracing::debug!("ONNX: inference complete");
 
         // Extract embeddings
@@ -1054,6 +1185,43 @@ impl Embedder for MiniLMEmbedder {
         self.dimension
     }
 
+    /// True sequence length (specials included, no truncation) from the real
+    /// tokenizer. Falls back to the calibrated heuristic when the model is
+    /// unavailable (simplified mode / load failure) — the chunker's
+    /// verification pass re-counts with this same function, so the guarantee
+    /// "no emitted chunk exceeds the budget under the active counter" holds
+    /// either way.
+    fn count_tokens(&self, text: &str) -> usize {
+        use crate::embeddings::chunking::SPECIAL_TOKEN_OVERHEAD;
+        if text.is_empty() {
+            return SPECIAL_TOKEN_OVERHEAD;
+        }
+        if !self.simplified_mode {
+            if let Ok(model) = self.ensure_model_loaded() {
+                if let Ok(encoding) = model.count_tokenizer.encode(text, true) {
+                    return encoding.get_ids().len();
+                }
+            }
+        }
+        crate::token_estimation::estimate_tokens(text) + SPECIAL_TOKEN_OVERHEAD
+    }
+
+    /// Document chunk budget: the model window minus the tokens the document
+    /// instruction prefix will consume at encode time (0 for symmetric
+    /// MiniLM; ~4 for e5's "passage: "). Keeps prefixed sequences inside the
+    /// tokenizer truncation window instead of silently pushing chunk tails
+    /// past it.
+    fn chunk_budget_tokens(&self) -> usize {
+        use crate::embeddings::chunking::{MODEL_TOKEN_WINDOW, SPECIAL_TOKEN_OVERHEAD};
+        if self.doc_prefix.is_empty() {
+            return MODEL_TOKEN_WINDOW;
+        }
+        let prefix_tokens = self
+            .count_tokens(&self.doc_prefix)
+            .saturating_sub(SPECIAL_TOKEN_OVERHEAD);
+        MODEL_TOKEN_WINDOW.saturating_sub(prefix_tokens)
+    }
+
     fn encode_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
         if texts.is_empty() {
             return Ok(Vec::new());
@@ -1239,6 +1407,108 @@ mod tests {
         assert_eq!(embeddings.len(), 3);
         for emb in embeddings {
             assert_eq!(emb.len(), 384);
+        }
+    }
+
+    /// Sequence-contract validation must pass on the shipped model assets and
+    /// must hard-fail on a tokenizer whose truncation is tighter than the
+    /// assumed window (the exact defect class this guard exists for).
+    ///
+    /// Asset-gated like the other real-model tests: skips when the tokenizer
+    /// has not been downloaded (CI fetches model assets before testing).
+    #[test]
+    fn test_sequence_contract_validation() {
+        use crate::embeddings::chunking::MODEL_TOKEN_WINDOW;
+
+        let config = EmbeddingConfig::from_env();
+        if !config.tokenizer_path.exists() {
+            eprintln!(
+                "skipping test_sequence_contract_validation: tokenizer not present at {:?}",
+                config.tokenizer_path
+            );
+            return;
+        }
+
+        // 1. The shipped assets satisfy the contract.
+        MiniLMEmbedder::validate_sequence_contract(&config)
+            .expect("shipped tokenizer must satisfy the sequence contract");
+
+        // 2. A tokenizer that truncates TIGHTER than the window must be
+        // rejected loudly, not silently truncate chunk tails.
+        let dir = std::env::temp_dir().join("shodh-seq-contract-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let tight_path = dir.join("tokenizer.json");
+        let raw = std::fs::read_to_string(&config.tokenizer_path).unwrap();
+        let mut parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        parsed["truncation"]["max_length"] =
+            serde_json::Value::from((MODEL_TOKEN_WINDOW / 2) as u64);
+        std::fs::write(&tight_path, serde_json::to_string(&parsed).unwrap()).unwrap();
+
+        let tight_config = EmbeddingConfig {
+            tokenizer_path: tight_path,
+            ..config
+        };
+        let err = MiniLMEmbedder::validate_sequence_contract(&tight_config)
+            .expect_err("tighter-than-window truncation must fail the contract");
+        assert!(
+            err.to_string().contains("Sequence contract violated"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// End-to-end guarantee with the REAL tokenizer: every chunk the
+    /// production chunker emits for a long text fits the model window — i.e.
+    /// the loaded (truncating) tokenizer does not drop a single token of any
+    /// chunk. This is the regression test for the silent-truncation defect
+    /// (chunks sized ~200 tokens vs tokenizer window 128).
+    ///
+    /// Asset-gated: skips when model assets are not downloaded.
+    #[test]
+    fn test_chunks_fit_real_tokenizer_window() {
+        use crate::embeddings::chunking::{chunk_text, ChunkConfig, MODEL_TOKEN_WINDOW};
+        use crate::embeddings::Embedder;
+
+        let config = EmbeddingConfig::from_env();
+        if !config.tokenizer_path.exists() {
+            eprintln!(
+                "skipping test_chunks_fit_real_tokenizer_window: tokenizer not present at {:?}",
+                config.tokenizer_path
+            );
+            return;
+        }
+
+        let embedder = MiniLMEmbedder::new(config.clone()).expect("embedder init");
+
+        // A realistic long memory: prose paragraphs well past the window
+        // (the old chunker produced ~800-char chunks ≈ 170-200 tokens here).
+        let text = (1..=60)
+            .map(|i| {
+                format!(
+                    "Finding number {i}: the retrieval subsystem logged a measurable \
+                     latency regression after the index rebuild completed on node {i}."
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        let budget = embedder.chunk_budget_tokens();
+        assert!(budget <= MODEL_TOKEN_WINDOW);
+        let chunk_config = ChunkConfig::for_budget(budget);
+        let counter = |t: &str| embedder.count_tokens(t);
+        let result = chunk_text(&text, &chunk_config, &counter);
+        assert!(result.was_chunked, "long text must be chunked");
+
+        // Count with a truncation-free tokenizer: every chunk must TRULY fit.
+        let mut free = Tokenizer::from_file(&config.tokenizer_path).unwrap();
+        free.with_truncation(None).unwrap();
+        free.with_padding(None);
+        for chunk in &result.chunks {
+            let true_len = free.encode(chunk.as_str(), true).unwrap().get_ids().len();
+            assert!(
+                true_len <= MODEL_TOKEN_WINDOW,
+                "chunk exceeds the model window ({true_len} > {MODEL_TOKEN_WINDOW} tokens): \
+                 its tail would be silently truncated: {chunk:?}"
+            );
         }
     }
 }

--- a/src/embeddings/minilm.rs
+++ b/src/embeddings/minilm.rs
@@ -146,7 +146,14 @@ pub struct EmbeddingConfig {
     /// Path to tokenizer file
     pub tokenizer_path: PathBuf,
 
-    /// Maximum sequence length (MiniLM default: 256)
+    /// Length of the ONNX input tensors, in tokens. Every forward pass costs
+    /// this length regardless of how many real tokens the text has, so it must
+    /// not exceed the tokenizer's truncation window — positions past the
+    /// window can only ever hold padding, and masked mean pooling discards
+    /// them (verified bit-identical: padding a 32-token input to 128 vs 256
+    /// yields the same pooled vector to the last bit, at ~2x the cost).
+    /// Defaults to [`MODEL_TOKEN_WINDOW`]; validated by
+    /// [`MiniLMEmbedder::validate_sequence_contract`].
     pub max_length: usize,
 
     /// Use quantized model for faster inference
@@ -573,6 +580,19 @@ impl MiniLMEmbedder {
     ///
     /// Hard-fails on violation: a mis-sized window corrupts every embedding
     /// written after it, so refusing to start is strictly cheaper.
+    ///
+    /// Rule 2 is an inequality, and today it is a STRICT one: window 128,
+    /// tensor 256. Positions 129..256 can only ever hold padding, and each
+    /// forward pass pays ~2.05x for them (measured at one intra-op thread,
+    /// interleaved: seq=128 88.9 ms vs seq=256 182.4 ms on the quantized
+    /// export). That is not free to reclaim: on the quantized export
+    /// `DynamicQuantizeLinear` derives its activation scale from the whole
+    /// tensor, padding included, so the tensor length is part of the
+    /// embedding function — pad-128 vs pad-256 measured worst cosine 0.9859,
+    /// i.e. shrinking it re-embeds every stored vector. (On the fp32 export
+    /// the same comparison is bit-identical, which is why a local-only check
+    /// would wrongly call it free.) Logged as waste, deliberately not
+    /// "fixed" here: it is a migration with its own recall gate.
     fn validate_sequence_contract(config: &EmbeddingConfig) -> Result<()> {
         use crate::embeddings::chunking::{ChunkConfig, MODEL_TOKEN_WINDOW};
 
@@ -590,6 +610,17 @@ impl MiniLMEmbedder {
              Fix EmbeddingConfig::max_length or MODEL_TOKEN_WINDOW.",
             config.max_length
         );
+        if config.max_length > MODEL_TOKEN_WINDOW {
+            tracing::info!(
+                "ONNX tensor length ({}) exceeds the token window ({MODEL_TOKEN_WINDOW}); the \
+                 extra {} positions can only ever hold padding, costing ~2x per forward pass. \
+                 Reclaiming them is a re-embed migration, not a free win: the quantized export \
+                 derives its activation scale from the padded tensor, so shortening it changes \
+                 every vector",
+                config.max_length,
+                config.max_length - MODEL_TOKEN_WINDOW
+            );
+        }
 
         // Inspect the truncation the shipped tokenizer.json declares. A window
         // TIGHTER than the code assumes is exactly the silent-loss bug this
@@ -867,12 +898,10 @@ impl MiniLMEmbedder {
         tracing::debug!("ONNX: session lock acquired, tokenizing...");
 
         // Tokenize input text
-        let t_tokenize = crate::stage_probe::start();
         let encoding = model
             .tokenizer
             .encode(text, true)
             .map_err(|e| anyhow::anyhow!("Tokenization failed: {e}"))?;
-        crate::stage_probe::record(t_tokenize, |p, d| p.tokenize += d);
 
         let tokens = encoding.get_ids();
         let attention_mask = encoding.get_attention_mask();
@@ -904,11 +933,8 @@ impl MiniLMEmbedder {
             .iter()
             .any(|i| i.name() == "token_type_ids");
 
-        // Run inference. Timed in isolation: `session.run` is the only part of
-        // this function that hardware acceleration could move, so it must be
-        // separable from tokenization, tensor construction, and mean pooling.
+        // Run inference
         tracing::debug!("ONNX: running inference...");
-        let t_forward = crate::stage_probe::start();
         let outputs = if wants_token_type {
             session.run(ort::inputs![
                 "input_ids" => &input_ids_value,
@@ -921,10 +947,6 @@ impl MiniLMEmbedder {
                 "attention_mask" => &attention_mask_value,
             ])?
         };
-        crate::stage_probe::record(t_forward, |p, d| {
-            p.onnx_forward += d;
-            p.forwards += 1;
-        });
         tracing::debug!("ONNX: inference complete");
 
         // Extract embeddings
@@ -1360,11 +1382,17 @@ mod tests {
 
     #[test]
     fn test_minilm_creation() {
-        // Test with default config
+        // 256 is DELIBERATE and load-bearing, not a leftover: on the quantized
+        // export CI ships, `DynamicQuantizeLinear` derives its activation
+        // scale from the whole tensor INCLUDING padding, so the tensor length
+        // is part of the embedding function. Shrinking it to the 128-token
+        // window is a ~2.05x speedup but changes every vector (measured worst
+        // cosine 0.9859 between pad-128 and pad-256 on the real quint8), i.e.
+        // it is a re-embed migration, not a free optimisation. Pinned so the
+        // change cannot be made accidentally.
         let config = EmbeddingConfig::default();
-
-        // Check dimension
         assert_eq!(config.max_length, 256);
+        assert!(config.max_length >= crate::embeddings::chunking::MODEL_TOKEN_WINDOW);
     }
 
     #[test]

--- a/src/embeddings/mod.rs
+++ b/src/embeddings/mod.rs
@@ -22,7 +22,9 @@ pub mod minilm;
 pub mod ner;
 
 // Re-export chunking types
-pub use chunking::{chunk_text, ChunkConfig, ChunkResult};
+pub use chunking::{
+    chunk_text, ChunkConfig, ChunkResult, MODEL_TOKEN_WINDOW, SPECIAL_TOKEN_OVERHEAD,
+};
 
 use anyhow::Result;
 
@@ -65,5 +67,22 @@ pub trait Embedder: Send + Sync {
     /// Batch encode multiple texts (default: sequential)
     fn encode_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
         texts.iter().map(|text| self.encode(text)).collect()
+    }
+
+    /// Count the FULL encoded sequence length of `text` — including special
+    /// tokens, WITHOUT truncation — i.e. the number of tokens the model would
+    /// have to fit in its window to see all of `text`. Chunking budgets are
+    /// enforced against this count, so implementations backed by a real
+    /// tokenizer MUST override the heuristic default (`MiniLMEmbedder` does).
+    fn count_tokens(&self, text: &str) -> usize {
+        crate::token_estimation::estimate_tokens(text) + chunking::SPECIAL_TOKEN_OVERHEAD
+    }
+
+    /// Maximum full-sequence tokens a DOCUMENT chunk may use so that, after
+    /// any document instruction prefix is prepended at encode time, the
+    /// sequence still fits the tokenizer's truncation window. Symmetric
+    /// models (MiniLM): the whole window.
+    fn chunk_budget_tokens(&self) -> usize {
+        chunking::MODEL_TOKEN_WINDOW
     }
 }

--- a/src/memory/retrieval.rs
+++ b/src/memory/retrieval.rs
@@ -639,16 +639,30 @@ impl RetrievalEngine {
     /// ATOMIC ARCHITECTURE: This method stores the vector mapping atomically
     /// in RocksDB alongside the memory data, ensuring no orphaned memories.
     ///
-    /// For long content, this chunks the text and creates multiple embeddings
-    /// to ensure ALL content is searchable, not just the first 256 tokens.
+    /// For long content, this chunks the text (in REAL tokenizer tokens, so
+    /// every chunk fits the model's sequence window) and creates multiple
+    /// embeddings to ensure ALL content is searchable — not just the tokens
+    /// that survive truncation.
     pub fn index_memory(&self, memory: &Memory) -> Result<()> {
         use crate::embeddings::chunking::{chunk_text, ChunkConfig};
 
         let text = Self::extract_searchable_text(memory);
-        let chunk_config = ChunkConfig::default();
-        let chunk_result = chunk_text(&text, &chunk_config);
+        // Budget in real tokens from the embedder's own tokenizer; counting
+        // with anything else is how content silently vanished past the
+        // truncation window before.
+        let chunk_config = ChunkConfig::for_budget(self.embedder.chunk_budget_tokens());
+        let counter = |t: &str| self.embedder.count_tokens(t);
+        let chunk_result = chunk_text(&text, &chunk_config, &counter);
 
         let vector_ids = if chunk_result.was_chunked {
+            tracing::debug!(
+                "Memory {} exceeds the {}-token embedding window; split into {} chunks \
+                 ({} chars total)",
+                memory.id.0,
+                chunk_config.max_tokens,
+                chunk_result.chunks.len(),
+                chunk_result.original_length
+            );
             // Long content: embed each chunk separately
             // Pre-compute all embeddings OUTSIDE the write lock to avoid blocking searches
             let embeddings: Vec<Vec<f32>> = chunk_result


### PR DESCRIPTION
`tokenizer.json` bakes in `Fixed(128)` padding and truncation, and the Rust side then re-pads to 256. So at most half of every forward pass carried real tokens, and anything past 128 tokens was **silently dropped** — long memories were unsearchable by their later content, with no error and no warning.

Adds token-aware chunking and a sequence-contract guard so the truncation cannot recur silently.

**Commits**
- `f4232aa7` the fix
- `bc49d9bc` corrects the first pass: a compile break, an overlap overflow, and a wrong tensor rationale. Also pins 256 with a test so it cannot be "tidied" back to 128 without deciding on the re-embedding migration first — a local-only check would have called that change free and silently re-embedded every stored vector on CI.
- `a8d153ce` rustfmt

**Verified:** `cargo check --lib --tests` passes; `cargo fmt --check` clean.

Supersedes an earlier draft of the same work that was byte-identical to `f4232aa7` but lacked `bc49d9bc`'s corrections. That branch has been deleted.