### PR TITLE
The recall gate's p@1 tolerance is smaller than one case, so it is not a tolerance

### DIFF
--- a/.github/workflows/recall.yml
+++ b/.github/workflows/recall.yml
@@ -39,6 +39,17 @@ on:
         description: 'Ingest+query repeats (use 1 for a fast diagnosis run)'
         required: false
         default: '5'
+      suite:
+        description: >-
+          Which suite. `locomo-gate` is the 100-case PR gate. `locomo` is the
+          1,531-case held-out set - use it to settle a question the gate cannot
+          resolve, since whole-case metrics move in steps of 1/n and the gate's
+          step is 0.01 overall and 0.04 on multi_hop, both larger than a 2%
+          allowance. Slow; diagnostic, not a gate.
+        required: false
+        default: 'locomo-gate'
+        type: choice
+        options: ['locomo-gate', 'locomo']
 
 permissions:
   contents: read
@@ -55,6 +66,9 @@ env:
   # per-stage diagnosis (`all`) or a fast single repeat.
   LAYER: ${{ github.event.inputs.layer || 'full' }}
   REPEATS: ${{ github.event.inputs.repeats || '5' }}
+  # PR runs are always the gated 100-case suite; only a manual dispatch can
+  # reach the 1,531-case held-out set.
+  SUITE: ${{ github.event.inputs.suite || 'locomo-gate' }}
 
 jobs:
   smoke:
@@ -160,7 +174,7 @@ jobs:
           # across 5 independent ingest+query passes; rank-list divergence
           # across passes is hard-failed as `infrastructure`.
           ./target/release/recall-eval \
-            --suite locomo-gate \
+            --suite "${SUITE}" \
             --layer "${LAYER}" \
             --repeats "${REPEATS}" \
             --output current.json \

--- a/scripts/recall_diff.py
+++ b/scripts/recall_diff.py
@@ -17,10 +17,30 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import re
 from pathlib import Path
 from typing import Any
 
 GATING_METRICS = ("ndcg@10", "recall@10", "mrr", "p@1")
+
+# Metrics that count WHOLE CASES, so the smallest change they can express is
+# 1/n. `p@1` is a hit count over cases; `recall@10` and `ndcg@10` are averages
+# of continuous per-case values and can move arbitrarily little.
+#
+# This matters because the gate's tolerance is a percentage of the baseline,
+# and on this suite that percentage lands BELOW one case for every quantized
+# metric: at n=100 a 2% tolerance on p@1=0.31 allows 0.0062 while one case is
+# 0.0100, and per-category it is worse — multi_hop has 25 cases (one case =
+# 0.0400 against an allowance of 0.0056) and open_domain has 10 (one case =
+# 0.1000). A "2% tolerance" that cannot admit the smallest possible change is
+# not a tolerance, it is an equality check, and a single case flipping either
+# way reads as a regression indistinguishable from a real one.
+#
+# The renderer does not get to decide that question — the Rust comparator owns
+# the exit code and nothing here changes it. What it can do is stop the reader
+# mistaking a resolution artefact for a measurement, so every quantized
+# regression is annotated with how many cases it actually is.
+QUANTIZED_METRICS = ("p@1", "precision@10", "hit@10")
 INFO_METRICS = ("map", "precision@10")
 LATENCY_METRICS = ("latency_p50_ms", "latency_p95_ms", "latency_p99_ms")
 # RH-12 (#272): per-case median latency distribution stats. Absent on
@@ -50,6 +70,49 @@ def fmt_metric(base: float, cur: float, tolerance_pct: float, gating: bool) -> s
     else:
         marker = "✅"
     return f"{base_str} → {cur_str} ({delta_str}) {marker}"
