### PR TITLE
The census parsed nothing because tracing colours its output, and the graph is 98.11% CoOccurs

### DIFF
--- a/.github/workflows/graph-lever-confound.yml
+++ b/.github/workflows/graph-lever-confound.yml
@@ -228,6 +228,7 @@ jobs:
         run: |
           python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
           import re, glob, collections
+          ANSI = re.compile(chr(27) + re.escape(chr(91)) + "[0-9;]*m")
           KEYS = ("semantic", "cue", "pair_table", "learned", "generic",
                   "fragment_blocked", "pmi_gated")
           print("## Edge-type census - what share of the graph is derivable?")
@@ -239,7 +240,7 @@ jobs:
               for line in open(log, errors="ignore"):
                   if "edge typing provenance" not in line:
                       continue
-                  for k, v in re.findall(r"(\w+)=(\d+)", line):
+                  for k, v in re.findall(r"(\w+)=(\d+)", ANSI.sub("", line)):
                       if k in KEYS:
                           tot[k] += int(v)
               typed = tot["semantic"] + tot["cue"] + tot["pair_table"] + tot["learned"]

--- a/.github/workflows/pmi-gate-ablation.yml
+++ b/.github/workflows/pmi-gate-ablation.yml
@@ -104,6 +104,7 @@ jobs:
           echo "## PMI² edge-gate ablation (gate_min=${{ github.event.inputs.gate_min || '0.0' }})" >> "$GITHUB_STEP_SUMMARY"
           python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
           import json, re, sys
+          ANSI = re.compile(chr(27) + re.escape(chr(91)) + "[0-9;]*m")
           def load(f):
               d = json.load(open(f))
               full = d['layers'].get('full') or next(iter(d['layers'].values()))
@@ -114,7 +115,7 @@ jobs:
               pat = re.compile(r'(\w+)=(\d+)')
               for line in open(logfile, errors='ignore'):
                   if 'edge typing provenance' not in line: continue
-                  for k, v in pat.findall(line):
+                  for k, v in pat.findall(ANSI.sub('', line)):
                       if k in tot: tot[k] += int(v)
               tot['stored_total'] = tot['semantic']+tot['cue']+tot['pair_table']+tot['learned']+tot['generic']+tot['fragment_blocked']
               return tot
@@ -185,7 +186,7 @@ jobs:
               for line in open(path, errors="ignore"):
                   if "edge typing provenance" not in line:
                       continue
-                  for key, value in pat.findall(line):
+                  for key, value in pat.findall(ANSI.sub('', line)):
                       if key in totals:
                           totals[key] += int(value)
               totals["stored_total"] = (

--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -845,6 +845,37 @@ fn summarise_reachability(report: &ReachabilityReport) {
             pct(c.cases_no_seed, c.cases),
         );
     }
+    // Substrate scoreboard. A typed path walk needs every hop to name a real
+    // relation; a hop through a symmetric type carries no order, so the typed
+    // share bounds what any composition scheme can express -- at a typed
+    // fraction p, a fully-typed k-hop path is about p^k.
+    let gs = &report.graph;
+    let stored = gs.typed_edges + gs.symmetric_edges;
+    if stored > 0 {
+        eprintln!(
+            "  relation substrate: {} stored edges, {} typed ({:.2}%), {} symmetric ({:.2}%)",
+            stored,
+            gs.typed_edges,
+            pct(gs.typed_edges, stored),
+            gs.symmetric_edges,
+            pct(gs.symmetric_edges, stored),
+        );
+        let p = gs.typed_edges as f64 / stored as f64;
+        eprintln!(
+            "  fully-typed path share: 2-hop ~{:.2}%, 3-hop ~{:.3}%  (p^k at p={:.4})",
+            100.0 * p * p,
+            100.0 * p * p * p,
+            p
+        );
+        let mut by_count: Vec<(&String, &usize)> = gs.relation_types.iter().collect();
+        by_count.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let top: Vec<String> = by_count
+            .iter()
+            .take(8)
+            .map(|(name, n)| format!("{name}={n}"))
+            .collect();
+        eprintln!("  relation types: {}", top.join("  "));
+    }
     eprintln!("  ≤2hop% is the canonical double-hop signal: high => graph-native fixes can lift multi_hop;");
     eprintln!("  low + high unreach% => gold has no associative path (extraction/construction gap or non-entity hop).");
 }

