### PR TITLE
Make the unmeasurable measurable: ablation gates, a vacuity guard, a sharded LongMemEval, and a secure HTTPS default

### DIFF
--- a/.github/workflows/locomo-recall.yml
+++ b/.github/workflows/locomo-recall.yml
@@ -119,6 +119,12 @@ jobs:
           # not once per run (which earned us a 429 rate-limit after this session's runs).
           dl() { curl -fL --retry 20 --retry-all-errors --retry-delay 15 --connect-timeout 30 -o "$1" "$2"; }
           [ -s "$MODEL_DIR/model_quantized.onnx" ] || dl "$MODEL_DIR/model_quantized.onnx" "$BASE/onnx/model_quint8_avx2.onnx"
+          # fp32 weights, so the cost of int8 quantisation on retrieval can be
+          # measured (SHODH_USE_QUANTIZED_MODEL=0). Semantic similarity is the
+          # strongest ranking signal in the pipeline and it has only ever been
+          # produced by the quantised model - the price of that has never been
+          # measured. Fetched unconditionally so the arm is always runnable.
+          [ -s "$MODEL_DIR/model.onnx" ]           || dl "$MODEL_DIR/model.onnx" "$BASE/onnx/model.onnx"
           [ -s "$MODEL_DIR/tokenizer.json" ]       || dl "$MODEL_DIR/tokenizer.json" "$BASE/tokenizer.json"
           ls -la "$MODEL_DIR"
 

--- a/.github/workflows/locomo-recall.yml
+++ b/.github/workflows/locomo-recall.yml
@@ -390,5 +390,6 @@ jobs:
             locomo-recall.log
             locomo-reachability.json
             locomo-reachability.log
+            pool.jsonl
             learning-curve.json
             learning-curve.log

--- a/.github/workflows/longmemeval.yml
+++ b/.github/workflows/longmemeval.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       limit:
-        description: 'Number of questions (representative mix via --shuffle). Blank = all 479.'
+        description: 'Total questions across ALL 10 shards (representative mix via --shuffle). Blank uses the default below - it does NOT mean all 479, GitHub substitutes the default for an empty input. ~7-12 min per question per shard.'
         required: false
         default: '50'
       extra_env:
@@ -40,9 +40,19 @@ concurrency:
 
 jobs:
   longmemeval:
