### PR TITLE
An LLM outage scored as an accuracy, and a reasoning judge was cut off before it could answer

### DIFF
--- a/benchmarks/locomo_layer_eval.py
+++ b/benchmarks/locomo_layer_eval.py
@@ -204,9 +204,15 @@ def evaluate_item(
                 choices=item["choices"],
                 context=context,
             )
-            per.judged = True
-            per.predicted_idx = predicted
-            per.correct = predicted == item["correct_choice_index"]
+            # `None` means no judgement was obtained (API error / unparseable
+            # response). Leave `judged` False so this arm is excluded from the
+            # accuracy denominator rather than scored as a wrong answer — a
+            # defaulted index makes every arm score the gold-label
+            # distribution, identically, which reads as "no layer matters".
+            if predicted is not None:
+                per.judged = True
+                per.predicted_idx = predicted
+                per.correct = predicted == item["correct_choice_index"]
         result.layers[layer] = per
 
     return result
@@ -299,9 +305,10 @@ def print_summary(agg: dict) -> None:
     )
     print(
         f"{'layer':<14} {'latency p50':>12} {'p95':>8} {'avg':>8}"
-        f"   {'jaccard@full':>12}   {'accuracy':>10}"
+        f"   {'jaccard@full':>12}   {'judged':>8}   {'accuracy':>10}"
     )
-    print("-" * 72)
+    print("-" * 84)
+    total = agg["total_items"]
     for layer in LAYER_MODES:
         s = agg["layers"][layer]
         acc = "—" if s["accuracy_pct"] is None else f"{s['accuracy_pct']:>8.2f}%"
@@ -309,8 +316,16 @@ def print_summary(agg: dict) -> None:
             f"{layer:<14} {s['latency_ms_p50']:>10.1f}ms "
             f"{s['latency_ms_p95']:>6.1f}ms "
             f"{s['latency_ms_avg']:>6.1f}ms"
-            f"     {s['jaccard_vs_full_avg']:>9.3f}     {acc}"
+            f"     {s['jaccard_vs_full_avg']:>9.3f}"
+            f"   {s['judged_count']:>4}/{total:<3}   {acc}"
         )
+    # The first arm evaluated pays the embedding-model warmup, so its latency
+    # is a startup cost, not a property of that layer. Say so rather than
+    # letting the column be read as a per-layer comparison.
+    print(
+        f"\nNOTE: `{LAYER_MODES[0]}` runs first and absorbs model/index warmup; "
+        "its latency is not comparable to the arms after it."
+    )
 
     print("\nAccuracy by question_type x layer:")
     print("-" * 72)
@@ -453,6 +468,19 @@ def main() -> int:
     with open(args.output, "w", encoding="utf-8") as f:
         json.dump(out, f, indent=2)
     print(f"Detailed results saved to: {args.output}")
+
+    # A run where the judge never answered has no accuracy result, only a
+    # latency and overlap result. Exit non-zero so an automated caller cannot
+    # mistake a formatted table for a measurement.
+    expected = LAYER_MODES if args.judge_all_layers else ("full",)
+    starved = [l for l in expected if agg["layers"][l]["judged_count"] == 0]
+    if starved:
+        print(
+            f"\nFATAL: no judgements obtained for {', '.join(starved)} across "
+            f"{agg['total_items']} items. The accuracy column is empty, not zero "
+            "— check the LLM provider (credits, key, rate limits) and re-run."
+        )
+        return 2
     return 0
 
 

--- a/benchmarks/locomo_mc10_eval.py
+++ b/benchmarks/locomo_mc10_eval.py
@@ -42,6 +42,7 @@ Usage:
 import argparse
 import json
 import os
+import sys
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
@@ -243,8 +244,11 @@ class EvalResult:
     question_id: str
     question_type: str
     correct: bool
-    predicted_idx: int
+    predicted_idx: Optional[int]
     correct_idx: int
+    # False when the judge returned no usable answer (API error / unparseable).
+    # Accuracy is computed over judged items only; see `select_answer_with_llm`.
+    judged: bool
     latency_store_ms: float
     latency_recall_ms: float
     num_memories_stored: int
@@ -360,8 +364,18 @@ def select_answer_with_llm(
     question: str,
     choices: list[str],
     context: str
-) -> int:
-    """Use LLM to select the best answer given retrieved context."""
+) -> Optional[int]:
+    """Use LLM to select the best answer given retrieved context.
+
+    Returns the chosen option index, or ``None`` when no judgement was
+    obtained — the API call failed, or the response contained no parseable
+    option digit. `None` MUST NOT be coerced to an index by callers: a
+    defaulted answer is indistinguishable from a real prediction, so every
+    arm scores the rate at which the gold label happens to sit at that
+    index and every arm scores it identically. That reads as "no layer
+    changes the answer", which is the hypothesis under test. Abstain
+    instead, and let the caller report the judged count alongside accuracy.
+    """
 
     choices_text = "\n".join([f"{i}. {choice}" for i, choice in enumerate(choices)])
 
