### PR TITLE
Repeatable audit detectors, and the PPR family's evidence was produced without the neural NER

### DIFF
--- a/.github/workflows/graph-lever-confound.yml
+++ b/.github/workflows/graph-lever-confound.yml
@@ -151,6 +151,12 @@ jobs:
           LEVERS: ${{ github.event.inputs.levers || 'SHODH_GRAPH_EDGE_DIR,SHODH_GRAPH_PREDICATE_WEIGHTS,SHODH_GRAPH_TYPED_ONLY,SHODH_GRAPH_REACH_INJECT' }}
           DISABLE: ${{ github.event.inputs.disable }}
           SHODH_MAX_CASES: ${{ github.event.inputs.max_cases }}
+          # The substrate scoreboard. state.rs logs "edge typing provenance" per
+          # memory at info; without this the counters never reach the log and the
+          # generic share stays an audit note of unknown vintage rather than a
+          # number from today's graph. Omitting it is what made the first run of
+          # this workflow unable to answer the question it was closest to.
+          RUST_LOG: shodh_memory::handlers::state=info
           SHODH_MODEL_PATH: $HOME/.cache/shodh-memory/models/minilm-l6
           SHODH_GLINER_MODEL_PATH: ${{ github.workspace }}/models/gliner-bi-edge
         run: |
@@ -205,6 +211,48 @@ jobs:
               echo "::endgroup::"
             done
           done
+
+      # WHAT SHARE OF THE GRAPH IS THE HAIRBALL?
+      #
+      # Co-occurrence is symmetric and fully determined by entity->episode
+      # incidence, which is already indexed (entity_episodes_cf). Materialising
+      # it turns n entities in one memory into n(n-1)/2 edges -- issue #90 saw
+      # 240k edges from 3k memories. Every generic edge stored is a fact the
+      # store could derive.
+      #
+      # It also decides whether typed path composition has substrate: a path
+      # grammar over CoOccurs is the abelian case in costume, and if generic is
+      # ~80% of edges then a fully-typed 2-hop path is ~4% of pairs.
+      - name: Edge-type census
+        if: always()
+        run: |
+          python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+          import re, glob, collections
+          KEYS = ("semantic", "cue", "pair_table", "learned", "generic",
+                  "fragment_blocked", "pmi_gated")
+          print("## Edge-type census - what share of the graph is derivable?")
+          print()
+          print("| arm | typed | generic | pmi_gated | generic share of stored |")
+          print("| --- | --- | --- | --- | --- |")
+          for log in sorted(glob.glob("gate*.log")):
+              tot = collections.Counter()
+              for line in open(log, errors="ignore"):
+                  if "edge typing provenance" not in line:
+                      continue
+                  for k, v in re.findall(r"(\w+)=(\d+)", line):
+                      if k in KEYS:
+                          tot[k] += int(v)
+              typed = tot["semantic"] + tot["cue"] + tot["pair_table"] + tot["learned"]
+              stored = typed + tot["generic"]
+              if stored == 0:
+                  continue
+              share = 100.0 * tot["generic"] / stored
+              print(f"| `{log[:-4]}` | {typed} | {tot['generic']} | {tot['pmi_gated']} | **{share:.1f}%** |")
+          print()
+          print("generic = untyped co-occurrence, symmetric, derivable from incidence.")
+          print("A high share means most stored edges carry no relation, so typed")
+          print("path composition has almost no substrate to walk.")
+          PY
 
       - name: Confound table
         if: always()

--- a/.github/workflows/graph-lever-confound.yml
+++ b/.github/workflows/graph-lever-confound.yml
@@ -54,6 +54,18 @@ on:
         description: 'Comma-separated graph flags to test one at a time, each set to 1.'
         required: false
         default: 'SHODH_GRAPH_EDGE_DIR,SHODH_GRAPH_PREDICATE_WEIGHTS,SHODH_GRAPH_TYPED_ONLY,SHODH_GRAPH_REACH_INJECT'
