### PR TITLE
A rule that never fires looks exactly like a rule that does nothing

### DIFF
--- a/src/bin/recall_eval.rs
+++ b/src/bin/recall_eval.rs
@@ -867,6 +867,40 @@ fn summarise_reachability(report: &ReachabilityReport) {
             100.0 * p * p * p,
             p
         );
+        // Entity labels. A label-pair typing rule that never matches is
+        // indistinguishable from one that does nothing, unless you can see this.
+        let mut labels: Vec<(&String, &usize)> = gs.entity_labels.iter().collect();
+        labels.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let shown: Vec<String> = labels
+            .iter()
+            .take(8)
+            .map(|(name, n)| format!("{name}={n}"))
+            .collect();
+        eprintln!("  entity labels: {}", shown.join("  "));
+
+        // Connectivity. A k-connected graph survives k-1 vertex deletions; if
+        // this shatters after a handful, connectivity is HUB-CARRIED and a high
+        // edge count was never high connectivity.
+        eprintln!(
+            "  components: {} (largest {:.1}% of entities)",
+            gs.components_all.0,
+            100.0 * gs.components_all.1
+        );
+        for (k, count, largest) in &gs.components_after_hub_removal {
+            eprintln!(
+                "    after removing top-{k:<3} hubs: {count:>5} components, largest {:.1}%",
+                100.0 * largest
+            );
+        }
+        eprintln!(
+            "  TYPED-only subgraph: {} components, largest {:.1}%, {} entities isolated ({:.1}%)",
+            gs.typed_components.0,
+            100.0 * gs.typed_components.1,
+            gs.typed_components.2,
+            100.0 * gs.typed_components.2 as f64 / gs.total_entities.max(1) as f64,
+        );
+        eprintln!("  (isolated-in-typed is the ceiling on what a grammar-guided walk can reach)");
+
         let mut by_count: Vec<(&String, &usize)> = gs.relation_types.iter().collect();
         by_count.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
         let top: Vec<String> = by_count

--- a/src/recall_harness/report.rs
+++ b/src/recall_harness/report.rs
@@ -704,6 +704,45 @@ pub struct GraphStructure {
     /// information. Derivable from entity->episode incidence rather than stored.
     #[serde(default)]
     pub symmetric_edges: usize,
+
+    /// Entity nodes by label, descending.
+    ///
+    /// Label-pair typing rules key off these, so a rule can be correct, enabled,
+    /// and still never fire because the labels it matches are not being
+    /// produced. Measured: `SHODH_PERSON_PERSON_KNOWS=1` yielded a
+    /// BYTE-IDENTICAL graph -- typed 215, generic 4815, pair_table 40, every
+    /// metric +0.0000 -- which is what a rule that never matches looks like.
+    /// Without this field there was no way to tell "the rule does nothing" from
+    /// "the rule never fired".
+    #[serde(default)]
+    pub entity_labels: BTreeMap<String, usize>,
+
+    /// Connected components of the FULL edge set: (count, largest as a fraction
+    /// of entities).
+    #[serde(default)]
+    pub components_all: (usize, f64),
+
+    /// Same, after deleting the top-N highest-degree entities, for N in
+    /// {1, 5, 10, 25}.
+    ///
+    /// A k-connected graph survives removal of k-1 vertices. If the graph
+    /// shatters once a handful of hubs go, its connectivity is HUB-CARRIED --
+    /// high edge count is not high connectivity. That matters twice: it is the
+    /// precondition for the Gyori-Lovasz partition theorem, and it says whether
+    /// the 94.8%-of-gold-within-one-hop figure is structure or a few
+    /// degree-301 nodes standing in the middle of everything.
+    #[serde(default)]
+    pub components_after_hub_removal: Vec<(usize, usize, f64)>,
+
+    /// Components of the TYPED-ONLY subgraph, plus how many entities are
+    /// isolated in it.
+    ///
+    /// The typed layer is the substrate any path automaton would walk. At mean
+    /// typed degree below 1 most entities may be isolated there, in which case
+    /// a grammar-guided walk has nothing to traverse for most queries -- worth
+    /// knowing BEFORE building the walker rather than after.
+    #[serde(default)]
+    pub typed_components: (usize, f64, usize),
 }
 
 /// Reachability tallies for one category (cumulative within-N-hops counts).

