### PR TITLE
Seven of nine measurement paths could measure on the fallback NER, and one workflow did

### DIFF
--- a/.github/workflows/graph-lever-confound.yml
+++ b/.github/workflows/graph-lever-confound.yml
@@ -101,11 +101,45 @@ jobs:
           [ -s "$MODEL_DIR/model_quantized.onnx" ] || dl "$MODEL_DIR/model_quantized.onnx" "$BASE/onnx/model_quint8_avx2.onnx"
           [ -s "$MODEL_DIR/tokenizer.json" ]       || dl "$MODEL_DIR/tokenizer.json" "$BASE/tokenizer.json"
 
+      # WITHOUT THIS THE MATRIX MEASURES NOTHING. The neural NER is GLiNER, and
+      # it is loaded from SHODH_GLINER_MODEL_PATH (default ./models/gliner-bi-edge).
+      # With no model the recogniser silently degrades to the rule-based
+      # fallback -- a different extractor than production ships, building a
+      # different graph. The first dispatch of this workflow omitted these steps
+      # and had to be cancelled; recall.yml has fetched and verified them all
+      # along, which is exactly why its numbers are the trustworthy ones.
+      - name: Cache GLiNER typer assets
+        id: gliner-cache
+        uses: actions/cache@v6
+        with:
+          path: models/gliner-bi-edge
+          key: gliner-bi-edge-onnx-v1
+
+      - name: Fetch GLiNER typer assets
+        if: steps.gliner-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p models/gliner-bi-edge
+          gh release download gliner-bi-edge-onnx-v1 --repo "$GITHUB_REPOSITORY" --dir models/gliner-bi-edge
+          ls -la models/gliner-bi-edge
+
+      - name: Verify model assets (hard gate)
+        run: |
+          GL="${{ github.workspace }}/models/gliner-bi-edge"
+          MM="$HOME/.cache/shodh-memory/models/minilm-l6"
+          test -s "$MM/model_quantized.onnx" || { echo "::error::MiniLM weights missing"; exit 1; }
+          test -s "$GL/model.onnx" || { echo "::error::GLiNER model missing - refusing to measure fallback NER"; exit 1; }
+          test -s "$GL/tokenizer.json" || { echo "::error::GLiNER tokenizer missing"; exit 1; }
+          test -s "$GL/label_embeddings.bin" || { echo "::error::GLiNER label embeddings missing"; exit 1; }
+
       - name: Run the matrix
         env:
           SUITE: ${{ github.event.inputs.suite || 'locomo-gate' }}
           LEVERS: ${{ github.event.inputs.levers || 'SHODH_GRAPH_EDGE_DIR,SHODH_GRAPH_PREDICATE_WEIGHTS,SHODH_GRAPH_TYPED_ONLY,SHODH_GRAPH_REACH_INJECT' }}
           SHODH_MAX_CASES: ${{ github.event.inputs.max_cases }}
+          SHODH_MODEL_PATH: $HOME/.cache/shodh-memory/models/minilm-l6
+          SHODH_GLINER_MODEL_PATH: ${{ github.workspace }}/models/gliner-bi-edge
         run: |
           set -u
           IFS=',' read -ra LEVER_LIST <<< "$LEVERS"
@@ -134,6 +168,12 @@ jobs:
                     --output "arm-${TAG}.json" \
                     --storage "./s-${TAG}" 2>"${TAG}.log" | tail -4 || echo "ARM ${TAG} FAILED"
               fi
+              # Surface the recogniser in the JOB log, not only in the per-arm
+              # file. The first dispatch was cancelled on inference because
+              # stderr was invisible here and the artifacts had not uploaded yet
+              # -- a diagnostic whose own fidelity cannot be read from its log is
+              # the failure mode this workflow exists to expose.
+              grep -m1 '^NER_BACKEND=' "${TAG}.log" || echo "NER_BACKEND=<not reported> for ${TAG}"
               # Storage is per-arm and large; drop it once the report is written.
               rm -rf "./s-${TAG}"
               echo "::endgroup::"

--- a/.github/workflows/locomo-recall.yml
+++ b/.github/workflows/locomo-recall.yml
@@ -128,6 +128,44 @@ jobs:
           [ -s "$MODEL_DIR/tokenizer.json" ]       || dl "$MODEL_DIR/tokenizer.json" "$BASE/tokenizer.json"
           ls -la "$MODEL_DIR"
 