+      disable:
+        description: >-
+          Comma-separated flags to set to 0, one arm each. `levers` turns things
+          ON; this turns things OFF, which is the only way to ablate a
+          default-ON behaviour. Nine default-ON behavioural flags exist that
+          nothing checked in ever flips -- their A/B evidence lives in commit
+          prose and CI run ids, at baselines from another era, with no
+          committed arm to re-run. SHODH_PPR is the sharp case: its
+          justification cites a funnel figure that was produced without the
+          neural NER.
+        required: false
+        default: ''
       max_cases:
         description: 'SHODH_MAX_CASES cap (blank = all)'
         required: false
@@ -137,12 +149,14 @@ jobs:
         env:
           SUITE: ${{ github.event.inputs.suite || 'locomo-gate' }}
           LEVERS: ${{ github.event.inputs.levers || 'SHODH_GRAPH_EDGE_DIR,SHODH_GRAPH_PREDICATE_WEIGHTS,SHODH_GRAPH_TYPED_ONLY,SHODH_GRAPH_REACH_INJECT' }}
+          DISABLE: ${{ github.event.inputs.disable }}
           SHODH_MAX_CASES: ${{ github.event.inputs.max_cases }}
           SHODH_MODEL_PATH: $HOME/.cache/shodh-memory/models/minilm-l6
           SHODH_GLINER_MODEL_PATH: ${{ github.workspace }}/models/gliner-bi-edge
         run: |
           set -u
           IFS=',' read -ra LEVER_LIST <<< "$LEVERS"
+          IFS=',' read -ra OFF_LIST <<< "${DISABLE:-}"
 
           # Every arm is (gate, lever) with its own ingest and its own store.
           # `none` is the gate-matched baseline each lever is measured against —
@@ -178,18 +192,32 @@ jobs:
               rm -rf "./s-${TAG}"
               echo "::endgroup::"
             done
+
+            # Ablation arms: set a default-ON flag to 0. Same gate-matched
+            # baseline, so the delta is the cost of removing the behaviour.
+            for OFF in ${OFF_LIST[@]+"${OFF_LIST[@]}"}; do
+              [ -z "$OFF" ] && continue
+              TAG="gate${GATE}-off-${OFF}"
+              echo "::group::arm ${TAG}"
+              env SHODH_GRAPH_PMI_GATE="$GATE" "${OFF}=0"                 ./target/release/recall-eval                   --suite "$SUITE"                   --output "arm-${TAG}.json"                   --storage "./s-${TAG}" 2>"${TAG}.log" | tail -4 || echo "ARM ${TAG} FAILED"
+              grep -m1 '^NER_BACKEND=' "${TAG}.log" || echo "NER_BACKEND=<not reported> for ${TAG}"
+              rm -rf "./s-${TAG}"
+              echo "::endgroup::"
+            done
           done
 
       - name: Confound table
         if: always()
         env:
           LEVERS: ${{ github.event.inputs.levers || 'SHODH_GRAPH_EDGE_DIR,SHODH_GRAPH_PREDICATE_WEIGHTS,SHODH_GRAPH_TYPED_ONLY,SHODH_GRAPH_REACH_INJECT' }}
+          DISABLE: ${{ github.event.inputs.disable }}
           SUITE: ${{ github.event.inputs.suite || 'locomo-gate' }}
         run: |
           python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
           import json, os, pathlib
 
           levers = [l for l in os.environ["LEVERS"].split(",") if l]
+          disabled = [l for l in os.environ.get("DISABLE", "").split(",") if l]
           suite = os.environ["SUITE"]
 
           def arm(gate, lever):
@@ -248,6 +276,25 @@ jobs:
                   else:
                       flag = "no"
               print(f"| `{lever}` | {fmt(d1)} | {fmt(d0)} | {flag} |")
