### PR TITLE
BM25 scored the same document differently because segment layout was not determined by the corpus

### DIFF
--- a/src/memory/hybrid_search.rs
+++ b/src/memory/hybrid_search.rs
@@ -197,9 +197,29 @@ impl BM25Index {
             .get_field("entities")
             .context("BM25 schema missing 'entities' field")?;
 
-        // 15MB writer heap — sufficient for edge workloads
+        // 15MB writer heap — sufficient for edge workloads.
+        //
+        // ONE INDEXING THREAD, and the count is the point rather than the heap.
+        // `Index::writer` picks a thread count from the available CPUs and
+        // distributes documents across them, so the SEGMENT LAYOUT of an index
+        // depends on how the work happened to be divided. BM25 scores are
+        // computed from per-segment corpus statistics, which means two ingests
+        // of the same corpus on the same machine can score the same document
+        // differently — not in the last bits, but by whole percent.
+        //
+        // That is the shape of the L1 determinism failure: divergent scores of
+        // 0.8% to 68%, never at ULP scale, present with BM25 in the pipeline and
+        // ABSENT when the vector leg runs alone. Every other candidate was ruled
+        // out first — the scoring clock, ONNX and rayon threads, recall-path
+        // writes, the knowledge graph's structure AND its weights, and the ANN
+        // index — each by measurement rather than by argument.
+        //
+        // A single indexing thread makes segment layout a function of the
+        // corpus alone. It costs ingest throughput on multi-core machines,
+        // which is the right trade for a memory whose product claim is that the
+        // same question over the same data returns the same answer.
         let writer = index
-            .writer(15_000_000)
+            .writer_with_num_threads(1, 15_000_000)
             .context("Failed to create index writer")?;
 
         let reader = index


### PR DESCRIPTION
**Draft: this is a hypothesis with a mechanism, not a confirmed fix.** It is opened to get the L1 gate running on it, which only fires on `pull_request`.

## The change

`BM25Index::new` now builds its writer with `writer_with_num_threads(1, 15_000_000)` instead of `Index::writer(15_000_000)`.

`Index::writer` picks an indexing thread count from the available CPUs and spreads documents across the threads, so which segment a document lands in depends on how the work was divided rather than on the corpus. BM25 scores are computed from per-segment corpus statistics. Two ingests of one corpus on one machine can therefore score the same document differently.

## Why this hypothesis

It is the first candidate whose mechanism matches every observation from the L1 determinism bisection:

- Divergent scores of 0.8% to 68%, never at ULP scale. Float non-associativity gives ~1e-7, four to six orders too small.
- Present with BM25 in the pipeline, absent when the vector leg runs alone with exact search (n=300, repeats=3, one branch, one code path: 5 divergences vs 1).
- The one divergence surviving the vector-only arm is a tie, not a score difference, which is a separate bug with a separate fix.

Ruled out before this, each by measurement: the scoring clock, ONNX and rayon thread counts, recall-path writes, the knowledge graph's structure and its accumulated weights (content-addressed fingerprint, zero differences across three ingests), and the ANN index.

## Evidence so far, and why it does not settle it

The held-out LoCoMo workflow on this commit (run 34454314145, cases=300, repeats=3) **still diverged on 2 cases**, conv-49_q90 and conv-49_q120. Both are the same adjacent swap, `D23:31` ↔ `D23:33` at ranks 8–9, so it is one mechanism.

The divergence count cannot confirm or refute the change. At the same config, main (c6411e3e) showed 1 divergence (conv-47_q38) and the bisection arm showed 5. The per-case artifact records no per-repeat scores, so whether the surviving swap is a tie (the second bug) or a genuine score difference is unknown.

The same run's recall@10 (0.5585 vs 0.4319 on main at c6411e3e) is **not attributable** to this change: #497, #509 and #545 sit between the two commits.

## What would confirm it

- The next instrument is the candidate set, not the ranking: record which candidates enter the final sort per case per repeat. The final sorts tie-break on (score, created_at, content, id), so an identical candidate set cannot produce a different order.
- L1 on this PR. Caveat: L1 has been failing on main since at least #509 with "Recall regression", not non-determinism, so a red L1 here must be read for which of the two it reports.

## Cost

Single-threaded BM25 indexing lowers ingest throughput on multi-core machines. That is the intended trade for a memory system whose claim is that the same question over the same data returns the same answer — a claim that is currently false on re-ingest.
