### PR TITLE
docs: require worktrees to live inside the project folder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@
 - MUST NOT run `cargo build` or `cargo run` unless the user explicitly asks. Only `cargo check`, `cargo clippy`, and `cargo test` are allowed by default.
 - MUST NOT add "Co-Authored-By" or "Generated with Claude Code" to commits. Clean commit messages only.
 - MUST NOT comment on GitHub issues/PRs without showing user a draft first.
+- MUST NOT create git worktrees outside the project folder. All worktrees go in `<repo>/.claude/worktrees/<name>`. Never `C:/smt`, never `~/.claude/worktrees`, never a sibling directory. A worktree outside `kalki-v2/` misses the parent `.cargo/config.toml`, builds to a different artifact path, and silently forks `target/` into two complete trees.
+- MUST remove a worktree once its branch is merged or abandoned. Before removing one, run `git status --porcelain` in it and confirm any untracked files exist in git — untracked content is the only thing `git worktree remove` cannot recover, since branch refs survive removal.
 
 ## Code Standards
 - IMPORTANT: Production grade code only. No TODOs, no placeholders, no mocks, no stubs.


### PR DESCRIPTION
Two MUST rules in `CLAUDE.md`. Two lines, no other changes.

The rule previously existed only in conversation, so it died at every session boundary and was never present in a dispatched subagent's context — which is a problem, because subagents create most of the worktrees. Ten had accumulated across four separate roots.

Both costs are stated in the rule rather than asserted:

- A worktree outside `kalki-v2/` never sees the parent `.cargo/config.toml`, which sets `build.target`. It therefore writes to `target/debug` instead of `target/x86_64-pc-windows-msvc/debug`, **forking `target/` into two complete trees**. That fork was 14.69 GB of a 46 GB `target/`.
- Branch refs survive `git worktree remove`, so **untracked files are the only content it can destroy**. One worktree held 291 untracked lines — the tantivy round-trip and pyo3 extract harnesses — that existed in no branch and no git object.