+
+          if disabled:
+              print()
+              print("### Cost of REMOVING a default-ON behaviour")
+              print()
+              print("| flag set to 0 | delta @ gate=1 | delta @ gate=0 |")
+              print("| --- | --- | --- |")
+              for flag in disabled:
+                  cells = []
+                  for g in (1, 0):
+                      a = arm(g, f"off-{flag}")
+                      b = base[g]
+                      cells.append(None if (a is None or b is None) else a[1][METRIC] - b[1][METRIC])
+                  fmt = lambda d: "n/a" if d is None else f"{d:+.4f}"
+                  print(f"| `{flag}=0` | {fmt(cells[0])} | {fmt(cells[1])} |")
+              print()
+              print("A delta near zero means the behaviour is not earning its default.")
+              print("A large negative means it is load-bearing and the escape hatch is")
+              print("expensive. An arm that FAILED means the escape hatch does not run.")
 
           print()
           print(f"_Delta is {METRIC} against the gate-matched baseline. Read recall@10 rather")

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Detectors for the defect classes this codebase has actually shipped.
+
+Every check here exists because the class was found in the wild, not because it
+is a general code smell:
+
+  flags        172 env flags, 124 of which nothing outside src/ ever sets. A
+               flag no test or workflow ever flips has never been ablated, so
+               its default is an assumption. Seven graph levers were called
+               "inert" on measurements taken with one such default (the PMI
+               edge gate) silently culling 97.4% of the graph.
+
+  dormant      Two whole modules (context.rs, injection.rs) were found alive
+               only via their own tests. Code with no production caller is not
+               dead weight, it is a claim of capability the product does not
+               make.
+
+  tests        A test that cannot fail is invisible to a failing-test sweep.
+               Tautological asserts hid an inert Hebbian layer for months.
+
+  ordering     A float sort with no tie-break leaves equal elements in input
+               order; when the input comes from a map and a truncation follows,
+               which rows survive is decided by iteration order. That is how
+               the hub degree cap was permanently deleting different edges on
+               every ingest.
+
+  escapes      Env vars that switch off a safety check. Each is a way to
+               produce numbers that look normal and are not.
+
+Run:  python scripts/audit.py [--class flags|dormant|tests|ordering|escapes]
+
+Exit code is always 0. This reports; it does not gate. Turning any of these
+into a hard gate is a separate decision that needs a clean baseline first --
+`dormant` in particular has known false positives (see its note).
+"""
+
+import argparse
+import io
+import os
+import re
+import sys
+from glob import glob
+
+SEP = chr(92)
+
+
+def load_rust(root="src"):
+    out = {}
+    for base, _, files in os.walk(root):
+        for f in files:
+            if f.endswith(".rs"):
+                p = os.path.join(base, f).replace(SEP, "/")
+                out[p] = io.open(p, encoding="utf-8", errors="replace").read()
+    return out
+
+
+def load_external():
+    """Everything that could exercise a flag: workflows, scripts, docs, tests."""
+    texts = []
+    for pat in (".github/workflows/*.yml", "scripts/*", "tests/**/*", "*.md", "docs/**/*"):
+        for p in glob(pat, recursive=True):
+            if os.path.isfile(p):
+                try:
+                    texts.append(io.open(p, encoding="utf-8", errors="replace").read())
+                except OSError:
+                    pass
+    return "\n".join(texts)
+
+
+def fn_bodies(src):
+    """(attrs, name, body) for every fn. Brace-matched, so nested blocks are kept."""
+    for m in re.finditer(r"((?:#\[[^\]]+\]\s*)*)fn\s+(\w+)\s*\([^)]*\)[^{]*\{", src):
+        i, depth = m.end(), 1
+        while i < len(src) and depth:
+            if src[i] == "{":
+                depth += 1
+            elif src[i] == "}":
+                depth -= 1
+            i += 1
+        yield m.group(1), m.group(2), src[m.end():i - 1]
+
+
+def strip_test_mods(src):
+    """Drop #[cfg(test)] modules so 'used only by its own tests' is detectable."""
+    out, i = [], 0
+    while True:
+        m = re.search(r"#\[cfg\(test\)\]\s*mod\s+\w+\s*\{", src[i:])
+        if not m:
+            out.append(src[i:])
+            return "".join(out)
+        start = i + m.start()
+        out.append(src[i:start])
+        j, depth = i + m.end(), 1
+        while j < len(src) and depth:
+            if src[j] == "{":
+                depth += 1
+            elif src[j] == "}":
+                depth -= 1
+            j += 1
+        i = j
+
+
+# ---------------------------------------------------------------- flags
+
+ENGINE = (
+    "src/memory/", "src/graph_memory.rs", "src/handlers/recall.rs", "src/relevance.rs",
+    "src/vector_db/", "src/embeddings/", "src/handlers/state.rs", "src/relation_typer.rs",
+)
+
+
+def audit_flags(rust, ext):
+    joined = "\n".join(rust.values())
+    flags = sorted(set(re.findall(r"SHODH_[A-Z0-9_]+", joined)))
+    rows = []
+    for flag in flags:
+        default, where = "?", []
+        for path, src in rust.items():
+            if flag not in src:
+                continue
+            where.append(path)
+            i = src.find(flag)
+            while i != -1:
+                window = src[i:i + 700]
+                if "unwrap_or(true)" in window:
+                    default = "ON"
+                elif "unwrap_or(false)" in window and default == "?":
+                    default = "OFF"
+                i = src.find(flag, i + 1)
+        engine = any(w.startswith(e) or w == e for w in where for e in ENGINE)
+        rows.append((flag, default, ext.count(flag), engine, where))
+
+    never = [r for r in rows if r[2] == 0]
+    on_never = [r for r in never if r[1] == "ON" and r[3]]
+
+    print("## flags — %d total" % len(rows))
+    print("   %d never set by any workflow, script or test." % len(never))
+    print()
+    print("   DEFAULT-ON BEHAVIOURAL FLAGS NEVER ABLATED (%d):" % len(on_never))
+    print("   Live in production; nothing has ever measured turning them off.")
+    for flag, _, _, _, where in sorted(on_never):
+        print("     %-36s %s" % (flag, where[0] if where else ""))
+    return len(on_never)
+
+
+# ---------------------------------------------------------------- dormant
+
+SKIP_NAMES = {"new", "default", "fmt", "from", "clone", "drop", "next", "eq", "hash"}
+
+
+def audit_dormant(rust):
+    prod = {p: strip_test_mods(s) for p, s in rust.items()}
+    prod_text = "\n".join(prod.values())
+    all_text = "\n".join(rust.values())
+
+    by_module = {}
+    for path, src in prod.items():
+        for m in re.finditer(r"\n\s*pub(?:\(crate\))?\s+(?:async\s+)?fn\s+(\w+)", src):
+            name = m.group(1)
+            if name.startswith("_") or name in SKIP_NAMES:
+                continue
+            if len(re.findall(r"\b%s\b" % re.escape(name), prod_text)) <= 1:
+                only_tests = len(re.findall(r"\b%s\b" % re.escape(name), all_text)) - 1
+                by_module.setdefault(path, []).append((name, only_tests))
+
+    total = sum(len(v) for v in by_module.values())
+    print("## dormant — %d public fns with no caller outside #[cfg(test)]" % total)
+    print("   NOTE: this crate is published, so a `pub fn` may be external API rather")
+    print("   than dead. Treat as a list to explain, not a list to delete.")
+    for path in sorted(by_module, key=lambda k: -len(by_module[k]))[:12]:
+        print("     %-44s %d" % (path, len(by_module[path])))
+    return total
+
+
+# ---------------------------------------------------------------- tests
+
+ASSERT = re.compile(r"\bassert\w*!|\bpanic!|\bunreachable!|\.unwrap\(\)|\.expect\(")
+TAUTOLOGIES = [
+    re.compile(r"assert!\(\s*true\s*[,)]"),
+    re.compile(r"assert_eq!\(\s*([A-Za-z_][\w.]*)\s*,\s*\1\s*[,)]"),
+    re.compile(r"assert!\(\s*\w+\.len\(\)\s*>=\s*0\s*[,)]"),
+]
+
+
+def audit_tests(rust):
+    silent, taut, total = [], [], 0
+    for path, src in rust.items():
+        # A local fn whose body asserts is an assertion helper; calling it counts.
+        helpers = {n for a, n, b in fn_bodies(src) if ASSERT.search(b)}
+        for attrs, name, body in fn_bodies(src):
+            if "#[test]" not in attrs and "#[tokio::test]" not in attrs:
+                continue
+            total += 1
+            for pat in TAUTOLOGIES:
+                if pat.search(body):
+                    taut.append((path, name))
+                    break
+            if ASSERT.search(body) or "?;" in body:
+                continue
+            if any(re.search(r"\b%s\s*\(" % re.escape(h), body) for h in helpers):
+                continue
+            silent.append((path, name))
+
+    print("## tests — %d test fns" % total)
+    print("   no assertion at all: %d" % len(silent))
+    for path, name in silent:
+        print("     %-44s %s" % (path, name))
+    print("   tautological assertion: %d" % len(taut))
+    for path, name in taut:
+        print("     %-44s %s" % (path, name))
+    return len(silent) + len(taut)
+
+
+# ---------------------------------------------------------------- ordering
+
+def audit_ordering(rust):
+    hits = []
+    for path, src in rust.items():
+        lines = src.split("\n")
+        for i, line in enumerate(lines):
+            if not re.search(r"\.(sort_by|sort_unstable_by|select_nth_unstable_by)\b", line):
+                continue
+            window = "\n".join(lines[i:i + 10])
+            if not re.search(r"partial_cmp|total_cmp", window):
+                continue
+            if ".then" in window:
+                continue
+            truncates = bool(re.search(r"\.truncate\(|\.take\(", window))
+            hits.append((path, i + 1, truncates))
+
+    print("## ordering — %d float sorts with no tie-break" % len(hits))
+    print("   A stable sort keeps equal elements in input order. When that input")
+    print("   came from a map and a truncation follows, which rows survive is")
+    print("   decided by iteration order. TRUNCATES marks that combination.")
+    for path, line, truncates in sorted(hits, key=lambda h: (not h[2], h[0])):
+        print("     %-9s %s:%d" % ("TRUNCATES" if truncates else "", path, line))
+    return sum(1 for h in hits if h[2])
+
+
+# ---------------------------------------------------------------- escapes
+
+def audit_escapes(rust, ext):
+    joined = "\n".join(rust.values())
+    names = sorted(set(re.findall(r"SHODH_(?:ALLOW|SKIP|DISABLE|FORCE)_[A-Z0-9_]+", joined)))
+    print("## escapes — %d switches that disable a safety check" % len(names))
+    print("   Each is a way to produce numbers that look normal and are not.")
+    for n in names:
+        where = [p for p, s in rust.items() if n in s]
+        print("     %-40s used outside src/: %-3d  %s"
+              % (n, ext.count(n), where[0] if where else ""))
+    return len(names)
+
+
+CHECKS = ("flags", "dormant", "tests", "ordering", "escapes")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--class", dest="only", choices=CHECKS)
+    args = ap.parse_args()
+
+    rust = load_rust()
+    ext = load_external()
+    print("audited %d rust files, %d lines\n"
+          % (len(rust), sum(s.count("\n") for s in rust.values())))
+
+    run = [args.only] if args.only else CHECKS
+    for name in run:
+        {
+            "flags": lambda: audit_flags(rust, ext),
+            "dormant": lambda: audit_dormant(rust),
+            "tests": lambda: audit_tests(rust),
+            "ordering": lambda: audit_ordering(rust),
+            "escapes": lambda: audit_escapes(rust, ext),
+        }[name]()
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -4,11 +4,21 @@
 Every check here exists because the class was found in the wild, not because it
 is a general code smell:
 