--- a/src/recall_harness/runner.rs
+++ b/src/recall_harness/runner.rs
@@ -2188,10 +2188,107 @@ pub fn analyze_graph_reachability(inputs: &RunInputs) -> Result<ReachabilityRepo
             .sum();
         let typed_edges: usize = relation_types.values().sum::<usize>() - symmetric_edges;
 
+        // Entity labels. A label-pair typing rule can be correct and enabled and
+        // still never fire, because the labels it matches are not produced.
+        let mut entity_labels: std::collections::BTreeMap<String, usize> = Default::default();
+        for e in &entities {
+            if e.labels.is_empty() {
+                *entity_labels.entry("<unlabelled>".to_string()).or_insert(0) += 1;
+            }
+            for l in &e.labels {
+                *entity_labels.entry(format!("{l:?}")).or_insert(0) += 1;
+            }
+        }
+
+        // Undirected adjacency, built once and reused for every component pass.
+        let index: std::collections::HashMap<uuid::Uuid, usize> = entities
+            .iter()
+            .enumerate()
+            .map(|(i, e)| (e.uuid, i))
+            .collect();
+        let mut adj: Vec<Vec<usize>> = vec![Vec::new(); entities.len()];
+        let mut typed_adj: Vec<Vec<usize>> = vec![Vec::new(); entities.len()];
+        let mut counted: std::collections::HashSet<uuid::Uuid> = Default::default();
+        for e in &entities {
+            for edge in g.get_entity_relationships(&e.uuid).unwrap_or_default() {
+                if !counted.insert(edge.uuid) {
+                    continue;
+                }
+                let (Some(&a), Some(&b)) =
+                    (index.get(&edge.from_entity), index.get(&edge.to_entity))
+                else {
+                    continue;
+                };
+                adj[a].push(b);
+                adj[b].push(a);
+                if !SYMMETRIC.contains(&format!("{:?}", edge.relation_type).as_str()) {
+                    typed_adj[a].push(b);
+                    typed_adj[b].push(a);
+                }
+            }
+        }
+
+        // Components by BFS over an adjacency list, with a set of deleted
+        // vertices. Iterative: a hub-heavy graph would blow a recursive stack.
+        let components = |adj: &Vec<Vec<usize>>, removed: &std::collections::HashSet<usize>| {
+            let n = adj.len();
+            let mut seen = vec![false; n];
+            let (mut count, mut largest) = (0usize, 0usize);
+            for start in 0..n {
+                if seen[start] || removed.contains(&start) {
+                    continue;
+                }
+                count += 1;
+                let mut size = 0usize;
+                let mut stack = vec![start];
+                seen[start] = true;
+                while let Some(v) = stack.pop() {
+                    size += 1;
+                    for &w in &adj[v] {
+                        if !seen[w] && !removed.contains(&w) {
+                            seen[w] = true;
+                            stack.push(w);
+                        }
+                    }
+                }
+                largest = largest.max(size);
+            }
+            (count, largest)
+        };
+
+        let n_ent = entities.len().max(1);
+        let none: std::collections::HashSet<usize> = Default::default();
+        let (c_all, l_all) = components(&adj, &none);
+        let components_all = (c_all, l_all as f64 / n_ent as f64);
+
+        // Delete the top-N by degree. A k-connected graph survives k-1
+        // deletions; if this shatters early, connectivity is hub-carried.
+        let mut by_degree: Vec<usize> = (0..entities.len()).collect();
+        by_degree.sort_unstable_by(|&a, &b| adj[b].len().cmp(&adj[a].len()).then(a.cmp(&b)));
+        let mut components_after_hub_removal = Vec::new();
+        for &k in &[1usize, 5, 10, 25] {
+            if k > by_degree.len() {
+                break;
+            }
+            let removed: std::collections::HashSet<usize> =
+                by_degree.iter().take(k).copied().collect();
+            let (c, l) = components(&adj, &removed);
+            let denom = (entities.len() - k).max(1);
+            components_after_hub_removal.push((k, c, l as f64 / denom as f64));
+        }
+
+        let (c_typed, l_typed) = components(&typed_adj, &none);
+        let isolated_typed = typed_adj.iter().filter(|a| a.is_empty()).count();
+        let typed_components = (c_typed, l_typed as f64 / n_ent as f64, isolated_typed);
+
         GraphStructure {
             relation_types,
             typed_edges,
             symmetric_edges,
+            entity_labels,
+            components_all,
+            components_after_hub_removal,
+            typed_components,
             total_entities,
             total_edges: degree_sum / 2,
             max_degree: degrees.first().copied().unwrap_or(0),


### PR DESCRIPTION
`SHODH_PERSON_PERSON_KNOWS=1`, measured on neural NER (run 33467886502),
produced a **byte-identical graph**: typed 215, generic 4815, `pair_table` 40,
every metric **+0.0000**.

That is not "no effect" — that is **no execution**. And it matters, because the
rule's own source comment calls Person↔Person falling through to `CoOccurs`
*"the mechanical cause of the >80%-untyped graph"*. A null result there is not a
verdict on the idea; it is a signal the rule never matched.

The label-pair table keys off `EntityLabel`. The schema **has** a `person`
coarse id and `gliner.rs` maps through `EntityLabel::from_coarse_id`, so the
path exists — which leaves *"the labels are not being produced"* as the live
hypothesis. Nothing reported entity labels, so it could not be checked. Same
shape as the four instrument defects already found this week: the mechanism was
present and the run could not see it.

## Three things, from one already-expensive run

**Entity labels** — distribution over entity nodes. Distinguishes *"the rule
does nothing"* from *"the rule never fired"*. Different findings, different
fixes, previously indistinguishable.

**Connectivity under hub removal** — components of the full graph, then after
deleting the top {1, 5, 10, 25} entities by degree. A *k*-connected graph
survives *k*−1 vertex deletions, so if this shatters after a handful,
connectivity is **hub-carried** and a high edge count was never high
connectivity.

This corpus has top degrees `[301, 301, 301, 297, …]` — pinned at
`MAX_ENTITY_DEGREE`, i.e. the cap rather than their natural degree — while
**94.8% of gold sits one hop away**. This says whether that figure is structure
or three nodes standing in the middle of everything.

It is also the precondition for the Győri–Lovász partition theorem
([arXiv 2608.30945](https://arxiv.org/abs/2608.30945), first polynomial-time
algorithm, Aug 2026): it needs *k*-connectivity to yield *k* parts. Shatter at 5
hubs and *k* ≈ 5 and the partition buys nothing; survive 25 and the theorem —
and its near-linear DAG case — becomes live for the typed layer.

**Typed-subgraph connectivity** — components and isolated-node count over typed
edges only. The typed layer is **771 edges over 2,261 entities**, mean degree
below 1, so most entities may be isolated there and a grammar-guided path walk
would have nothing to traverse for most queries. **The isolated fraction is a
hard ceiling on what any automaton over typed edges can reach** — worth knowing
before building the walker rather than after, which is the whole lesson of the
seven inert levers.

## Implementation notes

BFS is iterative with an explicit stack; a degree-301 hub would blow a recursive
one. Adjacency is built once and reused across every component pass,
de-duplicated by edge uuid because `get_entity_relationships` returns an edge
from each endpoint it is reachable from.

Reporting only — no behaviour change, no gate, no default touched.

84 harness tests pass.