+      # EVERY DIAGNOSTIC BELOW RAN WITHOUT THE NEURAL NER UNTIL NOW.
+      #
+      # The neural recogniser is GLiNER, loaded from SHODH_GLINER_MODEL_PATH
+      # (default ./models/gliner-bi-edge). This workflow never fetched it, and
+      # until the guard moved into `ingest_corpus` the analysis paths it drives
+      # -- reachability, entity-linking, the funnel, the learning curve, the
+      # ablation matrix, multi-hop, ontology, lineage, forgetting, temporal --
+      # carried no NER gate. So they degraded to the rule-based fallback in
+      # silence and reported the result as if it were the shipped system, while
+      # recall.yml fetched and verified the same assets all along.
+      #
+      # That is not a small fidelity difference. The extractor decides which
+      # entities exist, which decides which edges exist, which is the substrate
+      # every one of these diagnostics measures.
+      - name: Cache GLiNER typer assets
+        id: gliner-cache
+        uses: actions/cache@v6
+        with:
+          path: models/gliner-bi-edge
+          key: gliner-bi-edge-onnx-v1
+
+      - name: Fetch GLiNER typer assets
+        if: steps.gliner-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p models/gliner-bi-edge
+          gh release download gliner-bi-edge-onnx-v1 --repo "$GITHUB_REPOSITORY" --dir models/gliner-bi-edge
+          ls -la models/gliner-bi-edge
+
+      - name: Verify GLiNER assets (hard gate)
+        run: |
+          GL="${{ github.workspace }}/models/gliner-bi-edge"
+          test -s "$GL/model.onnx" || { echo "::error::GLiNER model missing - refusing to measure fallback NER"; exit 1; }
+          test -s "$GL/tokenizer.json" || { echo "::error::GLiNER tokenizer missing"; exit 1; }
+          test -s "$GL/label_embeddings.bin" || { echo "::error::GLiNER label embeddings missing"; exit 1; }
+          echo "SHODH_GLINER_MODEL_PATH=$GL" >> "$GITHUB_ENV"
+
       - name: Graph reachability diagnostic
         if: ${{ github.event.inputs.mode == 'reachability' }}
         env:

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -566,34 +566,8 @@ fn run_one_pass(
     // populated graph wired in). The manager is kept alive for the whole pass.
     let manager = build_manager(storage_path)?;
 
-    // NER-backend gate (eval fidelity): every CI number before 2026-06-11 was
-    // silently measured on the rule-based fallback NER (census-shape proof,
-    // run 27342411453). Refuse to measure on it again — a harness that tests a
-    // different recognizer than production ships is not measuring the system.
-    // SHODH_ALLOW_FALLBACK_NER=1 is the explicit, visible escape hatch.
-    let ner_backend = if manager.get_neural_ner().is_fallback_mode() {
-        "fallback"
-    } else {
-        "neural"
-    };
-    eprintln!("NER_BACKEND={ner_backend}");
-    // cfg!(test) exemption: lib tests exercise the harness MACHINERY on
-    // runners that may lack the model; the gate protects MEASUREMENTS (the
-    // recall-eval binary is never cfg(test)).
-    if ner_backend == "fallback"
-        && !cfg!(test)
-        && !std::env::var("SHODH_ALLOW_FALLBACK_NER")
-            .map(|v| v == "1")
-            .unwrap_or(false)
-    {
-        anyhow::bail!(
-            "recall harness refusing to run on the FALLBACK NER (model not \
-             loaded) — results would not measure the shipped system. Provide \
-             the pinned model or set SHODH_ALLOW_FALLBACK_NER=1 to override \
-             visibly."
-        );
-    }
-
+    // The NER-backend gate now lives in `ingest_corpus`, so every measurement
+    // path is covered rather than only the two that remembered to ask.
     let id_map = ingest_corpus(&manager, corpus)?;
     let system = manager.get_user_memory(EVAL_USER)?;
 
@@ -1015,10 +989,53 @@ pub(crate) fn build_manager(storage_path: &Path) -> Result<MultiUserMemoryManage
 /// memory, then build the entity graph from it. Without the
 /// `process_experience_into_graph` step the graph stays empty and Layer 2
 /// spreading activation is a no-op.
+/// Refuse to measure on the rule-based fallback NER.
+///
+/// This lives at the INGEST chokepoint rather than at each entry point, and the
+/// placement is the fix. The gate previously existed only inside `run_one_pass`
+/// and `run_longmemeval`; the other seven measurement paths that build a corpus
+/// -- `analyze_ablation`, `analyze_funnel`, `analyze_graph_reachability`,
+/// `analyze_linking`, `run_learning_arm`, `ingest_fresh` and
+/// `analyze_selective_forgetting` -- had none, so they would quietly measure a
+/// different recogniser than the one production ships and report the result as
+/// if it were the system.
+///
+/// That is not hypothetical. `.github/workflows/locomo-recall.yml` drives
+/// `--ablation`, `--funnel`, `--forgetting` and `--learning` and fetches no
+/// GLiNER model at all, while `recall.yml` fetches and verifies it. The
+/// ablation matrix -- the instrument behind the graph lever verdicts -- was on
+/// the fallback path, and nothing in its output said so.
+///
+/// Every path reaches ingest, so a guard here cannot be forgotten by a path
+/// written later. `SHODH_ALLOW_FALLBACK_NER=1` remains the visible escape
+/// hatch, and `cfg!(test)` is exempt because lib tests exercise the harness
+/// MACHINERY on runners that may lack the model -- the gate protects
+/// MEASUREMENTS, and the recall-eval binary is never `cfg(test)`.
+pub(crate) fn guard_ner_backend(manager: &MultiUserMemoryManager) -> Result<()> {
+    let backend = if manager.get_neural_ner().is_fallback_mode() {
+        "fallback"
+    } else {
+        "neural"
+    };
+    eprintln!("NER_BACKEND={backend}");
+    if backend == "fallback"
+        && !cfg!(test)
+        && !std::env::var("SHODH_ALLOW_FALLBACK_NER")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    {
+        anyhow::bail!(
+            "recall harness refusing to run on the FALLBACK NER (model not              loaded) -- results would not measure the shipped system. Provide              the pinned model or set SHODH_ALLOW_FALLBACK_NER=1 to override              visibly."
+        );
+    }
+    Ok(())
+}
+
 pub fn ingest_corpus(
     manager: &MultiUserMemoryManager,
     corpus: &[CorpusItem],
 ) -> Result<HashMap<String, Uuid>> {
+    guard_ner_backend(manager)?;
     let mut map = HashMap::with_capacity(corpus.len());
     let ner = manager.get_neural_ner();
     let user_mem = manager.get_user_memory(EVAL_USER)?;


### PR DESCRIPTION
The recall harness refuses to run on the rule-based fallback recogniser — a
harness that tests a different extractor than production ships is not measuring
the system. That gate existed in exactly **two** places: `run_one_pass` and
`run_longmemeval`.

The other **seven** paths that build a corpus had none:

`analyze_ablation` · `analyze_funnel` · `analyze_graph_reachability` ·
`analyze_linking` · `run_learning_arm` · `ingest_fresh` ·
`analyze_selective_forgetting`

## And one workflow drives almost all of them

`locomo-recall.yml` runs eleven diagnostics — graph reachability, entity-linking
accuracy, the per-stage funnel, the learning curve, **the ablation matrix**,
multi-hop, ontology, causal-lineage, forgetting, temporal — and fetched **no
GLiNER model at all**.

| workflow | GLiNER refs |
| --- | --- |
| `recall.yml` | 12 |
| `locomo-recall.yml` | **0** |
| `layer-ablation.yml` | **0** |
| `pmi-gate-ablation.yml` | **0** |

The extractor decides which entities exist → which edges exist → the substrate
every one of those diagnostics measures. Nothing in their output said which
recogniser had run.

## The fix is placement, not another copy

The gate now lives inside `ingest_corpus`, which **every** measurement path
reaches, so a path written later cannot forget it. Both inline copies are gone.
`SHODH_ALLOW_FALLBACK_NER=1` remains the visible escape hatch; `cfg!(test)`
stays exempt because lib tests exercise the harness *machinery* on runners that
may lack the model, while the gate protects *measurements* — and the
`recall-eval` binary is never `cfg(test)`.

Both workflows now fetch GLiNER from the pinned release and hard-fail on a
missing asset instead of proceeding degraded.

## How I found it

By running into it. The confound matrix I dispatched for #525 copied the
MiniLM-only setup from its neighbours, inherited the same defect, and had to be
cancelled. It also routed stderr to per-arm files, so `NER_BACKEND` was
invisible in the job log and I cancelled on inference rather than evidence — a
diagnostic whose own fidelity cannot be read from its log is the exact failure
that workflow exists to expose. It now greps `NER_BACKEND` into the job log per
arm.

## What this does NOT claim

That any specific stored finding is wrong. The gate's absence means those runs
carry **no evidence of which recogniser produced them** — a different and more
awkward thing than being known-wrong.

What it does mean: the ablation matrix, the instrument behind the seven "inert"
graph lever verdicts, has a **second confound** stacked on the PMI edge gate
(#525). Both need clearing before those results mean anything.

## Testing

84 harness tests pass with the guard in place, which shows the `cfg!(test)`
exemption works.

One honest limit: the bail path **cannot be unit-tested in-crate**, because
`cfg!(test)` exempts it by design. CI on a runner without the assets is what
demonstrates the gate fires.