### PR TITLE
fix(recall): recover legacy-format records + graceful degradation

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,0 +1,455 @@
+//! Read-only audit of the RocksDB stores.
+//!
+//! Classifies every record in the memory, graph, and shared DBs as
+//! decodable (current schema), legacy (decodes via fallback, needs
+//! migration), or undecodable (current and fallback schemas both fail).
+//! Undecodable records are archived with their raw bytes (hex) to a JSONL
+//! file so nothing is lost before any purge/migration decision.
+//!
+//! Mirror of the iteration/dispatch logic in `migration.rs`, with the
+//! difference that tagged/postcard records are decode-VERIFIED instead of
+//! being skipped on sight (the blind spot that let schema drift go
+//! undetected for two days).
+
+use anyhow::{Context, Result};
+use rocksdb::{ColumnFamilyDescriptor, IteratorMode, Options as RocksOptions, DB};
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::graph_memory::{EntityNode, EpisodicNode, RelationshipEdge};
+use crate::handlers::types::AuditEvent;
+use crate::memory::compression::SemanticFact;
+use crate::memory::lineage::{LineageBranch, LineageEdge};
+use crate::memory::storage::{deserialize_memory_for_migration, VectorMappingEntry, CF_OPLOG};
+use crate::memory::temporal_facts::TemporalFact;
+use crate::memory::types::Memory;
+use crate::graph_memory::GRAPH_CF_NAMES;
+use crate::migration::{
+    FACTS_EMBEDDING_PREFIX, FACTS_PREFIX, GRAPH_DATA_CFS, INDEX_ONLY_PREFIXES, LEARNING_PREFIX,
+    TEMPORAL_FACTS_PREFIX, VMAPPING_PREFIX,
+};
+use crate::serialization;
+
+const STORAGE_MAGIC: &[u8] = b"SHO";
+
+// ---------------------------------------------------------------------------
+// Report types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct AuditReport {
+    pub shared: DbAudit,
+    pub users: Vec<UserAudit>,
+    pub archive_path: Option<String>,
+    pub archived_records: usize,
+}
+
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct UserAudit {
+    pub user: String,
+    pub memory: DbAudit,
+    pub graph: DbAudit,
+}
+
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct DbAudit {
+    pub total: usize,
+    pub decodable: usize,
+    pub legacy: usize,
+    pub undecodable: usize,
+    pub skipped: usize,
+    pub cfs: Vec<CfAudit>,
+}
+
+#[derive(Debug, Default, Clone, serde::Serialize)]
+pub struct CfAudit {
+    pub cf: String,
+    pub total: usize,
+    pub decodable: usize,
+    pub legacy: usize,
+    pub undecodable: usize,
+    pub skipped: usize,
+    pub errors: BTreeMap<String, usize>,
+}
+
+impl std::fmt::Display for AuditReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "==== shodh-memory audit ====")?;
+        writeln!(
+            f,
+            "shared:   total={} decodable={} legacy={} undecodable={} skipped={}",
+            self.shared.total,
+            self.shared.decodable,
+            self.shared.legacy,
+            self.shared.undecodable,
+            self.shared.skipped
+        )?;
+        for u in &self.users {
+            writeln!(f, "user {}:", u.user)?;
+            writeln!(
+                f,
+                "  memory: total={} decodable={} legacy={} undecodable={} skipped={}",
+                u.memory.total, u.memory.decodable, u.memory.legacy, u.memory.undecodable, u.memory.skipped
+            )?;
+            for cf in &u.memory.cfs {
+                writeln!(
+                    f,
+                    "    cf {:<16} total={:<6} decodable={:<6} legacy={:<6} undecodable={:<6} skipped={}",
+                    cf.cf, cf.total, cf.decodable, cf.legacy, cf.undecodable, cf.skipped
+                )?;
+                for (err, n) in &cf.errors {
+                    writeln!(f, "      x{:<4} {err}", n)?;
+                }
+            }
+            writeln!(
+                f,
+                "  graph:  total={} decodable={} legacy={} undecodable={} skipped={}",
+                u.graph.total, u.graph.decodable, u.graph.legacy, u.graph.undecodable, u.graph.skipped
+            )?;
+            for cf in &u.graph.cfs {
+                writeln!(
+                    f,
+                    "    cf {:<16} total={:<6} decodable={:<6} legacy={:<6} undecodable={:<6} skipped={}",
+                    cf.cf, cf.total, cf.decodable, cf.legacy, cf.undecodable, cf.skipped
+                )?;
+                for (err, n) in &cf.errors {
+                    writeln!(f, "      x{:<4} {err}", n)?;
+                }
+            }
+        }
+        writeln!(
+            f,
+            "archive: {} ({} undecodable records)",
+            self.archive_path.as_deref().unwrap_or("(none)"),
+            self.archived_records
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+enum Verdict {
+    Decodable,
+    Legacy,
+    Undecodable(String),
+}
+
+fn classify_memory(value: &[u8]) -> Verdict {
+    match serialization::unwrap_sho(value) {
+        Some((version, payload)) => {
+            if version == serialization::SHO_VERSION_POSTCARD {
+                match postcard::from_bytes::<Memory>(payload) {
+                    Ok(_) => Verdict::Decodable,
+                    Err(e) => Verdict::Undecodable(format!("SHO v2 postcard payload: {e}")),
+                }
+            } else {
+                match deserialize_memory_for_migration(value) {
+                    Ok(_) => Verdict::Legacy,
+                    Err(e) => Verdict::Undecodable(format!("SHO v{version} legacy: {e:#}")),
+                }
+            }
+        }
+        None => {
+            if value.len() >= 3 && &value[..3] == STORAGE_MAGIC {
+                Verdict::Undecodable("SHO magic present but envelope/CRC invalid".into())
+            } else {
+                match deserialize_memory_for_migration(value) {
+                    Ok(_) => Verdict::Legacy,
+                    Err(e) => Verdict::Undecodable(format!("legacy chain: {e:#}")),
+                }
+            }
+        }
+    }
+}
+
+fn classify_generic<T: serde::de::DeserializeOwned>(value: &[u8]) -> Verdict {
+    match serialization::try_decode::<T>(value) {
+        // try_decode returns (val, needs_migration): true = legacy bincode,
+        // false = current tagged postcard.
+        Ok((_, true)) => Verdict::Legacy,
+        Ok((_, false)) => Verdict::Decodable,
+        Err(e) => Verdict::Undecodable(format!("{e}")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Archive (raw bytes of undecodable records)
+// ---------------------------------------------------------------------------
+
+struct Archive {
+    path: Option<PathBuf>,
+    writer: Option<std::fs::File>,
+    count: usize,
+}
+
+impl Archive {
+    fn open(path: Option<&Path>) -> Result<Self> {
+        let writer = match path {
+            Some(p) => Some(std::fs::File::create(p).with_context(|| format!("creating archive {}", p.display()))?),
+            None => None,
+        };
+        Ok(Self {
+            path: path.map(|p| p.to_path_buf()),
+            writer,
+            count: 0,
+        })
+    }
+
+    fn push(&mut self, db: &str, cf: &str, key: &[u8], value: &[u8], error: &str) -> Result<()> {
+        self.count += 1;
+        if let Some(w) = self.writer.as_mut() {
+            let rec = serde_json::json!({
+                "db": db,
+                "cf": cf,
+                "key_hex": hex(key),
+                "value_hex": hex(value),
+                "value_len": value.len(),
+                "error": error,
+            });
+            serde_json::to_writer(&mut *w, &rec)?;
+            w.write_all(b"\n")?;
+        }
+        Ok(())
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
+// Per-DB audits
+// ---------------------------------------------------------------------------
+
+fn open_db(db_dir: &Path, cfs: &[&str]) -> Result<DB> {
+    let mut opts = RocksOptions::default();
+    opts.create_if_missing(false);
+    opts.create_missing_column_families(true);
+    // Read-only open: the audit must be able to run against a live data
+    // dir (the serving process holds the RocksDB lock). Read-only mode
+    // skips the exclusive lock; error_if_log_file_exist=false tolerates
+    // the live WAL.
+    DB::open_cf_for_read_only(&opts, db_dir, cfs.iter().copied(), false)
+        .with_context(|| format!("opening DB at {}", db_dir.display()))
+}
+
+fn audit_shared_db(shared_dir: &Path, archive: &mut Archive) -> Result<DbAudit> {
+    let shared_cfs = [
+        "default",
+        "audit",
+        "todos",
+        "projects",
+        "todo_index",
+        "prospective",
+        "prospective_index",
+        "files",
+        "file_index",
+        "feedback",
+    ];
+    let db = open_db(shared_dir, &shared_cfs)?;
+    let mut audit = DbAudit::default();
+
+    for cf_name in shared_cfs {
+        let cf = match db.cf_handle(cf_name) {
+            Some(cf) => cf,
+            None => continue,
+        };
+        let mut cf_audit = CfAudit {
+            cf: cf_name.to_string(),
+            ..Default::default()
+        };
+        for item in db.iterator_cf(cf, IteratorMode::Start) {
+            let (key, value) = item?;
+            cf_audit.total += 1;
+            if cf_name == "audit" {
+                match classify_generic::<AuditEvent>(&value) {
+                    Verdict::Decodable => cf_audit.decodable += 1,
+                    Verdict::Legacy => cf_audit.legacy += 1,
+                    Verdict::Undecodable(e) => {
+                        cf_audit.undecodable += 1;
+                        *cf_audit.errors.entry(e.clone()).or_insert(0) += 1;
+                        archive.push("shared", cf_name, &key, &value, &e)?;
+                    }
+                }
+            } else {
+                cf_audit.skipped += 1;
+            }
+        }
+        audit.total += cf_audit.total;
+        audit.decodable += cf_audit.decodable;
+        audit.legacy += cf_audit.legacy;
+        audit.undecodable += cf_audit.undecodable;
+        audit.skipped += cf_audit.skipped;
+        audit.cfs.push(cf_audit);
+    }
+    Ok(audit)
+}
+
+fn audit_memory_db(mem_dir: &Path, archive: &mut Archive) -> Result<DbAudit> {
+    let cfs = ["default", "memory_index", CF_OPLOG];
+    let db = open_db(mem_dir, &cfs)?;
+    let mut audit = DbAudit::default();
+
+    for cf_name in cfs {
+        let cf = match db.cf_handle(cf_name) {
+            Some(cf) => cf,
+            None => continue,
+        };
+        let mut cf_audit = CfAudit {
+            cf: cf_name.to_string(),
+            ..Default::default()
+        };
+        for item in db.iterator_cf(cf, IteratorMode::Start) {
+            let (key, value) = item?;
+            cf_audit.total += 1;
+            if cf_name != "default" {
+                cf_audit.skipped += 1;
+                continue;
+            }
+            let verdict = if key.len() == 16 {
+                classify_memory(&value)
+            } else if key.starts_with(FACTS_PREFIX) {
+                classify_generic::<SemanticFact>(&value)
+            } else if key.starts_with(FACTS_EMBEDDING_PREFIX) {
+                classify_generic::<Vec<f32>>(&value)
+            } else if key.starts_with(b"lineage:edges:") {
+                classify_generic::<LineageEdge>(&value)
+            } else if key.starts_with(b"lineage:branches:") {
+                classify_generic::<LineageBranch>(&value)
+            } else if key.starts_with(TEMPORAL_FACTS_PREFIX) {
+                classify_generic::<TemporalFact>(&value)
+            } else if key.starts_with(VMAPPING_PREFIX) {
+                classify_generic::<VectorMappingEntry>(&value)
+            } else if key.starts_with(LEARNING_PREFIX)
+                || INDEX_ONLY_PREFIXES.iter().any(|p| key.starts_with(p))
+            {
+                Verdict::Decodable // index/ref records: nothing to verify
+            } else {
+                Verdict::Decodable // opaque/unknown: not an error
+            };
+            match verdict {
+                Verdict::Decodable => cf_audit.decodable += 1,
+                Verdict::Legacy => cf_audit.legacy += 1,
+                Verdict::Undecodable(e) => {
+                    cf_audit.undecodable += 1;
+                    *cf_audit.errors.entry(e.clone()).or_insert(0) += 1;
+                    archive.push("memory", cf_name, &key, &value, &e)?;
+                }
+            }
+        }
+        audit.total += cf_audit.total;
+        audit.decodable += cf_audit.decodable;
+        audit.legacy += cf_audit.legacy;
+        audit.undecodable += cf_audit.undecodable;
+        audit.skipped += cf_audit.skipped;
+        audit.cfs.push(cf_audit);
+    }
+    Ok(audit)
+}
+
+fn audit_graph_db(graph_dir: &Path, archive: &mut Archive) -> Result<DbAudit> {
+    let all_cfs: Vec<&str> = GRAPH_CF_NAMES.to_vec();
+    let cfs: Vec<&str> = std::iter::once("default").chain(all_cfs.iter().copied()).collect();
+    let db = open_db(graph_dir, &cfs)?;
+    let mut audit = DbAudit::default();
+
+    for cf_name in cfs {
+        let cf = match db.cf_handle(cf_name) {
+            Some(cf) => cf,
+            None => continue,
+        };
+        let mut cf_audit = CfAudit {
+            cf: cf_name.to_string(),
+            ..Default::default()
+        };
+        let data_cf = GRAPH_DATA_CFS.contains(&cf_name);
+        for item in db.iterator_cf(cf, IteratorMode::Start) {
+            let (key, value) = item?;
+            cf_audit.total += 1;
+            let verdict = if !data_cf {
+                Verdict::Decodable // index CF: skipped by design
+            } else {
+                match cf_name {
+                    "entities" => classify_generic::<EntityNode>(&value),
+                    "relationships" | "entity_edges" => classify_generic::<RelationshipEdge>(&value),
+                    "episodes" => classify_generic::<EpisodicNode>(&value),
+                    _ => Verdict::Decodable,
+                }
+            };
+            match verdict {
+                Verdict::Decodable => cf_audit.decodable += 1,
+                Verdict::Legacy => cf_audit.legacy += 1,
+                Verdict::Undecodable(e) => {
+                    cf_audit.undecodable += 1;
+                    *cf_audit.errors.entry(e.clone()).or_insert(0) += 1;
+                    archive.push("graph", cf_name, &key, &value, &e)?;
+                }
+            }
+        }
+        audit.total += cf_audit.total;
+        audit.decodable += cf_audit.decodable;
+        audit.legacy += cf_audit.legacy;
+        audit.undecodable += cf_audit.undecodable;
+        audit.skipped += cf_audit.skipped;
+        audit.cfs.push(cf_audit);
+    }
+    Ok(audit)
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+pub fn audit_all(storage_path: &Path, archive_path: Option<&Path>) -> Result<AuditReport> {
+    let mut archive = Archive::open(archive_path)?;
+    let mut report = AuditReport {
+        archive_path: archive_path.map(|p| p.display().to_string()),
+        ..Default::default()
+    };
+
+    let shared_dir = storage_path.join("shared");
+    if shared_dir.is_dir() {
+        report.shared = audit_shared_db(&shared_dir, &mut archive)?;
+    }
+
+    let mut users: Vec<String> = Vec::new();
+    if let Ok(rd) = std::fs::read_dir(storage_path) {
+        for entry in rd.flatten() {
+            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                let name = entry.file_name().to_string_lossy().to_string();
+                if !name.starts_with('.') && name != "backups" && entry.path().join("storage").is_dir() {
+                    users.push(name);
+                }
+            }
+        }
+    }
+    users.sort();
+
+    for user in users {
+        let base = storage_path.join(&user);
+        let mut ua = UserAudit {
+            user,
+            memory: DbAudit::default(),
+            graph: DbAudit::default(),
+        };
+        let mem_dir = base.join("storage");
+        if mem_dir.is_dir() {
+            ua.memory = audit_memory_db(&mem_dir, &mut archive)?;
+        }
+        let graph_dir = base.join("graph").join("graph");
+        if graph_dir.is_dir() {
+            ua.graph = audit_graph_db(&graph_dir, &mut archive)?;
+        }
+        report.users.push(ua);
+    }
+
+    report.archived_records = archive.count;
+    Ok(report)
+}

--- a/src/graph_memory.rs
+++ b/src/graph_memory.rs
@@ -36,7 +36,7 @@ const CF_RELATION_STATS: &str = "relation_stats";
 /// on one canonical node instead of minting parallel mention nodes.
 const CF_ALIAS: &str = "entity_alias";
 
-const GRAPH_CF_NAMES: &[&str] = &[
+pub(crate) const GRAPH_CF_NAMES: &[&str] = &[
     CF_ENTITIES,
     CF_RELATIONSHIPS,
     CF_EPISODES,
@@ -3825,10 +3825,16 @@ impl GraphMemory {
     pub fn get_entity(&self, uuid: &Uuid) -> Result<Option<EntityNode>> {
         let key = uuid.as_bytes();
         match self.db.get_cf(self.entities_cf(), key)? {
-            Some(value) => {
-                let (entity, _) = decode_entity_node(&value)?;
-                Ok(Some(entity))
-            }
+            Some(value) => match decode_entity_node(&value) {
+                Ok((entity, _)) => Ok(Some(entity)),
+                Err(e) => {
+                    // Schema drift or corruption: an undecodable record must
+                    // never brick recall or maintenance. Treat it as absent
+                    // and surface it for the audit/repair tooling.
+                    tracing::warn!(%uuid, error = %e, "entity record undecodable; treating as absent");
+                    Ok(None)
+                }
+            },
             None => Ok(None),
         }
     }
@@ -3848,7 +3854,28 @@ impl GraphMemory {
     pub fn delete_entity(&self, uuid: &Uuid) -> Result<bool> {
         let entity = match self.get_entity(uuid)? {
             Some(e) => e,
-            None => return Ok(false),
+            None => {
+                // Undecodable record (schema drift): get_entity already
+                // degraded it to None with a warning. If the raw key still
+                // exists, purge the primary record directly so the orphan
+                // cleanup can reclaim it. Its index entries are inert
+                // (every lookup resolves to None) and are left in place.
+                let exists = self
+                    .db
+                    .get_cf(self.entities_cf(), uuid.as_bytes())?
+                    .is_some();
+                if !exists {
+                    return Ok(false);
+                }
+                self.db.delete_cf(self.entities_cf(), uuid.as_bytes())?;
+                {
+                    let mut cache = self.entity_embedding_cache.write();
+                    cache.retain(|(id, _)| id != uuid);
+                }
+                self.entity_count.fetch_sub(1, Ordering::Relaxed);
+                tracing::warn!(uuid = %uuid, "Purged undecodable entity record by raw key");
+                return Ok(true);
+            }
         };
 
         // 1. Remove from entities CF

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,0 +1,190 @@
+//! Legacy v0.2.0 schema mirrors for schema-drift recovery.
+//!
+//! The npm-bundled v0.2.0 server (Jul 2 - Aug 19, 2026) wrote graph records
+//! with struct layouts that differ from the current build:
+//!   - `EntityLabel` gained 12 variants (Norp, Gpe, Facility, Vehicle,
+//!     Weapon, Work, Law, Title, Cyber, Money, Quantity, Time) mid-enum,
+//!     shifting every index after Module; an old `Other(String)` (index 23)
+//!     now decodes as `Module` and the trailing String corrupts the next
+//!     field.
+//!   - `EntityNode` gained trailing fields `fine_type`/`kb_id`.
+//!   - `RelationshipEdge` gained trailing fields `provenance`/`promoted_at`.
+//!
+//! These mirrors decode the old bytes (via `try_decode`, which handles both
+//! the postcard tag and the bincode fallbacks); the `From` impls convert to
+//! the current types with defaults for the added fields. Used by the
+//! migration command to repair records in place.
+//! DO NOT rename/reorder these fields — they must stay byte-compatible with
+//! v0.2.0 payloads.
+
+use std::collections::{HashMap, VecDeque};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::graph_memory::{
+    EdgeTier, EntityLabel, EntityNode, LtpStatus, ProvenanceRecord, RelationType, RelationshipEdge,
+};
+use crate::serialization;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum LegacyEntityLabel {
+    Person,
+    Organization,
+    Location,
+    Technology,
+    Concept,
+    Event,
+    Date,
+    Product,
+    Skill,
+    Keyword,
+    Project,
+    Task,
+    Document,
+    Repository,
+    Service,
+    Database,
+    Metric,
+    Configuration,
+    Environment,
+    Pipeline,
+    Team,
+    Role,
+    Module,
+    Other(String),
+}
+
+impl From<LegacyEntityLabel> for EntityLabel {
+    fn from(l: LegacyEntityLabel) -> Self {
+        match l {
+            LegacyEntityLabel::Person => EntityLabel::Person,
+            LegacyEntityLabel::Organization => EntityLabel::Organization,
+            LegacyEntityLabel::Location => EntityLabel::Location,
+            LegacyEntityLabel::Technology => EntityLabel::Technology,
+            LegacyEntityLabel::Concept => EntityLabel::Concept,
+            LegacyEntityLabel::Event => EntityLabel::Event,
+            LegacyEntityLabel::Date => EntityLabel::Date,
+            LegacyEntityLabel::Product => EntityLabel::Product,
+            LegacyEntityLabel::Skill => EntityLabel::Skill,
+            LegacyEntityLabel::Keyword => EntityLabel::Keyword,
+            LegacyEntityLabel::Project => EntityLabel::Project,
+            LegacyEntityLabel::Task => EntityLabel::Task,
+            LegacyEntityLabel::Document => EntityLabel::Document,
+            LegacyEntityLabel::Repository => EntityLabel::Repository,
+            LegacyEntityLabel::Service => EntityLabel::Service,
+            LegacyEntityLabel::Database => EntityLabel::Database,
+            LegacyEntityLabel::Metric => EntityLabel::Metric,
+            LegacyEntityLabel::Configuration => EntityLabel::Configuration,
+            LegacyEntityLabel::Environment => EntityLabel::Environment,
+            LegacyEntityLabel::Pipeline => EntityLabel::Pipeline,
+            LegacyEntityLabel::Team => EntityLabel::Team,
+            LegacyEntityLabel::Role => EntityLabel::Role,
+            LegacyEntityLabel::Module => EntityLabel::Module,
+            LegacyEntityLabel::Other(s) => EntityLabel::Other(s),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LegacyEntityNode {
+    pub uuid: Uuid,
+    pub name: String,
+    pub labels: Vec<LegacyEntityLabel>,
+    pub created_at: DateTime<Utc>,
+    pub last_seen_at: DateTime<Utc>,
+    pub mention_count: usize,
+    pub summary: String,
+    pub attributes: HashMap<String, String>,
+    pub name_embedding: Option<Vec<f32>>,
+    pub salience: f32,
+    pub is_proper_noun: bool,
+    pub selectivity: Option<f32>,
+}
+
+impl From<LegacyEntityNode> for EntityNode {
+    fn from(n: LegacyEntityNode) -> Self {
+        EntityNode {
+            uuid: n.uuid,
+            name: n.name,
+            labels: n.labels.into_iter().map(Into::into).collect(),
+            created_at: n.created_at,
+            last_seen_at: n.last_seen_at,
+            mention_count: n.mention_count,
+            summary: n.summary,
+            attributes: n.attributes,
+            name_embedding: n.name_embedding,
+            salience: n.salience,
+            is_proper_noun: n.is_proper_noun,
+            selectivity: n.selectivity,
+            fine_type: None,
+            kb_id: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LegacyRelationshipEdge {
+    pub uuid: Uuid,
+    pub from_entity: Uuid,
+    pub to_entity: Uuid,
+    pub relation_type: RelationType,
+    pub strength: f32,
+    pub created_at: DateTime<Utc>,
+    pub valid_at: DateTime<Utc>,
+    pub invalidated_at: Option<DateTime<Utc>>,
+    pub source_episode_id: Option<Uuid>,
+    pub context: String,
+    pub last_activated: DateTime<Utc>,
+    pub activation_count: u32,
+    pub ltp_status: LtpStatus,
+    pub tier: EdgeTier,
+    pub activation_timestamps: Option<VecDeque<DateTime<Utc>>>,
+    pub entity_confidence: Option<f32>,
+    pub endpoint_selectivity: Option<f32>,
+    pub forman_curvature: Option<f32>,
+}
+
+impl From<LegacyRelationshipEdge> for RelationshipEdge {
+    fn from(e: LegacyRelationshipEdge) -> Self {
+        RelationshipEdge {
+            uuid: e.uuid,
+            from_entity: e.from_entity,
+            to_entity: e.to_entity,
+            relation_type: e.relation_type,
+            strength: e.strength,
+            created_at: e.created_at,
+            valid_at: e.valid_at,
+            invalidated_at: e.invalidated_at,
+            source_episode_id: e.source_episode_id,
+            context: e.context,
+            last_activated: e.last_activated,
+            activation_count: e.activation_count,
+            ltp_status: e.ltp_status,
+            tier: e.tier,
+            activation_timestamps: e.activation_timestamps,
+            entity_confidence: e.entity_confidence,
+            endpoint_selectivity: e.endpoint_selectivity,
+            forman_curvature: e.forman_curvature,
+            provenance: Vec::<ProvenanceRecord>::new(),
+            promoted_at: None,
+        }
+    }
+}
+
+/// Decode a v0.2.0-era entity record (tagged postcard or legacy bincode) into
+/// a current-schema `EntityNode`.
+pub fn decode_legacy_entity(value: &[u8]) -> Result<EntityNode, String> {
+    let (legacy, _): (LegacyEntityNode, bool) =
+        serialization::try_decode(value).map_err(|e| format!("legacy EntityNode: {e}"))?;
+    Ok(legacy.into())
+}
+
+/// Decode a v0.2.0-era relationship record (tagged postcard or legacy bincode)
+/// into a current-schema `RelationshipEdge`.
+pub fn decode_legacy_relationship(value: &[u8]) -> Result<RelationshipEdge, String> {
+    let (legacy, _): (LegacyRelationshipEdge, bool) =
+        serialization::try_decode(value).map_err(|e| format!("legacy RelationshipEdge: {e}"))?;
+    Ok(legacy.into())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@ pub mod memory;
 pub mod metrics;
 pub mod middleware;
 pub mod mif;
+pub mod audit;
+pub mod legacy;
 pub mod migration;
 pub mod openie;
 pub mod query_parsing;

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,12 @@ enum Command {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Read-only audit: classify every record by decodability, archive failures
+    Audit {
+        /// Write undecodable records (db, cf, key/value hex, error) to this JSONL file
+        #[arg(long)]
+        archive: Option<PathBuf>,
+    },
     /// Internal safe named-pipe exchange used by the TypeScript client on Windows.
     #[command(hide = true)]
     IpcExchange {
@@ -162,6 +168,17 @@ fn main() -> Result<()> {
             if !report.errors.is_empty() {
                 std::process::exit(1);
             }
+            Ok(())
+        }
+        Some(Command::Audit { archive }) => {
+            eprintln!(
+                "Shodh-Memory: auditing storage at {} (archive: {})",
+                cli.storage_path.display(),
+                archive.as_deref().map(|p| p.display().to_string()).unwrap_or_else(|| "(none)".into())
+            );
+
+            let report = shodh_memory::audit::audit_all(&cli.storage_path, archive.as_deref())?;
+            eprintln!("{report}");
             Ok(())
         }
         Some(Command::IpcExchange { timeout_ms }) => {

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -2137,13 +2137,22 @@ impl<'de> Deserialize<'de> for Memory {
     where
         D: serde::Deserializer<'de>,
     {
-        let mut flat = MemoryFlat::deserialize(deserializer)?;
-        // Put the tail-carried toponyms back where they belong on the domain
-        // type. Records written before the field existed decode as empty.
-        flat.experience.toponyms = flat.toponyms;
-        Ok(Memory {
+        let flat = MemoryFlat::deserialize(deserializer)?;
+        Ok(Memory::from_flat(flat))
+    }
+}
+
+impl Memory {
+    /// Rebuild a `Memory` from its flat (wire) representation, moving the
+    /// tail-carried toponyms back onto the domain type.
+    pub(crate) fn from_flat(flat: MemoryFlat) -> Self {
+        Memory {
             id: flat.id,
-            experience: flat.experience,
+            experience: {
+                let mut exp = flat.experience;
+                exp.toponyms = flat.toponyms;
+                exp
+            },
             metadata: Arc::new(parking_lot::Mutex::new(MemoryMetadata {
                 importance: flat.importance,
                 access_count: flat.access_count,
@@ -2170,7 +2179,7 @@ impl<'de> Deserialize<'de> for Memory {
             related_todo_ids: flat.related_todo_ids,
             // Hierarchy
             parent_id: flat.parent_id,
-        })
+        }
     }
 }
 
@@ -5392,4 +5401,203 @@ mod tests {
             "new keys are added"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy v0.2.0 schema mirrors (schema-drift recovery)
+// ---------------------------------------------------------------------------
+// The npm-bundled v0.2.0 server (Jul 2 - Aug 19, 2026) wrote SHO v2 payloads
+// whose MemoryFlat layout differs from the current build:
+//   - NerEntityRecord gained a trailing `fine_label: Option<String>`
+//     (mid-payload inside Experience.ner_entities, so the trailing-field
+//     compat suffix in storage.rs cannot help)
+//   - MemoryFlat gained a trailing `toponyms: Vec<Toponym>`
+// These mirrors decode the old bytes; the From impls convert to the current
+// types (missing fields take their default values). Used by the migration
+// command to repair records in place. DO NOT rename/reorder these fields —
+// they must stay byte-compatible with v0.2.0 payloads.
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct LegacyNerEntityRecord {
+    pub text: String,
+    pub entity_type: String,
+    pub confidence: f32,
+    pub start_char: Option<usize>,
+    pub end_char: Option<usize>,
+}
+
+impl From<LegacyNerEntityRecord> for NerEntityRecord {
+    fn from(r: LegacyNerEntityRecord) -> Self {
+        NerEntityRecord {
+            text: r.text,
+            entity_type: r.entity_type,
+            confidence: r.confidence,
+            start_char: r.start_char,
+            end_char: r.end_char,
+            fine_label: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct LegacyExperience {
+    pub experience_type: ExperienceType,
+    pub content: String,
+    pub context: Option<RichContext>,
+    pub entities: Vec<String>,
+    pub metadata: HashMap<String, String>,
+    pub embeddings: Option<Vec<f32>>,
+    pub image_embeddings: Option<Vec<f32>>,
+    pub audio_embeddings: Option<Vec<f32>>,
+    pub video_embeddings: Option<Vec<f32>>,
+    pub media_refs: Vec<MediaRef>,
+    pub related_memories: Vec<MemoryId>,
+    pub causal_chain: Vec<MemoryId>,
+    pub outcomes: Vec<String>,
+    pub robot_id: Option<String>,
+    pub mission_id: Option<String>,
+    pub geo_location: Option<[f64; 3]>,
+    pub local_position: Option<[f32; 3]>,
+    pub heading: Option<f32>,
+    pub action_type: Option<String>,
+    pub reward: Option<f32>,
+    pub sensor_data: HashMap<String, f64>,
+    pub decision_context: Option<HashMap<String, String>>,
+    pub action_params: Option<HashMap<String, String>>,
+    pub outcome_type: Option<String>,
+    pub outcome_details: Option<String>,
+    pub confidence: Option<f32>,
+    pub alternatives_considered: Vec<String>,
+    pub weather: Option<HashMap<String, String>>,
+    pub terrain_type: Option<String>,
+    pub lighting: Option<String>,
+    pub nearby_agents: Vec<HashMap<String, String>>,
+    pub is_failure: bool,
+    pub is_anomaly: bool,
+    pub severity: Option<String>,
+    pub recovery_action: Option<String>,
+    pub root_cause: Option<String>,
+    pub pattern_id: Option<String>,
+    pub predicted_outcome: Option<String>,
+    pub prediction_accurate: Option<bool>,
+    pub tags: Vec<String>,
+    pub temporal_refs: Vec<String>,
+    pub ner_entities: Vec<LegacyNerEntityRecord>,
+    pub cooccurrence_pairs: Vec<(String, String)>,
+    pub importance_override: Option<f32>,
+}
+
+impl From<LegacyExperience> for Experience {
+    fn from(e: LegacyExperience) -> Self {
+        Experience {
+            experience_type: e.experience_type,
+            content: e.content,
+            context: e.context,
+            entities: e.entities,
+            metadata: e.metadata,
+            embeddings: e.embeddings,
+            image_embeddings: e.image_embeddings,
+            audio_embeddings: e.audio_embeddings,
+            video_embeddings: e.video_embeddings,
+            media_refs: e.media_refs,
+            related_memories: e.related_memories,
+            causal_chain: e.causal_chain,
+            outcomes: e.outcomes,
+            robot_id: e.robot_id,
+            mission_id: e.mission_id,
+            geo_location: e.geo_location,
+            local_position: e.local_position,
+            heading: e.heading,
+            action_type: e.action_type,
+            reward: e.reward,
+            sensor_data: e.sensor_data,
+            decision_context: e.decision_context,
+            action_params: e.action_params,
+            outcome_type: e.outcome_type,
+            outcome_details: e.outcome_details,
+            confidence: e.confidence,
+            alternatives_considered: e.alternatives_considered,
+            weather: e.weather,
+            terrain_type: e.terrain_type,
+            lighting: e.lighting,
+            nearby_agents: e.nearby_agents,
+            is_failure: e.is_failure,
+            is_anomaly: e.is_anomaly,
+            severity: e.severity,
+            recovery_action: e.recovery_action,
+            root_cause: e.root_cause,
+            pattern_id: e.pattern_id,
+            predicted_outcome: e.predicted_outcome,
+            prediction_accurate: e.prediction_accurate,
+            tags: e.tags,
+            temporal_refs: e.temporal_refs,
+            ner_entities: e.ner_entities.into_iter().map(Into::into).collect(),
+            cooccurrence_pairs: e.cooccurrence_pairs,
+            importance_override: e.importance_override,
+            toponyms: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct LegacyMemoryFlat {
+    pub id: MemoryId,
+    pub experience: LegacyExperience,
+    pub importance: f32,
+    pub access_count: u32,
+    pub created_at: DateTime<Utc>,
+    pub last_accessed: DateTime<Utc>,
+    pub compressed: bool,
+    pub tier: MemoryTier,
+    pub entity_refs: Vec<EntityRef>,
+    pub activation: f32,
+    pub last_retrieval_id: Option<Uuid>,
+    pub agent_id: Option<String>,
+    pub run_id: Option<String>,
+    pub actor_id: Option<String>,
+    pub temporal_relevance: f32,
+    pub score: Option<f32>,
+    pub external_id: Option<String>,
+    pub version: u32,
+    pub history: Vec<MemoryRevision>,
+    pub related_todo_ids: Vec<TodoId>,
+    pub parent_id: Option<MemoryId>,
+}
+
+impl From<LegacyMemoryFlat> for MemoryFlat {
+    fn from(f: LegacyMemoryFlat) -> Self {
+        MemoryFlat {
+            id: f.id,
+            experience: f.experience.into(),
+            importance: f.importance,
+            access_count: f.access_count,
+            created_at: f.created_at,
+            last_accessed: f.last_accessed,
+            compressed: f.compressed,
+            tier: f.tier,
+            entity_refs: f.entity_refs,
+            activation: f.activation,
+            last_retrieval_id: f.last_retrieval_id,
+            agent_id: f.agent_id,
+            run_id: f.run_id,
+            actor_id: f.actor_id,
+            temporal_relevance: f.temporal_relevance,
+            score: f.score,
+            external_id: f.external_id,
+            version: f.version,
+            history: f.history,
+            related_todo_ids: f.related_todo_ids,
+            parent_id: f.parent_id,
+            toponyms: Vec::new(),
+        }
+    }
+}
+
+/// Decode a v0.2.0-era SHO v2 payload (pre-fine_label / pre-toponyms) into a
+/// current-schema `Memory`. Returns Err if the payload is not valid legacy
+/// postcard.
+pub(crate) fn decode_legacy_memory_flat(payload: &[u8]) -> Result<Memory, String> {
+    let flat: LegacyMemoryFlat =
+        postcard::from_bytes(payload).map_err(|e| format!("legacy MemoryFlat postcard: {e}"))?;
+    Ok(Memory::from_flat(flat.into()))
 }

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -154,7 +154,10 @@ pub fn migrate_all(storage_path: &Path, dry_run: bool) -> Result<MigrationReport
         .filter(|e| {
             let name = e.file_name();
             let name_str = name.to_string_lossy();
-            e.path().is_dir() && name_str != "shared" && !name_str.ends_with(".pre_cf_migration")
+            e.path().is_dir()
+                && name_str != "shared"
+                && !name_str.ends_with(".pre_cf_migration")
+                && e.path().join("storage").is_dir()
         })
         .collect();
 
@@ -190,8 +193,15 @@ pub fn migrate_all(storage_path: &Path, dry_run: bool) -> Result<MigrationReport
             }
         }
 
-        // Graph DB (graph/ subdir)
-        let graph_dir = user_path.join("graph");
+        // Graph DB (graph/ subdir; the server keeps the RocksDB at
+        // graph/graph after the Aug 2026 layout move, older layouts used
+        // graph/ directly)
+        let graph_candidate = user_path.join("graph").join("graph");
+        let graph_dir = if graph_candidate.exists() {
+            graph_candidate
+        } else {
+            user_path.join("graph")
+        };
         if graph_dir.exists() {
             match migrate_graph_db(&graph_dir, dry_run) {
                 Ok((migrated, skipped)) => {
@@ -281,20 +291,20 @@ struct MemoryDbCounts {
 }
 
 /// Known prefixes for sub-stores in the memory DB default CF.
-const FACTS_PREFIX: &[u8] = b"facts:";
-const FACTS_BY_ENTITY_PREFIX: &[u8] = b"facts_by_entity:";
-const FACTS_BY_TYPE_PREFIX: &[u8] = b"facts_by_type:";
-const FACTS_EMBEDDING_PREFIX: &[u8] = b"facts_embedding:";
-const TEMPORAL_FACTS_PREFIX: &[u8] = b"temporal_facts:";
-const TEMPORAL_BY_ENTITY_PREFIX: &[u8] = b"temporal_by_entity:";
-const TEMPORAL_BY_EVENT_PREFIX: &[u8] = b"temporal_by_event:";
-const TEMPORAL_BY_TIME_PREFIX: &[u8] = b"temporal_by_time:";
-const VMAPPING_PREFIX: &[u8] = b"vmapping:";
-const LEARNING_PREFIX: &[u8] = b"learning:";
+pub(crate) const FACTS_PREFIX: &[u8] = b"facts:";
+pub(crate) const FACTS_BY_ENTITY_PREFIX: &[u8] = b"facts_by_entity:";
+pub(crate) const FACTS_BY_TYPE_PREFIX: &[u8] = b"facts_by_type:";
+pub(crate) const FACTS_EMBEDDING_PREFIX: &[u8] = b"facts_embedding:";
+pub(crate) const TEMPORAL_FACTS_PREFIX: &[u8] = b"temporal_facts:";
+pub(crate) const TEMPORAL_BY_ENTITY_PREFIX: &[u8] = b"temporal_by_entity:";
+pub(crate) const TEMPORAL_BY_EVENT_PREFIX: &[u8] = b"temporal_by_event:";
+pub(crate) const TEMPORAL_BY_TIME_PREFIX: &[u8] = b"temporal_by_time:";
+pub(crate) const VMAPPING_PREFIX: &[u8] = b"vmapping:";
+pub(crate) const LEARNING_PREFIX: &[u8] = b"learning:";
 
 /// Prefixes whose values are plain string references (not serialized structs).
 /// Index entries: their values are just key references — no binary format to migrate.
-const INDEX_ONLY_PREFIXES: &[&[u8]] = &[
+pub(crate) const INDEX_ONLY_PREFIXES: &[&[u8]] = &[
     b"stats:",
     b"interference:",
     b"interference_meta:",
@@ -377,6 +387,7 @@ fn migrate_memory_db(storage_dir: &Path, dry_run: bool) -> Result<MemoryDbCounts
                 &mut batch_count,
                 &mut counts.facts_migrated,
                 &mut counts.facts_skipped,
+                None,
             )?;
         } else if key.starts_with(FACTS_EMBEDDING_PREFIX) {
             // Vec<f32> embedding
@@ -390,6 +401,7 @@ fn migrate_memory_db(storage_dir: &Path, dry_run: bool) -> Result<MemoryDbCounts
                 &mut batch_count,
                 &mut counts.facts_migrated,
                 &mut counts.facts_skipped,
+                None,
             )?;
         } else if key.starts_with(b"lineage:edges:") {
             // LineageEdge
@@ -403,6 +415,7 @@ fn migrate_memory_db(storage_dir: &Path, dry_run: bool) -> Result<MemoryDbCounts
                 &mut batch_count,
                 &mut counts.lineage_migrated,
                 &mut counts.lineage_skipped,
+                None,
             )?;
         } else if key.starts_with(b"lineage:branches:") {
             // LineageBranch
@@ -416,6 +429,7 @@ fn migrate_memory_db(storage_dir: &Path, dry_run: bool) -> Result<MemoryDbCounts
                 &mut batch_count,
                 &mut counts.lineage_migrated,
                 &mut counts.lineage_skipped,
+                None,
             )?;
         } else if key.starts_with(TEMPORAL_FACTS_PREFIX) {
             // TemporalFact
@@ -429,6 +443,7 @@ fn migrate_memory_db(storage_dir: &Path, dry_run: bool) -> Result<MemoryDbCounts
                 &mut batch_count,
                 &mut counts.temporal_migrated,
                 &mut counts.temporal_skipped,
+                None,
             )?;
         } else if key.starts_with(VMAPPING_PREFIX) {
             // VectorMappingEntry
@@ -442,14 +457,41 @@ fn migrate_memory_db(storage_dir: &Path, dry_run: bool) -> Result<MemoryDbCounts
                 &mut batch_count,
                 &mut counts.vector_mappings_migrated,
                 &mut counts.vector_mappings_skipped,
+                None,
             )?;
         } else if key.len() == 16 {
             // Memory record (16-byte UUID key) — uses SHO envelope
-            if let Some((version, _payload)) = serialization::unwrap_sho(&value) {
+            if let Some((version, payload)) = serialization::unwrap_sho(&value) {
                 if version == serialization::SHO_VERSION_POSTCARD {
-                    // Already postcard
-                    counts.memories_skipped += 1;
-                    continue;
+                    // Tagged postcard — VERIFY the payload decodes with the
+                    // current schema. v0.2.0-era payloads (pre-fine_label)
+                    // carry the tag but fail; they are repaired below via the
+                    // legacy mirror instead of being skipped on sight.
+                    match crate::memory::storage::deserialize_memory_for_migration(&value) {
+                        Ok(_) => {
+                            counts.memories_skipped += 1;
+                            continue;
+                        }
+                        Err(_) => {
+                            match crate::memory::types::decode_legacy_memory_flat(payload) {
+                                Ok(memory) => {
+                                    if !dry_run {
+                                        let new_value = serialization::encode_sho(&memory)?;
+                                        batch.put(&*key, &new_value);
+                                        batch_count += 1;
+                                    }
+                                    counts.memories_migrated += 1;
+                                }
+                                Err(lerr) => {
+                                    eprintln!(
+                                        "  WARNING: memory key ({} bytes) undecodable by current and legacy ({lerr}) schemas",
+                                        key.len()
+                                    );
+                                }
+                            }
+                            continue;
+                        }
+                    }
                 }
             }
 
@@ -498,6 +540,7 @@ fn migrate_memory_db(storage_dir: &Path, dry_run: bool) -> Result<MemoryDbCounts
                     &mut batch_count,
                     &mut counts.vector_mappings_migrated,
                     &mut counts.vector_mappings_skipped,
+                    None,
                 )?;
             }
         }
@@ -521,27 +564,17 @@ fn migrate_memory_db(storage_dir: &Path, dry_run: bool) -> Result<MemoryDbCounts
 // ---------------------------------------------------------------------------
 
 /// Graph DB column families that contain serialized data (entities, edges, episodes).
-const GRAPH_DATA_CFS: &[&str] = &["entities", "relationships", "episodes", "entity_edges"];
-
-/// Graph DB column families that contain index data (string references, counts) — skip.
-const GRAPH_INDEX_CFS: &[&str] = &[
-    "entity_pair_index",
-    "entity_episodes",
-    "name_index",
-    "lowercase_index",
-    "stemmed_index",
-];
+pub(crate) const GRAPH_DATA_CFS: &[&str] = &["entities", "relationships", "episodes", "entity_edges"];
 
 fn migrate_graph_db(graph_dir: &Path, dry_run: bool) -> Result<(usize, usize)> {
     let mut opts = RocksOptions::default();
     opts.create_if_missing(false);
     opts.create_missing_column_families(true);
 
-    let all_cfs: Vec<&str> = GRAPH_DATA_CFS
-        .iter()
-        .chain(GRAPH_INDEX_CFS.iter())
-        .copied()
-        .collect();
+    // Open every CF the server knows about (GRAPH_CF_NAMES is the single
+    // source of truth; GRAPH_DATA_CFS is the typed subset). Missing CFs in
+    // the open list cause "Column families not opened" errors.
+    let all_cfs: Vec<&str> = crate::graph_memory::GRAPH_CF_NAMES.to_vec();
 
     let cfs: Vec<ColumnFamilyDescriptor> = std::iter::once(ColumnFamilyDescriptor::new(
         "default",
@@ -586,6 +619,12 @@ fn migrate_graph_db(graph_dir: &Path, dry_run: bool) -> Result<(usize, usize)> {
 
             match *cf_name {
                 "entities" => {
+                    // Data records carry 16-byte UUID keys; anything else in
+                    // this CF is a legacy reference record and is skipped.
+                    if key.len() != 16 {
+                        skipped += 1;
+                        continue;
+                    }
                     migrate_generic_record::<EntityNode>(
                         &db,
                         Some(cf),
@@ -596,9 +635,16 @@ fn migrate_graph_db(graph_dir: &Path, dry_run: bool) -> Result<(usize, usize)> {
                         &mut batch_count,
                         &mut migrated,
                         &mut skipped,
+                        Some(crate::legacy::decode_legacy_entity),
                     )?;
                 }
-                "relationships" | "entity_edges" => {
+                "relationships" => {
+                    // Data records carry 16-byte UUID keys; legacy reference
+                    // records (e.g. "mem_edge:<uuid>" entries) are skipped.
+                    if key.len() != 16 {
+                        skipped += 1;
+                        continue;
+                    }
                     // This offline format-migration is a byte-level postcard
                     // rewrite (trailing-field defaults only) — it does not
                     // decode through `graph_memory::decode_relationship_edge`,
@@ -618,7 +664,13 @@ fn migrate_graph_db(graph_dir: &Path, dry_run: bool) -> Result<(usize, usize)> {
                         &mut batch_count,
                         &mut migrated,
                         &mut skipped,
+                        Some(crate::legacy::decode_legacy_relationship),
                     )?;
+                }
+                "entity_edges" => {
+                    // Index CF: values are plain "1" markers (graph traversal
+                    // index), not serialized records. Nothing to migrate.
+                    skipped += 1;
                 }
                 "episodes" => {
                     migrate_generic_record::<EpisodicNode>(
@@ -631,6 +683,7 @@ fn migrate_graph_db(graph_dir: &Path, dry_run: bool) -> Result<(usize, usize)> {
                         &mut batch_count,
                         &mut migrated,
                         &mut skipped,
+                        None,
                     )?;
                 }
                 _ => {}
@@ -705,6 +758,7 @@ fn migrate_shared_db(shared_dir: &Path, dry_run: bool) -> Result<(usize, usize)>
             &mut batch_count,
             &mut migrated,
             &mut skipped,
+            None,
         )?;
 
         if batch_count >= BATCH_SIZE && !dry_run {
@@ -727,9 +781,12 @@ fn migrate_shared_db(shared_dir: &Path, dry_run: bool) -> Result<(usize, usize)>
 
 /// Migrate a single record from legacy bincode to tagged postcard.
 ///
-/// If the record already has the postcard format tag, it is skipped.
-/// Otherwise it is decoded via `try_decode` (postcard-first, bincode fallback)
-/// and re-encoded as tagged postcard.
+/// If the record already has the postcard format tag AND decodes with the
+/// current schema, it is skipped. Tagged records that fail current-schema
+/// decode (v0.2.0-era payloads with shifted enum indices or added trailing
+/// fields) are repaired via the optional legacy decoder. Untagged records are
+/// decoded via `try_decode` (postcard-first, bincode fallback) with the same
+/// legacy fallback, and re-encoded as tagged postcard.
 #[allow(clippy::too_many_arguments)]
 fn migrate_generic_record<T>(
     _db: &DB,
@@ -741,33 +798,59 @@ fn migrate_generic_record<T>(
     batch_count: &mut usize,
     migrated: &mut usize,
     skipped: &mut usize,
+    legacy: Option<fn(&[u8]) -> Result<T, String>>,
 ) -> Result<()>
 where
     T: serde::de::DeserializeOwned + serde::Serialize,
 {
-    // Already in postcard format — skip
-    if serialization::has_format_tag_pub(value) {
-        *skipped += 1;
-        return Ok(());
-    }
+    let tagged = serialization::has_format_tag_pub(value);
 
-    // Decode with legacy bincode fallback. A record that can't be decoded — e.g. a
-    // pre-postcard bincode record missing fields added after the cutover, which
-    // bincode cannot default — is SKIPPED and reported, never fatal: one bad record
-    // must not abort the whole column-family migration. (Such records are already
-    // unreadable by the server's compat decoder, so skipping loses nothing new.)
-    let (val, _needs_migration): (T, bool) = match serialization::try_decode(value) {
-        Ok(decoded) => decoded,
-        Err(e) => {
-            eprintln!(
-                "  skip: undecodable record (key len={}, value len={}): {e}",
-                key.len(),
-                value.len()
-            );
+    // Try the current schema first.
+    let decoded: Option<(T, bool)> = match serialization::try_decode(value) {
+        Ok(decoded) => Some(decoded),
+        Err(current_err) => {
+            match legacy {
+                Some(legacy_decode) => match legacy_decode(value) {
+                    Ok(val) => Some((val, true)),
+                    Err(legacy_err) => {
+                        eprintln!(
+                            "  skip: record undecodable by current ({current_err}) and legacy ({legacy_err}) schemas (key len={}, value len={})",
+                            key.len(),
+                            value.len()
+                        );
+                        None
+                    }
+                },
+                None => {
+                    eprintln!(
+                        "  skip: undecodable record (key len={}, value len={}): {current_err}",
+                        key.len(),
+                        value.len()
+                    );
+                    None
+                }
+            }
+        }
+    };
+
+    let Some((val, needs_rewrite)) = decoded else {
+        // Records that fail both schemas are not data-loss candidates when
+        // the key is not a data-record key (16-byte UUID): legacy index and
+        // reference records (e.g. old "mem_edge:<uuid>" entries in the
+        // relationships CF) are skipped silently rather than warned about.
+        if key.len() != 16 {
             *skipped += 1;
             return Ok(());
         }
+        *skipped += 1;
+        return Ok(());
     };
+
+    // Tagged records that decode cleanly are already current: skip.
+    if tagged && !needs_rewrite {
+        *skipped += 1;
+        return Ok(());
+    }
 
     if !dry_run {
         let new_value = serialization::encode(&val)?;


### PR DESCRIPTION
## Summary
Fixes the ~41h recall outage (Aug 19 19:46 onward) where /api/recall 500'd on every request after the Node→Rust server swap: the Rust build read graph/memory records written by the old server with drifted struct layouts and propagated the decode error.

## Changes
- **audit** subcommand (read-only, RocksDB read-only open so it runs against the live data dir): classifies every record decodable/legacy/undecodable, archives raw failures
- **legacy schema mirrors** matching v0.2.0 byte layout (EntityLabel enum order +12 variants, EntityNode/NerEntityRecord fine_label/RelationshipEdge/MemoryFlat toponyms drift) with From conversions to current types
- **migrate fixes**: verify-don't-trust tagged records, legacy fallback decode, skip index/reference records (mem_edge UUID markers, entity_edges "1" markers), accept graph/graph layout, require storage/ subdir for user detection
- **get_entity degradation**: undecodable records degrade to missing (warn) instead of propagating — one corrupt record can never 500 recall again
- **delete_entity raw-key purge** so maintenance can reclaim undecodable orphans
- **audit verdict fix**: decodable/legacy buckets were inverted (try_decode's needs_migration flag)

## Verification (all on production data)
- Migration: 133 memories + 3,010 graph entities recovered, marker written
- Post-migration audit on live data: memories 0 undecodable, entities 0, episodes 0; remaining 198,306 relationships + 83,545 entity_edges records are index markers, not data
- Previously-500 query returns full results on :3030 (production)
- Corrupt-data degradation test: recall returns 200 (empty) instead of 500
- Weekly decode-scan cron (silent watchdog) installed