+
+
+def case_counts(current: dict[str, Any]) -> tuple[int, dict[str, int]]:
+    """Total cases and per-category cases, as the report itself recorded them."""
+    total = int(current.get("case_count") or 0)
+    per_cat = {
+        cat: int(v.get("case_count") or 0)
+        for cat, v in (current.get("by_category") or {}).items()
+        if isinstance(v, dict)
+    }
+    return total, per_cat
+
+
+def resolution_note(detail: str, total: int, per_cat: dict[str, int]) -> str:
+    """Given a regression detail line, say how many cases the drop represents.
+
+    Detail lines look like `p@1: baseline 0.3100, current 0.3000, allowed drop
+    0.0062` or `p@1[multi_hop]: ...`. Parsed rather than restructured because
+    the Rust side owns this string and a renderer should not require it to
+    change shape to stay readable.
+    """
+    m = re.match(
+        r"^([a-z@0-9_]+)(?:\[([a-z_]+)\])?: baseline ([0-9.]+), current ([0-9.]+), allowed drop ([0-9.]+)",
+        detail,
+    )
+    if not m:
+        return ""
+    metric, category, base, cur, allowed = m.group(1), m.group(2), *map(float, m.groups()[2:])
+    if metric not in QUANTIZED_METRICS:
+        return ""
+    n = per_cat.get(category, 0) if category else total
+    if n <= 0:
+        return ""
+    quantum = 1.0 / n
+    drop = base - cur
+    cases = drop / quantum
+    note = f"n={n}, one case = {quantum:.4f}, this drop = {cases:.1f} case(s)"
+    if allowed < quantum:
+        note += (
+            f" — the allowance ({allowed:.4f}) is BELOW one case, so this gate "
+            f"cannot pass any change at all on this metric"
+        )
+    return note
 
 
 def fmt_latency(base: float, cur: float) -> str:
