### PR TITLE
security: confine per-user paths to their base directory, and stop printing the full API key

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -84,9 +84,10 @@ impl ShodhBackupEngine {
     /// path in it would escape `backup_path` at every join below. Every user-scoped path in this
     /// engine goes through here.
     fn user_backup_dir(&self, user_id: &str) -> Result<PathBuf> {
-        Ok(self
-            .backup_path
-            .join(crate::path_guard::sanitize_component(user_id, "backup user id")?))
+        Ok(self.backup_path.join(crate::path_guard::sanitize_component(
+            user_id,
+            "backup user id",
+        )?))
     }
 
     /// Create a full backup of a RocksDB database

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -79,6 +79,16 @@ impl ShodhBackupEngine {
         &self.backup_path
     }
 
+    /// The per-user backup directory, with the identifier validated as a single path component
+    /// BEFORE it is joined — `user_id` arrives from outside the process, and `../` or an absolute
+    /// path in it would escape `backup_path` at every join below. Every user-scoped path in this
+    /// engine goes through here.
+    fn user_backup_dir(&self, user_id: &str) -> Result<PathBuf> {
+        Ok(self
+            .backup_path
+            .join(crate::path_guard::sanitize_component(user_id, "backup user id")?))
+    }
+
     /// Create a full backup of a RocksDB database
     ///
     /// # Arguments
@@ -88,7 +98,7 @@ impl ShodhBackupEngine {
     /// # Returns
     /// BackupMetadata with backup details
     pub fn create_backup(&self, db: &DB, user_id: &str) -> Result<BackupMetadata> {
-        let backup_dir = self.backup_path.join(user_id);
+        let backup_dir = self.user_backup_dir(user_id)?;
         fs::create_dir_all(&backup_dir)?;
 
         // Create RocksDB backup engine
@@ -178,8 +188,7 @@ impl ShodhBackupEngine {
 
         // Step 2: Checkpoint each secondary store alongside the backup
         let secondary_dir = self
-            .backup_path
-            .join(user_id)
+            .user_backup_dir(user_id)?
             .join(format!("secondary_{}", metadata.backup_id));
         fs::create_dir_all(&secondary_dir)?;
 
@@ -280,7 +289,7 @@ impl ShodhBackupEngine {
 
         // Recompute checksum now that secondary stores are included.
         // The initial checksum from create_backup() only covered the main DB.
-        let backup_dir = self.backup_path.join(user_id);
+        let backup_dir = self.user_backup_dir(user_id)?;
         metadata.checksum = self.calculate_backup_checksum(&backup_dir, metadata.backup_id)?;
         self.save_metadata(&metadata)?;
 
@@ -307,7 +316,7 @@ impl ShodhBackupEngine {
         backup_id: Option<u32>,
         restore_path: &Path,
     ) -> Result<()> {
-        let backup_dir = self.backup_path.join(user_id);
+        let backup_dir = self.user_backup_dir(user_id)?;
 
         if !backup_dir.exists() {
             return Err(anyhow!("No backups found for user: {user_id}"));
@@ -349,7 +358,7 @@ impl ShodhBackupEngine {
 
     /// List all available backups for a user
     pub fn list_backups(&self, user_id: &str) -> Result<Vec<BackupMetadata>> {
-        let backup_dir = self.backup_path.join(user_id);
+        let backup_dir = self.user_backup_dir(user_id)?;
 
         if !backup_dir.exists() {
             return Ok(Vec::new());
@@ -393,7 +402,7 @@ impl ShodhBackupEngine {
         let resolved_backup_id = match backup_id {
             Some(id) => id,
             None => {
-                let backup_dir = self.backup_path.join(user_id);
+                let backup_dir = self.user_backup_dir(user_id)?;
                 let backup_opts = BackupEngineOptions::new(&backup_dir)?;
                 let env = Env::new()?;
                 let backup_engine = BackupEngine::open(&backup_opts, &env)?;
@@ -406,8 +415,7 @@ impl ShodhBackupEngine {
 
         // Step 3: Restore secondary stores from checkpoints
         let secondary_dir = self
-            .backup_path
-            .join(user_id)
+            .user_backup_dir(user_id)?
             .join(format!("secondary_{resolved_backup_id}"));
 
         let mut restored_stores = Vec::new();
@@ -556,7 +564,7 @@ impl ShodhBackupEngine {
             ));
         }
 
-        let backup_dir = self.backup_path.join(user_id);
+        let backup_dir = self.user_backup_dir(user_id)?;
 
         if !backup_dir.exists() {
             return Ok(0);
@@ -619,7 +627,7 @@ impl ShodhBackupEngine {
     /// Verify backup integrity using checksum
     pub fn verify_backup(&self, user_id: &str, backup_id: u32) -> Result<bool> {
         let metadata = self.load_metadata(user_id, backup_id)?;
-        let backup_dir = self.backup_path.join(user_id);
+        let backup_dir = self.user_backup_dir(user_id)?;
 
         let current_checksum = self.calculate_backup_checksum(&backup_dir, backup_id)?;
 
@@ -644,8 +652,7 @@ impl ShodhBackupEngine {
 
     fn load_metadata(&self, user_id: &str, backup_id: u32) -> Result<BackupMetadata> {
         let metadata_path = self
-            .backup_path
-            .join(user_id)
+            .user_backup_dir(user_id)?
             .join(format!("backup_{backup_id}.json"));
 
         let json = fs::read_to_string(metadata_path)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -558,7 +558,14 @@ fn handle_init() -> Result<()> {
         );
         std::fs::write(&config_path, config_content)?;
         eprintln!("  ✓ Config created: {}", config_path.display());
-        eprintln!("  ✓ API key generated: {}", api_key);
+        // The full key was just written to the config file with restricted permissions — that is
+        // where the user retrieves it. Printing it here lands it in every captured stderr, shell
+        // transcript and CI log this command runs under, so only a recognisable prefix is shown.
+        eprintln!(
+            "  ✓ API key generated: {}… (full key stored in {})",
+            api_key.get(..12).unwrap_or("sk-shodh"),
+            config_path.display()
+        );
     }
 
     // 3. Pre-download ONNX runtime + embedding model

--- a/src/handlers/state.rs
+++ b/src/handlers/state.rs
@@ -1259,6 +1259,15 @@ impl MultiUserMemoryManager {
     /// Uses double-checked locking to prevent TOCTOU races where concurrent
     /// first-access requests both miss the cache and try to open RocksDB.
     /// RocksDB holds exclusive file locks, so the second open would fail.
+    /// The per-user state directory, with the identifier validated as a single path component
+    /// BEFORE it is joined — `user_id` arrives from HTTP/MCP/CLI callers, and `../` or an
+    /// absolute path in it would escape `base_path` at every join below.
+    fn user_dir(&self, user_id: &str) -> Result<std::path::PathBuf> {
+        Ok(self
+            .base_path
+            .join(crate::path_guard::sanitize_component(user_id, "user id")?))
+    }
+
     pub fn get_user_memory(&self, user_id: &str) -> Result<Arc<parking_lot::RwLock<MemorySystem>>> {
         // Fast path: already cached
         if let Some(memory) = self.user_memories.get(user_id) {
@@ -1278,7 +1287,7 @@ impl MultiUserMemoryManager {
             return Ok(memory);
         }
 
-        let user_path = self.base_path.join(user_id);
+        let user_path = self.user_dir(user_id)?;
         let config = MemoryConfig {
             storage_path: user_path,
             ..self.default_config.clone()
@@ -1407,7 +1416,7 @@ impl MultiUserMemoryManager {
         }
 
         // Delete per-user filesystem (memories DB, graph DB, vector index files)
-        let user_path = self.base_path.join(user_id);
+        let user_path = self.user_dir(user_id)?;
         if user_path.exists() {
             let mut attempts = 0;
             let max_attempts = 10;
@@ -1756,7 +1765,7 @@ impl MultiUserMemoryManager {
         let mut saved = 0;
         for (user_id, memory_system) in self.cached_user_memories() {
             if let Some(guard) = memory_system.try_read() {
-                let index_path = self.base_path.join(&user_id).join("vector_index");
+                let index_path = self.user_dir(&user_id)?.join("vector_index");
                 if let Err(e) = guard.save_vector_index(&index_path) {
                     tracing::warn!("  Failed to save vector index for user {}: {}", user_id, e);
                 } else {
@@ -1866,7 +1875,7 @@ impl MultiUserMemoryManager {
             return Ok(graph);
         }
 
-        let graph_path = self.base_path.join(user_id).join("graph");
+        let graph_path = self.user_dir(user_id)?.join("graph");
         // Retry with backoff for RocksDB lock contention (same pattern as get_user_memory).
         // Graph eviction drops synchronously so contention is rare, but possible on Windows
         // where file handle release can lag.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 pub mod ab_testing;
 pub mod appositive;
 pub mod auth;
+pub mod path_guard;
 pub mod backup;
 pub mod catena;
 pub mod causal_vocab;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@
 pub mod ab_testing;
 pub mod appositive;
 pub mod auth;
-pub mod path_guard;
 pub mod backup;
 pub mod catena;
 pub mod causal_vocab;
@@ -44,6 +43,7 @@ pub mod middleware;
 pub mod mif;
 pub mod migration;
 pub mod openie;
+pub mod path_guard;
 pub mod query_parsing;
 pub mod recall_harness;
 pub mod relation_typer;

--- a/src/path_guard.rs
+++ b/src/path_guard.rs
@@ -29,7 +29,15 @@ mod tests {
     fn accepts_everything_the_api_layer_accepts() {
         // Parity with validate_user_id is the point — an id accepted at the API boundary must
         // never fail at the filesystem boundary. Unicode-alphanumeric ids are valid upstream.
-        for ok in ["all", "user-1", "a.b", "X_9", "someone@example.com", "名前", "müller"] {
+        for ok in [
+            "all",
+            "user-1",
+            "a.b",
+            "X_9",
+            "someone@example.com",
+            "名前",
+            "müller",
+        ] {
             assert!(sanitize_component(ok, "user id").is_ok(), "{ok}");
         }
     }
@@ -37,8 +45,19 @@ mod tests {
     #[test]
     fn rejects_everything_that_could_leave_the_directory() {
         for bad in [
-            "", ".", "..", "../x", "a/b", "a\\b", "/etc", "a\0b", ".hidden", "a..b",
-            "trailing.", "a b", &"x".repeat(129),
+            "",
+            ".",
+            "..",
+            "../x",
+            "a/b",
+            "a\\b",
+            "/etc",
+            "a\0b",
+            ".hidden",
+            "a..b",
+            "trailing.",
+            "a b",
+            &"x".repeat(129),
         ] {
             assert!(sanitize_component(bad, "user id").is_err(), "{bad:?}");
         }

--- a/src/path_guard.rs
+++ b/src/path_guard.rs
@@ -1,0 +1,46 @@
+//! The filesystem chokepoint for caller-supplied identifiers.
+//!
+//! `validation::validate_user_id` already states this codebase's identifier contract — and its
+//! rules are exactly what a path component needs (no separators in the charset, `..` rejected,
+//! no leading/trailing dot, bounded length). What was missing is ENFORCEMENT AT THE JOIN: the
+//! validator is called in some HTTP handlers and skipped in others, while every per-user
+//! directory is `base.join(user_id)` regardless. This module re-exports the same contract as the
+//! guard the state manager's and backup engine's join helpers route through, so an unvalidated
+//! id cannot reach a filesystem path whichever handler it arrived by.
+//!
+//! Deliberately a delegation, not a second vocabulary: two validators drift, and an id accepted
+//! at the API layer must never fail at the filesystem layer.
+
+/// Validate `value` as a safe single path component, under the SAME rules as
+/// `validation::validate_user_id`. Returns the same slice on success so call sites stay
+/// borrow-friendly; rejects rather than normalizes, since silently rewriting `../x` would hide
+/// the attempt.
+pub fn sanitize_component<'a>(value: &'a str, what: &str) -> anyhow::Result<&'a str> {
+    crate::validation::validate_user_id(value)
+        .map_err(|e| anyhow::anyhow!("invalid {what}: {e}"))?;
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_component;
+
+    #[test]
+    fn accepts_everything_the_api_layer_accepts() {
+        // Parity with validate_user_id is the point — an id accepted at the API boundary must
+        // never fail at the filesystem boundary. Unicode-alphanumeric ids are valid upstream.
+        for ok in ["all", "user-1", "a.b", "X_9", "someone@example.com", "名前", "müller"] {
+            assert!(sanitize_component(ok, "user id").is_ok(), "{ok}");
+        }
+    }
+
+    #[test]
+    fn rejects_everything_that_could_leave_the_directory() {
+        for bad in [
+            "", ".", "..", "../x", "a/b", "a\\b", "/etc", "a\0b", ".hidden", "a..b",
+            "trailing.", "a b", &"x".repeat(129),
+        ] {
+            assert!(sanitize_component(bad, "user id").is_err(), "{bad:?}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Every per-user directory in the codebase is `base.join(user_id)` where `user_id` arrives from HTTP/MCP/CLI callers. A value like `../other-user` (or an absolute path) escapes the base directory at every one of those joins — path traversal into, and out of, other tenants' directories, in both the state manager and the backup engine (backup **restore** included).

Your `validation::validate_user_id` already states exactly the right contract — but it is called in some HTTP handlers and skipped in others, while `handlers/state.rs` joins `user_id` into filesystem paths at 15 places with **no validation call anywhere in the file**. So this PR does not introduce a second validator: `src/path_guard.rs::sanitize_component` **delegates to `validate_user_id`** and becomes the chokepoint two guarded helpers route every user-scoped join through — `ShodhBackupEngine::user_backup_dir` and the state manager's `user_dir`. An unvalidated id can no longer reach a filesystem path regardless of which handler it arrived by, and the two layers cannot drift because there is only one rule.

**Compatibility:** because the guard is your own validator, every id the API layer accepts today (including Unicode-alphanumeric ids) keeps working at the filesystem layer — no existing on-disk user directory becomes unreachable. It rejects rather than normalizes, since silently rewriting `../x` would hide the attempt.

Separately, `shodh init` printed the freshly generated API key to stderr, which lands it in every captured transcript and CI log. It now prints the first 12 characters and points at the config file that already stores it with restricted permissions.

## Origin

Found by CodeQL's Rust analysis (`codeql/rust-queries`: `rust/path-injection` ×35, `rust/cleartext-logging`) running as part of a scheduled scanner fleet over a downstream deployment of this codebase. The same fix is applied and verified there.

## Verification

- `cargo check` clean on this branch.
- `path_guard` tests assert **parity with the API layer** (Unicode ids accepted; traversal, separators, NUL, dot-names, over-length rejected) so the two boundaries cannot disagree.
- Existing lib tests compile and pass.