### PR TITLE
main does not compile: ort rc.13 vs the cross-encoder's builder calls

### DIFF
--- a/src/embeddings/cross_encoder.rs
+++ b/src/embeddings/cross_encoder.rs
@@ -130,13 +130,13 @@ impl CrossEncoder {
         let session = Session::builder()
             .context("cross-encoder: session builder")?
             .with_intra_threads(num_threads)
-            .context("cross-encoder: intra threads")?
+            .map_err(|e| anyhow::anyhow!("cross-encoder: intra threads: {e}"))?
             .with_inter_threads(1)
-            .context("cross-encoder: inter threads")?
+            .map_err(|e| anyhow::anyhow!("cross-encoder: inter threads: {e}"))?
             .with_intra_op_spinning(false)
-            .context("cross-encoder: intra spinning")?
+            .map_err(|e| anyhow::anyhow!("cross-encoder: intra spinning: {e}"))?
             .with_inter_op_spinning(false)
-            .context("cross-encoder: inter spinning")?
+            .map_err(|e| anyhow::anyhow!("cross-encoder: inter spinning: {e}"))?
             .commit_from_file(&model_path)
             .context("cross-encoder: load onnx")?;
 


### PR DESCRIPTION
**main is currently broken.** #536 and #539 are each green and do not build together.

#539 took `ort` to 2.0.0-rc.13, where builder methods return `ort::Error<SessionBuilder>` instead of `ort::Error` — a typed error that hands the builder back for recovery, which no longer satisfies `anyhow::Context`'s bounds. That PR adapted the two existing sessions (`minilm.rs`, `gliner.rs`). #536 then added a **third** ort session, `cross_encoder.rs`, written against rc.11 and merged straight after.

Git saw no conflict — different files. Neither PR's CI could see it either, because neither ran against the other's merge result.

Four call sites converted to `map_err`, messages unchanged. `check`, `clippy`, `fmt` clean.

Merge this before anything else in the queue.