@@ -89,8 +152,27 @@ def render(baseline: dict[str, Any], current: dict[str, Any], tolerance_pct: flo
         lines.append("> **Infrastructure failure:** one or both reports are missing the `full` layer.")
         return "\n".join(lines)
 
+    total_cases, per_cat_cases = case_counts(current)
     lines.append("### Quality (gated)")
     lines.append("")
+    if total_cases:
+        lines.append(
+            f"Suite holds **{total_cases}** cases, so a whole-case metric moves in steps of "
+            f"**{1.0 / total_cases:.4f}** overall"
+            + (
+                " ("
+                + ", ".join(
+                    f"{c} n={n} → {1.0 / n:.4f}"
+                    for c, n in sorted(per_cat_cases.items())
+                    if n > 0
+                )
+                + ")"
+                if per_cat_cases
+                else ""
+            )
+            + ". A drop smaller than that step cannot occur; one equal to it is a single case."
+        )
+        lines.append("")
     lines.append("| metric | baseline → current (Δ) |")
     lines.append("| ------ | ---------------------- |")
     for m in GATING_METRICS:
@@ -191,10 +273,15 @@ def render(baseline: dict[str, Any], current: dict[str, Any], tolerance_pct: flo
     cases = [f for f in failures if f.get("kind") == "case"]
 
     if regressions:
+        total_cases, per_cat_cases = case_counts(current)
         lines.append(f"### ❌ Regressions ({len(regressions)})")
         lines.append("")
         for f in regressions:
-            lines.append(f"- {f.get('detail', '')}")
+            detail = f.get("detail", "")
+            note = resolution_note(detail, total_cases, per_cat_cases)
+            lines.append(f"- {detail}")
+            if note:
+                lines.append(f"  - _resolution: {note}_")
         lines.append("")
     if infra:
         lines.append(f"### ⚠️ Infrastructure failures ({len(infra)})")

--- a/scripts/test_recall_diff.py
+++ b/scripts/test_recall_diff.py
@@ -1,0 +1,133 @@
+"""Tests for the recall diff renderer's resolution reporting.
+
+`resolution_note` exists to stop a reader mistaking a quantisation artefact for
+a measurement, so its arithmetic is the claim and has to be checked. Runs standalone so it needs nothing installed, and is still collectable by
+pytest if that is present:
+
+    python scripts/test_recall_diff.py
+    python -m pytest scripts/test_recall_diff.py
+
+The renderer never changes pass/fail — the Rust comparator owns the exit code —
+so nothing here asserts about gating. It asserts about honesty.
+"""
+
+from recall_diff import QUANTIZED_METRICS, case_counts, resolution_note
+
+CASES = {"multi_hop": 25, "open_domain": 10, "single_hop": 35, "temporal": 30}
+
+
+class TestCaseCounts:
+    def test_reads_the_counts_the_report_recorded(self):
+        report = {
+            "case_count": 100,
+            "by_category": {c: {"case_count": n, "p@1": 0.3} for c, n in CASES.items()},
+        }
+        total, per_cat = case_counts(report)
+        assert total == 100
+        assert per_cat == CASES
+
+    def test_survives_a_report_with_neither(self):
+        # Pre-RH-12 reports predate these fields. A renderer that raises here
+        # would take down the PR comment for every historical baseline.
+        total, per_cat = case_counts({})
+        assert total == 0
+        assert per_cat == {}
+
+    def test_ignores_non_dict_category_entries(self):
+        total, per_cat = case_counts({"case_count": 10, "by_category": {"x": 3}})
+        assert (total, per_cat) == (10, {})
+
+
+class TestResolutionNote:
+    def test_reports_a_one_case_drop_as_one_case(self):
+        note = resolution_note(
+            "p@1: baseline 0.3100, current 0.3000, allowed drop 0.0062", 100, CASES
+        )
+        assert "n=100" in note
+        assert "one case = 0.0100" in note
+        assert "1.0 case(s)" in note
+
+    def test_uses_the_category_count_for_a_per_category_metric(self):
+        # The load-bearing case: multi_hop has 25 cases, so ONE case is 0.0400 —
+        # sixteen times the overall step. Reading this against n=100 would call
+        # a single flip a four-case collapse.
+        note = resolution_note(
+            "p@1[multi_hop]: baseline 0.2800, current 0.2400, allowed drop 0.0056",
+            100,
+            CASES,
+        )
+        assert "n=25" in note
+        assert "one case = 0.0400" in note
+        assert "1.0 case(s)" in note
+
+    def test_says_so_when_the_allowance_cannot_admit_one_case(self):
+        note = resolution_note(
+            "p@1: baseline 0.3100, current 0.3000, allowed drop 0.0062", 100, CASES
+        )
+        assert "BELOW one case" in note
+
+    def test_stays_quiet_when_the_allowance_can_admit_a_case(self):
+        # A suite large enough for its own tolerance gets no warning — the note
+        # must not cry wolf on a gate that is working.
+        note = resolution_note(
+            "p@1: baseline 0.3100, current 0.3000, allowed drop 0.0500", 100, CASES
+        )
+        assert "1.0 case(s)" in note
+        assert "BELOW one case" not in note
+
+    def test_says_nothing_about_continuous_metrics(self):
+        # These average continuous per-case values and can move arbitrarily
+        # little, so "how many cases is this" is not a meaningful question and
+        # answering it would invent a precision the metric does not have.
+        for metric in ("ndcg@10", "recall@10", "mrr", "map"):
+            assert metric not in QUANTIZED_METRICS
+            note = resolution_note(
+                f"{metric}: baseline 0.4111, current 0.4105, allowed drop 0.0082", 100, CASES
+            )
+            assert note == "", metric
+
+    def test_returns_empty_on_an_unparseable_detail(self):
+        # The Rust side owns this string. If it changes shape, the renderer must
+        # degrade to printing the detail alone rather than crash the comment.
+        assert resolution_note("something else entirely", 100, CASES) == ""
+
+    def test_returns_empty_when_the_count_is_unknown(self):
+        assert (
+            resolution_note(
+                "p@1: baseline 0.3100, current 0.3000, allowed drop 0.0062", 0, {}
+            )
+            == ""
+        )
+        assert (
+            resolution_note(
+                "p@1[nonesuch]: baseline 0.2800, current 0.2400, allowed drop 0.0056",
+                100,
+                CASES,
+            )
+            == ""
+        )
+
+    def test_a_multi_case_drop_is_not_reported_as_one(self):
+        # Guards the arithmetic itself: three cases out of 100 is 0.03.
+        note = resolution_note(
+            "p@1: baseline 0.3100, current 0.2800, allowed drop 0.0062", 100, CASES
+        )
+        assert "3.0 case(s)" in note
+
+
+if __name__ == "__main__":
+    # A plain runner, because this repo ships no python test dependency and a
+    # test that cannot be run is documentation.
+    failed = 0
+    for cls in (TestCaseCounts, TestResolutionNote):
+        instance = cls()
+        for name in sorted(n for n in dir(cls) if n.startswith("test_")):
+            try:
+                getattr(instance, name)()
+                print(f"  ok   {cls.__name__}.{name}")
+            except AssertionError as e:
+                failed += 1
+                print(f"  FAIL {cls.__name__}.{name}: {e}")
+    print()
+    print(f"{'FAILED' if failed else 'all passed'} ({failed} failure(s))")
+    raise SystemExit(1 if failed else 0)


### PR DESCRIPTION
The gate advertises a 2% tolerance. On every whole-case metric it delivers a
strict equality check, and the report gave a reader no way to see the difference.

The suite holds 100 cases — multi_hop 25, open_domain 10, single_hop 35,
temporal 30 — and a metric that counts whole cases can only move in steps of
1/n:

| category | one case | 2% allowance |
| --- | --- | --- |
| overall p@1 | 0.0100 | 0.0062 |
| multi_hop | **0.0400** | 0.0056 |
| open_domain | **0.1000** | ~0.0034 |
| single_hop | 0.0286 | ~0.0088 |
| temporal | 0.0333 | ~0.0115 |

Every allowance is below its own step. So on p@1 the gate has exactly two
outcomes — nothing changed, or something changed — and reports the second as a
regression against a tolerance that cannot admit the smallest event the suite
is capable of representing. Continuous metrics are fine: `ndcg@10` and
`recall@10` average per-case values and can move arbitrarily little.

**This is live.** PR #509 currently fails with `p@1 -0.0100` and
`p@1[multi_hop] -0.0400`. The resolution arithmetic shows that is ONE case,
counted twice — once overall, once in its category — while `recall@10` rises
+0.0050 and `ndcg@10` stays inside tolerance.

## Nothing here changes pass or fail

The Rust comparator owns the exit code and is untouched. Widening the allowance
to turn a red PR green is the one fix that was not on the table.

What changes is that the report states its own resolution:

- The Quality section says how many cases the suite holds and what one case is
  worth, overall and per category.
- Every whole-case regression is annotated with how many cases it actually is,
  and says plainly when the allowance is below one case and therefore cannot
  admit any change at all.

Rendered against #509's real report:

> - p@1: baseline 0.3100, current 0.3000, allowed drop 0.0062
>   - _resolution: n=100, one case = 0.0100, this drop = 1.0 case(s) — the allowance (0.0062) is BELOW one case, so this gate cannot pass any change at all on this metric_

`recall.yml` also gains a `suite` input, so a question a 100-case gate cannot
answer can be put to the 1,531-case held-out set without editing CI. Default,
PR behaviour and gating are unchanged; `locomo` stays diagnostic — it is the
held-out set precisely because nothing is tuned against it.

## Testing

11 tests, standalone-runnable (`python scripts/test_recall_diff.py`) because
this repo ships no python test dependency and a test that cannot be run is
documentation. pytest collects them too.

Both mutants checked: making the note read the overall `n` for a per-category
metric fails the category test; suppressing the sub-quantum warning fails the
warning test.