@@ -391,11 +405,12 @@ Your answer (single digit 0-9):"""
                 idx = int(char)
                 if 0 <= idx <= 9:
                     return idx
-        return 0  # Default to first option if parsing fails
+        print(f"LLM Unparseable: no option digit in {answer_text!r:.200}")
+        return None
 
     except Exception as e:
         print(f"LLM Error: {e}")
-        return 0
+        return None
 
 
 def evaluate_single_item(
@@ -426,7 +441,8 @@ def evaluate_single_item(
     )
 
     correct_idx = item["correct_choice_index"]
-    is_correct = predicted_idx == correct_idx
+    judged = predicted_idx is not None
+    is_correct = judged and predicted_idx == correct_idx
 
     return EvalResult(
         question_id=item["question_id"],
@@ -434,13 +450,16 @@ def evaluate_single_item(
         correct=is_correct,
         predicted_idx=predicted_idx,
         correct_idx=correct_idx,
+        judged=judged,
         latency_store_ms=store_latency,
         latency_recall_ms=recall_latency,
         num_memories_stored=num_stored,
         question_text=item["question"],
         retrieved_context=context,
         correct_answer=item["choices"][correct_idx],
-        predicted_answer=item["choices"][predicted_idx],
+        predicted_answer=(
+            item["choices"][predicted_idx] if judged else "<no judgement>"
+        ),
         all_choices=item["choices"]
     )
 
@@ -518,15 +537,36 @@ def run_evaluation(
     print("RESULTS")
     print("=" * 60)
 
-    # Overall accuracy
-    total_correct = sum(1 for r in results if r.correct)
-    overall_accuracy = total_correct / len(results) * 100
+    # Overall accuracy — over JUDGED items only. An item the judge never
+    # answered is an abstention, not a wrong answer: scoring it as wrong
+    # silently converts an outage into a quality number.
+    judged_results = [r for r in results if r.judged]
+    unjudged = len(results) - len(judged_results)
+    if not judged_results:
+        print(
+            f"\nFATAL: the judge returned no usable answer for any of "
+            f"{len(results)} items. No accuracy number exists for this run — "
+            f"check the LLM provider (credits, key, rate limits) and re-run."
+        )
+        sys.exit(2)
+    if unjudged:
+        print(
+            f"\nWARNING: {unjudged}/{len(results)} items unjudged "
+            f"({unjudged / len(results) * 100:.1f}%) — accuracy below is over "
+            f"the {len(judged_results)} judged items only."
+        )
 
-    print(f"\nOverall Accuracy: {overall_accuracy:.2f}% ({total_correct}/{len(results)})")
+    total_correct = sum(1 for r in judged_results if r.correct)
+    overall_accuracy = total_correct / len(judged_results) * 100
+
+    print(
+        f"\nOverall Accuracy: {overall_accuracy:.2f}% "
+        f"({total_correct}/{len(judged_results)} judged, {unjudged} unjudged)"
+    )
 
     # Per-category accuracy
     by_type = defaultdict(list)
-    for r in results:
+    for r in judged_results:
         by_type[r.question_type].append(r.correct)
 
     print("\nAccuracy by Question Type:")
@@ -550,6 +590,8 @@ def run_evaluation(
         "provider": provider_name,
         "model": model,
         "total_items": len(results),
+        "judged_items": len(judged_results),
+        "unjudged_items": unjudged,
         "overall_accuracy": overall_accuracy,
         "accuracy_by_type": {
             qtype: sum(correct_list) / len(correct_list) * 100
@@ -562,6 +604,7 @@ def run_evaluation(
                 "question_id": r.question_id,
                 "question_type": r.question_type,
                 "correct": r.correct,
+                "judged": r.judged,
                 "predicted_idx": r.predicted_idx,
                 "correct_idx": r.correct_idx,
                 "latency_store_ms": r.latency_store_ms,

--- a/benchmarks/locomo_mc10_eval.py
+++ b/benchmarks/locomo_mc10_eval.py
@@ -92,6 +92,18 @@ class ShodhMemoryClient:
 # LLM Provider Abstraction
 # ============================================================================
 
+# Completion budget for the judge's answer.
+#
+# This was hardcoded at 10 for every provider. A reasoning model spends its
+# first tokens thinking, so at 10 it returns `content: None` with
+# `finish_reason: "length"` and never emits the digit — measured against
+# `stealth/ox-alpha`, which answers correctly at 64 (29 completion tokens,
+# 19 of them internal) and returns nothing at 10. Ten tokens silently
+# disqualifies an entire class of judge. Override with
+# SHODH_JUDGE_MAX_TOKENS.
+JUDGE_MAX_TOKENS = int(os.environ.get("SHODH_JUDGE_MAX_TOKENS", "64"))
+
+
 class LLMProvider(ABC):
     """Abstract base class for LLM providers."""
 
@@ -113,10 +125,12 @@ class OpenAIProvider(LLMProvider):
         response = self.client.chat.completions.create(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
-            max_tokens=10,
+            max_tokens=JUDGE_MAX_TOKENS,
             temperature=0
         )
-        return response.choices[0].message.content.strip()
+        # `content` is None when the budget was spent on internal reasoning
+        # tokens; return "" so the caller reports an abstention, not a crash.
+        return (response.choices[0].message.content or "").strip()
 
 
 class OpenAICompatibleProvider(LLMProvider):
@@ -134,10 +148,12 @@ class OpenAICompatibleProvider(LLMProvider):
         response = self.client.chat.completions.create(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
-            max_tokens=10,
+            max_tokens=JUDGE_MAX_TOKENS,
             temperature=0
         )
-        return response.choices[0].message.content.strip()
+        # `content` is None when the budget was spent on internal reasoning
+        # tokens; return "" so the caller reports an abstention, not a crash.
+        return (response.choices[0].message.content or "").strip()
 
 
 class AnthropicProvider(LLMProvider):
@@ -151,10 +167,10 @@ class AnthropicProvider(LLMProvider):
     def complete(self, prompt: str) -> str:
         response = self.client.messages.create(
             model=self.model,
-            max_tokens=10,
+            max_tokens=JUDGE_MAX_TOKENS,
             messages=[{"role": "user", "content": prompt}]
         )
-        return response.content[0].text.strip()
+        return (response.content[0].text or "").strip() if response.content else ""
 
 
 class OllamaProvider(LLMProvider):
@@ -175,9 +191,9 @@ class OllamaProvider(LLMProvider):
         response = ollama.chat(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
-            options={"temperature": 0, "num_predict": 10}
+            options={"temperature": 0, "num_predict": JUDGE_MAX_TOKENS}
         )
-        return response["message"]["content"].strip()
+        return (response["message"]["content"] or "").strip()
 
 
 class BasetenProvider(LLMProvider):
@@ -201,7 +217,7 @@ class BasetenProvider(LLMProvider):
             headers={"Authorization": f"Api-Key {self.api_key}"},
             json={
                 "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": 10,
+                "max_tokens": JUDGE_MAX_TOKENS,
                 "temperature": 0
             }
         )
@@ -399,6 +415,14 @@ Your answer (single digit 0-9):"""
 
     try:
         answer_text = provider.complete(prompt)