--- a/src/recall_harness/report.rs
+++ b/src/recall_harness/report.rs
@@ -672,6 +672,38 @@ pub struct GraphStructure {
     /// the graph's shape is an artefact of ingest sequence.
     #[serde(default)]
     pub hub_saturation_skipped_edges: u64,
+
+    /// Stored edges by relation type, descending.
+    ///
+    /// The substrate scoreboard for typed path composition. A walk that carries
+    /// relation ORDER needs every hop of a path to name a real relation; a hop
+    /// through `CoOccurs` carries none, because co-occurrence is symmetric and
+    /// composing it with itself is the commutative case. So the typed share is
+    /// not bookkeeping, it bounds what a path grammar can express: at a typed
+    /// fraction p, a fully-typed k-hop path is about p^k of paths.
+    ///
+    /// Measured on the LoCoMo gate corpus this was 1.89% typed -- 215 edges of
+    /// 11,370, against 11,155 CoOccurs -- which makes a typed 2-hop path
+    /// roughly 0.04% and leaves composition nothing to walk. But LoCoMo is
+    /// casual dialogue, where "Hey, that hike sounds great" genuinely contains
+    /// no typed relation, so that number may say more about the corpus than
+    /// about the extractor. This field exists so the same question can be asked
+    /// of a DOCUMENT corpus, where the answer is likely different and where the
+    /// product actually runs.
+    #[serde(default)]
+    pub relation_types: BTreeMap<String, usize>,
+
+    /// Edges whose relation type carries direction and meaning, i.e. everything
+    /// except the symmetric association types. Counted here rather than derived
+    /// by the reader so the definition lives in one place.
+    #[serde(default)]
+    pub typed_edges: usize,
+
+    /// `CoOccurs`, `RelatedTo`, `AssociatedWith`, `CoRetrieved`, `WorksWith`,
+    /// `Knows`, `AlternativeTo` -- symmetric, so order across them is not
+    /// information. Derivable from entity->episode incidence rather than stored.
+    #[serde(default)]
+    pub symmetric_edges: usize,
 }
 
 /// Reachability tallies for one category (cumulative within-N-hops counts).

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -2150,7 +2150,48 @@ pub fn analyze_graph_reachability(inputs: &RunInputs) -> Result<ReachabilityRepo
         degrees.sort_unstable_by(|a, b| b.cmp(a));
         let total_entities = degrees.len();
         let degree_sum: usize = degrees.iter().sum();
