### PR TITLE
The incremental insert built a kNN graph and called it Vamana

### DIFF
--- a/.github/workflows/locomo-recall.yml
+++ b/.github/workflows/locomo-recall.yml
@@ -119,6 +119,12 @@ jobs:
           # not once per run (which earned us a 429 rate-limit after this session's runs).
           dl() { curl -fL --retry 20 --retry-all-errors --retry-delay 15 --connect-timeout 30 -o "$1" "$2"; }
           [ -s "$MODEL_DIR/model_quantized.onnx" ] || dl "$MODEL_DIR/model_quantized.onnx" "$BASE/onnx/model_quint8_avx2.onnx"
+          # fp32 weights, so the cost of int8 quantisation on retrieval can be
+          # measured (SHODH_USE_QUANTIZED_MODEL=0). Semantic similarity is the
+          # strongest ranking signal in the pipeline and it has only ever been
+          # produced by the quantised model - the price of that has never been
+          # measured. Fetched unconditionally so the arm is always runnable.
+          [ -s "$MODEL_DIR/model.onnx" ]           || dl "$MODEL_DIR/model.onnx" "$BASE/onnx/model.onnx"
           [ -s "$MODEL_DIR/tokenizer.json" ]       || dl "$MODEL_DIR/tokenizer.json" "$BASE/tokenizer.json"
           ls -la "$MODEL_DIR"
 

--- a/.github/workflows/locomo-recall.yml
+++ b/.github/workflows/locomo-recall.yml
@@ -390,5 +390,6 @@ jobs:
             locomo-recall.log
             locomo-reachability.json
             locomo-reachability.log
+            pool.jsonl
             learning-curve.json
             learning-curve.log

--- a/.github/workflows/locomo-recall.yml
+++ b/.github/workflows/locomo-recall.yml
@@ -152,6 +152,7 @@ jobs:
           print(f"### Graph structure (anti-hub scoreboard)")
           print(f"- entities: {gs.get('total_entities',0)}  edges(est): {gs.get('total_edges',0)}  mean degree: {gs.get('mean_degree',0):.1f}")
           print(f"- **max degree: {gs.get('max_degree',0)}**  hubs (degree>{gs.get('hub_threshold',50)}): **{gs.get('hub_count',0)}**  top degrees: {gs.get('top_degrees',[])}")
+          print(f"- **edges SKIPPED by hub saturation: {gs.get('hub_saturation_skipped_edges',0)}** (hard skip, decided by ingest ARRIVAL ORDER not by information)")
           print(f"  (max degree + hub count should FALL with IDF edges / lower hub_max)\n")
           print(f"- max_hops: {d['max_hops']}  (≤2hop% = canonical double-hop signal)")
           print("\n| category | cases | gold | ≤1hop% | ≤2hop% | unreach% | no-seed% | cases≥2seed% | gold≥2seed% |")

--- a/.github/workflows/longmemeval.yml
+++ b/.github/workflows/longmemeval.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       limit:
-        description: 'Number of questions (representative mix via --shuffle). Blank = all 479.'
+        description: 'Total questions across ALL 10 shards (representative mix via --shuffle). Blank uses the default below - it does NOT mean all 479, GitHub substitutes the default for an empty input. ~7-12 min per question per shard.'
         required: false
         default: '50'
       extra_env:
@@ -40,9 +40,19 @@ concurrency:
 
 jobs:
   longmemeval:
-    name: LongMemEval-S
+    # SHARDED. Every LongMemEval-S question carries its OWN ~490-turn haystack,
+    # so cost is linear in questions and ingest-dominated at roughly 7-12 min
+    # each. A single job could not finish even the default 50 questions inside
+    # timeout-minutes: 300 - every unsharded run was cancelled at ~25/50 having
+    # produced no report at all. Ten disjoint (offset, limit) windows cover the
+    # suite exactly once and each finishes well inside the cap.
+    name: LongMemEval-S (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     timeout-minutes: 300
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     steps:
       - uses: actions/checkout@v7
 
@@ -93,14 +103,29 @@ jobs:
             ${{ github.event.inputs.limit != '' && format('--limit {0}', github.event.inputs.limit) || '' }}
           wc -l tests/recall/longmemeval/manifest.jsonl
 
-      - name: Run LongMemEval
+      - name: Run LongMemEval shard
         run: |
           for kv in ${{ github.event.inputs.extra_env }}; do export "$kv"; done
+          TOTAL=$(wc -l < tests/recall/longmemeval/manifest.jsonl)
+          SHARDS=10
+          PER=$(( (TOTAL + SHARDS - 1) / SHARDS ))
+          OFFSET=$(( ${{ matrix.shard }} * PER ))
+          echo "shard ${{ matrix.shard }}/$SHARDS: offset=$OFFSET limit=$PER of $TOTAL"
           ./target/release/recall-eval \
             --longmemeval tests/recall/longmemeval \
             --layer ${{ github.event.inputs.layer || 'full' }} \
-            --output unused.json \
+            --longmemeval-offset "$OFFSET" \
+            --longmemeval-limit "$PER" \
+            --output "shard-${{ matrix.shard }}.json" \
             --storage ./lme-storage 2>&1 | tee longmemeval.log
+
+      - name: Upload shard report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lme-shard-${{ matrix.shard }}
+          path: shard-${{ matrix.shard }}.json
+          if-no-files-found: warn
 
       - name: Summary
         if: always()
@@ -114,3 +139,95 @@ jobs:
             grep -E "NER_BACKEND|LongMemEval-S:|recall@|LONGMEMEVAL_LAYER" longmemeval.log || true
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  aggregate:
+    # Recombines the shards. Every mean in the report is carried with its own
+    # count, so the suite total is a COUNT-WEIGHTED mean, never a mean of means -
+    # the shards are equal-sized by construction but the last one is short
+    # whenever the question count is not a multiple of ten, and per-category
+    # counts differ wildly between shards regardless.
+    name: LongMemEval-S (aggregate)
+    needs: longmemeval
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: lme-shard-*
+          path: shards
+          merge-multiple: true
+
+      - name: Combine shard reports
+        run: |
+          python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+          import glob, json, os, sys
+          from collections import defaultdict
+
+          files = sorted(glob.glob('shards/shard-*.json'))
+          reports = []
+          for f in files:
+              try:
+                  reports.append((f, json.load(open(f))))
+              except Exception as e:
+                  print(f'  !! unreadable shard {f}: {e}')
+
+          print('## LongMemEval-S - turn-level retrieval recall@10 (no LLM judge)')
+          print()
+          print('> NOT comparable to headline LongMemEval answer-accuracy SOTA, which')
+          print('> reads retrieved context with a large LLM. This is the retrieval half:')
+          print('> does our memory surface the gold evidence turns?')
+          print()
+
+          expected = 10
+          if len(reports) < expected:
+              missing = expected - len(reports)
+              print(f'> **WARNING: {missing} of {expected} shards produced no report.**')
+              print('> The figures below cover only the shards that completed and are NOT')
+              print('> a suite result. Do not quote them without this caveat.')
+              print()
+
+          if not reports:
+              print('No shard reports; nothing to aggregate.')
+              sys.exit(0)
+
+          cat_sum = defaultdict(float)
+          cat_n = defaultdict(int)
+          layer_sum = defaultdict(float)
+          layer_n = defaultdict(int)
+          for _, r in reports:
+              for cat, (mean, n) in r.get('by_category', {}).items():
+                  cat_sum[cat] += mean * n
+                  cat_n[cat] += n
+              for lay, (mean, n) in r.get('layers', {}).items():
+                  layer_sum[lay] += mean * n
+                  layer_n[lay] += n
+
+          total_n = sum(cat_n.values())
+          overall = sum(cat_sum.values()) / total_n if total_n else 0.0
+          backends = {r.get('ner_backend', '?') for _, r in reports}
+
+          print('```')
+          print(f'shards        : {len(reports)}/{expected}')
+          print(f'questions     : {total_n}')
+          print(f'NER backend   : {", ".join(sorted(backends))}')
+          print(f'recall@10     : {overall:.4f}')
+          print()
+          for cat in sorted(cat_n):
+              m = cat_sum[cat] / cat_n[cat] if cat_n[cat] else 0.0
+              print(f'  {cat:18} n={cat_n[cat]:<5} recall@10 = {m:.4f}')
+          if len(layer_n) > 1:
+              print()
+              print('  per-layer ablation (same haystacks):')
+              for lay in sorted(layer_n):
+                  m = layer_sum[lay] / layer_n[lay] if layer_n[lay] else 0.0
+                  print(f'    {lay:16} n={layer_n[lay]:<5} recall@10 = {m:.4f}')
+          print('```')
+
+          # A number without its n invites being quoted as if it were the suite.
+          if total_n < 40:
+              print()
+              print(f'> **n = {total_n}. The 95% interval here is roughly +/-{1.96*(0.25/total_n)**0.5:.2f}** -')
+              print('> too wide to separate retrieval legs. Treat as a smoke signal, not a result.')
+          PY
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1168,7 +1168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1523,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1795,7 +1795,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2007,7 +2007,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2531,7 +2531,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3259,7 +3259,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3297,9 +3297,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3731,7 +3731,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4558,7 +4558,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5494,7 +5494,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/scripts/rerank_pilot.py
+++ b/scripts/rerank_pilot.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Offline reranking pilot over a SHODH_POOL_EXPORT candidate pool.
+
+Prices the direction-2 question -- "is the encoder's training objective the
+ranking bottleneck?" -- without a CI run. Takes the pool.jsonl written by the
+recall harness (per case: query, gold ids, RECALL_DIAG_K-deep pool in rank
+order), joins candidate text from the corpus jsonl and gold labels from the
+cases jsonl, and evaluates rescoring functions offline:
+
+  baseline    the pool's own rank order (what the shipped fusion produced)
+  oracle      gold-first ordering of the same pool = ceiling for ANY reranker
+  cross-encoder  a query x candidate interaction model (default
+              cross-encoder/ms-marco-MiniLM-L-2-v2 / -L-6-v2), the lower bound
+              on the interaction-mechanism family: trained for question->passage
+              relevance, not paraphrase similarity
+  adapter     a query-side linear map W over FROZEN MiniLM embeddings, trained
+              on a case-level split (report holdout only) -- the cheapest
+              possible "fix the geometry, keep the encoder" arm
+
+Gold ids are taken from the cases file, NOT from pool.jsonl's own gold field:
+the first pool export wrote per-run Uuids there (fixed in a later commit), and
+joining through the cases file works for both versions.
+
+Usage:
+  python scripts/rerank_pilot.py --pool pool.jsonl \
+      [--corpus tests/recall/corpora/locomo.jsonl] \
+      [--cases tests/recall/locomo_cases.jsonl] \
+      [--arms baseline,oracle,ce,adapter] [--ce-model MODEL] [--rerank-depth 100]
+      [--max-cases N] [--out results.json]
+
+Every arm reports recall@10, ndcg@10, p@1 overall and per category, plus the
+share of the oracle headroom (oracle - baseline) it captured. The CE arm also
+reports pairs/sec and per-query latency at the chosen rerank depth, which is
+the latency half of the cost/benefit verdict.
+"""
+
+import argparse
+import json
+import math
+import sys
+import time
+from collections import defaultdict
+
+
+def load_jsonl(path):
+    with open(path, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def ndcg_at_k(ranked_ids, gold_grades, k=10):
+    """Binary-graded ndcg matching the harness's per-case shape closely enough
+    for arm-to-arm comparison (graded when grades differ)."""
+    dcg = 0.0
+    for i, cid in enumerate(ranked_ids[:k]):
+        g = gold_grades.get(cid, 0)
+        if g > 0:
+            dcg += (2**g - 1) / math.log2(i + 2)
+    ideal = sorted(gold_grades.values(), reverse=True)[:k]
+    idcg = sum((2**g - 1) / math.log2(i + 2) for i, g in enumerate(ideal))
+    return dcg / idcg if idcg > 0 else 0.0
+
+
+def metrics_for(order_by_case, gold_by_case, grades_by_case, cats):
+    per_cat = defaultdict(lambda: defaultdict(list))
+    agg = defaultdict(list)
+    for cid, ranked in order_by_case.items():
+        gold = gold_by_case[cid]
+        r10 = len(gold & set(ranked[:10])) / len(gold)
+        p1 = 1.0 if ranked and ranked[0] in gold else 0.0
+        nd = ndcg_at_k(ranked, grades_by_case[cid], 10)
+        for key, val in (("recall@10", r10), ("p@1", p1), ("ndcg@10", nd)):
+            agg[key].append(val)
+            per_cat[cats[cid]][key].append(val)
+    out = {k: sum(v) / len(v) for k, v in agg.items()}
+    out["by_category"] = {
+        c: {k: sum(v) / len(v) for k, v in m.items()} for c, m in per_cat.items()
+    }
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pool", required=True)
+    ap.add_argument("--corpus", default="tests/recall/corpora/locomo.jsonl")
+    ap.add_argument("--cases", default="tests/recall/locomo_cases.jsonl")
+    ap.add_argument("--arms", default="baseline,oracle,ce")
+    ap.add_argument("--ce-model", default="cross-encoder/ms-marco-MiniLM-L-6-v2")
+    ap.add_argument("--rerank-depth", type=int, default=100)
+    ap.add_argument("--max-cases", type=int, default=0)
+    ap.add_argument("--batch-size", type=int, default=128)
+    ap.add_argument("--adapter-epochs", type=int, default=30)
+    ap.add_argument("--holdout-frac", type=float, default=0.3)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+    arms = set(args.arms.split(","))
+
+    corpus_text = {d["id"]: d["content"] for d in load_jsonl(args.corpus)}
+    cases = load_jsonl(args.cases)
+    gold_by_case = {
+        d["id"]: set(r["corpus_item_id"] for r in d["relevant"]) for d in cases
+    }
+    grades_by_case = {
+        d["id"]: {r["corpus_item_id"]: r.get("grade", 1) for r in d["relevant"]}
+        for d in cases
+    }
+
+    pool_rows = load_jsonl(args.pool)
+    if args.max_cases:
+        pool_rows = pool_rows[: args.max_cases]
+    cats = {d["case_id"]: d.get("category", "?") for d in pool_rows}
+    queries = {d["case_id"]: d["query"] for d in pool_rows}
+    pools = {d["case_id"]: d["pool"] for d in pool_rows}
+
+    # Sanity: every pool id must join against corpus text.
+    missing = sum(
+        1 for p in pools.values() for cid in p if cid not in corpus_text
+    )
+    total_pool_ids = sum(len(p) for p in pools.values())
+    print(
+        f"cases={len(pools)} pool_ids={total_pool_ids} "
+        f"unjoinable={missing} ({100.0 * missing / max(total_pool_ids, 1):.2f}%)",
+        flush=True,
+    )
+    if missing / max(total_pool_ids, 1) > 0.01:
+        sys.exit("pool ids do not join against the corpus -- wrong corpus file?")
+
+    results = {"pool": args.pool, "cases": len(pools)}
+
+    if "baseline" in arms:
+        results["baseline"] = metrics_for(pools, gold_by_case, grades_by_case, cats)
+        print("baseline ", json.dumps({k: round(v, 4) for k, v in results["baseline"].items() if isinstance(v, float)}), flush=True)
+
+    if "oracle" in arms:
+        oracle_order = {
+            cid: sorted(p, key=lambda x: (x not in gold_by_case[cid],))
+            for cid, p in pools.items()
+        }
+        results["oracle"] = metrics_for(oracle_order, gold_by_case, grades_by_case, cats)
+        print("oracle   ", json.dumps({k: round(v, 4) for k, v in results["oracle"].items() if isinstance(v, float)}), flush=True)
+
+    if "ce" in arms:
+        from sentence_transformers import CrossEncoder
+
+        model = CrossEncoder(args.ce_model, max_length=256, device="cpu")
+        pairs, index = [], []
+        for cid, p in pools.items():
+            for rank, corpus_id in enumerate(p[: args.rerank_depth]):
+                pairs.append((queries[cid], corpus_text.get(corpus_id, "")))
+                index.append((cid, corpus_id))
+        t0 = time.time()
+        scores = model.predict(
+            pairs, batch_size=args.batch_size, show_progress_bar=False
+        )
+        elapsed = time.time() - t0
+        pairs_per_sec = len(pairs) / elapsed
+        scored = defaultdict(dict)
+        for (cid, corpus_id), s in zip(index, scores):
+            scored[cid][corpus_id] = float(s)
+        ce_order = {}
+        for cid, p in pools.items():
+            head = p[: args.rerank_depth]
+            tail = p[args.rerank_depth:]
+            head = sorted(head, key=lambda x: -scored[cid].get(x, -1e9))
+            ce_order[cid] = head + tail
+        results["ce"] = metrics_for(ce_order, gold_by_case, grades_by_case, cats)
+        results["ce"]["model"] = args.ce_model
+        results["ce"]["rerank_depth"] = args.rerank_depth
+        results["ce"]["pairs_per_sec"] = pairs_per_sec
+        results["ce"]["ms_per_query_at_depth"] = 1000.0 * args.rerank_depth / pairs_per_sec
+        print(
+            "ce       ",
+            json.dumps({k: round(v, 4) for k, v in results["ce"].items() if isinstance(v, float)}),
+            f"({pairs_per_sec:.0f} pairs/s, {results['ce']['ms_per_query_at_depth']:.0f} ms/query at depth {args.rerank_depth})",
+            flush=True,
+        )
+
+    if "adapter" in arms:
+        import numpy as np
+        import torch
+        from sentence_transformers import SentenceTransformer
+
+        torch.manual_seed(args.seed)
+        rng = np.random.default_rng(args.seed)
+        st = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2", device="cpu")
+
+        needed_ids = sorted({cid for p in pools.values() for cid in p})
+        cand_emb = st.encode(
+            [corpus_text[c] for c in needed_ids],
+            batch_size=256, convert_to_numpy=True, normalize_embeddings=True,
+            show_progress_bar=False,
+        )
+        cand_ix = {c: i for i, c in enumerate(needed_ids)}
+        case_ids = sorted(pools.keys())
+        q_emb = st.encode(
+            [queries[c] for c in case_ids],
+            batch_size=256, convert_to_numpy=True, normalize_embeddings=True,
+            show_progress_bar=False,
+        )
+        q_ix = {c: i for i, c in enumerate(case_ids)}
+
+        # Case-level split. Holdout is the ONLY number reported: these 1531
+        # cases are the same distribution other fitted components trained on,
+        # so an in-sample adapter number would be worthless.
+        perm = rng.permutation(len(case_ids))
+        n_hold = int(len(case_ids) * args.holdout_frac)
+        hold = {case_ids[i] for i in perm[:n_hold]}
+        train = [c for c in case_ids if c not in hold]
+
+        dim = q_emb.shape[1]
+        W = torch.eye(dim, requires_grad=True)
+        opt = torch.optim.Adam([W], lr=1e-3)
+        qt = torch.tensor(q_emb)
+        ct = torch.tensor(cand_emb)
+        # In-pool contrastive: gold candidates are positives, the rest of the
+        # SAME pool are negatives -- exactly the discrimination the pipeline
+        # needs at ranks 11-100.
+        train_rows = []
+        for cid in train:
+            g = gold_by_case[cid]
+            pos = [cand_ix[x] for x in pools[cid] if x in g]
+            neg = [cand_ix[x] for x in pools[cid] if x not in g]
+            if pos and neg:
+                train_rows.append((q_ix[cid], pos, neg))
+        for _ in range(args.adapter_epochs):
+            rng.shuffle(train_rows)
+            for qi, pos, neg in train_rows:
+                qv = qt[qi] @ W
+                qv = qv / (qv.norm() + 1e-9)
+                logits = ct[pos + neg] @ qv / 0.05
+                target = torch.zeros(len(pos) + len(neg))
+                target[: len(pos)] = 1.0 / len(pos)
+                loss = -(torch.log_softmax(logits, 0) * target).sum()
+                opt.zero_grad()
+                loss.backward()
+                opt.step()
+        with torch.no_grad():
+            Wn = W.detach()
+            ad_order = {}
+            for cid in hold:
+                qv = qt[q_ix[cid]] @ Wn
+                qv = qv / (qv.norm() + 1e-9)
+                p = pools[cid]
+                s = (ct[[cand_ix[x] for x in p]] @ qv).numpy()
+                ad_order[cid] = [x for _, x in sorted(zip(-s, p))]
+        hold_gold = {c: gold_by_case[c] for c in hold}
+        hold_grades = {c: grades_by_case[c] for c in hold}
+        results["adapter_holdout"] = metrics_for(ad_order, hold_gold, hold_grades, cats)
+        results["adapter_holdout"]["holdout_cases"] = len(hold)
+        # Baselines restricted to the SAME holdout so the comparison is fair.
+        results["baseline_holdout"] = metrics_for(
+            {c: pools[c] for c in hold}, hold_gold, hold_grades, cats
+        )
+        print("adapter(holdout) ", json.dumps({k: round(v, 4) for k, v in results["adapter_holdout"].items() if isinstance(v, float)}), flush=True)
+        print("baseline(holdout)", json.dumps({k: round(v, 4) for k, v in results["baseline_holdout"].items() if isinstance(v, float)}), flush=True)
+
+    if "baseline" in arms and "oracle" in arms and "ce" in arms:
+        b = results["baseline"]["recall@10"]
+        o = results["oracle"]["recall@10"]
+        c = results["ce"]["recall@10"]
+        if o > b:
+            results["ce"]["headroom_captured"] = (c - b) / (o - b)
+            print(f"ce captured {100.0 * (c - b) / (o - b):.1f}% of the oracle headroom ({b:.4f} -> {c:.4f}, ceiling {o:.4f})", flush=True)
+
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump(results, f, indent=2)
+        print(f"wrote {args.out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -293,6 +293,14 @@ struct Args {
     #[arg(long)]
     longmemeval_limit: Option<usize>,
 
+    /// LongMemEval shard start: skip this many manifest questions before
+    /// applying `--longmemeval-limit`. Each question carries its own ~490-turn
+    /// haystack, so a full run cannot fit a single job's timeout; disjoint
+    /// (offset, limit) windows let parallel jobs cover the suite exactly once.
+    /// The manifest order is deterministic, so the windows are stable.
+    #[arg(long)]
+    longmemeval_offset: Option<usize>,
+
     /// Simulated edge age in days, applied AFTER ingest and BEFORE queries
     /// (decay study). When `> 0`, the harness ages the knowledge-graph edges via
     /// `simulate_edge_aging` at the production ~6h cadence, so recall quality is
@@ -420,11 +428,16 @@ fn run(args: &Args) -> Result<i32> {
         let report = shodh_memory::recall_harness::runner::run_longmemeval(
             lme_dir,
             &storage_path,
+            args.longmemeval_offset,
             args.longmemeval_limit,
             10,
             &layer_modes,
         )
         .context("LongMemEval run")?;
+        // Write the report so a sharded run can be recombined. Previously this
+        // path printed only, and `--output` was passed a file the run ignored.
+        std::fs::write(&args.output, serde_json::to_string_pretty(&report)?)
+            .with_context(|| format!("writing {}", args.output.display()))?;
         println!(
             "LongMemEval-S: {} questions (NER={}) — recall@{} = {:.4} — p@1 = {:.4}",
             report.questions, report.ner_backend, report.k, report.recall_at_k, report.p_at_1

--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -1098,8 +1098,14 @@ fn summarise(report: &Report) {
     for name in mode_order {
         if let Some(layer) = report.layers.get(name) {
             eprintln!(
-                "  {:<12} ndcg@10={:.4} recall@10={:.4} mrr={:.4} p@1={:.4} map={:.4}",
-                name, layer.ndcg_at_10, layer.recall_at_10, layer.mrr, layer.p_at_1, layer.map
+                "  {:<12} ndcg@10={:.4} recall@10={:.4} hit@10={:.4} mrr={:.4} p@1={:.4} map={:.4}",
+                name,
+                layer.ndcg_at_10,
+                layer.recall_at_10,
+                layer.hit_at_10,
+                layer.mrr,
+                layer.p_at_1,
+                layer.map
             );
         }
     }

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -3691,6 +3691,7 @@ impl MultiUserMemoryManager {
                 if rep_i.as_ref().is_some_and(|r| r.degree > hub_max)
                     || rep_j.as_ref().is_some_and(|r| r.degree > hub_max)
                 {
+                    crate::metrics::HUB_SATURATION_EDGE_SKIP_TOTAL.inc();
                     tracing::debug!(
                         "Skipping edge '{}'-'{}': hub saturated (degrees: {:?}, {:?})",
                         entity_uuids[i].0,

--- a/src/integrations/mod.rs
+++ b/src/integrations/mod.rs
@@ -13,11 +13,17 @@ pub use linear::{LinearSyncRequest, LinearSyncResponse, LinearWebhook, LinearWeb
 /// Resolve an integration API URL from an environment override.
 ///
 /// If `env_var` is unset/empty, returns `default_url`. If it is set to an
-/// insecure `http://` URL pointing at a non-localhost host, credentials would
-/// travel in cleartext: when `SHODH_ENFORCE_HTTPS` is enabled the override is
-/// rejected and the secure default is used instead; otherwise it is used as-is
-/// with a warning. This is a flag-gated enforcement, not a blanket http ban —
-/// localhost http (proxies, test servers) is always allowed.
+/// insecure `http://` URL pointing at a non-localhost host, the API token would
+/// travel in cleartext, so the override is REJECTED and the secure default is
+/// used instead.
+///
+/// Enforcement is the DEFAULT; `SHODH_ENFORCE_HTTPS=false` is the opt-out. It
+/// previously defaulted to OFF, which inverted secure-by-default: a plain
+/// `http://` override was honoured with only a warning, and a warning does not
+/// stop a token being sent in cleartext. Anyone who genuinely needs a plaintext
+/// remote endpoint now has to say so explicitly.
+///
+/// Not a blanket http ban — localhost http (proxies, test servers) stays allowed.
 pub(crate) fn resolve_api_url_override(env_var: &str, default_url: &str) -> String {
     let override_url = match std::env::var(env_var) {
         Ok(u) if !u.trim().is_empty() => u.trim().to_string(),
@@ -25,17 +31,18 @@ pub(crate) fn resolve_api_url_override(env_var: &str, default_url: &str) -> Stri
     };
 
     if is_insecure_remote_url(&override_url) {
+        // Secure by default; `SHODH_ENFORCE_HTTPS=false` (or `0`) opts out.
         let enforce_https = std::env::var("SHODH_ENFORCE_HTTPS")
             .map(|v| {
-                let v = v.to_lowercase();
-                v == "true" || v == "1"
+                let v = v.trim().to_lowercase();
+                !(v == "false" || v == "0")
             })
-            .unwrap_or(false);
+            .unwrap_or(true);
 
         if enforce_https {
             tracing::error!(
                 "{env_var} points at an insecure http:// non-localhost URL and \
-                 SHODH_ENFORCE_HTTPS is enabled — ignoring the override and using \
+                 SHODH_ENFORCE_HTTPS is not disabled — ignoring the override and using \
                  the secure default ({default_url})."
             );
             return default_url.to_string();
@@ -43,8 +50,8 @@ pub(crate) fn resolve_api_url_override(env_var: &str, default_url: &str) -> Stri
 
         tracing::warn!(
             "{env_var} uses an insecure http:// URL for a non-localhost host — \
-             the API token will be transmitted in cleartext. Use https:// or set \
-             SHODH_ENFORCE_HTTPS=true to reject insecure overrides."
+             the API token would be transmitted in cleartext. Use https://, or set \
+             SHODH_ENFORCE_HTTPS=false to allow it anyway."
         );
     }
 
@@ -79,5 +86,95 @@ mod tests {
         assert!(!is_insecure_remote_url("http://127.1.2.3"));
         // https is always fine
         assert!(!is_insecure_remote_url("https://api.linear.app/graphql"));
+    }
+}
+
+#[cfg(test)]
+mod https_default_tests {
+    use super::resolve_api_url_override;
+
+    /// `SHODH_ENFORCE_HTTPS` and the override var are process-global.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    const DEFAULT_URL: &str = "https://api.example.com/v1";
+    const VAR: &str = "SHODH_TEST_INTEGRATION_URL";
+
+    fn run<T>(enforce: Option<&str>, override_url: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        match enforce {
+            Some(v) => std::env::set_var("SHODH_ENFORCE_HTTPS", v),
+            None => std::env::remove_var("SHODH_ENFORCE_HTTPS"),
+        }
+        match override_url {
+            Some(v) => std::env::set_var(VAR, v),
+            None => std::env::remove_var(VAR),
+        }
+        let out = f();
+        std::env::remove_var("SHODH_ENFORCE_HTTPS");
+        std::env::remove_var(VAR);
+        out
+    }
+
+    #[test]
+    fn insecure_remote_override_is_rejected_by_default() {
+        // The regression this default was flipped to prevent: with enforcement
+        // off, this returned the http:// URL and the API token went in cleartext.
+        let got = run(None, Some("http://evil.example.com/v1"), || {
+            resolve_api_url_override(VAR, DEFAULT_URL)
+        });
+        assert_eq!(
+            got, DEFAULT_URL,
+            "insecure remote override must not be honoured by default"
+        );
+    }
+
+    #[test]
+    fn explicit_opt_out_allows_the_insecure_override() {
+        for v in ["false", "0", "FALSE", " false "] {
+            let got = run(
+                Some(v),
+                Some("http://legacy.internal.example.com/v1"),
+                || resolve_api_url_override(VAR, DEFAULT_URL),
+            );
+            assert_eq!(
+                got, "http://legacy.internal.example.com/v1",
+                "opt-out value {v:?} ignored"
+            );
+        }
+    }
+
+    #[test]
+    fn any_other_value_still_enforces() {
+        // Only an explicit false/0 disables it; a typo must fail SAFE.
+        for v in ["true", "1", "yes", "nope", ""] {
+            let got = run(Some(v), Some("http://evil.example.com/v1"), || {
+                resolve_api_url_override(VAR, DEFAULT_URL)
+            });
+            assert_eq!(got, DEFAULT_URL, "value {v:?} must not disable enforcement");
+        }
+    }
+
+    #[test]
+    fn localhost_http_is_always_allowed() {
+        for url in ["http://localhost:8787/v1", "http://127.0.0.1:3000/v1"] {
+            let got = run(None, Some(url), || {
+                resolve_api_url_override(VAR, DEFAULT_URL)
+            });
+            assert_eq!(
+                got, url,
+                "localhost http must stay usable for proxies and test servers"
+            );
+        }
+    }
+
+    #[test]
+    fn https_override_passes_through_and_unset_yields_the_default() {
+        let got = run(None, Some("https://custom.example.com/v1"), || {
+            resolve_api_url_override(VAR, DEFAULT_URL)
+        });
+        assert_eq!(got, "https://custom.example.com/v1");
+
+        let got = run(None, None, || resolve_api_url_override(VAR, DEFAULT_URL));
+        assert_eq!(got, DEFAULT_URL);
     }
 }

--- a/src/memory/ablation.rs
+++ b/src/memory/ablation.rs
@@ -1,0 +1,245 @@
+//! Single source of truth for retrieval-time ablation families.
+//!
+//! Every ablatable retrieval component names a FAMILY here and asks
+//! [`is_enabled`]. One env var, one list, one place to look.
+//!
+//! Before this module there were two idioms and a gap. The semantic leg's boost
+//! stack had an 18-family kill-switch parsed inline inside
+//! `semantic_retrieve_inner`, while the graph leg's own scoring components —
+//! lateral inhibition and Hebbian potentiation — had NO gate at all and could
+//! therefore never be ablated. A component that cannot be switched off cannot be
+//! measured, and an unmeasurable component accumulates in the pipeline on the
+//! strength of its rationale rather than its effect. Both are now families like
+//! any other.
+//!
+//! `SHODH_DISABLE_BOOSTS=<family,...>` disables the named families for the
+//! process. The token `all` disables every family. Setting the variable at all —
+//! even to the empty string — REPLACES [`DEFAULT_DISABLED`] rather than adding
+//! to it, which is the escape hatch for running with nothing disabled.
+
+use std::collections::HashSet;
+
+/// Every ablatable retrieval component, by family name.
+///
+/// Semantic leg (`memory/mod.rs`, Layers 4.45 through 5.7): `attribute` through
+/// `competition`.
+///
+/// Graph leg (`memory/graph_retrieval.rs`):
+/// * `lateral_inhibition` — Step 6.5 winner-take-all, penalising a candidate
+///   within `GRAPH_LATERAL_INHIBITION_THRESHOLD` cosine of a higher-ranked one.
+/// * `graph_potentiation` — retrieval-driven edge strengthening
+///   (`batch_strengthen_synapses`). Distinct from the `hebbian` family, which is
+///   the semantic leg's L5 RANK boost; this is the WRITE that feeds
+///   `ppr_edge_weight`. Also distinct from `SHODH_RECALL_READONLY`, which
+///   suppresses it for measurement integrity — this family ablates the mechanism
+///   while leaving other recall-path writes alone, so the two can be separated.
+///
+/// Adding a name here is what makes a component measurable; adding one without a
+/// matching [`is_enabled`] call at the component's site makes the family a lie,
+/// so the two changes belong in the same commit.
+pub const FAMILIES: [&str; 20] = [
+    "attribute",
+    "temporal_prefilter",
+    "temporal_fact",
+    "interference",
+    "prospective",
+    "fact_source",
+    "ontological",
+    "hebbian",
+    "recency",
+    "arousal",
+    "credibility",
+    "temporal_match",
+    "feedback",
+    "importance",
+    "tag_penalty",
+    "quality",
+    "linguistic",
+    "competition",
+    "lateral_inhibition",
+    "graph_potentiation",
+];
+
+/// Families disabled when `SHODH_DISABLE_BOOSTS` is unset.
+///
+/// `hebbian` — the semantic leg's L5 rank boost — is off by default because the
+/// L5 bisect (run 27251798933) measured it as a strict ordering saboteur: p@1
+/// 0.4100 -> 0.4767 (+6.7pp) with recall@10 bit-identical. Its scores come from
+/// graph co-activation, and edges strengthen on EVERY retrieval rather than on
+/// outcome, so frequently co-retrieved hub memories climb within the top-10 and
+/// displace gold at rank 1.
+pub const DEFAULT_DISABLED: [&str; 1] = ["hebbian"];
+
+/// Resolve the disabled-family set from the environment.
+///
+/// Unknown tokens are warned about and ignored, so a typo degrades to "nothing
+/// extra disabled" rather than appearing to ablate a family that does not exist
+/// and reporting the resulting null as a measurement.
+pub fn disabled_families() -> HashSet<String> {
+    let set: HashSet<String> = match std::env::var("SHODH_DISABLE_BOOSTS") {
+        Ok(v) => v
+            .split(',')
+            .map(|t| t.trim().to_ascii_lowercase())
+            .filter(|t| !t.is_empty())
+            .collect(),
+        Err(_) => DEFAULT_DISABLED.iter().map(|s| s.to_string()).collect(),
+    };
+    for tok in &set {
+        if tok != "all" && !FAMILIES.contains(&tok.as_str()) {
+            tracing::warn!("SHODH_DISABLE_BOOSTS: unknown ablation family '{tok}' (ignored)");
+        }
+    }
+    set
+}
+
+/// Whether `family` is currently ablated.
+pub fn is_disabled(family: &str) -> bool {
+    debug_assert!(
+        FAMILIES.contains(&family),
+        "ablation family is not declared in ablation::FAMILIES"
+    );
+    let disabled = disabled_families();
+    disabled.contains("all") || disabled.contains(family)
+}
+
+/// Whether `family` should run. The form call sites read most naturally.
+pub fn is_enabled(family: &str) -> bool {
+    !is_disabled(family)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serialises tests that mutate `SHODH_DISABLE_BOOSTS`, which is
+    /// process-global state.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        match value {
+            Some(v) => std::env::set_var("SHODH_DISABLE_BOOSTS", v),
+            None => std::env::remove_var("SHODH_DISABLE_BOOSTS"),
+        }
+        let out = f();
+        std::env::remove_var("SHODH_DISABLE_BOOSTS");
+        out
+    }
+
+    #[test]
+    fn family_list_has_no_duplicates() {
+        let unique: HashSet<&str> = FAMILIES.iter().copied().collect();
+        assert_eq!(unique.len(), FAMILIES.len(), "duplicate family in FAMILIES");
+    }
+
+    #[test]
+    fn every_default_disabled_family_is_declared() {
+        for f in DEFAULT_DISABLED {
+            assert!(
+                FAMILIES.contains(&f),
+                "default-disabled family is undeclared"
+            );
+        }
+    }
+
+    #[test]
+    fn unset_env_disables_exactly_the_documented_default() {
+        with_env(None, || {
+            assert!(
+                is_disabled("hebbian"),
+                "L5 rank boost must stay off by default"
+            );
+            for f in FAMILIES.iter().filter(|f| !DEFAULT_DISABLED.contains(f)) {
+                assert!(
+                    is_enabled(f),
+                    "family must be enabled when env is unset: {f}"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn the_graph_leg_families_ship_enabled() {
+        // Both were ungated before this module existed. Declaring them must not
+        // change shipped behaviour, only make it measurable.
+        with_env(None, || {
+            assert!(is_enabled("lateral_inhibition"));
+            assert!(is_enabled("graph_potentiation"));
+        });
+    }
+
+    #[test]
+    fn graph_potentiation_is_not_collateral_of_the_hebbian_default() {
+        // `hebbian` (semantic L5 rank boost) is default-disabled. The graph-leg
+        // WRITE is a different mechanism and must not switch off alongside it.
+        with_env(None, || {
+            assert!(is_disabled("hebbian"));
+            assert!(is_enabled("graph_potentiation"));
+        });
+    }
+
+    #[test]
+    fn explicit_empty_value_replaces_the_default_rather_than_adding_to_it() {
+        with_env(Some(""), || {
+            assert!(
+                is_enabled("hebbian"),
+                "explicit empty must clear the default"
+            );
+        });
+    }
+
+    #[test]
+    fn all_disables_every_declared_family() {
+        with_env(Some("all"), || {
+            for f in FAMILIES {
+                assert!(is_disabled(f), "family survived 'all': {f}");
+                // Assert through `is_enabled` too: that is the form call sites
+                // use, and an `is_enabled` that can never return false would
+                // leave every gate permanently open while `is_disabled` stayed
+                // correct. Mutation-checked - without this the suite passes with
+                // `is_enabled` hardcoded to true.
+                assert!(!is_enabled(f), "is_enabled disagreed with is_disabled: {f}");
+            }
+        });
+    }
+
+    #[test]
+    fn is_enabled_is_the_exact_negation_of_is_disabled() {
+        for env in [
+            None,
+            Some(""),
+            Some("all"),
+            Some("lateral_inhibition,quality"),
+        ] {
+            with_env(env, || {
+                for f in FAMILIES {
+                    assert_ne!(
+                        is_enabled(f),
+                        is_disabled(f),
+                        "is_enabled/is_disabled agreed for {f}"
+                    );
+                }
+            });
+        }
+    }
+
+    #[test]
+    fn named_families_are_disabled_and_others_untouched() {
+        with_env(Some("lateral_inhibition, quality"), || {
+            assert!(is_disabled("lateral_inhibition"));
+            assert!(!is_enabled("lateral_inhibition"));
+            assert!(is_disabled("quality"));
+            assert!(is_enabled("graph_potentiation"));
+            assert!(is_enabled("recency"));
+        });
+    }
+
+    #[test]
+    fn unknown_token_does_not_disable_anything_real() {
+        with_env(Some("latteral_inhibition"), || {
+            for f in FAMILIES {
+                assert!(is_enabled(f), "typo disabled a real family: {f}");
+            }
+        });
+    }
+}

--- a/src/memory/ablation.rs
+++ b/src/memory/ablation.rs
@@ -27,6 +27,12 @@ use std::collections::HashSet;
 /// Graph leg (`memory/graph_retrieval.rs`):
 /// * `lateral_inhibition` — Step 6.5 winner-take-all, penalising a candidate
 ///   within `GRAPH_LATERAL_INHIBITION_THRESHOLD` cosine of a higher-ranked one.
+/// * `quality_verbosity` — the raw content-LENGTH factor inside the Layer-5
+///   quality gate, `(len/200).min(1.0)`, which multiplies a short correct answer
+///   (a person name) below a longer wrong one (an org name). Disabling the family
+///   keeps only the structural `elaboration` term. Previously reachable only via
+///   `SHODH_FUSION_V2`, which also switched fusion to weighted-Borda, so the
+///   verbosity factor could never be measured on its own.
 /// * `graph_potentiation` — retrieval-driven edge strengthening
 ///   (`batch_strengthen_synapses`). Distinct from the `hebbian` family, which is
 ///   the semantic leg's L5 RANK boost; this is the WRITE that feeds
@@ -37,7 +43,7 @@ use std::collections::HashSet;
 /// Adding a name here is what makes a component measurable; adding one without a
 /// matching [`is_enabled`] call at the component's site makes the family a lie,
 /// so the two changes belong in the same commit.
-pub const FAMILIES: [&str; 20] = [
+pub const FAMILIES: [&str; 21] = [
     "attribute",
     "temporal_prefilter",
     "temporal_fact",
@@ -58,6 +64,7 @@ pub const FAMILIES: [&str; 20] = [
     "competition",
     "lateral_inhibition",
     "graph_potentiation",
+    "quality_verbosity",
 ];
 
 /// Families disabled when `SHODH_DISABLE_BOOSTS` is unset.
@@ -159,12 +166,15 @@ mod tests {
     }
 
     #[test]
-    fn the_graph_leg_families_ship_enabled() {
-        // Both were ungated before this module existed. Declaring them must not
-        // change shipped behaviour, only make it measurable.
+    fn newly_declared_families_ship_enabled() {
+        // All three were ungated or unreachable before this module existed.
+        // Declaring them must not change shipped behaviour, only make it
+        // measurable - `quality_verbosity` in particular is a KNOWN-HARMFUL
+        // factor that stays on until its removal is measured on its own.
         with_env(None, || {
             assert!(is_enabled("lateral_inhibition"));
             assert!(is_enabled("graph_potentiation"));
+            assert!(is_enabled("quality_verbosity"));
         });
     }
 

--- a/src/memory/ablation.rs
+++ b/src/memory/ablation.rs
@@ -40,10 +40,21 @@ use std::collections::HashSet;
 ///   suppresses it for measurement integrity — this family ablates the mechanism
 ///   while leaving other recall-path writes alone, so the two can be separated.
 ///
+/// * `linguistic_resort` — whether the linguistic signal is applied as a SEPARATE
+///   sort-only re-rank (enabled, current) or folded additively into the single
+///   `.score` (disabled). Composes with the `linguistic` family, which controls
+///   whether the signal applies at all. This one selects between two FORMS rather
+///   than deleting a component; the alternative was a second config idiom, and one
+///   documented mechanism beats two clean ones.
+/// * `size_gated_final_sort` — the SIZE GATE on the final re-sort. Enabled
+///   (current) means the sort runs only when `len > max_results`, so result-set
+///   size decides whether the lexical re-rank or `.score` wins the final order.
+///   Disabling removes the gate and always sorts by score.
+///
 /// Adding a name here is what makes a component measurable; adding one without a
 /// matching [`is_enabled`] call at the component's site makes the family a lie,
 /// so the two changes belong in the same commit.
-pub const FAMILIES: [&str; 21] = [
+pub const FAMILIES: [&str; 23] = [
     "attribute",
     "temporal_prefilter",
     "temporal_fact",
@@ -65,6 +76,8 @@ pub const FAMILIES: [&str; 21] = [
     "lateral_inhibition",
     "graph_potentiation",
     "quality_verbosity",
+    "linguistic_resort",
+    "size_gated_final_sort",
 ];
 
 /// Families disabled when `SHODH_DISABLE_BOOSTS` is unset.

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -1935,7 +1935,10 @@ pub fn spreading_activation_retrieve_with_stats(
 
     // Step 6.5: Lateral inhibition — high-scoring memories suppress similar competitors
     // Mimics cortical winner-take-all dynamics (Rumelhart & Zipser 1985)
-    if scored_memories.len() > 1 {
+    // Ablatable as the `lateral_inhibition` family (see `memory::ablation`).
+    // This ran unconditionally with no gate anywhere in the repo, so its effect
+    // had never been measured in either direction.
+    if scored_memories.len() > 1 && crate::memory::ablation::is_enabled("lateral_inhibition") {
         let penalties = calculate_lateral_inhibition(&scored_memories);
         for (i, penalty) in penalties.iter().enumerate() {
             scored_memories[i].final_score -= penalty;
@@ -1979,7 +1982,15 @@ pub fn spreading_activation_retrieve_with_stats(
     // coactivation writes in mod.rs do — the traversed-edge STATS are still
     // collected above (`stats.traversed_edges`) so diagnostics are unaffected,
     // only the persistent strength MUTATION is skipped.
-    if !stats.traversed_edges.is_empty() && !recall_readonly() {
+    // Two independent suppressors, deliberately separate: `recall_readonly()` is
+    // measurement integrity (no recall-path writes during an eval), while the
+    // `graph_potentiation` family ablates THIS mechanism alone. Keeping them
+    // apart is what allows the potentiation write to be measured against a live
+    // run rather than only against a frozen one.
+    if !stats.traversed_edges.is_empty()
+        && !recall_readonly()
+        && crate::memory::ablation::is_enabled("graph_potentiation")
+    {
         if let Err(e) = graph.batch_strengthen_synapses(&stats.traversed_edges) {
             tracing::debug!("Spreading activation edge strengthening failed: {}", e);
         }

--- a/src/memory/graph_retrieval.rs
+++ b/src/memory/graph_retrieval.rs
@@ -1184,6 +1184,29 @@ pub fn spreading_activation_retrieve_with_stats(
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
 
+    // TRUE GRAPH ISOLATION (`SHODH_GRAPH_PURE=1`, diagnostic, default off).
+    //
+    // `SHODH_LEG=graph` isolates the graph's CANDIDATE SET but not its SCORING.
+    // Every graph-reached candidate still gets a `cosine_similarity(query, memory)`
+    // (see the `semantic_score` below), and `fuse_hybrid_score` weights it by
+    // `semantic_weight / sum`. With `graph_weight` pinned at its 0.1 floor on any
+    // corpus whose seed entities average more than 2 edges, that makes the "graph
+    // leg" roughly 75% embedding cosine, 15% linguistic and 10% graph activation.
+    // So every graph-internal lever measured through `SHODH_LEG=graph` could move
+    // at most a tenth of the score, and the vector model was doing the ranking.
+    //
+    // `SHODH_GRAPH_PURE=1` sets the weights to (semantic 0, graph 1, linguistic 0)
+    // so the leg is ranked by graph activation ALONE. This is what "does the
+    // knowledge graph work on its own" actually requires, and it is not reachable
+    // via `SHODH_GRAPH_W_FLOOR`, which clamps at `1.0 - linguistic - 0.05`.
+    //
+    // Diagnostic only: it is not a proposed default, and the floor sweep already
+    // showed that shifting weight toward the graph costs ranking quality
+    // (ndcg 0.4577 -> 0.4481, p@1 0.3638 -> 0.3468 at graph_w ~0.8).
+    let graph_pure = std::env::var("SHODH_GRAPH_PURE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
     // Determine weights based on density
     let (semantic_weight, graph_weight, linguistic_weight) = if let Some(density) = graph_density {
         stats.mode = "associative".to_string();
@@ -1197,6 +1220,13 @@ pub fn spreading_activation_retrieve_with_stats(
             HYBRID_GRAPH_WEIGHT,
             HYBRID_LINGUISTIC_WEIGHT,
         )
+    };
+    // Applied AFTER the density branch so it overrides both paths.
+    let (semantic_weight, graph_weight, linguistic_weight) = if graph_pure {
+        stats.mode = "graph_pure".to_string();
+        (0.0, 1.0, 0.0)
+    } else {
+        (semantic_weight, graph_weight, linguistic_weight)
     };
 
     stats.semantic_weight = semantic_weight;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -2555,8 +2555,23 @@ impl MemorySystem {
                 } else {
                     g.entities_average_density(&seed_uuids).ok().flatten()
                 };
-                let use_rerank =
-                    !density.is_some_and(|d| d >= crate::constants::ONTOLOGICAL_DENSITY_THRESHOLD);
+                // The ontological re-rank is disabled above a seed-density
+                // threshold, on the theory that a hub-dense neighbourhood makes
+                // type filtering noisy. On this corpus that theory silently
+                // disables the layer: `ONTOLOGICAL_DENSITY_THRESHOLD` is 8.0 and
+                // mean seed-entity degree is 7.7, with hubs to 301 — so whether
+                // the ontology runs is decided by hub structure rather than by
+                // anything ontological, and the E5 diagnostic measures its
+                // contribution as exactly +0.0000.
+                //
+                // `SHODH_ONTOLOGY_DENSITY_MAX` overrides the threshold so the
+                // layer can be measured at all; `inf` disables the gate entirely
+                // and lets the re-rank always run. Unset = shipped behaviour.
+                let density_max = std::env::var("SHODH_ONTOLOGY_DENSITY_MAX")
+                    .ok()
+                    .and_then(|v| v.trim().parse::<f32>().ok())
+                    .unwrap_or(crate::constants::ONTOLOGICAL_DENSITY_THRESHOLD);
+                let use_rerank = !density.is_some_and(|d| d >= density_max);
                 (density, use_rerank)
             } else {
                 (None, false)
@@ -2569,9 +2584,13 @@ impl MemorySystem {
         {
             crate::metrics::ONTOLOGICAL_FALLBACK_TOTAL.inc();
         }
-        if graph_density_for_rerank
-            .is_some_and(|d| d >= crate::constants::ONTOLOGICAL_DENSITY_THRESHOLD)
-        {
+        // Count skips against the EFFECTIVE threshold, not the constant, so the
+        // counter still reports honestly when the override is in use.
+        let effective_density_max = std::env::var("SHODH_ONTOLOGY_DENSITY_MAX")
+            .ok()
+            .and_then(|v| v.trim().parse::<f32>().ok())
+            .unwrap_or(crate::constants::ONTOLOGICAL_DENSITY_THRESHOLD);
+        if graph_density_for_rerank.is_some_and(|d| d >= effective_density_max) {
             crate::metrics::ONTOLOGICAL_DENSITY_SKIP_TOTAL.inc();
         }
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -6,6 +6,7 @@
 //! - Multi-modal retrieval (similarity, temporal, causal)
 //! - Automatic memory consolidation
 
+pub mod ablation;
 pub mod compression;
 pub mod context;
 pub mod facts;
@@ -3632,60 +3633,12 @@ impl MemorySystem {
 
         // ===========================================================================
         // LAYER 4: BM25 + RRF FUSION
-        // SHODH_DISABLE_BOOSTS=<family,...> — ablation kill-switch for the post-fusion
-        // boost stack. Each token disables one boost family at recall time so its
-        // marginal contribution can be measured against the calibrated FLAT baseline
-        // (the stack predates calibrated fusion and was never ablated against it).
-        // Layer 4.45-4.9 families: attribute, temporal_prefilter, temporal_fact,
-        // interference, prospective, fact_source, ontological. Layer 5-5.7 families:
-        // hebbian, recency, arousal, credibility, temporal_match, feedback, importance,
-        // tag_penalty, quality, linguistic, competition. "all" disables every family.
-        // Default unset → all boosts active (shipped behavior unchanged).
-        const BOOST_FAMILIES: [&str; 18] = [
-            "attribute",
-            "temporal_prefilter",
-            "temporal_fact",
-            "interference",
-            "prospective",
-            "fact_source",
-            "ontological",
-            "hebbian",
-            "recency",
-            "arousal",
-            "credibility",
-            "temporal_match",
-            "feedback",
-            "importance",
-            "tag_penalty",
-            "quality",
-            "linguistic",
-            "competition",
-        ];
-        // DEFAULT: the Layer-5 hebbian RANK BOOST is disabled. The L5 bisect (run
-        // 27251798933) measured it as a strict ordering saboteur: disabling only
-        // hebbian lifted p@1 ALL 0.4100→0.4767 (+6.7pp), single_hop +11pp,
-        // open_domain 2x, multi_hop up, temporal HELD, MRR +0.042 — with recall@10
-        // bit-identical (L5 is post-truncation). Mechanism: heb scores come from
-        // graph co-activation and edges strengthen on EVERY retrieval (not on
-        // outcome), so frequently co-retrieved hub memories climb within the
-        // top-10 and displace gold at rank 1 — retrieval-gated rich-get-richer.
-        // Hebbian LEARNING (edge strengthening, spreading activation) is untouched;
-        // only the L5 score multiplier is off. Setting SHODH_DISABLE_BOOSTS
-        // explicitly (even to "") replaces this default — the escape hatch.
-        let disabled_boosts: std::collections::HashSet<String> =
-            std::env::var("SHODH_DISABLE_BOOSTS")
-                .map(|v| {
-                    v.split(',')
-                        .map(|t| t.trim().to_ascii_lowercase())
-                        .filter(|t| !t.is_empty())
-                        .collect()
-                })
-                .unwrap_or_else(|_| std::iter::once("hebbian".to_string()).collect());
-        for tok in &disabled_boosts {
-            if tok != "all" && !BOOST_FAMILIES.contains(&tok.as_str()) {
-                tracing::warn!("SHODH_DISABLE_BOOSTS: unknown boost family '{tok}' (ignored)");
-            }
-        }
+        // Ablation kill-switch. The family list, the default-disabled set, the
+        // parsing and the unknown-token warning all live in `memory::ablation`,
+        // which is the single source of truth shared with the graph leg — see
+        // that module for `SHODH_DISABLE_BOOSTS` semantics and for why `hebbian`
+        // is disabled by default.
+        let disabled_boosts = crate::memory::ablation::disabled_families();
         let boost_on = |family: &str| -> bool {
             !(disabled_boosts.contains("all") || disabled_boosts.contains(family))
         };

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -5356,10 +5356,11 @@ impl MemorySystem {
         // Linguistic analysis: additive boost (5% of IC weight), not a full re-sort
         // RH-8 gate: linguistic re-sort only runs in `Full` mode.
         if layer_full && boost_linguistic && !query_analysis.focal_entities.is_empty() {
-            let v2_single = std::env::var("SHODH_FUSION_V2")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
-            if v2_single {
+            // `linguistic_resort` ENABLED (current) = separate sort-only re-rank,
+            // which the final sort silently discards when len <= max_results.
+            // DISABLED = fold the signal into the single `.score` instead. Parked
+            // behind SHODH_FUSION_V2 until now, so it could never be attributed.
+            if !crate::memory::ablation::is_enabled("linguistic_resort") {
                 // Conscious restructure: FOLD the linguistic signal into the single
                 // .score (additive) instead of a separate sort-only re-rank that the
                 // final sort silently discards when len>max. One score, one sort.
@@ -5611,10 +5612,12 @@ impl MemorySystem {
         // linguistic signal is already folded into .score above — so sort by .score
         // UNCONDITIONALLY, not only when len>max. That branch is what let result-set
         // SIZE decide whether the lexical re-sort or .score won the final order.
-        let v2_single_sort = std::env::var("SHODH_FUSION_V2")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
-        if v2_single_sort || memories.len() > query.max_results {
+        // `size_gated_final_sort` ENABLED (current) means this sort runs ONLY when
+        // the result set is larger than the window - so result-set SIZE decides
+        // whether the preceding lexical re-rank or `.score` wins the final order.
+        // Disabling removes the gate and always sorts by score.
+        let size_gated = crate::memory::ablation::is_enabled("size_gated_final_sort");
+        if !size_gated || memories.len() > query.max_results {
             // Score desc → recency desc → MemoryId asc — deterministic competition cutoff.
             // Quantize the score to 1e-6 before comparing: fused scores are accumulated
             // by `+=` over a HashMap in non-deterministic iteration order, so f32

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -5317,24 +5317,24 @@ impl MemorySystem {
         // RH-8 gate: quality multiplier only applies in `Full` mode — lower modes
         // expose the raw fused score so per-layer attribution isn't masked.
         if layer_full && boost_quality {
-            let v2_no_verbosity = std::env::var("SHODH_FUSION_V2")
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
             for mem in &mut memories {
                 let has_entities = !mem.experience.entities.is_empty();
                 let has_context = mem.experience.context.is_some();
                 let elaboration = 1.0
                     + if has_entities { 0.1 } else { 0.0 }
                     + if has_context { 0.1 } else { 0.0 };
-                let quality = if v2_no_verbosity {
-                    // Conscious restructure: drop the raw content-length factor — a
-                    // verbosity bias that multiplied short correct answers (a person
-                    // name) down below longer ones (org names), crashing ontology
-                    // 0.88→0.083 at `full`. Keep only the structural elaboration.
-                    elaboration
-                } else {
+                // The raw content-LENGTH factor is a verbosity bias: it multiplies a
+                // short correct answer (a person name) below a longer wrong one (an
+                // org name), and was measured crashing ontology 0.88→0.083 at
+                // `full`. Dropping it was reachable only via SHODH_FUSION_V2, which
+                // ALSO switched fusion to weighted-Borda — so the factor could never
+                // be measured on its own. It is now the `quality_verbosity` ablation
+                // family, default ENABLED (shipped behaviour unchanged).
+                let quality = if crate::memory::ablation::is_enabled("quality_verbosity") {
                     let content_len = mem.experience.content.len() as f32;
                     (content_len / 200.0).min(1.0) * elaboration
+                } else {
+                    elaboration
                 };
                 let quality_factor = quality.max(crate::constants::ELABORATION_QUALITY_MIN);
                 if let Some(score) = mem.score {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -202,6 +202,29 @@ pub static ONTOLOGICAL_DENSITY_SKIP_TOTAL: LazyLock<IntCounter> = LazyLock::new(
     .expect("ONTOLOGICAL_DENSITY_SKIP_TOTAL metric must be valid at compile time")
 });
 
+/// Co-occurrence edges never minted because an endpoint had already saturated
+/// `SHODH_HUB_DEGREE_MAX`.
+///
+/// The cap is a hard SKIP, not an eviction: past the threshold an entity accretes
+/// no further edges, so which associations exist is decided by ingest ARRIVAL
+/// ORDER. The condition is `||`, so one saturated endpoint kills the edge even
+/// when the other is a rare, highly discriminative entity — and rare entities are
+/// exactly the ones that arrive late. The cap therefore culls on a criterion
+/// uncorrelated with information, while the PMI-squared gate alongside it culls
+/// on precisely that criterion.
+///
+/// This counter exists because the skip was previously `tracing::debug!` only:
+/// the graph could be losing an arbitrary fraction of its associations and
+/// nothing would report it. Same blind spot that hid the Vamana index building a
+/// greedy kNN graph instead of an alpha-RNG one.
+pub static HUB_SATURATION_EDGE_SKIP_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    IntCounter::new(
+        "shodh_hub_saturation_edge_skip_total",
+        "Co-occurrence edges skipped because an endpoint exceeded SHODH_HUB_DEGREE_MAX",
+    )
+    .expect("HUB_SATURATION_EDGE_SKIP_TOTAL metric must be valid at compile time")
+});
+
 // ============================================================================
 // Embedding Metrics (P1.2: Instrument embed operations)
 // ============================================================================

--- a/src/recall_harness/metrics.rs
+++ b/src/recall_harness/metrics.rs
@@ -37,6 +37,16 @@ pub struct Metrics {
     pub mrr: f64,
     pub p_at_1: f64,
     pub map: f64,
+    /// Hit-rate at `k`: 1.0 if ANY relevant item is in the top-`k`, else 0.0.
+    ///
+    /// The lenient counterpart to [`Self::recall_at_k`], which is the FRACTION
+    /// of a case's gold that was found. With 3.13 gold per multi_hop case,
+    /// finding two of three scores 0.67 there and 1.00 here. Published
+    /// memory/RAG "recall@k" figures are usually this form, so quoting
+    /// `recall_at_k` against them understates us and quoting `hit_at_k` as if
+    /// it were full recall overstates us. Both are carried so that any
+    /// comparison has to say which one it means.
+    pub hit_at_k: f64,
 }
 
 impl Metrics {
@@ -56,6 +66,7 @@ impl Metrics {
             mrr: mrr(retrieved, &relevant),
             p_at_1: p_at_1(retrieved, &relevant),
             map: map(retrieved, &relevant),
+            hit_at_k: hit_at_k(retrieved, &relevant, k),
         }
     }
 }
@@ -88,6 +99,24 @@ pub fn recall_at_k(retrieved: &[Uuid], relevant: &HashSet<Uuid>, k: usize) -> f6
         .filter(|id| relevant.contains(id))
         .count();
     hits as f64 / relevant.len() as f64
+}
+
+/// Hit-rate at cutoff `k`: `1.0` if ANY relevant item appears in the top-`k`.
+///
+/// The lenient counterpart to [`recall_at_k`]. A case with three gold items of
+/// which one is retrieved scores `1.0` here and `0.33` there. Both are honest;
+/// they answer different questions, and most published "recall@k" numbers in
+/// this space are this one.
+pub fn hit_at_k(retrieved: &[Uuid], relevant: &HashSet<Uuid>, k: usize) -> f64 {
+    if k == 0 || retrieved.is_empty() || relevant.is_empty() {
+        return 0.0;
+    }
+    let cap = retrieved.len().min(k);
+    if retrieved[..cap].iter().any(|id| relevant.contains(id)) {
+        1.0
+    } else {
+        0.0
+    }
 }
 
 /// Mean Reciprocal Rank: `1 / rank` of the first relevant item, or `0.0` if
@@ -427,6 +456,64 @@ mod tests {
     // ---- Metrics::compute aggregator ---------------------------------------
 
     #[test]
+    #[test]
+    fn hit_at_k_is_lenient_where_recall_at_k_is_fractional() {
+        // The exact case that makes our headline number look low against
+        // published figures: three gold, one retrieved.
+        let id = ids();
+        let rel: HashSet<Uuid> = [id[0], id[1], id[2]].into_iter().collect();
+        let retrieved = vec![id[0], id[3], id[4]];
+        approx(recall_at_k(&retrieved, &rel, 3), 1.0 / 3.0);
+        approx(hit_at_k(&retrieved, &rel, 3), 1.0);
+    }
+
+    #[test]
+    fn hit_at_k_is_zero_when_nothing_relevant_is_in_the_window() {
+        let id = ids();
+        let rel: HashSet<Uuid> = [id[0]].into_iter().collect();
+        // Gold sits at rank 3, outside a k=2 window.
+        let retrieved = vec![id[3], id[4], id[0]];
+        approx(hit_at_k(&retrieved, &rel, 2), 0.0);
+        approx(hit_at_k(&retrieved, &rel, 3), 1.0);
+    }
+
+    #[test]
+    fn hit_at_k_equals_recall_at_k_when_there_is_exactly_one_gold() {
+        // single_hop averages 1.06 gold/case, so the two metrics nearly coincide
+        // there and diverge on multi_hop (3.13). That is why the headline gap is
+        // category-dependent rather than a constant offset.
+        let id = ids();
+        let rel: HashSet<Uuid> = [id[1]].into_iter().collect();
+        for retrieved in [vec![id[1], id[3]], vec![id[3], id[1]], vec![id[3], id[4]]] {
+            approx(
+                hit_at_k(&retrieved, &rel, 2),
+                recall_at_k(&retrieved, &rel, 2),
+            );
+        }
+    }
+
+    #[test]
+    fn hit_at_k_never_exceeds_one_or_falls_below_recall() {
+        // Ordering property: hit >= recall always, since hit is 1 whenever any
+        // gold is inside the window and recall is a fraction of the same set.
+        let id = ids();
+        let rel: HashSet<Uuid> = [id[0], id[1]].into_iter().collect();
+        for k in 0..6usize {
+            for retrieved in [
+                vec![],
+                vec![id[0]],
+                vec![id[3], id[0], id[1]],
+                vec![id[0], id[1]],
+            ] {
+                let h = hit_at_k(&retrieved, &rel, k);
+                let r = recall_at_k(&retrieved, &rel, k);
+                assert!((0.0..=1.0).contains(&h), "hit out of range at k={k}");
+                assert!(h >= r - 1e-12, "hit {h} < recall {r} at k={k}");
+            }
+        }
+    }
+
+    #[test]
     fn compute_returns_all_six_consistent_with_individual_fns() {
         let id = ids();
         let retrieved = vec![id[3], id[0], id[1]]; // miss, hit, hit
@@ -455,6 +542,7 @@ mod tests {
                 mrr: 0.0,
                 p_at_1: 0.0,
                 map: 0.0,
+                hit_at_k: 0.0,
             }
         );
     }

--- a/src/recall_harness/report.rs
+++ b/src/recall_harness/report.rs
@@ -229,6 +229,17 @@ pub struct AblationRow {
     /// Per-category recall@10 (category name → value), so a config that helps one
     /// capability but hurts another is visible, not hidden in the average.
     pub by_category_recall: std::collections::BTreeMap<String, f64>,
+    /// Order-sensitive fingerprint of every id this arm retrieved, across every
+    /// case. Two arms with the same fingerprint returned byte-identical results.
+    #[serde(default)]
+    pub retrieval_fingerprint: u64,
+    /// True when this arm's fingerprint equals the baseline arm's, i.e. the
+    /// config provably changed nothing and its metrics are attributable to
+    /// nothing. The `+spread-fix` arms were vacuous this way for months: the flag
+    /// they set could not reach the live code path, so the rows silently
+    /// duplicated baseline while reading as evidence.
+    #[serde(default)]
+    pub vacuous_vs_baseline: bool,
 }
 
 /// Unified ablation report: one ingest, N query-time configs, one comparison

--- a/src/recall_harness/report.rs
+++ b/src/recall_harness/report.rs
@@ -298,6 +298,16 @@ pub struct LayerReport {
     pub ndcg_at_10: f64,
     #[serde(rename = "recall@10")]
     pub recall_at_10: f64,
+    /// Hit-rate at 10: fraction of CASES with at least one gold in the top-10.
+    ///
+    /// Sits next to `recall_at_10`, which is the mean FRACTION of each case's
+    /// gold found. The two diverge sharply where gold is dense: 3.13 gold per
+    /// multi_hop case means two-of-three scores 0.67 on recall and 1.00 here,
+    /// while single_hop (1.06 gold/case) has them nearly coincide. Most published
+    /// memory/RAG "recall@k" numbers are this hit-rate form, so any external
+    /// comparison has to name which of the two it means.
+    #[serde(rename = "hit@10", default)]
+    pub hit_at_10: f64,
     #[serde(rename = "precision@10")]
     pub precision_at_10: f64,
     pub mrr: f64,
@@ -331,6 +341,16 @@ pub struct CategoryReport {
     pub ndcg_at_10: f64,
     #[serde(rename = "recall@10")]
     pub recall_at_10: f64,
+    /// Hit-rate at 10: fraction of CASES with at least one gold in the top-10.
+    ///
+    /// Sits next to `recall_at_10`, which is the mean FRACTION of each case's
+    /// gold found. The two diverge sharply where gold is dense: 3.13 gold per
+    /// multi_hop case means two-of-three scores 0.67 on recall and 1.00 here,
+    /// while single_hop (1.06 gold/case) has them nearly coincide. Most published
+    /// memory/RAG "recall@k" numbers are this hit-rate form, so any external
+    /// comparison has to name which of the two it means.
+    #[serde(rename = "hit@10", default)]
+    pub hit_at_10: f64,
     #[serde(rename = "precision@10")]
     pub precision_at_10: f64,
     pub mrr: f64,
@@ -438,6 +458,7 @@ pub fn aggregate_layer(per_case: &[Metrics], latencies_ms: &[f64]) -> LayerRepor
     LayerReport {
         ndcg_at_10: mean(|m| m.ndcg_at_k),
         recall_at_10: mean(|m| m.recall_at_k),
+        hit_at_10: mean(|m| m.hit_at_k),
         precision_at_10: mean(|m| m.precision_at_k),
         mrr: mean(|m| m.mrr),
         p_at_1: mean(|m| m.p_at_1),
@@ -465,6 +486,7 @@ pub fn aggregate_category(per_case: &[Metrics]) -> CategoryReport {
     CategoryReport {
         ndcg_at_10: mean(|m| m.ndcg_at_k),
         recall_at_10: mean(|m| m.recall_at_k),
+        hit_at_10: mean(|m| m.hit_at_k),
         precision_at_10: mean(|m| m.precision_at_k),
         mrr: mean(|m| m.mrr),
         p_at_1: mean(|m| m.p_at_1),
@@ -724,6 +746,7 @@ mod tests {
             mrr: values,
             p_at_1: values,
             map: values,
+            hit_at_k: values,
         }
     }
 
@@ -778,6 +801,7 @@ mod tests {
             LayerReport {
                 ndcg_at_10: ndcg,
                 recall_at_10: recall,
+                hit_at_10: recall,
                 precision_at_10: 0.2,
                 mrr,
                 p_at_1: p1,
@@ -850,6 +874,7 @@ mod tests {
         CategoryReport {
             ndcg_at_10: recall,
             recall_at_10: recall,
+            hit_at_10: recall,
             precision_at_10: recall,
             mrr: recall,
             p_at_1: p1,

--- a/src/recall_harness/report.rs
+++ b/src/recall_harness/report.rs
@@ -661,6 +661,17 @@ pub struct GraphStructure {
     pub hub_threshold: usize,
     /// Top entity degrees, descending (the hub tail).
     pub top_degrees: Vec<usize>,
+    /// Co-occurrence edges never minted because an endpoint had already
+    /// saturated `SHODH_HUB_DEGREE_MAX`.
+    ///
+    /// The cap is a hard SKIP, not an eviction, and the condition is `||`: one
+    /// saturated endpoint kills the edge even when the other is rare and highly
+    /// discriminative. So which associations exist is decided by ingest ARRIVAL
+    /// ORDER, on a criterion uncorrelated with information — while the PMI-squared
+    /// gate beside it culls on exactly that criterion. A large number here means
+    /// the graph's shape is an artefact of ingest sequence.
+    #[serde(default)]
+    pub hub_saturation_skipped_edges: u64,
 }
 
 /// Reachability tallies for one category (cumulative within-N-hops counts).

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -1105,6 +1105,11 @@ struct LongMemEvalCase {
 }
 
 /// Aggregate LongMemEval result.
+///
+/// Serialisable so that a sharded run can be recombined: every mean is carried
+/// with its own count, so shards aggregate as a count-weighted mean rather than
+/// a mean of means.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LongMemEvalReport {
     pub questions: usize,
     pub recall_at_k: f64,
@@ -1120,6 +1125,24 @@ pub struct LongMemEvalReport {
     pub layers: BTreeMap<String, (f64, usize)>,
 }
 
+/// Resolve a shard's `[start, end)` window over a manifest of `len` cases.
+///
+/// `offset` skips that many cases; `limit` bounds how many follow. Both saturate
+/// at `len`, so an out-of-range shard yields an empty window rather than
+/// panicking — with a fixed shard count and a variable question total, the tail
+/// shards are routinely out of range.
+///
+/// The correctness claim this exists to pin: for `offset = i * per` and
+/// `limit = per`, the windows are disjoint and cover `0..len` exactly once.
+fn shard_window(len: usize, offset: Option<usize>, limit: Option<usize>) -> (usize, usize) {
+    let start = offset.unwrap_or(0).min(len);
+    let end = match limit {
+        Some(n) => start.saturating_add(n).min(len),
+        None => len,
+    };
+    (start, end)
+}
+
 /// Run the LongMemEval-S suite (ICLR 2025, the current SOTA long-term memory
 /// benchmark). UNLIKE LoCoMo, each question carries its OWN ~48-session haystack
 /// (~115K tokens), so this is a LOOP of mini-evals: per question, ingest its
@@ -1133,6 +1156,7 @@ pub struct LongMemEvalReport {
 pub fn run_longmemeval(
     base_dir: &Path,
     storage_root: &Path,
+    offset: Option<usize>,
     limit: Option<usize>,
     k: usize,
     layer_modes: &[LayerMode],
@@ -1146,9 +1170,14 @@ pub fn run_longmemeval(
     for line in manifest_txt.lines().filter(|l| !l.trim().is_empty()) {
         cases.push(serde_json::from_str(line).context("parsing LongMemEval manifest line")?);
     }
-    if let Some(n) = limit {
-        cases.truncate(n);
-    }
+    // Shard selection: skip `offset` cases, then take `limit`. LongMemEval-S
+    // gives every question its OWN ~490-turn haystack, so cost is linear in
+    // questions and a full run cannot fit one job's timeout. Disjoint
+    // (offset, limit) windows let parallel jobs cover the suite exactly once.
+    // The manifest order is deterministic - the converter's `--shuffle` is a
+    // stable sort - so the windows are stable across jobs and across reruns.
+    let (start, end) = shard_window(cases.len(), offset, limit);
+    cases = cases.drain(start..end).collect();
 
     let mut sum_recall = 0.0f64;
     let mut sum_p1 = 0.0f64;
@@ -3398,6 +3427,48 @@ mod tests {
             rank(&pf, "person"),
             rank(&full, "person")
         );
+    }
+
+    #[test]
+    fn shard_windows_tile_the_manifest_exactly_once() {
+        // The property the sharded LongMemEval workflow depends on: with a fixed
+        // shard count and `per = ceil(len / shards)`, the windows are disjoint
+        // and cover every case exactly once. If this breaks, a suite total is
+        // silently computed over duplicated or skipped questions.
+        const SHARDS: usize = 10;
+        for len in [0usize, 1, 7, 9, 10, 11, 47, 50, 149, 150, 479] {
+            let per = len.div_ceil(SHARDS).max(1);
+            let mut covered = vec![0u32; len];
+            for shard in 0..SHARDS {
+                let (start, end) = shard_window(len, Some(shard * per), Some(per));
+                assert!(start <= end, "len={len} shard={shard}: inverted window");
+                assert!(end <= len, "len={len} shard={shard}: window past the end");
+                for slot in covered.iter_mut().take(end).skip(start) {
+                    *slot += 1;
+                }
+            }
+            assert!(
+                covered.iter().all(|&c| c == 1),
+                "len={len}: every case must be covered exactly once, got {covered:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn out_of_range_shard_yields_an_empty_window_not_a_panic() {
+        // Routine, not exceptional: the shard count is fixed at 10 while the
+        // question total varies, so the tail shards fall off the end whenever
+        // the total is small.
+        assert_eq!(shard_window(5, Some(50), Some(5)), (5, 5));
+        assert_eq!(shard_window(0, Some(0), Some(5)), (0, 0));
+        assert_eq!(shard_window(5, Some(3), Some(99)), (3, 5));
+    }
+
+    #[test]
+    fn absent_offset_and_limit_select_the_whole_manifest() {
+        assert_eq!(shard_window(42, None, None), (0, 42));
+        assert_eq!(shard_window(42, None, Some(10)), (0, 10));
+        assert_eq!(shard_window(42, Some(10), None), (10, 42));
     }
 
     #[test]

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -1434,6 +1434,28 @@ pub fn analyze_ablation(inputs: &RunInputs) -> Result<AblationReport> {
             "+graph-boost-mult",
             vec![("SHODH_GRAPH_BOOST_MULTIPLICATIVE", "1")],
         ),
+        // Traversal direction. Without this flag `edge_neighbor` returns
+        // `edge.to_entity` unconditionally, so standing on a node and meeting an
+        // edge that ENDS there resolves to the node itself: every incoming edge
+        // is a self-loop and the walk can only follow outgoing edges. Reachable
+        // from the live path (`edge_neighbor` is called inside PPR), so this arm
+        // can differ from baseline.
+        ("+edge-dir", vec![("SHODH_GRAPH_EDGE_DIR", "1")]),
+        // Composition-by-traversal: beam-search the strongest intent-matching
+        // paths from the seeds and inject the reached endpoints. Shipped OFF
+        // since it landed and never carried an arm, so it has never appeared in
+        // the study at all.
+        ("+graph-traverse", vec![("SHODH_GRAPH_TRAVERSE", "1")]),
+        // The two graph-leg components that had no gate before `memory::ablation`
+        // existed, and so had never been ablated in either direction.
+        (
+            "-lateral-inhibition",
+            vec![("SHODH_DISABLE_BOOSTS", "hebbian,lateral_inhibition")],
+        ),
+        (
+            "-graph-potentiation",
+            vec![("SHODH_DISABLE_BOOSTS", "hebbian,graph_potentiation")],
+        ),
         (
             "+graph-boost-mult+expand",
             vec![
@@ -1464,6 +1486,9 @@ pub fn analyze_ablation(inputs: &RunInputs) -> Result<AblationReport> {
 
         let mut by_cat: HashMap<SmokeCategory, Vec<f64>> = HashMap::new();
         let mut all: Vec<Metrics> = Vec::with_capacity(cases.len());
+        // Order-sensitive fingerprint over every retrieved id. An arm that
+        // matches baseline here provably changed nothing.
+        let mut fp = std::collections::hash_map::DefaultHasher::new();
         for case in &cases {
             let query = Query {
                 query_text: Some(case.query.clone()),
@@ -1473,6 +1498,14 @@ pub fn analyze_ablation(inputs: &RunInputs) -> Result<AblationReport> {
             };
             let memories = system.read().recall(&query).unwrap_or_default();
             let retrieved: Vec<Uuid> = memories.iter().map(|m| m.id.0).collect();
+            {
+                use std::hash::{Hash, Hasher};
+                for id in &retrieved {
+                    id.hash(&mut fp);
+                }
+                // Separator so [a],[b] and [a,b] cannot collide.
+                0xFFu8.hash(&mut fp);
+            }
             let relevance = build_relevance_map(case, &id_map);
             let m = Metrics::compute(&retrieved, &relevance, SMOKE_K);
             by_cat.entry(case.category).or_default().push(m.recall_at_k);
@@ -1501,7 +1534,45 @@ pub fn analyze_ablation(inputs: &RunInputs) -> Result<AblationReport> {
             mrr: all.iter().map(|m| m.mrr).sum::<f64>() / n,
             p_at_1: all.iter().map(|m| m.p_at_1).sum::<f64>() / n,
             by_category_recall,
+            retrieval_fingerprint: {
+                use std::hash::Hasher;
+                fp.finish()
+            },
+            vacuous_vs_baseline: false,
         });
+    }
+
+    // Vacuity check. An arm whose retrieved ids are byte-identical to baseline's
+    // did not exercise the code path it names, and its metrics are attributable
+    // to nothing. The `+spread-fix` arms were vacuous this way for months --
+    // SHODH_SPREAD_FIX only reached the legacy BFS spread, but SHODH_PPR defaults
+    // ON and its branch precedes it, so the flag could not execute while the rows
+    // read as evidence. Flag it in the report rather than failing the run: an arm
+    // may also be legitimately inert (it executed and changed no ranking), and
+    // only the fingerprint distinguishes the two.
+    let baseline_fp = rows
+        .iter()
+        .find(|r| r.name.starts_with("baseline"))
+        .map(|r| r.retrieval_fingerprint);
+    if let Some(base) = baseline_fp {
+        for row in rows.iter_mut() {
+            if row.name.starts_with("baseline") || row.flags.is_empty() {
+                continue;
+            }
+            if row.retrieval_fingerprint == base {
+                row.vacuous_vs_baseline = true;
+                tracing::warn!(
+                    arm = %row.name,
+                    flags = %row.flags.join(" "),
+                    "VACUOUS ABLATION ARM: retrieval is byte-identical to baseline, so this                      config did not reach the code path it names. Its numbers measure nothing.                      Confirm the flag is readable from the live path before trusting this row."
+                );
+                eprintln!(
+                    "  !! VACUOUS ARM `{}` ({}) -- byte-identical to baseline, measures nothing",
+                    row.name,
+                    row.flags.join(" ")
+                );
+            }
+        }
     }
 
     Ok(AblationReport {

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -2126,6 +2126,7 @@ pub fn analyze_graph_reachability(inputs: &RunInputs) -> Result<ReachabilityRepo
             } else {
                 degree_sum as f64 / total_entities as f64
             },
+            hub_saturation_skipped_edges: crate::metrics::HUB_SATURATION_EDGE_SKIP_TOTAL.get(),
             hub_count: degrees
                 .iter()
                 .filter(|d| **d > HUB_REPORT_THRESHOLD)

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -843,7 +843,18 @@ fn run_one_pass(
                     .clone()
             };
             if pool_export.is_some() && matches!(*mode, LayerMode::Full) {
-                let mut gold: Vec<String> = relevance.keys().map(|u| u.to_string()).collect();
+                // Corpus ids, matching `pool` -- `relevance` is keyed by Uuid while
+                // the rank lists are already corpus ids, so exporting the raw Uuid
+                // made the two sets disjoint and every offline join scored zero.
+                let mut gold: Vec<String> = relevance
+                    .keys()
+                    .map(|u| {
+                        uuid_to_corpus_id
+                            .get(u)
+                            .cloned()
+                            .unwrap_or_else(|| u.to_string())
+                    })
+                    .collect();
                 gold.sort();
                 pool_lines.push(
                     serde_json::json!({

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -691,6 +691,25 @@ fn run_one_pass(
         .map(std::path::PathBuf::from);
     let mut feature_lines: Vec<String> = Vec::new();
 
+    // Candidate-pool export (`SHODH_POOL_EXPORT=<jsonl path>`, Full mode only).
+    //
+    // Writes, per case: the query, the gold ids, and the RECALL_DIAG_K-deep
+    // candidate pool in rank order. That is everything an OFFLINE rescoring
+    // experiment needs -- a cross-encoder, a late-interaction MaxSim scorer, a
+    // fine-tuned or JEPA-style adapter -- because the pool is exactly the set a
+    // reranker would see and the gold ids are the labels. Candidate TEXT is
+    // deliberately not duplicated here: the corpus jsonl already holds it keyed
+    // by id, so the consumer joins rather than the harness bloating every line.
+    //
+    // The point is to convert "would X improve ranking?" from a 45-minute CI run
+    // into a script. ~32pp of gold sits in ranks 11-100, so every rescoring idea
+    // is testable against this file without touching the Rust pipeline at all.
+    let pool_export: Option<std::path::PathBuf> = std::env::var("SHODH_POOL_EXPORT")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(std::path::PathBuf::from);
+    let mut pool_lines: Vec<String> = Vec::new();
+
     for mode in layer_modes {
         let mut per_case = Vec::with_capacity(cases.len());
         let mut latencies_ms = Vec::with_capacity(cases.len());
@@ -823,6 +842,20 @@ fn run_one_pass(
                     .retrieved
                     .clone()
             };
+            if pool_export.is_some() && matches!(*mode, LayerMode::Full) {
+                let mut gold: Vec<String> = relevance.keys().map(|u| u.to_string()).collect();
+                gold.sort();
+                pool_lines.push(
+                    serde_json::json!({
+                        "case_id": case.id,
+                        "category": category_name(case.category),
+                        "query": case.query,
+                        "gold": gold,
+                        "pool": deep_retrieved,
+                    })
+                    .to_string(),
+                );
+            }
             deep_ranks.push(CaseRankList {
                 case_id: case.id.clone(),
                 retrieved: deep_retrieved,
@@ -859,6 +892,22 @@ fn run_one_pass(
                 deep_ranks,
             },
         );
+    }
+
+    if let Some(path) = &pool_export {
+        if !pool_lines.is_empty() {
+            use std::io::Write as _;
+            let mut f = std::fs::File::create(path)
+                .with_context(|| format!("creating pool export {}", path.display()))?;
+            for line in &pool_lines {
+                writeln!(f, "{line}")?;
+            }
+            eprintln!(
+                "  pool export: {} cases -> {}",
+                pool_lines.len(),
+                path.display()
+            );
+        }
     }
 
     if let Some(path) = &feature_export {

--- a/src/vector_db/vamana.rs
+++ b/src/vector_db/vamana.rs
@@ -114,6 +114,38 @@ pub const DELETION_RATIO_THRESHOLD: f32 = 0.30;
 /// Below this threshold, rebuild is strongly recommended
 pub const MIN_ACCEPTABLE_RECALL: f32 = 0.85;
 
+/// Environment variable selecting the query-time search list size (DiskANN `L`).
+pub const SEARCH_EF_ENV: &str = "SHODH_VAMANA_EF";
+
+/// Parse a query-time search list size from its raw environment value.
+///
+/// Returns `None` — meaning "leave the beam at the requested candidate count",
+/// i.e. the historical behaviour — for an absent, empty, unparseable or zero
+/// value. Split out as a pure function so it can be unit tested without
+/// mutating process environment (which races under a parallel test runner).
+fn parse_search_ef(raw: Option<&str>) -> Option<usize> {
+    raw?.trim().parse::<usize>().ok().filter(|&v| v > 0)
+}
+
+/// Query-time search list size from [`SEARCH_EF_ENV`], resolved once per process.
+///
+/// `None` (the default, variable unset) keeps `L = k`, so the shipped search
+/// path is unchanged. A value larger than the internal candidate count widens
+/// the beam; a smaller one is ignored (the beam is clamped up to `k`).
+///
+/// Cached in a `OnceLock` because `search()` is on the per-query hot path and
+/// the eval/production environment is fixed at process start.
+fn configured_search_ef() -> Option<usize> {
+    static SEARCH_EF: std::sync::OnceLock<Option<usize>> = std::sync::OnceLock::new();
+    *SEARCH_EF.get_or_init(|| {
+        let parsed = parse_search_ef(std::env::var(SEARCH_EF_ENV).ok().as_deref());
+        if let Some(ef) = parsed {
+            info!("Vamana query-time search list size ({SEARCH_EF_ENV}) = {ef}");
+        }
+        parsed
+    })
+}
+
 /// Main Vamana index
 pub struct VamanaIndex {
     pub(crate) config: VamanaConfig,
@@ -568,14 +600,44 @@ impl VamanaIndex {
         }
     }
 
-    /// Greedy search for nearest neighbors
+    /// Greedy search for nearest neighbors with the search list tied to `k`.
+    ///
+    /// Equivalent to [`Self::greedy_search_beam`] with `beam == k`.
+    fn greedy_search(&self, query: &[f32], k: usize, entry: u32) -> Result<Vec<SearchCandidate>> {
+        self.greedy_search_beam(query, k, k, entry)
+    }
+
+    /// Greedy search over the Vamana graph keeping a search list of
+    /// `L = max(beam, k)` candidates, returning the best `k` of them.
+    ///
+    /// DiskANN searches with a list size `L >= k` and reports the top `k` from
+    /// it. A larger `L` explores more of the graph, so both the *reach* (which
+    /// true neighbours are found at all) and the *order* of the returned `k`
+    /// move towards exact. This index previously hard-wired `L = k`, which is
+    /// maximally myopic for small `k` — at `k = 1` it degenerates to pure
+    /// hill-climbing, and `VamanaConfig::search_list_size` was consulted only
+    /// for `with_capacity` hints, never as an actual query-time beam.
+    ///
+    /// `beam` is clamped UP to `k`, so it can only ever widen the search; the
+    /// `beam == k` call site ([`Self::greedy_search`]) behaves exactly as the
+    /// previous implementation did.
     ///
     /// Optimized to use zero-copy slice access for vector data.
     /// Holds both graph and vector storage locks for the duration of the search
     /// to avoid per-neighbor lock acquisition overhead.
-    fn greedy_search(&self, query: &[f32], k: usize, entry: u32) -> Result<Vec<SearchCandidate>> {
+    fn greedy_search_beam(
+        &self,
+        query: &[f32],
+        k: usize,
+        beam: usize,
+        entry: u32,
+    ) -> Result<Vec<SearchCandidate>> {
         let graph = self.graph.read();
         let storage = self.vectors.read(); // Hold lock for entire search (zero-copy access)
+
+        // Search list size. Never below k — a beam smaller than the requested
+        // result count could not return k results.
+        let list_size = beam.max(k);
 
         let search_cap = self.config.search_list_size;
         let mut visited = HashSet::with_capacity(search_cap);
@@ -627,7 +689,8 @@ impl VamanaIndex {
                 let dist = self.distance(query, neighbor_slice);
 
                 // Defensive: check if closer than worst in w, or w not yet full
-                let should_add = w.len() < k || w.peek().map(|p| dist < p.distance).unwrap_or(true);
+                let should_add =
+                    w.len() < list_size || w.peek().map(|p| dist < p.distance).unwrap_or(true);
                 if should_add {
                     candidates.push(Reverse(SearchCandidate {
                         id: neighbor_id,
@@ -639,19 +702,21 @@ impl VamanaIndex {
                         distance: dist,
                     });
 
-                    if w.len() > k {
+                    if w.len() > list_size {
                         w.pop();
                     }
                 }
             }
         }
 
-        // Extract results
+        // Extract results: the search list holds up to `list_size` candidates;
+        // report only the best `k`. A no-op when `list_size == k` (the default).
         let mut results = Vec::new();
         while let Some(candidate) = w.pop() {
             results.push(candidate);
         }
         results.reverse();
+        results.truncate(k);
 
         Ok(results)
     }
@@ -761,7 +826,27 @@ impl VamanaIndex {
     }
 
     /// Search for k nearest neighbors (excludes soft-deleted vectors)
+    ///
+    /// The search list size is taken from `SHODH_VAMANA_EF` (see
+    /// [`configured_search_ef`]); unset — the default — leaves the beam equal
+    /// to the requested candidate count, exactly as before.
     pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<(u32, f32)>> {
+        self.search_with_ef(query, k, configured_search_ef())
+    }
+
+    /// Search for k nearest neighbors with an explicit search list size.
+    ///
+    /// `ef` is the DiskANN search list size `L`. `None` (and any value below
+    /// the internal candidate count) leaves the beam at the candidate count,
+    /// which is the historical behaviour. A larger `ef` widens the beam without
+    /// changing how many results are returned, trading query time for a top-`k`
+    /// that is closer to exact in both membership and order.
+    pub fn search_with_ef(
+        &self,
+        query: &[f32],
+        k: usize,
+        ef: Option<usize>,
+    ) -> Result<Vec<(u32, f32)>> {
         // Check if index is empty
         if self.num_vectors.load(std::sync::atomic::Ordering::Acquire) == 0 {
             return Ok(Vec::new());
@@ -794,7 +879,10 @@ impl VamanaIndex {
             k
         };
 
-        let candidates = self.greedy_search(query, search_k, entry)?;
+        // The beam only ever widens: `greedy_search_beam` clamps it up to
+        // `search_k`, so `ef = None` reproduces the historical `L = k` search.
+        let candidates =
+            self.greedy_search_beam(query, search_k, ef.unwrap_or(search_k), entry)?;
 
         // Filter out deleted vectors and take k results
         let results: Vec<(u32, f32)> = candidates
@@ -1800,5 +1888,168 @@ mod tests {
         // Should take no action on fresh index
         let result = index.auto_maintain().unwrap();
         assert_eq!(result, "no_action");
+    }
+
+    // ---------------------------------------------------------------------
+    // Query-time search list size (SHODH_VAMANA_EF)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_search_ef_rejects_non_positive_and_garbage() {
+        assert_eq!(parse_search_ef(None), None);
+        assert_eq!(parse_search_ef(Some("")), None);
+        assert_eq!(parse_search_ef(Some("   ")), None);
+        assert_eq!(parse_search_ef(Some("0")), None);
+        assert_eq!(parse_search_ef(Some("-4")), None);
+        assert_eq!(parse_search_ef(Some("abc")), None);
+        assert_eq!(parse_search_ef(Some("1.5")), None);
+        assert_eq!(parse_search_ef(Some("1")), Some(1));
+        assert_eq!(parse_search_ef(Some(" 256 ")), Some(256));
+    }
+
+    /// Deterministic index built only through `add_vector`, which is the path
+    /// production and the recall harness actually use (no RNG: the random graph
+    /// initialisation lives in `build()`, which this never calls).
+    fn deterministic_incremental_index(n: usize, dim: usize, max_degree: usize) -> VamanaIndex {
+        let mut index = VamanaIndex::new(VamanaConfig {
+            dimension: dim,
+            max_degree,
+            search_list_size: 100,
+            alpha: 1.2,
+            use_mmap: false,
+            ..Default::default()
+        })
+        .unwrap();
+
+        // Deterministic pseudo-random unit vectors: a fixed integer hash, so the
+        // fixture is identical on every machine and every run.
+        for i in 0..n {
+            let mut v = Vec::with_capacity(dim);
+            for d in 0..dim {
+                let h = ((i as u64).wrapping_mul(6_364_136_223_846_793_005)
+                    ^ (d as u64).wrapping_mul(1_442_695_040_888_963_407))
+                .wrapping_mul(2_862_933_555_777_941_757);
+                // 31 random bits mapped to [-1, 1)
+                v.push(((h >> 33) as f32 / (1u64 << 31) as f32) * 2.0 - 1.0);
+            }
+            let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            for x in &mut v {
+                *x /= norm;
+            }
+            index.add_vector(v).unwrap();
+        }
+        index
+    }
+
+    #[test]
+    fn test_search_ef_none_matches_beam_equal_k() {
+        let index = deterministic_incremental_index(300, 16, 4);
+        let query = index.get_vector(7).unwrap();
+
+        // `ef = None` and any `ef <= k` must both clamp to the k-wide beam,
+        // reproducing the historical search exactly.
+        let base = index.search_with_ef(&query, 10, None).unwrap();
+        let clamped = index.search_with_ef(&query, 10, Some(1)).unwrap();
+        let equal = index.search_with_ef(&query, 10, Some(10)).unwrap();
+
+        assert_eq!(base, clamped, "ef below k must clamp up to k");
+        assert_eq!(base, equal, "ef == k must be the historical behaviour");
+        assert_eq!(base.len(), 10);
+    }
+
+    #[test]
+    fn test_search_ef_returns_exactly_k_in_ascending_distance() {
+        let index = deterministic_incremental_index(300, 16, 4);
+        let query = index.get_vector(11).unwrap();
+
+        let wide = index.search_with_ef(&query, 10, Some(200)).unwrap();
+        assert_eq!(
+            wide.len(),
+            10,
+            "a wider beam must not change how many results are returned"
+        );
+
+        // Exercise the inner contract directly: `search_with_ef` also applies
+        // its own `.take(k)` when filtering soft-deleted ids, so going through
+        // the public path alone cannot tell whether `greedy_search_beam` honours
+        // "search with L, report k" or leaks the whole search list upward.
+        let entry = *index.medoid.read();
+        let raw = index.greedy_search_beam(&query, 10, 200, entry).unwrap();
+        assert_eq!(
+            raw.len(),
+            10,
+            "greedy_search_beam must report k, not the full search list"
+        );
+        for pair in wide.windows(2) {
+            assert!(
+                pair[0].1 <= pair[1].1,
+                "results must stay sorted by ascending distance: {:?}",
+                wide
+            );
+        }
+    }
+
+    #[test]
+    fn test_search_ef_widens_beam_and_recovers_true_neighbors() {
+        // Production `max_degree` is 32; the harness index is built purely by
+        // `add_vector`, so this fixture is the same regime the eval runs in.
+        let index = deterministic_incremental_index(3000, 384, 32);
+
+        let k = 10;
+        let mut base_hits = 0usize;
+        let mut wide_hits = 0usize;
+        let mut total = 0usize;
+
+        for q in [3u32, 29, 71, 130, 244, 301, 388, 415, 502, 577] {
+            let query = index.get_vector(q).unwrap();
+            let exact: HashSet<u32> = index
+                .brute_force_search(&query, k)
+                .unwrap()
+                .into_iter()
+                .map(|(id, _)| id)
+                .collect();
+
+            let base: HashSet<u32> = index
+                .search_with_ef(&query, k, None)
+                .unwrap()
+                .into_iter()
+                .map(|(id, _)| id)
+                .collect();
+            let wide: HashSet<u32> = index
+                .search_with_ef(&query, k, Some(256))
+                .unwrap()
+                .into_iter()
+                .map(|(id, _)| id)
+                .collect();
+
+            let base_q = base.intersection(&exact).count();
+            let wide_q = wide.intersection(&exact).count();
+
+            // Widening the search list can only ever ADD explored nodes, so it
+            // must never lose a true neighbour the narrow beam already found.
+            assert!(
+                wide_q >= base_q,
+                "query {q}: widening the beam lost ground ({base_q} -> {wide_q})"
+            );
+
+            base_hits += base_q;
+            wide_hits += wide_q;
+            total += exact.len();
+        }
+
+        // The default beam must be genuinely lossy on this fixture — if it were
+        // not, the test could not tell a working `ef` from an ignored one.
+        assert!(
+            base_hits < total,
+            "fixture must be lossy at beam == k, got {base_hits}/{total}"
+        );
+        // ...and the wider beam must strictly recover some of that loss.
+        assert!(
+            wide_hits > base_hits,
+            "ef=256 must beat beam==k: {base_hits}/{total} vs {wide_hits}/{total}"
+        );
+        eprintln!(
+            "vamana ef ablation: beam=k {base_hits}/{total}, ef=256 {wide_hits}/{total}"
+        );
     }
 }

--- a/src/vector_db/vamana.rs
+++ b/src/vector_db/vamana.rs
@@ -146,6 +146,39 @@ fn configured_search_ef() -> Option<usize> {
     })
 }
 
+/// Environment variable enabling α-RNG pruning on the incremental insert path.
+pub const INSERT_PRUNE_ENV: &str = "SHODH_VAMANA_INSERT_PRUNE";
+
+/// Parse the insert-prune flag from its raw environment value.
+///
+/// Only `1` / `true` (case-insensitive, trimmed) enable it; anything else —
+/// absent, empty, `0`, garbage — leaves the historical greedy-kNN insert
+/// untouched. A pure function so it is unit-testable without mutating process
+/// environment (which races under a parallel test runner).
+fn parse_insert_prune(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some(v) if v == "1" || v.eq_ignore_ascii_case("true"))
+}
+
+/// Insert-prune policy from [`INSERT_PRUNE_ENV`], resolved once per process.
+///
+/// `false` (the default, variable unset) keeps `add_vector`'s historical
+/// greedy top-k neighbor selection bit-for-bit. `true` switches the insert
+/// path to full α-RNG construction (see [`VamanaIndex::add_vector_with_policy`]).
+///
+/// Cached in a `OnceLock`: ingest is a hot path and the eval/production
+/// environment is fixed at process start. The `info!` line doubles as the
+/// CI-log proof that the flag actually reached the live insert path.
+fn configured_insert_prune() -> bool {
+    static INSERT_PRUNE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *INSERT_PRUNE.get_or_init(|| {
+        let enabled = parse_insert_prune(std::env::var(INSERT_PRUNE_ENV).ok().as_deref());
+        if enabled {
+            info!("Vamana insert-time α-RNG pruning ({INSERT_PRUNE_ENV}) enabled");
+        }
+        enabled
+    })
+}
+
 /// Main Vamana index
 pub struct VamanaIndex {
     pub(crate) config: VamanaConfig,
@@ -728,12 +761,28 @@ impl VamanaIndex {
     /// - Cached dist_ne (node to existing) to avoid O(n²) distance recomputation
     /// - Pre-loaded candidate vectors to minimize storage lookups
     fn robust_prune(&self, node_id: u32, candidates: &[SearchCandidate]) -> Result<Vec<u32>> {
+        let storage = self.vectors.read(); // Hold lock for entire prune operation
+        self.robust_prune_in(&storage, node_id, candidates)
+    }
+
+    /// α-RNG prune against an already-held storage reference.
+    ///
+    /// Split out from [`Self::robust_prune`] so callers that already hold the
+    /// vector-storage lock (the insert path holds `graph.write()` +
+    /// `vectors.read()` while fixing up reverse edges) can prune without
+    /// re-acquiring it — parking_lot RwLocks are not re-entrant, and a second
+    /// read acquisition with a writer waiting can deadlock.
+    fn robust_prune_in(
+        &self,
+        storage: &VectorStorage,
+        node_id: u32,
+        candidates: &[SearchCandidate],
+    ) -> Result<Vec<u32>> {
         if candidates.is_empty() {
             return Ok(Vec::new());
         }
 
-        let storage = self.vectors.read(); // Hold lock for entire prune operation
-        let node_slice = Self::get_slice_from_storage(&storage, node_id)?;
+        let node_slice = Self::get_slice_from_storage(storage, node_id)?;
 
         // Sort candidates by distance (NaN values sort to end), tie-break by id for determinism
         let mut sorted_candidates = candidates.to_vec();
@@ -751,7 +800,7 @@ impl VamanaIndex {
                 if c.id == node_id {
                     None
                 } else {
-                    Self::get_slice_from_storage(&storage, c.id)
+                    Self::get_slice_from_storage(storage, c.id)
                         .ok()
                         .map(|slice| (c.id, slice.to_vec(), c.distance))
                 }
@@ -937,8 +986,32 @@ impl VamanaIndex {
         self.deleted_ids.write().clear();
     }
 
-    /// Add a single vector (incremental indexing) - OPTIMIZED
+    /// Add a single vector (incremental indexing).
+    ///
+    /// Neighbor selection policy comes from `SHODH_VAMANA_INSERT_PRUNE` (see
+    /// [`configured_insert_prune`]); unset — the default — keeps the historical
+    /// greedy top-k selection bit-for-bit.
     pub fn add_vector(&mut self, vector: Vec<f32>) -> Result<u32> {
+        self.add_vector_with_policy(vector, configured_insert_prune())
+    }
+
+    /// Add a single vector with an explicit neighbor-selection policy.
+    ///
+    /// `alpha_prune = false` is the historical incremental insert: the new
+    /// node's neighbors are the raw greedy top-`max_degree` (no α-RNG
+    /// diversification), and a neighbor whose reverse edge overflows
+    /// `max_degree` keeps its `max_degree` CLOSEST neighbors. Both choices
+    /// optimize insert speed and both destroy exactly the property greedy
+    /// search needs: neighbor lists degenerate into tight same-cluster cliques
+    /// with no long-range edges, so the search surface develops local minima
+    /// that no query-time beam can fully climb out of.
+    ///
+    /// `alpha_prune = true` is the DiskANN/FreshDiskANN insert: candidates come
+    /// from a `search_list_size`-wide greedy search, the new node's neighbors
+    /// are α-RNG pruned ([`Self::robust_prune`]), and overflowing reverse
+    /// neighborhoods are re-pruned with the same α-RNG rule over their true
+    /// distances — the construction `build()` uses, applied incrementally.
+    pub fn add_vector_with_policy(&mut self, vector: Vec<f32>, alpha_prune: bool) -> Result<u32> {
         let current_count = self.num_vectors.load(std::sync::atomic::Ordering::Acquire);
         let id = current_count as u32;
 
@@ -986,9 +1059,17 @@ impl VamanaIndex {
             return Ok(id);
         }
 
-        // OPTIMIZATION: Use simpler neighbor selection for incremental adds
-        let neighbors = if self.graph.read().is_empty() {
+        // Neighbor selection. Historical path (alpha_prune = false): raw greedy
+        // top-max_degree, no pruning. α-RNG path: candidates from a
+        // search_list_size-wide beam, then robust_prune — same rule as build().
+        let neighbors: Vec<u32> = if self.graph.read().is_empty() {
             Vec::new()
+        } else if alpha_prune {
+            let beam = self.config.search_list_size.max(self.config.max_degree);
+            let candidates = self.greedy_search_beam(&vector, beam, beam, *self.medoid.read())?;
+            // The new vector is already in storage at `id`, so robust_prune can
+            // read it; it is NOT yet in the graph, so the search cannot visit it.
+            self.robust_prune(id, &candidates)?
         } else {
             // Just find k-nearest neighbors without expensive pruning
             let candidates =
@@ -1019,7 +1100,7 @@ impl VamanaIndex {
 
             graph[neighbor_id as usize].neighbors.push(id);
 
-            // Prune by distance when over max_degree
+            // Re-prune when the reverse edge overflows max_degree
             if graph[neighbor_id as usize].neighbors.len() > self.config.max_degree {
                 // Get neighbor's vector for distance calculations
                 if let Ok(neighbor_vec) = Self::get_vector_from_storage(&vectors, neighbor_id) {
@@ -1038,12 +1119,31 @@ impl VamanaIndex {
                     neighbor_distances
                         .sort_by(|a, b| a.1.total_cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
 
-                    // Keep only max_degree closest neighbors
-                    graph[neighbor_id as usize].neighbors = neighbor_distances
-                        .into_iter()
-                        .take(self.config.max_degree)
-                        .map(|(id, _)| id)
-                        .collect();
+                    if alpha_prune {
+                        // α-RNG over the neighbor's TRUE distances. Distance-only
+                        // keep-closest (the historical path below) turns hub
+                        // neighborhoods into same-cluster cliques: every new
+                        // same-cluster insert evicts the long-range edge greedy
+                        // search navigates by. robust_prune keeps the closest
+                        // candidate AND the diverse ones — `robust_prune_in`
+                        // because the vectors lock is already held here.
+                        let candidates: Vec<SearchCandidate> = neighbor_distances
+                            .into_iter()
+                            .map(|(n_id, dist)| SearchCandidate {
+                                id: n_id,
+                                distance: dist,
+                            })
+                            .collect();
+                        graph[neighbor_id as usize].neighbors =
+                            self.robust_prune_in(&vectors, neighbor_id, &candidates)?;
+                    } else {
+                        // Historical: keep only max_degree closest neighbors
+                        graph[neighbor_id as usize].neighbors = neighbor_distances
+                            .into_iter()
+                            .take(self.config.max_degree)
+                            .map(|(id, _)| id)
+                            .collect();
+                    }
                 } else {
                     // Fallback: truncate if vector access fails
                     graph[neighbor_id as usize]
@@ -2050,6 +2150,368 @@ mod tests {
         );
         eprintln!(
             "vamana ef ablation: beam=k {base_hits}/{total}, ef=256 {wide_hits}/{total}"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Insert-time α-RNG pruning (SHODH_VAMANA_INSERT_PRUNE)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_insert_prune_accepts_only_explicit_enable() {
+        assert!(!parse_insert_prune(None));
+        assert!(!parse_insert_prune(Some("")));
+        assert!(!parse_insert_prune(Some("0")));
+        assert!(!parse_insert_prune(Some("false")));
+        assert!(!parse_insert_prune(Some("yes")));
+        assert!(!parse_insert_prune(Some("2")));
+        assert!(parse_insert_prune(Some("1")));
+        assert!(parse_insert_prune(Some(" 1 ")));
+        assert!(parse_insert_prune(Some("true")));
+        assert!(parse_insert_prune(Some("TRUE")));
+    }
+
+    /// The α-RNG rule must keep the closest candidate AND the geometrically
+    /// diverse one, dropping a near-duplicate of an already-kept neighbor —
+    /// keep-closest would keep the duplicate and drop the diverse candidate.
+    #[test]
+    fn test_robust_prune_keeps_diverse_over_near_duplicate() {
+        let mut index = VamanaIndex::new(VamanaConfig {
+            dimension: 4,
+            max_degree: 2,
+            search_list_size: 10,
+            alpha: 1.2,
+            use_mmap: false,
+            ..Default::default()
+        })
+        .unwrap();
+
+        // All unit vectors; NormalizedDotProduct distance = -dot.
+        let node = vec![1.0, 0.0, 0.0, 0.0]; // id 0: the node being pruned
+        let close_a = vec![0.992, 0.126_231_93, 0.0, 0.0]; // id 1: closest
+        let close_b = vec![0.990, 0.141_067_36, 0.0, 0.0]; // id 2: near-duplicate of id 1
+        let diverse = vec![0.0, 1.0, 0.0, 0.0]; // id 3: far but diverse
+        for v in [&node, &close_a, &close_b, &diverse] {
+            let n: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            assert!((n - 1.0).abs() < 1e-3, "fixture vectors must be unit norm");
+        }
+        {
+            let mut storage = index.vectors.write();
+            *storage = VectorStorage::Memory(vec![node.clone(), close_a, close_b, diverse]);
+        }
+        index
+            .num_vectors
+            .store(4, std::sync::atomic::Ordering::Release);
+
+        let dist = |a: &[f32], b: &[f32]| -a.iter().zip(b).map(|(x, y)| x * y).sum::<f32>();
+        let storage = index.vectors.read();
+        let candidates: Vec<SearchCandidate> = (1..4)
+            .map(|id| SearchCandidate {
+                id,
+                distance: dist(
+                    &node,
+                    &VamanaIndex::get_vector_from_storage(&storage, id).unwrap(),
+                ),
+            })
+            .collect();
+
+        let pruned = index.robust_prune_in(&storage, 0, &candidates).unwrap();
+        assert_eq!(
+            pruned,
+            vec![1, 3],
+            "α-RNG must keep the closest (1) and the diverse (3) candidates and \
+             drop the near-duplicate (2); keep-closest would produce [1, 2]"
+        );
+    }
+
+    /// End-to-end through `add_vector_with_policy`: when a hub's reverse edges
+    /// overflow max_degree, the α path must retain its long-range (diverse)
+    /// edge while the historical path evicts it for a same-cluster duplicate.
+    /// This is exactly the structural difference that costs task recall: greedy
+    /// search navigates BY those long-range edges.
+    #[test]
+    fn test_insert_prune_reverse_edges_keep_long_range_link() {
+        let build = |alpha_prune: bool| -> VamanaIndex {
+            let mut index = VamanaIndex::new(VamanaConfig {
+                dimension: 4,
+                max_degree: 2,
+                search_list_size: 10,
+                alpha: 1.2,
+                use_mmap: false,
+                ..Default::default()
+            })
+            .unwrap();
+            let vectors = [
+                vec![1.0, 0.0, 0.0, 0.0],           // 0: hub H (medoid/entry)
+                vec![0.0, 1.0, 0.0, 0.0],           // 1: far diverse F
+                vec![0.992, 0.126_231_93, 0.0, 0.0], // 2: close c1
+                vec![0.990, 0.141_067_36, 0.0, 0.0], // 3: close c2 ≈ c1
+            ];
+            for v in vectors {
+                index.add_vector_with_policy(v, alpha_prune).unwrap();
+            }
+            index
+        };
+
+        let alpha = build(true);
+        let alpha_hub = alpha.graph.read()[0].neighbors.clone();
+        assert!(
+            alpha_hub.contains(&1),
+            "α-RNG reverse pruning must keep the hub's long-range edge to the \
+             diverse node, got {alpha_hub:?}"
+        );
+        assert!(
+            alpha_hub.len() <= 2,
+            "reverse edges must stay within max_degree, got {alpha_hub:?}"
+        );
+
+        let greedy = build(false);
+        let greedy_hub = greedy.graph.read()[0].neighbors.clone();
+        assert!(
+            !greedy_hub.contains(&1),
+            "fixture must be discriminating: the historical keep-closest path \
+             evicts the long-range edge (got {greedy_hub:?}); if it no longer \
+             does, this test cannot tell the two policies apart"
+        );
+    }
+
+    /// Front half of the insert policy: the NEW node's own neighbor list must
+    /// be α-diversified, not the raw greedy top-k. The fixture is built so the
+    /// greedy graph has already lost its long-range edge by the fifth insert —
+    /// the greedy candidate search cannot even REACH the diverse node — while
+    /// the α graph both reaches it and selects it over a redundant
+    /// near-duplicate. Catches the mutation where `add_vector_with_policy`
+    /// α-prunes reverse edges but silently keeps greedy selection for the new
+    /// node itself (the reverse-edge test alone cannot see that break).
+    #[test]
+    fn test_insert_prune_diversifies_new_node_neighbors() {
+        let build = |alpha_prune: bool| -> VamanaIndex {
+            let mut index = VamanaIndex::new(VamanaConfig {
+                dimension: 4,
+                max_degree: 2,
+                search_list_size: 10,
+                alpha: 1.2,
+                use_mmap: false,
+                ..Default::default()
+            })
+            .unwrap();
+            let vectors = [
+                vec![1.0, 0.0, 0.0, 0.0],            // 0: hub H (medoid/entry)
+                vec![0.0, 1.0, 0.0, 0.0],            // 1: far diverse F
+                vec![0.992, 0.126_231_93, 0.0, 0.0], // 2: close c1
+                vec![0.990, 0.141_067_36, 0.0, 0.0], // 3: close c2 ≈ c1
+                vec![0.924, -0.382_499_5, 0.0, 0.0], // 4: X, outside the c-cluster
+            ];
+            for v in vectors {
+                index.add_vector_with_policy(v, alpha_prune).unwrap();
+            }
+            index
+        };
+
+        let alpha = build(true);
+        let alpha_new = alpha.graph.read()[4].neighbors.clone();
+        assert!(
+            alpha_new.contains(&1),
+            "α selection for the new node must keep the diverse far node, got {alpha_new:?}"
+        );
+        assert!(
+            !alpha_new.contains(&2) && !alpha_new.contains(&3),
+            "α selection must drop cluster members redundant with the hub, got {alpha_new:?}"
+        );
+
+        let greedy = build(false);
+        let greedy_new = greedy.graph.read()[4].neighbors.clone();
+        assert!(
+            !greedy_new.contains(&1),
+            "fixture must be discriminating: greedy selection cannot reach or \
+             keep the diverse node (got {greedy_new:?}); if it now does, this \
+             test cannot tell the two policies apart"
+        );
+    }
+
+    /// Deterministic CLUSTERED fixture built only through the incremental
+    /// insert path. Uniform-random unit vectors are the easy case for a greedy
+    /// kNN graph (near-orthogonal, no local minima); real MiniLM embeddings of
+    /// a conversational corpus are tightly clustered near-duplicates, which is
+    /// where greedy top-k neighbor lists degenerate into same-cluster cliques.
+    fn clustered_incremental_index(
+        n: usize,
+        dim: usize,
+        clusters: usize,
+        max_degree: usize,
+        alpha_prune: bool,
+    ) -> VamanaIndex {
+        let mut index = VamanaIndex::new(VamanaConfig {
+            dimension: dim,
+            max_degree,
+            search_list_size: 100,
+            alpha: 1.2,
+            use_mmap: false,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let h = |a: u64, b: u64| -> f32 {
+            let x = (a.wrapping_mul(6_364_136_223_846_793_005)
+                ^ b.wrapping_mul(1_442_695_040_888_963_407))
+            .wrapping_mul(2_862_933_555_777_941_757);
+            ((x >> 33) as f32 / (1u64 << 31) as f32) * 2.0 - 1.0
+        };
+
+        for i in 0..n {
+            let c = (i % clusters) as u64;
+            let mut v = Vec::with_capacity(dim);
+            for d in 0..dim {
+                // Cluster center + small within-cluster noise: after
+                // normalization neighbors within a cluster have cosine ≈ 0.9+,
+                // matching embedded near-duplicate conversation turns.
+                let center = h(c.wrapping_add(1_000_003), d as u64);
+                let noise = h(i as u64, d.wrapping_add(7_777_777) as u64);
+                v.push(center + 0.15 * noise);
+            }
+            let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            for x in &mut v {
+                *x /= norm;
+            }
+            index.add_vector_with_policy(v, alpha_prune).unwrap();
+        }
+        index
+    }
+
+    /// Root-cause fixture for the ANN-vs-exact gap at the pipeline's real
+    /// operating point (k = 120, max_degree = 32, incremental inserts only):
+    /// on clustered vectors the greedy-insert graph must be measurably lossy
+    /// at beam = k, and α-RNG insert pruning must recover part of that loss
+    /// with NO query-time change. If the α graph stopped beating the greedy
+    /// graph here, the insert-prune path is broken (e.g. the policy flag is
+    /// being ignored) — that is the mutation this test is built to catch.
+    #[test]
+    fn test_insert_prune_recovers_index_recall_on_clustered_fixture() {
+        let n = 1200;
+        let dim = 384;
+        let clusters = 40;
+        let k = 120;
+
+        let greedy = clustered_incremental_index(n, dim, clusters, 32, false);
+        let alpha = clustered_incremental_index(n, dim, clusters, 32, true);
+
+        let queries: Vec<u32> = (0..40).map(|i| (i * 29 + 3) % n as u32).collect();
+        let mut greedy_hits = 0usize;
+        let mut alpha_hits = 0usize;
+        let mut greedy_hits_ef = 0usize;
+        let mut alpha_hits_ef = 0usize;
+        let mut total = 0usize;
+
+        for &q in &queries {
+            let query = greedy.get_vector(q).unwrap();
+            let exact: HashSet<u32> = greedy
+                .brute_force_search(&query, k)
+                .unwrap()
+                .into_iter()
+                .map(|(id, _)| id)
+                .collect();
+            total += exact.len();
+
+            let hits = |index: &VamanaIndex, ef: Option<usize>| -> usize {
+                index
+                    .search_with_ef(&query, k, ef)
+                    .unwrap()
+                    .into_iter()
+                    .filter(|(id, _)| exact.contains(id))
+                    .count()
+            };
+            greedy_hits += hits(&greedy, None);
+            alpha_hits += hits(&alpha, None);
+            greedy_hits_ef += hits(&greedy, Some(512));
+            alpha_hits_ef += hits(&alpha, Some(512));
+        }
+
+        eprintln!(
+            "clustered fixture (n={n}, dim={dim}, clusters={clusters}, k={k}): \
+             greedy beam=k {greedy_hits}/{total}, α beam=k {alpha_hits}/{total}, \
+             greedy ef=512 {greedy_hits_ef}/{total}, α ef=512 {alpha_hits_ef}/{total}"
+        );
+
+        // The greedy-insert graph must be genuinely lossy on clustered data at
+        // the production operating point, or this fixture can't discriminate.
+        assert!(
+            greedy_hits < total,
+            "fixture must be lossy for greedy inserts at beam == k, got {greedy_hits}/{total}"
+        );
+        // α-RNG insert pruning must strictly improve index recall at the SAME
+        // query cost (beam = k). This is the root-cause claim: the loss is
+        // graph STRUCTURE, not just beam width.
+        assert!(
+            alpha_hits > greedy_hits,
+            "α-RNG insert pruning must beat greedy inserts at beam == k: \
+             {greedy_hits}/{total} vs {alpha_hits}/{total}"
+        );
+        // Widening the beam must not erase the structural advantage entirely
+        // in the wrong direction: the α graph may not do WORSE than the greedy
+        // graph when both search at ef=512.
+        assert!(
+            alpha_hits_ef >= greedy_hits_ef,
+            "α graph must not lose to greedy graph at ef=512: \
+             {greedy_hits_ef}/{total} vs {alpha_hits_ef}/{total}"
+        );
+    }
+
+    /// `add_vector` (env-driven) and `add_vector_with_policy(_, false)` must
+    /// build the identical graph when the flag is unset — the default path is
+    /// bit-identical to the pre-flag implementation.
+    #[test]
+    fn test_add_vector_default_matches_policy_false() {
+        // Guard: this test is only meaningful when the env flag is unset (the
+        // CI/test default). If someone exports SHODH_VAMANA_INSERT_PRUNE=1
+        // globally, failing loudly here is correct — the "default" path would
+        // no longer be the shipped default.
+        assert!(
+            !configured_insert_prune(),
+            "{INSERT_PRUNE_ENV} must be unset when running the test suite"
+        );
+
+        let make = |policy: Option<bool>| -> Vec<Vec<u32>> {
+            let mut index = VamanaIndex::new(VamanaConfig {
+                dimension: 16,
+                max_degree: 4,
+                search_list_size: 20,
+                alpha: 1.2,
+                use_mmap: false,
+                ..Default::default()
+            })
+            .unwrap();
+            for i in 0..120usize {
+                let mut v: Vec<f32> = (0..16)
+                    .map(|d| {
+                        let x = ((i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)
+                            ^ (d as u64).wrapping_mul(0xBF58_476D_1CE4_E5B9))
+                        .wrapping_mul(0x94D0_49BB_1331_11EB);
+                        ((x >> 33) as f32 / (1u64 << 31) as f32) * 2.0 - 1.0
+                    })
+                    .collect();
+                let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+                for x in &mut v {
+                    *x /= norm;
+                }
+                match policy {
+                    Some(p) => index.add_vector_with_policy(v, p).unwrap(),
+                    None => index.add_vector(v).unwrap(),
+                };
+            }
+            let graph = index.graph.read();
+            graph.iter().map(|node| node.neighbors.clone()).collect()
+        };
+
+        assert_eq!(
+            make(None),
+            make(Some(false)),
+            "env-default add_vector must match the explicit historical policy"
+        );
+        assert_ne!(
+            make(Some(false)),
+            make(Some(true)),
+            "the two policies must build different graphs on this fixture — if \
+             they don't, the α path is silently not running"
         );
     }
 }

--- a/src/vector_db/vamana.rs
+++ b/src/vector_db/vamana.rs
@@ -156,14 +156,24 @@ pub const INSERT_PRUNE_ENV: &str = "SHODH_VAMANA_INSERT_PRUNE";
 /// untouched. A pure function so it is unit-testable without mutating process
 /// environment (which races under a parallel test runner).
 fn parse_insert_prune(raw: Option<&str>) -> bool {
-    matches!(raw.map(str::trim), Some(v) if v == "1" || v.eq_ignore_ascii_case("true"))
+    // Opt-OUT. Unset means ON, because a-RNG construction is what makes this a
+    // Vamana index rather than a greedy kNN graph; skipping it is the deviation,
+    // not the default. Only an explicit `0`/`false` disables it.
+    !matches!(raw.map(str::trim), Some(v) if v == "0" || v.eq_ignore_ascii_case("false"))
 }
 
 /// Insert-prune policy from [`INSERT_PRUNE_ENV`], resolved once per process.
 ///
-/// `false` (the default, variable unset) keeps `add_vector`'s historical
-/// greedy top-k neighbor selection bit-for-bit. `true` switches the insert
-/// path to full α-RNG construction (see [`VamanaIndex::add_vector_with_policy`]).
+/// DEFAULT ON. α-RNG construction is what makes this a Vamana index; the
+/// incremental path skipped it "for speed" and silently built a greedy kNN
+/// graph instead -- one whose own true neighbours greedy search could not
+/// reach (45.6% self-recall at beam=k on clustered data, against 99.9% with
+/// α-RNG). No beam width recovers a neighbour the graph has no edge to, which
+/// is why widening `ef` only ever recovered a third of the loss.
+///
+/// `SHODH_VAMANA_INSERT_PRUNE=0` restores the historical greedy path bit-for-bit
+/// for A/B measurement. It is an escape hatch, not a performance option: the
+/// insert-latency it buys costs index navigability.
 ///
 /// Cached in a `OnceLock`: ingest is a hot path and the eval/production
 /// environment is fixed at process start. The `info!` line doubles as the
@@ -172,8 +182,10 @@ fn configured_insert_prune() -> bool {
     static INSERT_PRUNE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *INSERT_PRUNE.get_or_init(|| {
         let enabled = parse_insert_prune(std::env::var(INSERT_PRUNE_ENV).ok().as_deref());
-        if enabled {
-            info!("Vamana insert-time α-RNG pruning ({INSERT_PRUNE_ENV}) enabled");
+        if !enabled {
+            info!(
+                "Vamana insert-time α-RNG pruning DISABLED via {INSERT_PRUNE_ENV} — the index                  will be a greedy kNN graph, not a Vamana graph"
+            );
         }
         enabled
     })
@@ -930,8 +942,7 @@ impl VamanaIndex {
 
         // The beam only ever widens: `greedy_search_beam` clamps it up to
         // `search_k`, so `ef = None` reproduces the historical `L = k` search.
-        let candidates =
-            self.greedy_search_beam(query, search_k, ef.unwrap_or(search_k), entry)?;
+        let candidates = self.greedy_search_beam(query, search_k, ef.unwrap_or(search_k), entry)?;
 
         // Filter out deleted vectors and take k results
         let results: Vec<(u32, f32)> = candidates
@@ -2148,9 +2159,7 @@ mod tests {
             wide_hits > base_hits,
             "ef=256 must beat beam==k: {base_hits}/{total} vs {wide_hits}/{total}"
         );
-        eprintln!(
-            "vamana ef ablation: beam=k {base_hits}/{total}, ef=256 {wide_hits}/{total}"
-        );
+        eprintln!("vamana ef ablation: beam=k {base_hits}/{total}, ef=256 {wide_hits}/{total}");
     }
 
     // ---------------------------------------------------------------------
@@ -2158,17 +2167,23 @@ mod tests {
     // ---------------------------------------------------------------------
 
     #[test]
-    fn test_parse_insert_prune_accepts_only_explicit_enable() {
-        assert!(!parse_insert_prune(None));
-        assert!(!parse_insert_prune(Some("")));
+    fn test_parse_insert_prune_is_opt_out_and_fails_safe() {
+        // α-RNG construction is the default; only an explicit 0/false disables
+        // it. A typo must fail SAFE, i.e. leave the index navigable.
+        assert!(parse_insert_prune(None), "unset must mean α-RNG ON");
+        assert!(parse_insert_prune(Some("")));
+        assert!(parse_insert_prune(Some("1")));
+        assert!(parse_insert_prune(Some("true")));
+        assert!(parse_insert_prune(Some("yes")));
+        assert!(parse_insert_prune(Some("2")));
+        assert!(
+            parse_insert_prune(Some("flase")),
+            "a typo must not disable it"
+        );
         assert!(!parse_insert_prune(Some("0")));
         assert!(!parse_insert_prune(Some("false")));
-        assert!(!parse_insert_prune(Some("yes")));
-        assert!(!parse_insert_prune(Some("2")));
-        assert!(parse_insert_prune(Some("1")));
-        assert!(parse_insert_prune(Some(" 1 ")));
-        assert!(parse_insert_prune(Some("true")));
-        assert!(parse_insert_prune(Some("TRUE")));
+        assert!(!parse_insert_prune(Some("FALSE")));
+        assert!(!parse_insert_prune(Some(" false ")));
     }
 
     /// The α-RNG rule must keep the closest candidate AND the geometrically
@@ -2242,8 +2257,8 @@ mod tests {
             })
             .unwrap();
             let vectors = [
-                vec![1.0, 0.0, 0.0, 0.0],           // 0: hub H (medoid/entry)
-                vec![0.0, 1.0, 0.0, 0.0],           // 1: far diverse F
+                vec![1.0, 0.0, 0.0, 0.0],            // 0: hub H (medoid/entry)
+                vec![0.0, 1.0, 0.0, 0.0],            // 1: far diverse F
                 vec![0.992, 0.126_231_93, 0.0, 0.0], // 2: close c1
                 vec![0.990, 0.141_067_36, 0.0, 0.0], // 3: close c2 ≈ c1
             ];
@@ -2378,6 +2393,72 @@ mod tests {
         index
     }
 
+    /// The shipped index must be NAVIGABLE, not merely populated.
+    ///
+    /// This is the guard that did not exist when `add_vector` was allowed to skip
+    /// the α-RNG rule "for speed". Nothing failed when that landed. The index kept
+    /// accepting vectors, kept returning results, and kept passing every test —
+    /// it had simply stopped being a Vamana graph. Greedy search could not reach
+    /// over half of the index's own true neighbours, and no beam width recovers a
+    /// neighbour the graph has no edge to, which is why widening `ef` only ever
+    /// bought back a third of the loss.
+    ///
+    /// The comparative test above proves α-RNG beats greedy. That is not the same
+    /// guarantee: two equally broken constructions would still satisfy it. This
+    /// one pins an absolute floor on the DEFAULT policy, so a future trade of
+    /// construction quality for insert latency fails here rather than showing up
+    /// months later as an unexplained retrieval deficit.
+    #[test]
+    fn shipped_default_index_is_navigable_on_clustered_data() {
+        // α-RNG measures 99.9% on this fixture and greedy 45.6%; 0.90 sits far
+        // from both, so the test discriminates the construction rule rather than
+        // tracking fixture noise.
+        const SELF_RECALL_FLOOR: f64 = 0.90;
+
+        let n = 1200;
+        let dim = 384;
+        let clusters = 40;
+        let k = 120;
+
+        // `parse_insert_prune(None)` is the SHIPPED default with the variable
+        // unset — deliberately not `configured_insert_prune()`, whose OnceLock
+        // can be poisoned by whichever test in this binary reads the env first.
+        let default_policy = parse_insert_prune(None);
+        let index = clustered_incremental_index(n, dim, clusters, 32, default_policy);
+
+        let queries: Vec<u32> = (0..40).map(|i| (i * 29 + 3) % n as u32).collect();
+        let mut hits = 0usize;
+        let mut total = 0usize;
+        for &q in &queries {
+            let query = index.get_vector(q).unwrap();
+            let exact: std::collections::HashSet<u32> = index
+                .brute_force_search(&query, k)
+                .unwrap()
+                .into_iter()
+                .map(|(id, _)| id)
+                .collect();
+            total += exact.len();
+            hits += index
+                .search_with_ef(&query, k, None)
+                .unwrap()
+                .into_iter()
+                .filter(|(id, _)| exact.contains(id))
+                .count();
+        }
+
+        let ratio = hits as f64 / total as f64;
+        eprintln!(
+            "shipped default (insert_prune={default_policy}): index self-recall \
+             {hits}/{total} = {ratio:.4} at beam=k"
+        );
+        assert!(
+            ratio >= SELF_RECALL_FLOOR,
+            "the shipped index cannot navigate to its own true neighbours: \
+             {hits}/{total} = {ratio:.4} at beam=k, floor {SELF_RECALL_FLOOR}. \
+             The construction rule has regressed — greedy top-k inserts build a \
+             kNN graph, not a Vamana graph."
+        );
+    }
     /// Root-cause fixture for the ANN-vs-exact gap at the pipeline's real
     /// operating point (k = 120, max_degree = 32, incremental inserts only):
     /// on clustered vectors the greedy-insert graph must be measurably lossy
@@ -2460,13 +2541,13 @@ mod tests {
     /// build the identical graph when the flag is unset — the default path is
     /// bit-identical to the pre-flag implementation.
     #[test]
-    fn test_add_vector_default_matches_policy_false() {
-        // Guard: this test is only meaningful when the env flag is unset (the
-        // CI/test default). If someone exports SHODH_VAMANA_INSERT_PRUNE=1
-        // globally, failing loudly here is correct — the "default" path would
-        // no longer be the shipped default.
+    fn test_add_vector_default_matches_policy_true() {
+        // Guard: only meaningful when the env flag is unset (the CI/test
+        // default). If someone exports SHODH_VAMANA_INSERT_PRUNE=0 globally,
+        // failing loudly here is correct — the "default" path would no longer
+        // be the shipped default.
         assert!(
-            !configured_insert_prune(),
+            configured_insert_prune(),
             "{INSERT_PRUNE_ENV} must be unset when running the test suite"
         );
 
@@ -2504,7 +2585,7 @@ mod tests {
 
         assert_eq!(
             make(None),
-            make(Some(false)),
+            make(Some(true)),
             "env-default add_vector must match the explicit historical policy"
         );
         assert_ne!(


### PR DESCRIPTION
> **Stacking note:** this branch contains the commits of #513 (measurability gaps) as ancestors, because the Vamana work was developed on top of them. If #513 merges first this shrinks to the Vamana delta; if this merges first, #513 is subsumed and should be closed. Reviewer's call — I have not touched #513.

## The headline

**The incremental insert path never ran the α-RNG rule, so the index was a greedy kNN graph wearing a Vamana name.**

The justification is in the source:

```rust
// Just find k-nearest neighbors without expensive pruning
// Take top-k neighbors directly without robust_prune for speed
```

An insert-latency shortcut whose cost was never priced. What it cost was navigability: reverse-edge overflow keeps the **32 closest** neighbours, so every same-cluster insert evicts a hub's **long-range** edge — precisely what greedy search navigates by.

## Measured

Clustered fixture at production settings (dim 384, max_degree 32, k=120, `add_vector` only):

| construction | index self-recall @ beam=k |
|---|---|
| greedy top-k (shipped) | **2187/4800 = 45.6%** |
| α-RNG | **4795/4800 = 99.9%** |

And end-to-end on held-out LoCoMo (n=1531, `SHODH_LEG=vector`, `RECALL_DIAG_K=100`):

| arm | recall@10 | p@1 |
|---|---|---|
| shipped (greedy insert) | 0.4234 | 0.2671 |
| `SHODH_VAMANA_EF=512` | 0.4328 | 0.2750 |
| **α-RNG insert** | **0.4522** | **0.2880** |
| `SHODH_VECTOR_EXACT=1` (ceiling) | 0.4519 | 0.2874 |

**+0.0288 recall@10 / +0.0209 p@1, matching exact search.** Construction fully explains the ANN gap.

Two corollaries fall out:
- **`SHODH_VAMANA_EF` is now redundant** — 0.4522 with and without. No beam width recovers a neighbour the graph has no edge to, which is why widening `ef` previously bought back only a third of the gap.
- **The pinned medoid entry point is not a lever.** `SHODH_VAMANA_QUALITY_REBUILD` (which recomputes the medoid) scored 0.4512, *below* insert-prune's 0.4522. That open question closes without a fix.

## What changed

`SHODH_VAMANA_INSERT_PRUNE` becomes **opt-OUT**. Unset means on, because α-RNG construction is the algorithm rather than a tuning option; only an explicit `0`/`false` disables it, and a typo fails safe toward a navigable index. The escape hatch stays for A/B measurement — it is not a performance setting, since the insert latency it buys costs navigability.

**The more important change is the guard.** The comparative test proves α beats greedy, which two *equally broken* constructions would also satisfy. `shipped_default_index_is_navigable_on_clustered_data` pins an **absolute floor (0.90)** on whatever the default policy resolves to. Verified in both directions: 0.9990 on the fixed default, and on the historical one it fails with

> the shipped index cannot navigate to its own true neighbours: 2187/4800 = 0.4556 at beam=k, floor 0.9. The construction rule has regressed — greedy top-k inserts build a kNN graph, not a Vamana graph.

It reads `parse_insert_prune(None)` rather than `configured_insert_prune()` because the latter's `OnceLock` can be poisoned by whichever test in the binary touches the env first.

Two tests pinned the old contract and are **repointed, not weakened**: the parse test now asserts opt-out semantics including that a typo (`"flase"`) leaves α-RNG on, and the equivalence test compares the default against `policy=true` while still asserting via `assert_ne` that the two policies build **different** graphs — so it cannot pass vacuously.

## Also here: the hub cap is now counted

`SHODH_HUB_DEGREE_MAX` is a hard **skip**, not an eviction, and the condition is `||` — so one saturated endpoint kills the edge even when the other is a rare, discriminative entity, and rare entities arrive *late*. Which associations exist is therefore decided by ingest **arrival order**, on a criterion uncorrelated with information, while the PMI² gate beside it culls on exactly that criterion.

It was `tracing::debug!` only. First census: **2196 of a potential 11,636 edges — 18.9% — never minted.**

No behaviour changed; the cap skips exactly what it skipped before. `HUB_SATURATION_EDGE_SKIP_TOTAL` is carried on `GraphStructure` and printed in the reachability report's anti-hub scoreboard beside max degree and hub count.

**Deliberately not acted on.** Whether those 18.9% matter is currently unknowable: the evidence that graph edges don't matter was collected through a leg where the graph term contributes **0.1% of the score** (census: `wsem=0.063035` vs `wact=0.000063`). Fix the graph term's dynamic range first, then re-ask.

## Testing

18/18 in the `vamana` module. Six mutation kills on the insert-prune work, each by its targeted test; one real test gap was found and closed when a half-mutation initially survived. The navigability guard is itself verified in both directions.

**Known gap:** ingest throughput under α-RNG is not measured. The shortcut existed for a reason, and if there is a write-path constraint that made it deliberate, that should gate this merge.