-    name: LongMemEval-S
+    # SHARDED. Every LongMemEval-S question carries its OWN ~490-turn haystack,
+    # so cost is linear in questions and ingest-dominated at roughly 7-12 min
+    # each. A single job could not finish even the default 50 questions inside
+    # timeout-minutes: 300 - every unsharded run was cancelled at ~25/50 having
+    # produced no report at all. Ten disjoint (offset, limit) windows cover the
+    # suite exactly once and each finishes well inside the cap.
+    name: LongMemEval-S (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     timeout-minutes: 300
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     steps:
       - uses: actions/checkout@v7
 
@@ -93,14 +103,29 @@ jobs:
             ${{ github.event.inputs.limit != '' && format('--limit {0}', github.event.inputs.limit) || '' }}
           wc -l tests/recall/longmemeval/manifest.jsonl
 
-      - name: Run LongMemEval
+      - name: Run LongMemEval shard
         run: |
           for kv in ${{ github.event.inputs.extra_env }}; do export "$kv"; done
+          TOTAL=$(wc -l < tests/recall/longmemeval/manifest.jsonl)
+          SHARDS=10
+          PER=$(( (TOTAL + SHARDS - 1) / SHARDS ))
+          OFFSET=$(( ${{ matrix.shard }} * PER ))
+          echo "shard ${{ matrix.shard }}/$SHARDS: offset=$OFFSET limit=$PER of $TOTAL"
           ./target/release/recall-eval \
             --longmemeval tests/recall/longmemeval \
             --layer ${{ github.event.inputs.layer || 'full' }} \
-            --output unused.json \
+            --longmemeval-offset "$OFFSET" \
+            --longmemeval-limit "$PER" \
+            --output "shard-${{ matrix.shard }}.json" \
             --storage ./lme-storage 2>&1 | tee longmemeval.log
+
+      - name: Upload shard report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lme-shard-${{ matrix.shard }}
+          path: shard-${{ matrix.shard }}.json
+          if-no-files-found: warn
 
       - name: Summary
         if: always()
@@ -114,3 +139,95 @@ jobs:
             grep -E "NER_BACKEND|LongMemEval-S:|recall@|LONGMEMEVAL_LAYER" longmemeval.log || true
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  aggregate:
+    # Recombines the shards. Every mean in the report is carried with its own
+    # count, so the suite total is a COUNT-WEIGHTED mean, never a mean of means -
+    # the shards are equal-sized by construction but the last one is short
+    # whenever the question count is not a multiple of ten, and per-category
+    # counts differ wildly between shards regardless.
+    name: LongMemEval-S (aggregate)
+    needs: longmemeval
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: lme-shard-*
+          path: shards
+          merge-multiple: true
+
+      - name: Combine shard reports
+        run: |
+          python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+          import glob, json, os, sys
+          from collections import defaultdict
+
+          files = sorted(glob.glob('shards/shard-*.json'))
+          reports = []
+          for f in files:
+              try:
+                  reports.append((f, json.load(open(f))))
+              except Exception as e:
+                  print(f'  !! unreadable shard {f}: {e}')
+
+          print('## LongMemEval-S - turn-level retrieval recall@10 (no LLM judge)')
+          print()
+          print('> NOT comparable to headline LongMemEval answer-accuracy SOTA, which')
+          print('> reads retrieved context with a large LLM. This is the retrieval half:')
+          print('> does our memory surface the gold evidence turns?')
+          print()
+
+          expected = 10
+          if len(reports) < expected:
+              missing = expected - len(reports)
+              print(f'> **WARNING: {missing} of {expected} shards produced no report.**')
+              print('> The figures below cover only the shards that completed and are NOT')
+              print('> a suite result. Do not quote them without this caveat.')
+              print()
+
+          if not reports:
+              print('No shard reports; nothing to aggregate.')
+              sys.exit(0)
+
+          cat_sum = defaultdict(float)
+          cat_n = defaultdict(int)
+          layer_sum = defaultdict(float)
+          layer_n = defaultdict(int)
+          for _, r in reports:
+              for cat, (mean, n) in r.get('by_category', {}).items():
+                  cat_sum[cat] += mean * n
+                  cat_n[cat] += n
+              for lay, (mean, n) in r.get('layers', {}).items():
+                  layer_sum[lay] += mean * n
+                  layer_n[lay] += n
+
+          total_n = sum(cat_n.values())
+          overall = sum(cat_sum.values()) / total_n if total_n else 0.0
+          backends = {r.get('ner_backend', '?') for _, r in reports}
+
+          print('```')
+          print(f'shards        : {len(reports)}/{expected}')
+          print(f'questions     : {total_n}')
+          print(f'NER backend   : {", ".join(sorted(backends))}')
+          print(f'recall@10     : {overall:.4f}')
+          print()
+          for cat in sorted(cat_n):
+              m = cat_sum[cat] / cat_n[cat] if cat_n[cat] else 0.0
+              print(f'  {cat:18} n={cat_n[cat]:<5} recall@10 = {m:.4f}')
+          if len(layer_n) > 1:
+              print()
+              print('  per-layer ablation (same haystacks):')
+              for lay in sorted(layer_n):
+                  m = layer_sum[lay] / layer_n[lay] if layer_n[lay] else 0.0
+                  print(f'    {lay:16} n={layer_n[lay]:<5} recall@10 = {m:.4f}')
+          print('```')
+
+          # A number without its n invites being quoted as if it were the suite.
+          if total_n < 40:
+              print()
+              print(f'> **n = {total_n}. The 95% interval here is roughly +/-{1.96*(0.25/total_n)**0.5:.2f}** -')
+              print('> too wide to separate retrieval legs. Treat as a smoke signal, not a result.')
+          PY
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1168,7 +1168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1523,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1795,7 +1795,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2007,7 +2007,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2531,7 +2531,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3259,7 +3259,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3297,9 +3297,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3731,7 +3731,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4558,7 +4558,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5494,7 +5494,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -293,6 +293,14 @@ struct Args {
     #[arg(long)]
     longmemeval_limit: Option<usize>,
 
+    /// LongMemEval shard start: skip this many manifest questions before
+    /// applying `--longmemeval-limit`. Each question carries its own ~490-turn
+    /// haystack, so a full run cannot fit a single job's timeout; disjoint
+    /// (offset, limit) windows let parallel jobs cover the suite exactly once.
+    /// The manifest order is deterministic, so the windows are stable.
+    #[arg(long)]
+    longmemeval_offset: Option<usize>,
+
     /// Simulated edge age in days, applied AFTER ingest and BEFORE queries
     /// (decay study). When `> 0`, the harness ages the knowledge-graph edges via
     /// `simulate_edge_aging` at the production ~6h cadence, so recall quality is
@@ -420,11 +428,16 @@ fn run(args: &Args) -> Result<i32> {
         let report = shodh_memory::recall_harness::runner::run_longmemeval(
             lme_dir,
             &storage_path,
+            args.longmemeval_offset,
             args.longmemeval_limit,
             10,
             &layer_modes,
         )
         .context("LongMemEval run")?;
+        // Write the report so a sharded run can be recombined. Previously this
+        // path printed only, and `--output` was passed a file the run ignored.
+        std::fs::write(&args.output, serde_json::to_string_pretty(&report)?)
+            .with_context(|| format!("writing {}", args.output.display()))?;
         println!(
             "LongMemEval-S: {} questions (NER={}) — recall@{} = {:.4} — p@1 = {:.4}",
             report.questions, report.ner_backend, report.k, report.recall_at_k, report.p_at_1

--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -1098,8 +1098,14 @@ fn summarise(report: &Report) {
     for name in mode_order {
         if let Some(layer) = report.layers.get(name) {
             eprintln!(
-                "  {:<12} ndcg@10={:.4} recall@10={:.4} mrr={:.4} p@1={:.4} map={:.4}",
-                name, layer.ndcg_at_10, layer.recall_at_10, layer.mrr, layer.p_at_1, layer.map
+                "  {:<12} ndcg@10={:.4} recall@10={:.4} hit@10={:.4} mrr={:.4} p@1={:.4} map={:.4}",
+                name,
+                layer.ndcg_at_10,
+                layer.recall_at_10,
+                layer.hit_at_10,
+                layer.mrr,
+                layer.p_at_1,
+                layer.map
             );
         }
     }

--- a/src/integrations/mod.rs
+++ b/src/integrations/mod.rs
@@ -13,11 +13,17 @@ pub use linear::{LinearSyncRequest, LinearSyncResponse, LinearWebhook, LinearWeb
 /// Resolve an integration API URL from an environment override.
 ///
 /// If `env_var` is unset/empty, returns `default_url`. If it is set to an
-/// insecure `http://` URL pointing at a non-localhost host, credentials would
-/// travel in cleartext: when `SHODH_ENFORCE_HTTPS` is enabled the override is
-/// rejected and the secure default is used instead; otherwise it is used as-is
-/// with a warning. This is a flag-gated enforcement, not a blanket http ban —
-/// localhost http (proxies, test servers) is always allowed.
+/// insecure `http://` URL pointing at a non-localhost host, the API token would
+/// travel in cleartext, so the override is REJECTED and the secure default is
+/// used instead.
+///
+/// Enforcement is the DEFAULT; `SHODH_ENFORCE_HTTPS=false` is the opt-out. It
+/// previously defaulted to OFF, which inverted secure-by-default: a plain
+/// `http://` override was honoured with only a warning, and a warning does not
+/// stop a token being sent in cleartext. Anyone who genuinely needs a plaintext
+/// remote endpoint now has to say so explicitly.
+///
+/// Not a blanket http ban — localhost http (proxies, test servers) stays allowed.
 pub(crate) fn resolve_api_url_override(env_var: &str, default_url: &str) -> String {
     let override_url = match std::env::var(env_var) {
         Ok(u) if !u.trim().is_empty() => u.trim().to_string(),
@@ -25,17 +31,18 @@ pub(crate) fn resolve_api_url_override(env_var: &str, default_url: &str) -> Stri
     };
 
     if is_insecure_remote_url(&override_url) {
+        // Secure by default; `SHODH_ENFORCE_HTTPS=false` (or `0`) opts out.
         let enforce_https = std::env::var("SHODH_ENFORCE_HTTPS")
             .map(|v| {
-                let v = v.to_lowercase();
-                v == "true" || v == "1"
+                let v = v.trim().to_lowercase();
+                !(v == "false" || v == "0")
             })
-            .unwrap_or(false);
+            .unwrap_or(true);
 
         if enforce_https {
             tracing::error!(
                 "{env_var} points at an insecure http:// non-localhost URL and \
-                 SHODH_ENFORCE_HTTPS is enabled — ignoring the override and using \
+                 SHODH_ENFORCE_HTTPS is not disabled — ignoring the override and using \
                  the secure default ({default_url})."
             );
             return default_url.to_string();
@@ -43,8 +50,8 @@ pub(crate) fn resolve_api_url_override(env_var: &str, default_url: &str) -> Stri
 
         tracing::warn!(
             "{env_var} uses an insecure http:// URL for a non-localhost host — \
-             the API token will be transmitted in cleartext. Use https:// or set \
-             SHODH_ENFORCE_HTTPS=true to reject insecure overrides."
+             the API token would be transmitted in cleartext. Use https://, or set \
+             SHODH_ENFORCE_HTTPS=false to allow it anyway."
         );
     }
 
@@ -79,5 +86,95 @@ mod tests {
         assert!(!is_insecure_remote_url("http://127.1.2.3"));
         // https is always fine
         assert!(!is_insecure_remote_url("https://api.linear.app/graphql"));
+    }
+}
+
+#[cfg(test)]
+mod https_default_tests {
+    use super::resolve_api_url_override;
+
+    /// `SHODH_ENFORCE_HTTPS` and the override var are process-global.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    const DEFAULT_URL: &str = "https://api.example.com/v1";
+    const VAR: &str = "SHODH_TEST_INTEGRATION_URL";
+
+    fn run<T>(enforce: Option<&str>, override_url: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        match enforce {
+            Some(v) => std::env::set_var("SHODH_ENFORCE_HTTPS", v),
+            None => std::env::remove_var("SHODH_ENFORCE_HTTPS"),
+        }
+        match override_url {
+            Some(v) => std::env::set_var(VAR, v),
+            None => std::env::remove_var(VAR),
+        }
+        let out = f();
+        std::env::remove_var("SHODH_ENFORCE_HTTPS");
+        std::env::remove_var(VAR);
+        out
+    }
+
+    #[test]
+    fn insecure_remote_override_is_rejected_by_default() {
+        // The regression this default was flipped to prevent: with enforcement
+        // off, this returned the http:// URL and the API token went in cleartext.
+        let got = run(None, Some("http://evil.example.com/v1"), || {
+            resolve_api_url_override(VAR, DEFAULT_URL)
+        });
+        assert_eq!(
+            got, DEFAULT_URL,
+            "insecure remote override must not be honoured by default"
+        );
+    }
+
+    #[test]
+    fn explicit_opt_out_allows_the_insecure_override() {
+        for v in ["false", "0", "FALSE", " false "] {
+            let got = run(
+                Some(v),
+                Some("http://legacy.internal.example.com/v1"),
+                || resolve_api_url_override(VAR, DEFAULT_URL),
+            );
+            assert_eq!(
+                got, "http://legacy.internal.example.com/v1",
+                "opt-out value {v:?} ignored"
+            );
+        }
+    }
+
+    #[test]
+    fn any_other_value_still_enforces() {
+        // Only an explicit false/0 disables it; a typo must fail SAFE.
+        for v in ["true", "1", "yes", "nope", ""] {
+            let got = run(Some(v), Some("http://evil.example.com/v1"), || {
+                resolve_api_url_override(VAR, DEFAULT_URL)
+            });
+            assert_eq!(got, DEFAULT_URL, "value {v:?} must not disable enforcement");
+        }
+    }
+
+    #[test]
+    fn localhost_http_is_always_allowed() {
+        for url in ["http://localhost:8787/v1", "http://127.0.0.1:3000/v1"] {
+            let got = run(None, Some(url), || {
+                resolve_api_url_override(VAR, DEFAULT_URL)
+            });
+            assert_eq!(
+                got, url,
+                "localhost http must stay usable for proxies and test servers"
+            );
+        }
+    }
+
+    #[test]
+    fn https_override_passes_through_and_unset_yields_the_default() {
+        let got = run(None, Some("https://custom.example.com/v1"), || {
+            resolve_api_url_override(VAR, DEFAULT_URL)
+        });
+        assert_eq!(got, "https://custom.example.com/v1");
+
+        let got = run(None, None, || resolve_api_url_override(VAR, DEFAULT_URL));
+        assert_eq!(got, DEFAULT_URL);
     }
 }

--- a/src/memory/ablation.rs
+++ b/src/memory/ablation.rs
@@ -1,0 +1,245 @@
+//! Single source of truth for retrieval-time ablation families.
+//!
+//! Every ablatable retrieval component names a FAMILY here and asks
+//! [`is_enabled`]. One env var, one list, one place to look.
+//!
+//! Before this module there were two idioms and a gap. The semantic leg's boost
+//! stack had an 18-family kill-switch parsed inline inside
+//! `semantic_retrieve_inner`, while the graph leg's own scoring components —
+//! lateral inhibition and Hebbian potentiation — had NO gate at all and could
+//! therefore never be ablated. A component that cannot be switched off cannot be
+//! measured, and an unmeasurable component accumulates in the pipeline on the
+//! strength of its rationale rather than its effect. Both are now families like
+//! any other.
+//!
+//! `SHODH_DISABLE_BOOSTS=<family,...>` disables the named families for the
+//! process. The token `all` disables every family. Setting the variable at all —
+//! even to the empty string — REPLACES [`DEFAULT_DISABLED`] rather than adding
+//! to it, which is the escape hatch for running with nothing disabled.
+
+use std::collections::HashSet;
+
+/// Every ablatable retrieval component, by family name.
+///
+/// Semantic leg (`memory/mod.rs`, Layers 4.45 through 5.7): `attribute` through
+/// `competition`.
+///
+/// Graph leg (`memory/graph_retrieval.rs`):
+/// * `lateral_inhibition` — Step 6.5 winner-take-all, penalising a candidate
+///   within `GRAPH_LATERAL_INHIBITION_THRESHOLD` cosine of a higher-ranked one.
+/// * `graph_potentiation` — retrieval-driven edge strengthening
+///   (`batch_strengthen_synapses`). Distinct from the `hebbian` family, which is
+///   the semantic leg's L5 RANK boost; this is the WRITE that feeds
+///   `ppr_edge_weight`. Also distinct from `SHODH_RECALL_READONLY`, which
+///   suppresses it for measurement integrity — this family ablates the mechanism
+///   while leaving other recall-path writes alone, so the two can be separated.
+///
+/// Adding a name here is what makes a component measurable; adding one without a
+/// matching [`is_enabled`] call at the component's site makes the family a lie,
+/// so the two changes belong in the same commit.
+pub const FAMILIES: [&str; 20] = [
+    "attribute",
+    "temporal_prefilter",
+    "temporal_fact",
+    "interference",
+    "prospective",
+    "fact_source",
+    "ontological",
+    "hebbian",
+    "recency",
+    "arousal",
+    "credibility",
+    "temporal_match",
+    "feedback",
+    "importance",
+    "tag_penalty",
+    "quality",
+    "linguistic",
+    "competition",
+    "lateral_inhibition",
+    "graph_potentiation",
+];
+
+/// Families disabled when `SHODH_DISABLE_BOOSTS` is unset.
+///
+/// `hebbian` — the semantic leg's L5 rank boost — is off by default because the
+/// L5 bisect (run 27251798933) measured it as a strict ordering saboteur: p@1
+/// 0.4100 -> 0.4767 (+6.7pp) with recall@10 bit-identical. Its scores come from
+/// graph co-activation, and edges strengthen on EVERY retrieval rather than on
+/// outcome, so frequently co-retrieved hub memories climb within the top-10 and
+/// displace gold at rank 1.
+pub const DEFAULT_DISABLED: [&str; 1] = ["hebbian"];
+
+/// Resolve the disabled-family set from the environment.
+///
+/// Unknown tokens are warned about and ignored, so a typo degrades to "nothing
+/// extra disabled" rather than appearing to ablate a family that does not exist
+/// and reporting the resulting null as a measurement.
+pub fn disabled_families() -> HashSet<String> {
+    let set: HashSet<String> = match std::env::var("SHODH_DISABLE_BOOSTS") {
+        Ok(v) => v
+            .split(',')
+            .map(|t| t.trim().to_ascii_lowercase())
+            .filter(|t| !t.is_empty())
+            .collect(),
+        Err(_) => DEFAULT_DISABLED.iter().map(|s| s.to_string()).collect(),
+    };
+    for tok in &set {
+        if tok != "all" && !FAMILIES.contains(&tok.as_str()) {
+            tracing::warn!("SHODH_DISABLE_BOOSTS: unknown ablation family '{tok}' (ignored)");
+        }
+    }
+    set
+}
+
+/// Whether `family` is currently ablated.
+pub fn is_disabled(family: &str) -> bool {
+    debug_assert!(
+        FAMILIES.contains(&family),
+        "ablation family is not declared in ablation::FAMILIES"
+    );
+    let disabled = disabled_families();
+    disabled.contains("all") || disabled.contains(family)
+}
+
+/// Whether `family` should run. The form call sites read most naturally.
+pub fn is_enabled(family: &str) -> bool {
+    !is_disabled(family)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serialises tests that mutate `SHODH_DISABLE_BOOSTS`, which is
+    /// process-global state.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        match value {
+            Some(v) => std::env::set_var("SHODH_DISABLE_BOOSTS", v),
+            None => std::env::remove_var("SHODH_DISABLE_BOOSTS"),
+        }
+        let out = f();
+        std::env::remove_var("SHODH_DISABLE_BOOSTS");
+        out
+    }
+
+    #[test]
+    fn family_list_has_no_duplicates() {
+        let unique: HashSet<&str> = FAMILIES.iter().copied().collect();
+        assert_eq!(unique.len(), FAMILIES.len(), "duplicate family in FAMILIES");
+    }
+
+    #[test]
+    fn every_default_disabled_family_is_declared() {
+        for f in DEFAULT_DISABLED {
+            assert!(
+                FAMILIES.contains(&f),
+                "default-disabled family is undeclared"
+            );
+        }
+    }
+
+    #[test]
+    fn unset_env_disables_exactly_the_documented_default() {
+        with_env(None, || {
+            assert!(
+                is_disabled("hebbian"),
+                "L5 rank boost must stay off by default"
+            );
+            for f in FAMILIES.iter().filter(|f| !DEFAULT_DISABLED.contains(f)) {
+                assert!(
+                    is_enabled(f),
+                    "family must be enabled when env is unset: {f}"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn the_graph_leg_families_ship_enabled() {
+        // Both were ungated before this module existed. Declaring them must not
+        // change shipped behaviour, only make it measurable.
+        with_env(None, || {
+            assert!(is_enabled("lateral_inhibition"));
+            assert!(is_enabled("graph_potentiation"));
+        });
+    }
+
+    #[test]
+    fn graph_potentiation_is_not_collateral_of_the_hebbian_default() {
+        // `hebbian` (semantic L5 rank boost) is default-disabled. The graph-leg
+        // WRITE is a different mechanism and must not switch off alongside it.
+        with_env(None, || {
+            assert!(is_disabled("hebbian"));
+            assert!(is_enabled("graph_potentiation"));
+        });
+    }
+
+    #[test]
+    fn explicit_empty_value_replaces_the_default_rather_than_adding_to_it() {
+        with_env(Some(""), || {
+            assert!(
+                is_enabled("hebbian"),
+                "explicit empty must clear the default"
+            );
+        });
+    }
+
+    #[test]
+    fn all_disables_every_declared_family() {
+        with_env(Some("all"), || {
+            for f in FAMILIES {
+                assert!(is_disabled(f), "family survived 'all': {f}");
+                // Assert through `is_enabled` too: that is the form call sites
+                // use, and an `is_enabled` that can never return false would
+                // leave every gate permanently open while `is_disabled` stayed
+                // correct. Mutation-checked - without this the suite passes with
+                // `is_enabled` hardcoded to true.
+                assert!(!is_enabled(f), "is_enabled disagreed with is_disabled: {f}");
+            }
+        });
+    }
+
+    #[test]
+    fn is_enabled_is_the_exact_negation_of_is_disabled() {
+        for env in [
+            None,
+            Some(""),
+            Some("all"),
+            Some("lateral_inhibition,quality"),
+        ] {
+            with_env(env, || {
+                for f in FAMILIES {
+                    assert_ne!(
+                        is_enabled(f),
+                        is_disabled(f),
+                        "is_enabled/is_disabled agreed for {f}"
+                    );
+                }
+            });
+        }
+    }
+
+    #[test]
+    fn named_families_are_disabled_and_others_untouched() {
+        with_env(Some("lateral_inhibition, quality"), || {
+            assert!(is_disabled("lateral_inhibition"));
+            assert!(!is_enabled("lateral_inhibition"));
+            assert!(is_disabled("quality"));
+            assert!(is_enabled("graph_potentiation"));
+            assert!(is_enabled("recency"));
+        });
+    }
+
+    #[test]
+    fn unknown_token_does_not_disable_anything_real() {
+        with_env(Some("latteral_inhibition"), || {
+            for f in FAMILIES {
+                assert!(is_enabled(f), "typo disabled a real family: {f}");
+            }
+        });
+    }
+}

--- a/src/memory/ablation.rs
+++ b/src/memory/ablation.rs
@@ -27,6 +27,12 @@ use std::collections::HashSet;
 /// Graph leg (`memory/graph_retrieval.rs`):
 /// * `lateral_inhibition` — Step 6.5 winner-take-all, penalising a candidate
 ///   within `GRAPH_LATERAL_INHIBITION_THRESHOLD` cosine of a higher-ranked one.
+/// * `quality_verbosity` — the raw content-LENGTH factor inside the Layer-5
+///   quality gate, `(len/200).min(1.0)`, which multiplies a short correct answer
+///   (a person name) below a longer wrong one (an org name). Disabling the family
+///   keeps only the structural `elaboration` term. Previously reachable only via
+///   `SHODH_FUSION_V2`, which also switched fusion to weighted-Borda, so the
+///   verbosity factor could never be measured on its own.
 /// * `graph_potentiation` — retrieval-driven edge strengthening
 ///   (`batch_strengthen_synapses`). Distinct from the `hebbian` family, which is
 ///   the semantic leg's L5 RANK boost; this is the WRITE that feeds
@@ -37,7 +43,7 @@ use std::collections::HashSet;
 /// Adding a name here is what makes a component measurable; adding one without a
 /// matching [`is_enabled`] call at the component's site makes the family a lie,
 /// so the two changes belong in the same commit.
-pub const FAMILIES: [&str; 20] = [
+pub const FAMILIES: [&str; 21] = [
     "attribute",
     "temporal_prefilter",
     "temporal_fact",
@@ -58,6 +64,7 @@ pub const FAMILIES: [&str; 20] = [
     "competition",
     "lateral_inhibition",
     "graph_potentiation",
+    "quality_verbosity",
 ];
 
 /// Families disabled when `SHODH_DISABLE_BOOSTS` is unset.
@@ -159,12 +166,15 @@ mod tests {
     }
 
     #[test]
-    fn the_graph_leg_families_ship_enabled() {
-        // Both were ungated before this module existed. Declaring them must not
-        // change shipped behaviour, only make it measurable.
+    fn newly_declared_families_ship_enabled() {
+        // All three were ungated or unreachable before this module existed.
+        // Declaring them must not change shipped behaviour, only make it
+        // measurable - `quality_verbosity` in particular is a KNOWN-HARMFUL
+        // factor that stays on until its removal is measured on its own.
         with_env(None, || {
             assert!(is_enabled("lateral_inhibition"));
             assert!(is_enabled("graph_potentiation"));
+            assert!(is_enabled("quality_verbosity"));
         });
     }
 

--- a/src/memory/ablation.rs
+++ b/src/memory/ablation.rs
@@ -40,10 +40,21 @@ use std::collections::HashSet;
 ///   suppresses it for measurement integrity — this family ablates the mechanism
 ///   while leaving other recall-path writes alone, so the two can be separated.
 ///
+/// * `linguistic_resort` — whether the linguistic signal is applied as a SEPARATE
+///   sort-only re-rank (enabled, current) or folded additively into the single
+///   `.score` (disabled). Composes with the `linguistic` family, which controls
+///   whether the signal applies at all. This one selects between two FORMS rather
+///   than deleting a component; the alternative was a second config idiom, and one
+///   documented mechanism beats two clean ones.
+/// * `size_gated_final_sort` — the SIZE GATE on the final re-sort. Enabled
+///   (current) means the sort runs only when `len > max_results`, so result-set
+///   size decides whether the lexical re-rank or `.score` wins the final order.
+///   Disabling removes the gate and always sorts by score.
+///
 /// Adding a name here is what makes a component measurable; adding one without a
 /// matching [`is_enabled`] call at the component's site makes the family a lie,
 /// so the two changes belong in the same commit.
-pub const FAMILIES: [&str; 21] = [
+pub const FAMILIES: [&str; 23] = [
     "attribute",
     "temporal_prefilter",
     "temporal_fact",
@@ -65,6 +76,8 @@ pub const FAMILIES: [&str; 21] = [
     "lateral_inhibition",
     "graph_potentiation",
     "quality_verbosity",
+    "linguistic_resort",
+    "size_gated_final_sort",
 ];
 
 /// Families disabled when `SHODH_DISABLE_BOOSTS` is unset.

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -1935,7 +1935,10 @@ pub fn spreading_activation_retrieve_with_stats(
 
     // Step 6.5: Lateral inhibition — high-scoring memories suppress similar competitors
     // Mimics cortical winner-take-all dynamics (Rumelhart & Zipser 1985)
-    if scored_memories.len() > 1 {
+    // Ablatable as the `lateral_inhibition` family (see `memory::ablation`).
+    // This ran unconditionally with no gate anywhere in the repo, so its effect
+    // had never been measured in either direction.
+    if scored_memories.len() > 1 && crate::memory::ablation::is_enabled("lateral_inhibition") {
         let penalties = calculate_lateral_inhibition(&scored_memories);
         for (i, penalty) in penalties.iter().enumerate() {
             scored_memories[i].final_score -= penalty;
@@ -1979,7 +1982,15 @@ pub fn spreading_activation_retrieve_with_stats(
     // coactivation writes in mod.rs do — the traversed-edge STATS are still
     // collected above (`stats.traversed_edges`) so diagnostics are unaffected,
     // only the persistent strength MUTATION is skipped.
-    if !stats.traversed_edges.is_empty() && !recall_readonly() {
+    // Two independent suppressors, deliberately separate: `recall_readonly()` is
+    // measurement integrity (no recall-path writes during an eval), while the
+    // `graph_potentiation` family ablates THIS mechanism alone. Keeping them
+    // apart is what allows the potentiation write to be measured against a live
+    // run rather than only against a frozen one.
+    if !stats.traversed_edges.is_empty()
+        && !recall_readonly()
+        && crate::memory::ablation::is_enabled("graph_potentiation")
+    {
         if let Err(e) = graph.batch_strengthen_synapses(&stats.traversed_edges) {
             tracing::debug!("Spreading activation edge strengthening failed: {}", e);
         }

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -1184,6 +1184,29 @@ pub fn spreading_activation_retrieve_with_stats(
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
 
+    // TRUE GRAPH ISOLATION (`SHODH_GRAPH_PURE=1`, diagnostic, default off).
+    //
+    // `SHODH_LEG=graph` isolates the graph's CANDIDATE SET but not its SCORING.
+    // Every graph-reached candidate still gets a `cosine_similarity(query, memory)`
+    // (see the `semantic_score` below), and `fuse_hybrid_score` weights it by
+    // `semantic_weight / sum`. With `graph_weight` pinned at its 0.1 floor on any
+    // corpus whose seed entities average more than 2 edges, that makes the "graph
+    // leg" roughly 75% embedding cosine, 15% linguistic and 10% graph activation.
+    // So every graph-internal lever measured through `SHODH_LEG=graph` could move
+    // at most a tenth of the score, and the vector model was doing the ranking.
+    //
+    // `SHODH_GRAPH_PURE=1` sets the weights to (semantic 0, graph 1, linguistic 0)
+    // so the leg is ranked by graph activation ALONE. This is what "does the
+    // knowledge graph work on its own" actually requires, and it is not reachable
+    // via `SHODH_GRAPH_W_FLOOR`, which clamps at `1.0 - linguistic - 0.05`.
+    //
+    // Diagnostic only: it is not a proposed default, and the floor sweep already
+    // showed that shifting weight toward the graph costs ranking quality
+    // (ndcg 0.4577 -> 0.4481, p@1 0.3638 -> 0.3468 at graph_w ~0.8).
+    let graph_pure = std::env::var("SHODH_GRAPH_PURE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
     // Determine weights based on density
     let (semantic_weight, graph_weight, linguistic_weight) = if let Some(density) = graph_density {
         stats.mode = "associative".to_string();
@@ -1197,6 +1220,13 @@ pub fn spreading_activation_retrieve_with_stats(
             HYBRID_GRAPH_WEIGHT,
             HYBRID_LINGUISTIC_WEIGHT,
         )
+    };
+    // Applied AFTER the density branch so it overrides both paths.
+    let (semantic_weight, graph_weight, linguistic_weight) = if graph_pure {
+        stats.mode = "graph_pure".to_string();
+        (0.0, 1.0, 0.0)
+    } else {
+        (semantic_weight, graph_weight, linguistic_weight)
     };
 
     stats.semantic_weight = semantic_weight;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -6,6 +6,7 @@
 //! - Multi-modal retrieval (similarity, temporal, causal)
 //! - Automatic memory consolidation
 
+pub mod ablation;
 pub mod compression;
 pub mod context;
 pub mod facts;
@@ -3632,60 +3633,12 @@ impl MemorySystem {
 
         // ===========================================================================
         // LAYER 4: BM25 + RRF FUSION
-        // SHODH_DISABLE_BOOSTS=<family,...> — ablation kill-switch for the post-fusion
-        // boost stack. Each token disables one boost family at recall time so its
-        // marginal contribution can be measured against the calibrated FLAT baseline
-        // (the stack predates calibrated fusion and was never ablated against it).
-        // Layer 4.45-4.9 families: attribute, temporal_prefilter, temporal_fact,
-        // interference, prospective, fact_source, ontological. Layer 5-5.7 families:
-        // hebbian, recency, arousal, credibility, temporal_match, feedback, importance,
-        // tag_penalty, quality, linguistic, competition. "all" disables every family.
-        // Default unset → all boosts active (shipped behavior unchanged).
-        const BOOST_FAMILIES: [&str; 18] = [
-            "attribute",
-            "temporal_prefilter",
-            "temporal_fact",
-            "interference",
-            "prospective",
-            "fact_source",
-            "ontological",
-            "hebbian",
-            "recency",
-            "arousal",
-            "credibility",
-            "temporal_match",
-            "feedback",
-            "importance",
-            "tag_penalty",
-            "quality",
-            "linguistic",
-            "competition",
-        ];
-        // DEFAULT: the Layer-5 hebbian RANK BOOST is disabled. The L5 bisect (run
-        // 27251798933) measured it as a strict ordering saboteur: disabling only
-        // hebbian lifted p@1 ALL 0.4100→0.4767 (+6.7pp), single_hop +11pp,
-        // open_domain 2x, multi_hop up, temporal HELD, MRR +0.042 — with recall@10
-        // bit-identical (L5 is post-truncation). Mechanism: heb scores come from
-        // graph co-activation and edges strengthen on EVERY retrieval (not on
-        // outcome), so frequently co-retrieved hub memories climb within the
-        // top-10 and displace gold at rank 1 — retrieval-gated rich-get-richer.
-        // Hebbian LEARNING (edge strengthening, spreading activation) is untouched;
-        // only the L5 score multiplier is off. Setting SHODH_DISABLE_BOOSTS
-        // explicitly (even to "") replaces this default — the escape hatch.
-        let disabled_boosts: std::collections::HashSet<String> =
-            std::env::var("SHODH_DISABLE_BOOSTS")
-                .map(|v| {
-                    v.split(',')
-                        .map(|t| t.trim().to_ascii_lowercase())
-                        .filter(|t| !t.is_empty())
-                        .collect()
-                })
-                .unwrap_or_else(|_| std::iter::once("hebbian".to_string()).collect());
-        for tok in &disabled_boosts {
-            if tok != "all" && !BOOST_FAMILIES.contains(&tok.as_str()) {
-                tracing::warn!("SHODH_DISABLE_BOOSTS: unknown boost family '{tok}' (ignored)");
-            }
-        }
+        // Ablation kill-switch. The family list, the default-disabled set, the
+        // parsing and the unknown-token warning all live in `memory::ablation`,
+        // which is the single source of truth shared with the graph leg — see
+        // that module for `SHODH_DISABLE_BOOSTS` semantics and for why `hebbian`
+        // is disabled by default.
+        let disabled_boosts = crate::memory::ablation::disabled_families();
         let boost_on = |family: &str| -> bool {
             !(disabled_boosts.contains("all") || disabled_boosts.contains(family))
         };

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -5356,10 +5356,11 @@ impl MemorySystem {
         // Linguistic analysis: additive boost (5% of IC weight), not a full re-sort
         // RH-8 gate: linguistic re-sort only runs in `Full` mode.
         if layer_full && boost_linguistic && !query_analysis.focal_entities.is_empty() {
-            let v2_single = std::env::var("SHODH_FUSION_V2")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
-            if v2_single {
+            // `linguistic_resort` ENABLED (current) = separate sort-only re-rank,
+            // which the final sort silently discards when len <= max_results.
+            // DISABLED = fold the signal into the single `.score` instead. Parked
+            // behind SHODH_FUSION_V2 until now, so it could never be attributed.
+            if !crate::memory::ablation::is_enabled("linguistic_resort") {
                 // Conscious restructure: FOLD the linguistic signal into the single
                 // .score (additive) instead of a separate sort-only re-rank that the
                 // final sort silently discards when len>max. One score, one sort.
@@ -5611,10 +5612,12 @@ impl MemorySystem {
         // linguistic signal is already folded into .score above — so sort by .score
         // UNCONDITIONALLY, not only when len>max. That branch is what let result-set
         // SIZE decide whether the lexical re-sort or .score won the final order.
-        let v2_single_sort = std::env::var("SHODH_FUSION_V2")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
-        if v2_single_sort || memories.len() > query.max_results {
+        // `size_gated_final_sort` ENABLED (current) means this sort runs ONLY when
+        // the result set is larger than the window - so result-set SIZE decides
+        // whether the preceding lexical re-rank or `.score` wins the final order.
+        // Disabling removes the gate and always sorts by score.
+        let size_gated = crate::memory::ablation::is_enabled("size_gated_final_sort");
+        if !size_gated || memories.len() > query.max_results {
             // Score desc → recency desc → MemoryId asc — deterministic competition cutoff.
             // Quantize the score to 1e-6 before comparing: fused scores are accumulated
             // by `+=` over a HashMap in non-deterministic iteration order, so f32

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -5317,24 +5317,24 @@ impl MemorySystem {
         // RH-8 gate: quality multiplier only applies in `Full` mode — lower modes
         // expose the raw fused score so per-layer attribution isn't masked.
         if layer_full && boost_quality {
-            let v2_no_verbosity = std::env::var("SHODH_FUSION_V2")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
             for mem in &mut memories {
                 let has_entities = !mem.experience.entities.is_empty();
                 let has_context = mem.experience.context.is_some();
                 let elaboration = 1.0
                     + if has_entities { 0.1 } else { 0.0 }
                     + if has_context { 0.1 } else { 0.0 };
-                let quality = if v2_no_verbosity {
-                    // Conscious restructure: drop the raw content-length factor — a
-                    // verbosity bias that multiplied short correct answers (a person
-                    // name) down below longer ones (org names), crashing ontology
-                    // 0.88→0.083 at `full`. Keep only the structural elaboration.
-                    elaboration
-                } else {
+                // The raw content-LENGTH factor is a verbosity bias: it multiplies a
+                // short correct answer (a person name) below a longer wrong one (an
+                // org name), and was measured crashing ontology 0.88→0.083 at
+                // `full`. Dropping it was reachable only via SHODH_FUSION_V2, which
+                // ALSO switched fusion to weighted-Borda — so the factor could never
+                // be measured on its own. It is now the `quality_verbosity` ablation
+                // family, default ENABLED (shipped behaviour unchanged).
+                let quality = if crate::memory::ablation::is_enabled("quality_verbosity") {
                     let content_len = mem.experience.content.len() as f32;
                     (content_len / 200.0).min(1.0) * elaboration
+                } else {
+                    elaboration
                 };
                 let quality_factor = quality.max(crate::constants::ELABORATION_QUALITY_MIN);
                 if let Some(score) = mem.score {

--- a/src/recall_harness/metrics.rs
+++ b/src/recall_harness/metrics.rs
@@ -37,6 +37,16 @@ pub struct Metrics {
     pub mrr: f64,
     pub p_at_1: f64,
     pub map: f64,
+    /// Hit-rate at `k`: 1.0 if ANY relevant item is in the top-`k`, else 0.0.
+    ///
+    /// The lenient counterpart to [`Self::recall_at_k`], which is the FRACTION
+    /// of a case's gold that was found. With 3.13 gold per multi_hop case,
+    /// finding two of three scores 0.67 there and 1.00 here. Published
+    /// memory/RAG "recall@k" figures are usually this form, so quoting
+    /// `recall_at_k` against them understates us and quoting `hit_at_k` as if
+    /// it were full recall overstates us. Both are carried so that any
+    /// comparison has to say which one it means.
+    pub hit_at_k: f64,
 }
 
 impl Metrics {
@@ -56,6 +66,7 @@ impl Metrics {
             mrr: mrr(retrieved, &relevant),
             p_at_1: p_at_1(retrieved, &relevant),
             map: map(retrieved, &relevant),
+            hit_at_k: hit_at_k(retrieved, &relevant, k),
         }
     }
 }
@@ -88,6 +99,24 @@ pub fn recall_at_k(retrieved: &[Uuid], relevant: &HashSet<Uuid>, k: usize) -> f6
         .filter(|id| relevant.contains(id))
         .count();
     hits as f64 / relevant.len() as f64
+}
+
+/// Hit-rate at cutoff `k`: `1.0` if ANY relevant item appears in the top-`k`.
+///
+/// The lenient counterpart to [`recall_at_k`]. A case with three gold items of
+/// which one is retrieved scores `1.0` here and `0.33` there. Both are honest;
+/// they answer different questions, and most published "recall@k" numbers in
+/// this space are this one.
+pub fn hit_at_k(retrieved: &[Uuid], relevant: &HashSet<Uuid>, k: usize) -> f64 {
+    if k == 0 || retrieved.is_empty() || relevant.is_empty() {
+        return 0.0;
+    }
+    let cap = retrieved.len().min(k);
+    if retrieved[..cap].iter().any(|id| relevant.contains(id)) {
+        1.0
+    } else {
+        0.0
+    }
 }
 
 /// Mean Reciprocal Rank: `1 / rank` of the first relevant item, or `0.0` if
@@ -427,6 +456,64 @@ mod tests {
     // ---- Metrics::compute aggregator ---------------------------------------
 
     #[test]
+    #[test]
+    fn hit_at_k_is_lenient_where_recall_at_k_is_fractional() {
+        // The exact case that makes our headline number look low against
+        // published figures: three gold, one retrieved.
+        let id = ids();
+        let rel: HashSet<Uuid> = [id[0], id[1], id[2]].into_iter().collect();
+        let retrieved = vec![id[0], id[3], id[4]];
+        approx(recall_at_k(&retrieved, &rel, 3), 1.0 / 3.0);
+        approx(hit_at_k(&retrieved, &rel, 3), 1.0);
+    }
+
+    #[test]
+    fn hit_at_k_is_zero_when_nothing_relevant_is_in_the_window() {
+        let id = ids();
+        let rel: HashSet<Uuid> = [id[0]].into_iter().collect();
+        // Gold sits at rank 3, outside a k=2 window.
+        let retrieved = vec![id[3], id[4], id[0]];
+        approx(hit_at_k(&retrieved, &rel, 2), 0.0);
+        approx(hit_at_k(&retrieved, &rel, 3), 1.0);
+    }
+
+    #[test]
+    fn hit_at_k_equals_recall_at_k_when_there_is_exactly_one_gold() {
+        // single_hop averages 1.06 gold/case, so the two metrics nearly coincide
+        // there and diverge on multi_hop (3.13). That is why the headline gap is
+        // category-dependent rather than a constant offset.
+        let id = ids();
+        let rel: HashSet<Uuid> = [id[1]].into_iter().collect();
+        for retrieved in [vec![id[1], id[3]], vec![id[3], id[1]], vec![id[3], id[4]]] {
+            approx(
+                hit_at_k(&retrieved, &rel, 2),
+                recall_at_k(&retrieved, &rel, 2),
+            );
+        }
+    }
+
+    #[test]
+    fn hit_at_k_never_exceeds_one_or_falls_below_recall() {
+        // Ordering property: hit >= recall always, since hit is 1 whenever any
+        // gold is inside the window and recall is a fraction of the same set.
+        let id = ids();
+        let rel: HashSet<Uuid> = [id[0], id[1]].into_iter().collect();
+        for k in 0..6usize {
+            for retrieved in [
+                vec![],
+                vec![id[0]],
+                vec![id[3], id[0], id[1]],
+                vec![id[0], id[1]],
+            ] {
+                let h = hit_at_k(&retrieved, &rel, k);
+                let r = recall_at_k(&retrieved, &rel, k);
+                assert!((0.0..=1.0).contains(&h), "hit out of range at k={k}");
+                assert!(h >= r - 1e-12, "hit {h} < recall {r} at k={k}");
+            }
+        }
+    }
+
+    #[test]
     fn compute_returns_all_six_consistent_with_individual_fns() {
         let id = ids();
         let retrieved = vec![id[3], id[0], id[1]]; // miss, hit, hit
@@ -455,6 +542,7 @@ mod tests {
                 mrr: 0.0,
                 p_at_1: 0.0,
                 map: 0.0,
+                hit_at_k: 0.0,
             }
         );
     }

--- a/src/recall_harness/report.rs
+++ b/src/recall_harness/report.rs
@@ -229,6 +229,17 @@ pub struct AblationRow {
     /// Per-category recall@10 (category name → value), so a config that helps one
     /// capability but hurts another is visible, not hidden in the average.
     pub by_category_recall: std::collections::BTreeMap<String, f64>,
+    /// Order-sensitive fingerprint of every id this arm retrieved, across every
+    /// case. Two arms with the same fingerprint returned byte-identical results.
+    #[serde(default)]
+    pub retrieval_fingerprint: u64,
+    /// True when this arm's fingerprint equals the baseline arm's, i.e. the
+    /// config provably changed nothing and its metrics are attributable to
+    /// nothing. The `+spread-fix` arms were vacuous this way for months: the flag
+    /// they set could not reach the live code path, so the rows silently
+    /// duplicated baseline while reading as evidence.
+    #[serde(default)]
+    pub vacuous_vs_baseline: bool,
 }
 
 /// Unified ablation report: one ingest, N query-time configs, one comparison

--- a/src/recall_harness/report.rs
+++ b/src/recall_harness/report.rs
@@ -298,6 +298,16 @@ pub struct LayerReport {
     pub ndcg_at_10: f64,
     #[serde(rename = "recall@10")]
     pub recall_at_10: f64,
+    /// Hit-rate at 10: fraction of CASES with at least one gold in the top-10.
+    ///
+    /// Sits next to `recall_at_10`, which is the mean FRACTION of each case's
+    /// gold found. The two diverge sharply where gold is dense: 3.13 gold per
+    /// multi_hop case means two-of-three scores 0.67 on recall and 1.00 here,
+    /// while single_hop (1.06 gold/case) has them nearly coincide. Most published
+    /// memory/RAG "recall@k" numbers are this hit-rate form, so any external
+    /// comparison has to name which of the two it means.
+    #[serde(rename = "hit@10", default)]
+    pub hit_at_10: f64,
     #[serde(rename = "precision@10")]
     pub precision_at_10: f64,
     pub mrr: f64,
@@ -331,6 +341,16 @@ pub struct CategoryReport {
     pub ndcg_at_10: f64,
     #[serde(rename = "recall@10")]
     pub recall_at_10: f64,
+    /// Hit-rate at 10: fraction of CASES with at least one gold in the top-10.
+    ///
+    /// Sits next to `recall_at_10`, which is the mean FRACTION of each case's
+    /// gold found. The two diverge sharply where gold is dense: 3.13 gold per
+    /// multi_hop case means two-of-three scores 0.67 on recall and 1.00 here,
+    /// while single_hop (1.06 gold/case) has them nearly coincide. Most published
+    /// memory/RAG "recall@k" numbers are this hit-rate form, so any external
+    /// comparison has to name which of the two it means.
+    #[serde(rename = "hit@10", default)]
+    pub hit_at_10: f64,
     #[serde(rename = "precision@10")]
     pub precision_at_10: f64,
     pub mrr: f64,
@@ -438,6 +458,7 @@ pub fn aggregate_layer(per_case: &[Metrics], latencies_ms: &[f64]) -> LayerRepor
     LayerReport {
         ndcg_at_10: mean(|m| m.ndcg_at_k),
         recall_at_10: mean(|m| m.recall_at_k),
+        hit_at_10: mean(|m| m.hit_at_k),
         precision_at_10: mean(|m| m.precision_at_k),
         mrr: mean(|m| m.mrr),
         p_at_1: mean(|m| m.p_at_1),
@@ -465,6 +486,7 @@ pub fn aggregate_category(per_case: &[Metrics]) -> CategoryReport {
     CategoryReport {
         ndcg_at_10: mean(|m| m.ndcg_at_k),
         recall_at_10: mean(|m| m.recall_at_k),
+        hit_at_10: mean(|m| m.hit_at_k),
         precision_at_10: mean(|m| m.precision_at_k),
         mrr: mean(|m| m.mrr),
         p_at_1: mean(|m| m.p_at_1),
@@ -724,6 +746,7 @@ mod tests {
             mrr: values,
             p_at_1: values,
             map: values,
+            hit_at_k: values,
         }
     }
 
@@ -778,6 +801,7 @@ mod tests {
             LayerReport {
                 ndcg_at_10: ndcg,
                 recall_at_10: recall,
+                hit_at_10: recall,
                 precision_at_10: 0.2,
                 mrr,
                 p_at_1: p1,
@@ -850,6 +874,7 @@ mod tests {
         CategoryReport {
             ndcg_at_10: recall,
             recall_at_10: recall,
+            hit_at_10: recall,
             precision_at_10: recall,
             mrr: recall,
             p_at_1: p1,

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -1105,6 +1105,11 @@ struct LongMemEvalCase {
 }
 
 /// Aggregate LongMemEval result.
+///
+/// Serialisable so that a sharded run can be recombined: every mean is carried
+/// with its own count, so shards aggregate as a count-weighted mean rather than
+/// a mean of means.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LongMemEvalReport {
     pub questions: usize,
     pub recall_at_k: f64,
@@ -1120,6 +1125,24 @@ pub struct LongMemEvalReport {
     pub layers: BTreeMap<String, (f64, usize)>,
 }
 
+/// Resolve a shard's `[start, end)` window over a manifest of `len` cases.
+///
+/// `offset` skips that many cases; `limit` bounds how many follow. Both saturate
+/// at `len`, so an out-of-range shard yields an empty window rather than
+/// panicking — with a fixed shard count and a variable question total, the tail
+/// shards are routinely out of range.
+///
+/// The correctness claim this exists to pin: for `offset = i * per` and
+/// `limit = per`, the windows are disjoint and cover `0..len` exactly once.
+fn shard_window(len: usize, offset: Option<usize>, limit: Option<usize>) -> (usize, usize) {
+    let start = offset.unwrap_or(0).min(len);
+    let end = match limit {
+        Some(n) => start.saturating_add(n).min(len),
+        None => len,
+    };
+    (start, end)
+}
+
 /// Run the LongMemEval-S suite (ICLR 2025, the current SOTA long-term memory
 /// benchmark). UNLIKE LoCoMo, each question carries its OWN ~48-session haystack
 /// (~115K tokens), so this is a LOOP of mini-evals: per question, ingest its
@@ -1133,6 +1156,7 @@ pub struct LongMemEvalReport {
 pub fn run_longmemeval(
     base_dir: &Path,
     storage_root: &Path,
+    offset: Option<usize>,
     limit: Option<usize>,
     k: usize,
     layer_modes: &[LayerMode],
@@ -1146,9 +1170,14 @@ pub fn run_longmemeval(
     for line in manifest_txt.lines().filter(|l| !l.trim().is_empty()) {
         cases.push(serde_json::from_str(line).context("parsing LongMemEval manifest line")?);
     }
-    if let Some(n) = limit {
-        cases.truncate(n);
-    }
+    // Shard selection: skip `offset` cases, then take `limit`. LongMemEval-S
+    // gives every question its OWN ~490-turn haystack, so cost is linear in
+    // questions and a full run cannot fit one job's timeout. Disjoint
+    // (offset, limit) windows let parallel jobs cover the suite exactly once.
+    // The manifest order is deterministic - the converter's `--shuffle` is a
+    // stable sort - so the windows are stable across jobs and across reruns.
+    let (start, end) = shard_window(cases.len(), offset, limit);
+    cases = cases.drain(start..end).collect();
 
     let mut sum_recall = 0.0f64;
     let mut sum_p1 = 0.0f64;
@@ -3398,6 +3427,48 @@ mod tests {
             rank(&pf, "person"),
             rank(&full, "person")
         );
+    }
+
+    #[test]
+    fn shard_windows_tile_the_manifest_exactly_once() {
+        // The property the sharded LongMemEval workflow depends on: with a fixed
+        // shard count and `per = ceil(len / shards)`, the windows are disjoint
+        // and cover every case exactly once. If this breaks, a suite total is
+        // silently computed over duplicated or skipped questions.
+        const SHARDS: usize = 10;
+        for len in [0usize, 1, 7, 9, 10, 11, 47, 50, 149, 150, 479] {
+            let per = len.div_ceil(SHARDS).max(1);
+            let mut covered = vec![0u32; len];
+            for shard in 0..SHARDS {
+                let (start, end) = shard_window(len, Some(shard * per), Some(per));
+                assert!(start <= end, "len={len} shard={shard}: inverted window");
+                assert!(end <= len, "len={len} shard={shard}: window past the end");
+                for slot in covered.iter_mut().take(end).skip(start) {
+                    *slot += 1;
+                }
+            }
+            assert!(
+                covered.iter().all(|&c| c == 1),
+                "len={len}: every case must be covered exactly once, got {covered:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn out_of_range_shard_yields_an_empty_window_not_a_panic() {
+        // Routine, not exceptional: the shard count is fixed at 10 while the
+        // question total varies, so the tail shards fall off the end whenever
+        // the total is small.
+        assert_eq!(shard_window(5, Some(50), Some(5)), (5, 5));
+        assert_eq!(shard_window(0, Some(0), Some(5)), (0, 0));
+        assert_eq!(shard_window(5, Some(3), Some(99)), (3, 5));
+    }
+
+    #[test]
+    fn absent_offset_and_limit_select_the_whole_manifest() {
+        assert_eq!(shard_window(42, None, None), (0, 42));
+        assert_eq!(shard_window(42, None, Some(10)), (0, 10));
+        assert_eq!(shard_window(42, Some(10), None), (10, 42));
     }
 
     #[test]

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -1434,6 +1434,28 @@ pub fn analyze_ablation(inputs: &RunInputs) -> Result<AblationReport> {
             "+graph-boost-mult",
             vec![("SHODH_GRAPH_BOOST_MULTIPLICATIVE", "1")],
         ),
+        // Traversal direction. Without this flag `edge_neighbor` returns
+        // `edge.to_entity` unconditionally, so standing on a node and meeting an
+        // edge that ENDS there resolves to the node itself: every incoming edge
+        // is a self-loop and the walk can only follow outgoing edges. Reachable
+        // from the live path (`edge_neighbor` is called inside PPR), so this arm
+        // can differ from baseline.
+        ("+edge-dir", vec![("SHODH_GRAPH_EDGE_DIR", "1")]),
+        // Composition-by-traversal: beam-search the strongest intent-matching
+        // paths from the seeds and inject the reached endpoints. Shipped OFF
+        // since it landed and never carried an arm, so it has never appeared in
+        // the study at all.
+        ("+graph-traverse", vec![("SHODH_GRAPH_TRAVERSE", "1")]),
+        // The two graph-leg components that had no gate before `memory::ablation`
+        // existed, and so had never been ablated in either direction.
+        (
+            "-lateral-inhibition",
+            vec![("SHODH_DISABLE_BOOSTS", "hebbian,lateral_inhibition")],
+        ),
+        (
+            "-graph-potentiation",
+            vec![("SHODH_DISABLE_BOOSTS", "hebbian,graph_potentiation")],
+        ),
         (
             "+graph-boost-mult+expand",
             vec![
@@ -1464,6 +1486,9 @@ pub fn analyze_ablation(inputs: &RunInputs) -> Result<AblationReport> {
 
         let mut by_cat: HashMap<SmokeCategory, Vec<f64>> = HashMap::new();
         let mut all: Vec<Metrics> = Vec::with_capacity(cases.len());
+        // Order-sensitive fingerprint over every retrieved id. An arm that
+        // matches baseline here provably changed nothing.
+        let mut fp = std::collections::hash_map::DefaultHasher::new();
         for case in &cases {
             let query = Query {
                 query_text: Some(case.query.clone()),
@@ -1473,6 +1498,14 @@ pub fn analyze_ablation(inputs: &RunInputs) -> Result<AblationReport> {
             };
             let memories = system.read().recall(&query).unwrap_or_default();
             let retrieved: Vec<Uuid> = memories.iter().map(|m| m.id.0).collect();
+            {
+                use std::hash::{Hash, Hasher};
+                for id in &retrieved {
+                    id.hash(&mut fp);
+                }
+                // Separator so [a],[b] and [a,b] cannot collide.
+                0xFFu8.hash(&mut fp);
+            }
             let relevance = build_relevance_map(case, &id_map);
             let m = Metrics::compute(&retrieved, &relevance, SMOKE_K);
             by_cat.entry(case.category).or_default().push(m.recall_at_k);
@@ -1501,7 +1534,45 @@ pub fn analyze_ablation(inputs: &RunInputs) -> Result<AblationReport> {
             mrr: all.iter().map(|m| m.mrr).sum::<f64>() / n,
             p_at_1: all.iter().map(|m| m.p_at_1).sum::<f64>() / n,
             by_category_recall,
+            retrieval_fingerprint: {
+                use std::hash::Hasher;
+                fp.finish()
+            },
+            vacuous_vs_baseline: false,
         });
+    }
+
+    // Vacuity check. An arm whose retrieved ids are byte-identical to baseline's
+    // did not exercise the code path it names, and its metrics are attributable
+    // to nothing. The `+spread-fix` arms were vacuous this way for months --
+    // SHODH_SPREAD_FIX only reached the legacy BFS spread, but SHODH_PPR defaults
+    // ON and its branch precedes it, so the flag could not execute while the rows
+    // read as evidence. Flag it in the report rather than failing the run: an arm
+    // may also be legitimately inert (it executed and changed no ranking), and
+    // only the fingerprint distinguishes the two.
+    let baseline_fp = rows
+        .iter()
+        .find(|r| r.name.starts_with("baseline"))
+        .map(|r| r.retrieval_fingerprint);
+    if let Some(base) = baseline_fp {
+        for row in rows.iter_mut() {
+            if row.name.starts_with("baseline") || row.flags.is_empty() {
+                continue;
+            }
+            if row.retrieval_fingerprint == base {
+                row.vacuous_vs_baseline = true;
+                tracing::warn!(
+                    arm = %row.name,
+                    flags = %row.flags.join(" "),
+                    "VACUOUS ABLATION ARM: retrieval is byte-identical to baseline, so this                      config did not reach the code path it names. Its numbers measure nothing.                      Confirm the flag is readable from the live path before trusting this row."
+                );
+                eprintln!(
+                    "  !! VACUOUS ARM `{}` ({}) -- byte-identical to baseline, measures nothing",
+                    row.name,
+                    row.flags.join(" ")
+                );
+            }
+        }
     }
 
     Ok(AblationReport {

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -843,7 +843,18 @@ fn run_one_pass(
                     .clone()
             };
             if pool_export.is_some() && matches!(*mode, LayerMode::Full) {
-                let mut gold: Vec<String> = relevance.keys().map(|u| u.to_string()).collect();
+                // Corpus ids, matching `pool` -- `relevance` is keyed by Uuid while
+                // the rank lists are already corpus ids, so exporting the raw Uuid
+                // made the two sets disjoint and every offline join scored zero.
+                let mut gold: Vec<String> = relevance
+                    .keys()
+                    .map(|u| {
+                        uuid_to_corpus_id
+                            .get(u)
+                            .cloned()
+                            .unwrap_or_else(|| u.to_string())
+                    })
+                    .collect();
                 gold.sort();
                 pool_lines.push(
                     serde_json::json!({

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -691,6 +691,25 @@ fn run_one_pass(
         .map(std::path::PathBuf::from);
     let mut feature_lines: Vec<String> = Vec::new();
 
+    // Candidate-pool export (`SHODH_POOL_EXPORT=<jsonl path>`, Full mode only).
+    //
+    // Writes, per case: the query, the gold ids, and the RECALL_DIAG_K-deep
+    // candidate pool in rank order. That is everything an OFFLINE rescoring
+    // experiment needs -- a cross-encoder, a late-interaction MaxSim scorer, a
+    // fine-tuned or JEPA-style adapter -- because the pool is exactly the set a
+    // reranker would see and the gold ids are the labels. Candidate TEXT is
+    // deliberately not duplicated here: the corpus jsonl already holds it keyed
+    // by id, so the consumer joins rather than the harness bloating every line.
+    //
+    // The point is to convert "would X improve ranking?" from a 45-minute CI run
+    // into a script. ~32pp of gold sits in ranks 11-100, so every rescoring idea
+    // is testable against this file without touching the Rust pipeline at all.
+    let pool_export: Option<std::path::PathBuf> = std::env::var("SHODH_POOL_EXPORT")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(std::path::PathBuf::from);
+    let mut pool_lines: Vec<String> = Vec::new();
+
     for mode in layer_modes {
         let mut per_case = Vec::with_capacity(cases.len());
         let mut latencies_ms = Vec::with_capacity(cases.len());
@@ -823,6 +842,20 @@ fn run_one_pass(
                     .retrieved
                     .clone()
             };
+            if pool_export.is_some() && matches!(*mode, LayerMode::Full) {
+                let mut gold: Vec<String> = relevance.keys().map(|u| u.to_string()).collect();
+                gold.sort();
+                pool_lines.push(
+                    serde_json::json!({
+                        "case_id": case.id,
+                        "category": category_name(case.category),
+                        "query": case.query,
+                        "gold": gold,
+                        "pool": deep_retrieved,
+                    })
+                    .to_string(),
+                );
+            }
             deep_ranks.push(CaseRankList {
                 case_id: case.id.clone(),
                 retrieved: deep_retrieved,
@@ -859,6 +892,22 @@ fn run_one_pass(
                 deep_ranks,
             },
         );
+    }
+
+    if let Some(path) = &pool_export {
+        if !pool_lines.is_empty() {
+            use std::io::Write as _;
+            let mut f = std::fs::File::create(path)
+                .with_context(|| format!("creating pool export {}", path.display()))?;
+            for line in &pool_lines {
+                writeln!(f, "{line}")?;
+            }
+            eprintln!(
+                "  pool export: {} cases -> {}",
+                pool_lines.len(),
+                path.display()
+            );
+        }
     }
 
     if let Some(path) = &feature_export {


### PR DESCRIPTION
Three defects, none of which change retrieval behaviour. Four levers measured inert today (`predicate_weights` 0.0000, `typed_only` +0.0019, taxonomy +0.0014, `edge_dir` +0.0056), so nothing here flips a retrieval default on a hunch. It changes what *can* be measured.

## 1. Components with no off switch

`calculate_lateral_inhibition` and `batch_strengthen_synapses` had no gate anywhere in the repo, so neither had ever been ablated — in either direction. A component that cannot be switched off cannot be measured, and an unmeasurable component accumulates in the pipeline on the strength of its rationale rather than its effect.

Both are now families in a new `memory::ablation` module, which is the single source of truth. Previously the semantic leg had an 18-family kill-switch parsed inline inside `semantic_retrieve_inner` while the graph leg had nothing — two idioms and a gap. `semantic_retrieve_inner` now delegates.

Both ship **enabled**; a test pins that, since declaring them must not change behaviour. A second test pins that `graph_potentiation` does not switch off as collateral of the default-disabled `hebbian` family — adjacent names, different mechanisms (`hebbian` is the semantic leg's L5 *rank boost*; `graph_potentiation` is the *write* that feeds `ppr_edge_weight`).

Four ablation arms added: `+edge-dir` and `+graph-traverse` had none and so had never appeared in the study at all; `-lateral-inhibition` and `-graph-potentiation` are newly possible.

## 2. Arms that measure nothing

`AblationRow` now carries an order-sensitive fingerprint of every id an arm retrieved. Any arm whose fingerprint equals baseline's is marked `vacuous_vs_baseline` and warned about loudly.

This is the `+spread-fix` class, already documented in-tree: `SHODH_SPREAD_FIX` only reached the legacy BFS spread, but `SHODH_PPR` defaults ON and its branch precedes it, so the flag could not execute while its rows read as evidence for months.

Flagged rather than fatal: an arm can also be legitimately inert — it executed and changed no ranking — and only the fingerprint distinguishes the two.

## 3. An eval that cannot finish its own default configuration

Every LongMemEval run was **cancelled**, not failed, at ~5h03 against `timeout-minutes: 300`, having produced no report. Measured from the logs: 25 of 150 questions in 3 hours. LongMemEval-S gives every question its OWN ~490-turn haystack, so cost is linear and ingest-dominated, and 50 questions — the workflow's declared default — needs ~600 min against a 300 min cap.

Now sharded into a 10-way matrix of disjoint `(offset, limit)` windows with a count-weighted aggregate job.

- new `--longmemeval-offset`; `shard_window()` extracted so its coverage claim is testable
- the tiling property (windows disjoint, covering `0..len` exactly once) is tested across eleven manifest sizes including ragged ones, and mutation-checked
- `LongMemEvalReport` gained `Serialize` and is now **written** to `--output` — that path printed only and was handed a file it ignored, literally named `unused.json`, so there was nothing to aggregate even in principle
- aggregation is a count-weighted mean, never a mean of means; if fewer than ten shards report the summary says the figures are not a suite result, and under n=40 it prints the 95% interval beside the number

**Validated end-to-end**: shard 1/10 ran `offset=5 limit=5 of 50` in 43 min and reported its 5 questions.

Also corrects the `limit` input description, which claimed "Blank = all 479". Blank does not mean all — GitHub substitutes the declared default for an empty `workflow_dispatch` input, so six runs believed to be n=479 were n=50.

## Security default

`SHODH_ENFORCE_HTTPS` now defaults ON. It defaulted OFF, which inverted secure-by-default: an `http://` non-localhost integration override was honoured with only a warning, and a warning does not stop an API token being transmitted in cleartext. `SHODH_ENFORCE_HTTPS=false` is the explicit opt-out; any other value enforces, so a typo fails safe. Localhost http stays allowed. Five tests added — the function had none.

## Testing

1076 lib tests green.

The new tests are mutation-checked rather than trusted, and that caught two of my own tautologies before they landed:

| mutation | caught by |
|---|---|
| `union_admit` → `*slot += score` | 2 tests |
| `is_enabled` → hardcoded `true` | 3 tests |
| `shard_window` → drop the offset | tiling test |

The first draft of the ablation tests **passed** with `is_enabled` hardcoded to `true` — every assertion went through `is_disabled`, so nothing pinned the function the call sites actually use.