-  flags        172 env flags, 124 of which nothing outside src/ ever sets. A
-               flag no test or workflow ever flips has never been ablated, so
-               its default is an assumption. Seven graph levers were called
-               "inert" on measurements taken with one such default (the PMI
-               edge gate) silently culling 97.4% of the graph.
+  flags        172 env flags, 85 of which nothing outside src/ ever sets.
+
+               CAREFUL WITH THIS ONE. "Never set by anything checked in" is NOT
+               "never measured" -- most of these carry a documented A/B in the
+               source comment beside them, with a CI run id. The finding is
+               narrower and different: those measurements are NOT REPRODUCIBLE.
+               The evidence lives in commit prose and run ids that expire, at
+               baselines from another era (recall@10 0.6976 and 0.7124 against
+               today's 0.5268), with no committed arm to re-run and no
+               regression guard. A first pass of this audit reported them as
+               unmeasured, which was wrong.
+
+               The sharp case is SHODH_PPR: its default-ON justification cites
+               "funnel graph present% 51->76", and the funnel was independently
+               established to have run without the neural NER.
 
   dormant      Two whole modules (context.rs, injection.rs) were found alive
                only via their own tests. Code with no production caller is not
@@ -127,7 +137,12 @@ def audit_flags(rust, ext):
                     default = "OFF"
                 i = src.find(flag, i + 1)
         engine = any(w.startswith(e) or w == e for w in where for e in ENGINE)
-        rows.append((flag, default, ext.count(flag), engine, where))
+        # ASSIGNED, not merely mentioned. Counting mentions lets documentation
+        # silence the detector: adding this flag's name to a workflow input
+        # description made it drop off its own list, which is a false negative
+        # introduced by writing about it.
+        assigned = len(re.findall(r"%s\s*[:=]" % re.escape(flag), ext))
+        rows.append((flag, default, assigned, engine, where))
 
     never = [r for r in rows if r[2] == 0]
     on_never = [r for r in never if r[1] == "ON" and r[3]]
@@ -135,8 +150,10 @@ def audit_flags(rust, ext):
     print("## flags — %d total" % len(rows))
     print("   %d never set by any workflow, script or test." % len(never))
     print()
-    print("   DEFAULT-ON BEHAVIOURAL FLAGS NEVER ABLATED (%d):" % len(on_never))
-    print("   Live in production; nothing has ever measured turning them off.")
+    print("   DEFAULT-ON BEHAVIOURAL FLAGS NOT EXERCISED BY ANYTHING CHECKED IN (%d):" % len(on_never))
+    print("   Live in production. Most carry an A/B in the source comment beside")
+    print("   them -- read it before assuming unmeasured. What is missing is a")
+    print("   re-runnable arm, so nothing would catch a regression.")
     for flag, _, _, _, where in sorted(on_never):
         print("     %-36s %s" % (flag, where[0] if where else ""))
     return len(on_never)

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -975,6 +975,22 @@ pub const EVAL_USER: &str = "recall-eval";
 /// activation / lineage / ontology layer disabled. The manager wires a per-user
 /// graph + NER, so the eval exercises the same ingest path production does.
 pub(crate) fn build_manager(storage_path: &Path) -> Result<MultiUserMemoryManager> {
+    // Pin here, not at the entry points. The pinning was applied per analysis
+    // fn and two paths never got it: bridge_harness::ingest_fresh and
+    // forgetting_harness::analyze_selective_forgetting, both called straight
+    // from the recall-eval dispatch. Unpinned they run with ONNX threads at
+    // the PRODUCTION default of 24 on a 4-core runner, rayon on every core,
+    // SHODH_RECALL_READONLY unset so recall MUTATES usage state mid-eval, and
+    // a live scoring clock -- the last two documented in pin_harness_threads
+    // itself as the causes of repeat non-determinism it exists to prevent.
+    //
+    // This is the chokepoint rather than ingest_corpus because the env has to
+    // be set before MultiUserMemoryManager::new below, which initialises the
+    // embedder and reads the thread counts. Every measurement path calls
+    // build_manager, and it is crate-internal to the harness, so the
+    // production server is unaffected. The per-entry-point calls that remain
+    // are now redundant, and harmless: the function only sets what is unset.
+    pin_harness_threads();
     std::fs::create_dir_all(storage_path)
         .with_context(|| format!("creating storage dir {}", storage_path.display()))?;
     MultiUserMemoryManager::new(storage_path.to_path_buf(), ServerConfig::default())


### PR DESCRIPTION
Two things: an audit that keeps working after this session, and the finding it
produced when followed properly.

## `scripts/audit.py`

160,141 lines across 144 files. Nobody reads that line by line. Detectors read
all of it, one defect class at a time, and every class here was found in the
wild rather than borrowed from a style guide.

| class | finding |
| --- | --- |
| flags | 172 total; **98** never *assigned* by anything checked in |
| dormant | **198** pub fns with no caller outside `#[cfg(test)]` — `context.rs` 19, `injection.rs` 8, the two modules a prior audit already found inert |
| tests | **4** of 1091 assert nothing; one is a **security** test (`injection_attempt_stays_data`) |
| ordering | **45** float sorts with no tie-break, **19** truncating immediately after — the hub-cap bug shape. 9 on the recall path |
| escapes | **6** switches that disable a safety check |

Reports, does not gate. Exit code always 0.

## The finding, and the correction that produced it

The first pass said nine default-ON flags had "never been ablated". **That was
an overstatement** — nearly all carry a documented A/B with a CI run id beside
them. The accurate problem is narrower: those measurements are **not
reproducible**, so nothing would catch a regression.

Following that thread found the real thing.

`SHODH_PPR`'s default-ON justification cites run 27252898191 and *"funnel graph
present% 51→76"*. The workflow that produced it — `ppr-confirm.yml` — is in
`.github/workflows-archive/` (retired, no longer dispatchable) and **provisions
no GLiNER model**. Its only `gliner` mention is a branch name in its own
trigger. Seven siblings are identical:

`ppr-confirm` · `ppr-specificity-ab` · `ppr-passage-ab` · `ppr-agreement-ab` ·
`reach-inject-ab` · `substrate-fixes-ab` · `vamana-rebuild-ab` ·
`semantic-relations-ab`

**All eight provision GLiNER zero times.** They measured the fallback
recogniser — which decides which entities exist, hence which edges exist, hence
the substrate PPR propagates over. And the funnel figure that comment leans on
is the same one already established invalid for this exact reason.

**The fair half:** `batched-guard.yml` is *live* with **17** GLiNER references,
including *"Production typer is GLiNER bi-edge — measured, never the fallback."*
Someone saw this and built the fix. `SHODH_SEMANTIC_RELATIONS` was re-measured
there on "real-NER arms" — that default is **sound** and is not part of this
finding. Only the PPR family was never re-measured on the neural path.

## The `disable` input

The confound workflow could only turn flags **on**, which cannot ablate a
default-ON behaviour. Arms now run `FLAG=0` against the same gate-matched
baseline, and the table reports the cost of **removing** a behaviour.

This answers a second question in the same run. The source promises
*"`SHODH_PPR=0` restores the legacy BFS spread"*. That branch is real — an
`else if` for bidirectional and an `else` for unidirectional, confirmed by
brace-matching rather than grep — but **nothing has executed it since PPR went
default-ON**. It is an unverified promise on the operational escape hatch for
the core propagation algorithm. An arm that *fails* tells us the hatch is
rotten, which is better learned now than under pressure.

## A false negative I created

The flag detector counted a flag as exercised if any file merely **mentioned**
it. Writing this workflow's input description dropped `SHODH_PPR` off its own
list. It now counts assignments (`FLAG=` / `FLAG:`), which moved "never set"
from 84 to 98.

## Verification

YAML parses; the arm loop passes `bash -n`; a stub binary confirms each
ablation arm receives exactly its own `FLAG=0` with **no leakage between arms**.
The tests detector was also corrected mid-audit — it reported 23 silent tests
including 13 in `recall_harness/metrics.rs`, which was a false positive (they
assert through a local `approx` helper). It now follows assertion helpers, and
the count is 4.