+
+        // Relation-type histogram over STORED edges. Walked from the entity side
+        // and de-duplicated by edge uuid, because get_entity_relationships
+        // returns an edge once from each endpoint it is reachable from and
+        // counting incidences would double most of them.
+        //
+        // SYMMETRIC types carry no order, so a path hop through one contributes
+        // nothing a composition could be non-commutative about. They are also
+        // the ones fully determined by entity->episode incidence, so this split
+        // is the same line as "stored vs derivable".
+        const SYMMETRIC: [&str; 7] = [
+            "CoOccurs",
+            "RelatedTo",
+            "AssociatedWith",
+            "CoRetrieved",
+            "WorksWith",
+            "Knows",
+            "AlternativeTo",
+        ];
+        let mut relation_types: std::collections::BTreeMap<String, usize> = Default::default();
+        let mut seen_edges: std::collections::HashSet<uuid::Uuid> = Default::default();
+        for e in &entities {
+            for edge in g.get_entity_relationships(&e.uuid).unwrap_or_default() {
+                if !seen_edges.insert(edge.uuid) {
+                    continue;
+                }
+                *relation_types
+                    .entry(format!("{:?}", edge.relation_type))
+                    .or_insert(0) += 1;
+            }
+        }
+        let symmetric_edges: usize = relation_types
+            .iter()
+            .filter(|(name, _)| SYMMETRIC.contains(&name.as_str()))
+            .map(|(_, n)| *n)
+            .sum();
+        let typed_edges: usize = relation_types.values().sum::<usize>() - symmetric_edges;
+
         GraphStructure {
+            relation_types,
+            typed_edges,
+            symmetric_edges,
             total_entities,
             total_edges: degree_sum / 2,
             max_degree: degrees.first().copied().unwrap_or(0),


### PR DESCRIPTION
Three things, in the order they were found.

## 1. The edge census parsed nothing

A run whose logs held **3,145 provenance lines** produced an empty table.

tracing's fmt layer emits ANSI even into a pipe, so the line is not
`semantic=0 cue=0 generic=1` but
`ESC[3msemanticESC[0mESC[2m=ESC[0m0 ...`, and `(\w+)=(\d+)` matches nothing
across the escapes. Being a report rather than a gate, it said so quietly.

**`pmi-gate-ablation.yml` carries the same parser.** That workflow's entire job
is counting edges, and its **"−97.4% edges"** figure — the justification for
making the PMI gate default-ON, and the confound that put seven graph-lever
verdicts in doubt — comes from this code path. I am *not* claiming that number
is wrong; ANSI depends on invocation. I am saying it **cannot be verified from
the parser as written**.

Both parsers now strip ANSI, built as `chr(27) + re.escape(chr(91)) + "[0-9;]*m"`
rather than written with escapes — because writing it with escapes is how it got
mangled twice while being fixed. Verified against a real line from run
33394299321.

## 2. What the census then showed

From that run's ingest provenance — 3,145 memories, 11,370 edges, 3.6/memory:

| mechanism | edges | share |
| --- | --- | --- |
| semantic | 80 | 0.70% |
| cue | 95 | 0.84% |
| pair_table | 40 | 0.35% |
| **learned** | **0** | **0.00%** |
| **generic (CoOccurs)** | **11,155** | **98.11%** |

The note in `state.rs` says ">80% CoOccurs". It is **98.11%**.

`learned = 0` is not a bug — learned pair typing bootstraps from cue evidence
needing support ≥ 3 per label-pair, and 95 cue edges across thousands of pairs
never reaches it. Starved, not broken.

**Why typed yield is low, precisely:** text typing comes from **47 hand-written
cue strings covering 9 relation types** (`Triggers` 10, `CreatedBy` 6,
`SupersededBy`/`Manages`/`WorksAt` 5 each, `DependsOn`/`LocatedIn`/`PartOf`/`Uses`
4 each). The enum has **37 variants** — 28 are unreachable from text. And the
vocabulary is enterprise ("deprecated", "headquartered", "employed by") while
the eval corpus is casual dialogue.

## 3. The substrate is now reportable on any corpus

`GraphStructure` carries a relation-type histogram over stored edges, split
typed vs symmetric, and the reachability summary prints it with the path
arithmetic:

```
relation substrate: 11370 stored edges, 215 typed (1.89%), 11155 symmetric (98.11%)
fully-typed path share: 2-hop ~0.04%, 3-hop ~0.001%  (p^k at p=0.0189)
```

This matters because a walk carrying relation ORDER needs every hop to name a
real relation; a hop through `CoOccurs` carries none, since composing a
symmetric relation with itself *is* the commutative case. At typed fraction `p`,
a fully-typed `k`-hop path is about `p^k`.

**LoCoMo is casual dialogue**, so 1.89% may describe the corpus rather than the
extractor — and the product runs on documents. Nothing reported the typed
fraction on *any* corpus, so the question could not be asked. Now it can.

The symmetric set (`CoOccurs`, `RelatedTo`, `AssociatedWith`, `CoRetrieved`,
`WorksWith`, `Knows`, `AlternativeTo`) is the same line as "derivable from
entity→episode incidence rather than stored", so this also sizes the derived
co-occurrence proposal.

## Deliberately not done

No relation-extraction model. Current zero-shot RE is ~25.6% micro-F1 for
GLiNER-Relex and 8.1% end-to-end for GLiREL, on DeBERTa-v3-large at ~0.9s/doc on
an L4 GPU — outside the runtime budget, and at that precision a composition
scheme is *worse* off: one wrong relation type corrupts an entire path, while a
missing one merely shortens it.

84 harness tests pass.