+        if not answer_text:
+            # Reasoning models exhaust the completion budget on internal
+            # tokens and return an empty body with finish_reason="length".
+            print(
+                "LLM Empty: no completion body — raise SHODH_JUDGE_MAX_TOKENS "
+                f"(currently {JUDGE_MAX_TOKENS})"
+            )
+            return None
         # Extract digit from response
         for char in answer_text:
             if char.isdigit():


### PR DESCRIPTION
Two defects in the LoCoMo judge path, both of which manufacture results rather than fail.

## 1. A judge that never answered is not a judge that answered wrong

`select_answer_with_llm` returned `0` in three different situations: the model
chose option 0, the call errored, and the response had no parseable digit. The
caller then set `judged = True` unconditionally.

So an LLM outage produced a fully formatted results table, exit code 0, and an
accuracy equal to the rate at which the gold label happens to sit at index 0 —
identical across every arm, which reads as *"no layer changes the answer."*
That is precisely the hypothesis these harnesses exist to test, so the failure
mode manufactures a confirmation of it. The per-layer run that surfaced this hit
HTTP 402 on all 72 calls and reported 16.67% for all six arms.

Now: return `None` on both error paths, leave `judged` false, and compute
accuracy over judged items only. Report `judged/total` per arm, warn on partial
starvation, and exit 2 when an arm the caller asked to judge received no
judgements at all. An empty accuracy column is not a zero.

Also labels the first arm's latency as absorbing model warmup — it was being
read as a per-layer cost.

## 2. Ten completion tokens silently disqualifies every reasoning judge

`max_tokens` was hardcoded at 10 across all five providers. A reasoning model
spends its first tokens thinking, so it returns `content: None` with
`finish_reason: "length"` and never emits the digit. Measured on a realistic
1044-token prompt: nothing at 10, correct answer at 64 (29 completion tokens,
19 of them internal).

Combined with defect 1 this was silent twice over — the provider returned
`None`, `.strip()` raised, the `except` swallowed it, and the item scored as a
confident answer of "0".

All five providers now route through `JUDGE_MAX_TOKENS` (default 64, override
with `SHODH_JUDGE_MAX_TOKENS`), return `""` rather than crashing on an empty
body, and report an explicit abstention naming the budget to raise.

## Scope

Benchmark harness only — `benchmarks/locomo_layer_eval.py` and
`benchmarks/locomo_mc10_eval.py`. No change to `src/`.

Rebased onto the post-#514 main, so it carries the h2 0.4.18 advisory fix.